### PR TITLE
fix #140: add proper avatar origin to CSP

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -47,14 +47,21 @@ SECURE_BROWSER_XSS_FILTER = config('DJANGO_SECURE_BROWSER_XSS_FILTER', True)
 SESSION_COOKIE_SECURE = config(
     'DJANGO_SESSION_COOKIE_SECURE', False, cast=bool
 )
+# maps fxa profile hosts to respective avatar hosts for CSP
+AVATAR_IMG_SRC_MAP = {
+    'https://stable.dev.lcip.org/profile/v1':   'stable.dev.lcip.org',
+    'https://profile.stage.mozaws.net/v1':      'mozillausercontent.com',
+    'https://profile.accounts.firefox.com/v1':  'firefoxusercontent.com',
+}
+AVATAR_IMG_SRC = AVATAR_IMG_SRC_MAP[config(
+    'FXA_PROFILE_ENDPOINT', 'https://profile.accounts.firefox.com/v1'
+)]
 CSP_DEFAULT_SRC = ("'self'",)
 CSP_SCRIPT_SRC = ("'self'",)
 CSP_STYLE_SRC = ("'self'",)
 CSP_IMG_SRC = (
     "'self'",
-    config('FXA_PROFILE_ENDPOINT', 'https://profile.accounts.firefox.com/v1'),
-    "https://placehold.it",
-    "https://stable.dev.lcip.org/profile/",
+    AVATAR_IMG_SRC,
 )
 REFERRER_POLICY = 'strict-origin-when-cross-origin'
 


### PR DESCRIPTION
Avatar images are served from different origins based on the FXA environment. This change updates our CSP to include the proper avatar origin.