### PR TITLE
Context menu alias generation improvements - wip

### DIFF
--- a/extension/css/add_input_icon.css
+++ b/extension/css/add_input_icon.css
@@ -16,6 +16,7 @@
   pointer-events: none;
   padding: 0 !important;
   width: 100%;
+  height: 100%;
   z-index: 99999999999999999;
 }
 
@@ -134,3 +135,141 @@ button.relay-error-dismiss:focus {
   border: 0;
 }
 
+logo-wrapper {
+  width: 100%;
+  max-width: 320px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-content: center;
+  margin-bottom: 32px;
+}
+
+
+logotype {
+  background-image: url("/images/logotype.svg");
+  width: 60%;
+  height: 30px;
+  margin: 6px auto auto 0;
+}
+
+logomark {
+  content: "";
+  background-image: url("/images/logomark.svg");
+  width: 38px;
+  height: 40px;
+  margin: auto 6px auto auto;
+}
+
+logotype,
+logomark {
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-position: center;
+}
+
+.relay-modal-wrapper {
+  position: fixed;
+  top: 48px;
+  width: 100%;
+  left: 0;
+  right: 0;
+  display: block;
+  z-index: 100000000;
+  display: flex;
+  align-content: center;
+  align-items: center;
+  justify-content: center;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+
+}
+
+.relay-modal-content {
+  max-width: 500px;
+  min-width: 400px;
+  background-color: rgba(255, 255, 255, 1);
+  border-radius: 8px;
+  padding: 2rem 2rem calc(50px + 2rem) 2rem;
+  box-shadow: 0 7px 12px -3px rgba(28, 28, 29, 0.502);
+  display: flex;
+  flex-direction: column;
+  align-content: center;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.relay-modal-message-alias-wrapper {
+  height: 48px;
+  margin-bottom: 12px;
+  font-size: 18px;
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  border-bottom: 1px solid #ededf0;
+}
+
+.relay-modal-message {
+  font-size: 16px;
+  line-height: 1.3;
+  text-align: center;
+  max-width: 300px;
+  font-weight: 300px;
+  color: rgba(0, 0, 0, .6);
+  margin-bottom: 32px;
+}
+
+.relay-message-copied {
+  font-size: 12px;
+  background-color: #9059ff;
+  border-radius: 2px;
+  padding: 3px 6px;
+  color: rgba(255, 255, 255, 1);
+  margin-left: 8px;
+}
+
+.relay-modal-close-button {
+  height: 48px;
+  padding:12px;
+  border-radius: 0;
+  border: 1px solid rgba(255, 255, 255, 0);
+  background: #f9f9fa;
+  color: #20123a;
+  font-size: 17px;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  justify-content: center;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  transition: all 0.2s ease;
+}
+
+.relay-modal-close-button:hover,
+.relay-modal-close-button:focus {
+  background: #f2f2f2;
+  transition: all 0.2s ease;
+}
+
+.relay-modal-close-button:active {
+  background: #eaeaea;
+  transition: all 0.2s ease;
+}
+
+.relay-modal-dashboard-link {
+  margin: auto;
+  text-decoration: none;
+  font-size: 16px;
+}
+
+.relay-modal-dashbord-link::after {
+  height: 20px;
+  width: 20px;
+  margin-left: 4px;
+}

--- a/extension/css/add_input_icon.css
+++ b/extension/css/add_input_icon.css
@@ -16,7 +16,6 @@
   pointer-events: none;
   padding: 0 !important;
   width: 100%;
-  height: 100%;
   z-index: 99999999999999999;
 }
 
