### PR TITLE
Fixup authentication error page.

### DIFF
--- a/privaterelay/templates/socialaccount/authentication_error.html
+++ b/privaterelay/templates/socialaccount/authentication_error.html
@@ -1,25 +1,12 @@
 {% extends "base.html" %}
 
 {% block content %}
-
-<div class="dashboard-header-wrapper">
-  {% include "includes/header.html" %}
-</div>
-
-<main id="profile-main" class="container bg-light dashboard-container container" data-api-token="{{ user.profile_set.first.api_token }}">
-    <!-- Empty State -->
-    <!-- List of Emails -->
-    <div class="main-list content-row">
-        <div class="p-4">
-          <div class="mx-auto max-w-4xl ">
-            <div class="">
-              <ul class="messages">
-                <li class="error">Sorry, Private Relay sign-ups are currently invitation-only. Please check again later.</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-    </div>
+<main id="profile-main" class="flx env-bg container bg-light dashboard-container" data-api-token="{{ user.profile_set.first.api_token }}">
+  <div class="appear-smoothly flx flx-col al-cntr jst-cntr auth-error-wrapper">
+    <div class="flx flx-col al-cntr jst-cntr auth-error">
+        <p class="ff-Met no-active-aliases text-center">Sorry, the Private Relay Beta is currently by invitation only. Please check again later.</p>
+      </div>
+  </div>
 </main>
 
 {% endblock %}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -795,6 +795,18 @@ ul.messages {
 
 /* end no aliases screen */
 
+/* auth error */
+
+.auth-error-wrapper {
+  max-width: 400px;
+  line-height: 1.4;
+  border-radius: 8px;
+  padding: 2px;
+  margin: 5vh auto auto auto;
+}
+
+/* end auth error */
+
 @media screen and (max-width: 1050px) {
   .home-hero {
     align-items: flex-start;
@@ -961,6 +973,10 @@ ul.messages {
 }
 
 @media screen and (max-width: 550px) {
+  .no-active-aliases {
+    font-size: 1.2rem;
+  }
+
   .fx-private-relay-logotype {
     display: none;
   }


### PR DESCRIPTION
- Changes the UI on the authentication error page so that it looks like this:
<img width="1124" alt="Screen Shot 2020-04-09 at 2 33 42 PM" src="https://user-images.githubusercontent.com/22355127/78933660-41ac7080-7a6f-11ea-9494-9434e2686a19.png">

To consider: Adding a "Join the waitlist" button to make this feel like less of a dead end. Especially since we aren't providing a date for when this will be more widely available.