### PR TITLE
Disable default autocomplete email list.

### DIFF
--- a/extension/js/add_dropdown_to_email_inputs.js
+++ b/extension/js/add_dropdown_to_email_inputs.js
@@ -18,9 +18,12 @@
     document.body.appendChild(relayAddressesDatalist);
 
     // set the "list" attribute of all email inputs to "relay-addresses"
+
     const emailInputs = document.querySelectorAll("input[type='email']");
     for (const emailInput of emailInputs) {
       emailInput.setAttribute("list", "relay-addresses");
+      // disable autocomplete so that only generated private relay addresses appear
+      emailInput.setAttribute("autocomplete", "false");
     }
   }
 


### PR DESCRIPTION
Prevent the default autocomplete list from showing non-private relay email addresses.