@@ -172,6 +171,7 @@ logomark {
   position: fixed;
   top: 48px;
   width: 100%;
+  height: 100%;
   left: 0;
   right: 0;
   display: block;

--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -46,22 +46,17 @@ async function makeRelayAddressForTargetElement(info, tab) {
     return;
   }
 
-  const options = {};
-
-  // Check if input is inside iframe and send the iframe's src if so
-  if (info.frameUrl && info.pageUrl) {
-    const iframeUrl = info.frameUrl;
-    const pageUrl = info.pageUrl;
-    const iframeSrc = (iframeUrl.includes(pageUrl)) ? iframeUrl.replace(pageUrl, "/") : iframeUrl;
-
-    options.iframeSrc = iframeSrc;
-  }
-  browser.tabs.sendMessage(tab.id, {
-    type: "fillTargetWithRelayAddress",
-    targetElementId : info.targetElementId,
-    relayAddress: newRelayAddress,
-    options,
-  });
+  browser.tabs.sendMessage(
+      tab.id,
+      {
+        type: "fillTargetWithRelayAddress",
+        targetElementId : info.targetElementId,
+        relayAddress: newRelayAddress,
+      },
+      {
+        frameId: info.frameId,
+    },
+  );
 }
 
 browser.menus.create({

--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -46,10 +46,21 @@ async function makeRelayAddressForTargetElement(info, tab) {
     return;
   }
 
+  const options = {};
+
+  // Check if input is inside iframe and send the iframe's src if so
+  if (info.frameUrl && info.pageUrl) {
+    const iframeUrl = info.frameUrl;
+    const pageUrl = info.pageUrl;
+    const iframeSrc = (iframeUrl.includes(pageUrl)) ? iframeUrl.replace(pageUrl, "/") : iframeUrl;
+
+    options.iframeSrc = iframeSrc;
+  }
   browser.tabs.sendMessage(tab.id, {
     type: "fillTargetWithRelayAddress",
     targetElementId : info.targetElementId,
     relayAddress: newRelayAddress,
+    options,
   });
 }
 

--- a/extension/js/fill_relay_address.js
+++ b/extension/js/fill_relay_address.js
@@ -1,6 +1,90 @@
+function showModal(modalContentString, modalType) {
+    const modalWrapper = document.createElement("div");
+    modalWrapper.classList = ["relay-modal-wrapper"];
+
+    const modalContent = document.createElement("div");
+    modalContent.classList = ["relay-modal-content"];
+
+    const logoWrapper = document.createElement("logo-wrapper");
+    const logoMark = document.createElement("logomark");
+    const logoType = document.createElement("logotype");
+
+    [logoMark, logoType].forEach(customEl => {
+        logoWrapper.appendChild(customEl);
+    });
+
+    modalContent.appendChild(logoWrapper);
+
+    const modalAliasWrapper = document.createElement("div");
+    modalAliasWrapper.classList = ["relay-modal-message-alias-wrapper"];
+
+    if (modalType === "new-alias") {
+        const modalAlias = document.createElement("span");
+        modalAlias.textContent = modalContentString;
+        modalAlias.classList = ["relay-modal-alias"];
+
+        const purpleCopiedBlurb = document.createElement("span");
+        purpleCopiedBlurb.textContent = "Copied!";
+        purpleCopiedBlurb.classList = ["relay-message-copied"];
+
+        [modalAlias, purpleCopiedBlurb].forEach(textEl => {
+            modalAliasWrapper.appendChild(textEl);
+        });
+
+        const modalMessage = document.createElement("span");
+        modalMessage.textContent = "You just created a new alias!";
+        modalMessage.classList = ["relay-modal-message relay-modal-headline"];
+
+        [modalAliasWrapper, modalMessage].forEach(textEl => {
+            modalContent.appendChild(textEl);
+        });
+    }
+
+    const modalCloseButton = document.createElement("button");
+    modalCloseButton.classList = ["relay-modal-close-button"];
+    modalCloseButton.textContent = "Got it!";
+
+    // Remove relay modal on button click
+    modalCloseButton.addEventListener("click", () => {
+        modalWrapper.remove();
+    });
+
+    // Remove relay modal on clicks outside of modal.
+    modalWrapper.addEventListener("click", (e) => {
+        const originalTarget = e.explicitOriginalTarget;
+        if (originalTarget.classList.contains("relay-modal-wrapper")) {
+            modalWrapper.remove();
+        }
+    });
+
+    modalContent.appendChild(modalCloseButton);
+    modalWrapper.appendChild(modalContent);
+    document.body.appendChild(modalWrapper)
+
+    window.navigator.clipboard.writeText(modalContentString);
+    return;
+}
+
+
 browser.runtime.onMessage.addListener((message, sender, response) => {
     if (message.type === "fillTargetWithRelayAddress") {
-        let inputElement = browser.menus.getTargetElement(message.targetElementId);
-        inputElement.value = message.relayAddress;
+
+        // attempt to find the email input
+        let emailInput = browser.menus.getTargetElement(message.targetElementId);
+
+        // find email inputs in frame
+        if (!emailInput && message.options.iframeSrc) {
+            const parentIframe = document.querySelector(`iframe[src^="${message.options.iframeSrc}"]`);
+            // Later: Do better detecting of iframe input
+            const foundEmailInputs = parentIframe.contentWindow.document.body.querySelectorAll("input[type='email'], input[name='email']");
+            emailInput = (foundEmailInputs.length > 0) ? foundEmailInputs[0] : emailInput;
+        }
+
+        // default to showing the new alias in a modal if the input still hasn't been found
+        if (!emailInput) {
+            return showModal(message.relayAddress, "new-alias");
+        }
+
+        emailInput.value = message.relayAddress;
     }
 });

--- a/extension/js/fill_relay_address.js
+++ b/extension/js/fill_relay_address.js
@@ -70,17 +70,7 @@ browser.runtime.onMessage.addListener((message, sender, response) => {
     if (message.type === "fillTargetWithRelayAddress") {
 
         // attempt to find the email input
-        let emailInput = browser.menus.getTargetElement(message.targetElementId);
-
-        // find email inputs in frame
-        if (!emailInput && message.options.iframeSrc) {
-            const parentIframe = document.querySelector(`iframe[src^="${message.options.iframeSrc}"]`);
-            // Later: Do better detecting of iframe input
-            const foundEmailInputs = parentIframe.contentWindow.document.body.querySelectorAll("input[type='email'], input[name='email']");
-            emailInput = (foundEmailInputs.length > 0) ? foundEmailInputs[0] : emailInput;
-        }
-
-        // default to showing the new alias in a modal if the input still hasn't been found
+        const emailInput = browser.menus.getTargetElement(message.targetElementId);
         if (!emailInput) {
             return showModal(message.relayAddress, "new-alias");
         }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -47,7 +47,8 @@
           "<all_urls>"
       ],
       "js": ["js/add_input_icon.js", "js/fill_relay_address.js"],
-      "css": ["css/add_input_icon.css"]
+      "css": ["css/add_input_icon.css"],
+      "all_frames": true
     }
   ],
 


### PR DESCRIPTION
- Do a better job of targeting/filling inputs that are nested inside of iframes when the alias is created via the context menu.
- If the email input can't be found, show the new alias in a branded modal. 

<img width="437" alt="Screen Shot 2020-04-30 at 1 10 48 PM" src="https://user-images.githubusercontent.com/22355127/80744346-2075f780-8ae4-11ea-89c7-0bcb241d73b5.png">
