### PR TITLE
Avoid 'executeScript' when filling relay address, use content-script file

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -1,42 +1,5 @@
 const RELAY_SITE_ORIGIN = "http://127.0.0.1:8000";
 
-/**
- * Escapes any occurances of &, ", <, > or / with XML entities.
- *
- * @param {string} str
- *        The string to escape.
- * @return {string} The escaped string.
- */
-function escapeXML(str) {
-  const replacements = { "&": "&amp;", "\"": "&quot;", "'": "&apos;", "<": "&lt;", ">": "&gt;", "/": "&#x2F;" };
-  return String(str).replace(/[&"'<>/]/g, m => replacements[m]);
-}
-
-/**
- * A tagged template function which escapes any XML metacharacters in
- * interpolated values.
- *
- * @param {Array<string>} strings
- *        An array of literal strings extracted from the templates.
- * @param {Array} values
- *        An array of interpolated values extracted from the template.
- * @returns {string}
- *        The result of the escaped values interpolated with the literal
- *        strings.
- */
-
-function escaped(strings, ...values) {
-  const result = [];
-
-  for (const [i, string] of strings.entries()) {
-    result.push(string);
-    if (i < values.length)
-      result.push(escapeXML(values[i]));
-  }
-
-  return result.join("");
-}
-
 async function makeRelayAddress() {
   const apiToken = await browser.storage.local.get("apiToken");
 
@@ -72,9 +35,10 @@ async function makeRelayAddressForTargetElement(info, tab) {
     return;
   }
 
-  browser.tabs.executeScript(tab.id, {
-    frameId: info.frameId,
-    code: escaped`let inputElement = browser.menus.getTargetElement(${info.targetElementId});inputElement.value = "${newRelayAddressResponse}";`,
+  browser.tabs.sendMessage(tab.id, {
+    type: "fillTargetWithRelayAddress",
+    targetElementId : info.targetElementId,
+    relayAddress: newRelayAddressResponse,
   });
 }
 

--- a/extension/js/fill_relay_address.js
+++ b/extension/js/fill_relay_address.js
@@ -1,4 +1,4 @@
-browser.runtime.onMessage((message, sender, response) => {
+browser.runtime.onMessage.addListener((message, sender, response) => {
     if (message.type === "fillTargetWithRelayAddress") {
         let inputElement = browser.menus.getTargetElement(message.targetElementId);
         inputElement.value = message.relayAddress;

--- a/extension/js/fill_relay_address.js
+++ b/extension/js/fill_relay_address.js
@@ -1,0 +1,6 @@
+browser.runtime.onMessage((message, sender, response) => {
+    if (message.type === "fillTargetWithRelayAddress") {
+        let inputElement = browser.menus.getTargetElement(message.targetElementId);
+        inputElement.value = message.relayAddress;
+    }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -39,7 +39,7 @@
       "matches": [
           "<all_urls>"
       ],
-      "js": ["js/add_input_icon.js"]
+      "js": ["js/add_input_icon.js", "js/fill_relay_address.js"]
     }
   ],
 


### PR DESCRIPTION
Fix #112.

I haven't been able to test this code yet, please let me know what you think of it.