### PR TITLE
fix #253: add check for browser.menus API calls

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -59,19 +59,21 @@ async function makeRelayAddressForTargetElement(info, tab) {
   );
 }
 
-browser.menus.create({
-  id: "fx-private-relay-generate-alias",
-  title: "Generate Email Alias",
-  contexts: ["editable"]
-});
+if (browser.menus) {
+  browser.menus.create({
+    id: "fx-private-relay-generate-alias",
+    title: "Generate Email Alias",
+    contexts: ["editable"]
+  });
 
-browser.menus.onClicked.addListener( async (info, tab) => {
-  switch (info.menuItemId) {
-    case "fx-private-relay-generate-alias":
-      await makeRelayAddressForTargetElement(info, tab);
-      break;
-  }
-});
+  browser.menus.onClicked.addListener( async (info, tab) => {
+    switch (info.menuItemId) {
+      case "fx-private-relay-generate-alias":
+        await makeRelayAddressForTargetElement(info, tab);
+        break;
+    }
+  });
+}
 
 browser.runtime.onMessage.addListener(async (m) => {
   let response;

--- a/extension/js/fill_relay_address.js
+++ b/extension/js/fill_relay_address.js
@@ -70,7 +70,7 @@ browser.runtime.onMessage.addListener((message, sender, response) => {
     if (message.type === "fillTargetWithRelayAddress") {
 
         // attempt to find the email input
-        const emailInput = browser.menus.getTargetElement(message.targetElementId);
+        const emailInput = browser.menus && browser.menus.getTargetElement(message.targetElementId);
         if (!emailInput) {
             return showModal(message.relayAddress, "new-alias");
         }


### PR DESCRIPTION
Fixes #253. We wrap all `browser.menus` calls with a check since this is not supported in Fenix/GeckoView. 