### PR TITLE
fix #258: make the popup page into a mobile responsive page

### DIFF
--- a/extension/css/popup.css
+++ b/extension/css/popup.css
@@ -16,12 +16,14 @@
 
 body {
   --panelWidth: 360px;
+  /* Any changes to --panelHeight should be reflected in the screen media query */
   --panelHeight: 300px;
   --ink: #20123a;
   --Metropolis: "Metropolis", "SF Pro Text", "Segoe UI", Roboto, "Open Sans";
   --fxGradient: linear-gradient(-90deg, #ff9100 0%, #f10366 50%, #6173ff 100%);
   font-family: "Inter UI", "SF Pro Text", 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   font-size: 17px;
+  margin: 0;
   -moz-osx-font-smoothing: grayscale;
 }
 
@@ -75,6 +77,14 @@ p {
   margin-top: 0;
   line-height: 1.5;
   text-align: center;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
 }
 
 .intro {
@@ -316,4 +326,58 @@ alias-creation {
   padding: 3px 6px;
   color: rgba(255, 255, 255, 1);
   margin-left: 8px;
+}
+
+/* For mobile screens with a bigger height viewport than the browser popup.
+   This takes the --panelHeight + 1px as its min-height. */
+@media screen and (min-height: 301px) {
+  .panel {
+    height: 100vh;
+  }
+
+  logo-wrapper {
+    margin-top: 2rem;
+  }
+
+  logomark {
+    width: 48px;
+    height: 50px;
+  }
+
+  logotype {
+    width: 70%;
+    height: 50px;
+  }
+
+  .intro {
+    margin-top: 5rem;
+    margin-bottom: 2rem;
+  }
+
+  .intro,
+  .alias,
+  .error-message {
+    font-size: 1rem;
+  }
+
+  .message-copied {
+    font-size: 0.8rem;
+  }
+
+  .text-link {
+    border-bottom: 1px solid var(--ink);
+  }
+
+  .create-account {
+    font-size: 1.1rem;
+    padding: 1rem 3rem;
+  }
+
+  alias-creation {
+    margin-top: 12rem;
+  }
+
+  .view-dashboard {
+    margin: auto auto 0 auto;
+  }
 }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -2,6 +2,7 @@
 <html id="1">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Firefox Private Relay</title>
     <link rel="stylesheet" href="css/popup.css">
     <script src="js/popup.js"></script>
@@ -13,9 +14,11 @@
           <logomark></logomark>
           <logotype></logotype>
         </logo-wrapper>
-        <p class="intro">Create an account or <a class="text-link close-popup-after-click" href="http://127.0.0.1:8000/?utm_source=addon&utm_medium=popup">sign in</a> to access your dashboard and create aliases.</p>
-        <div class="gradient-button-wrapper">
-            <a class="button create-account new-tab close-popup-after-click" href="http://127.0.0.1:8000/?utm_source=addon&utm_medium=popup">Create Account</a>
+        <div class="content">
+          <p class="intro">Create an account or <a class="text-link close-popup-after-click" href="http://127.0.0.1:8000/?utm_source=addon&utm_medium=popup">sign in</a> to access your dashboard and create aliases.</p>
+          <div class="gradient-button-wrapper">
+              <a class="button create-account new-tab close-popup-after-click" href="http://127.0.0.1:8000/?utm_source=addon&utm_medium=popup">Create Account</a>
+          </div>
         </div>
         <!-- <p class="already-signed-up">Have an account?<a class="text-link" href="http://127.0.0.1:8000/">Sign in</a></span></p> -->
       </main>


### PR DESCRIPTION
Fixes #258. To test this, it is either best to run an emulator with the extension as described in https://github.com/mozilla/fx-private-relay/pull/254#issuecomment-622964146 or to run `popup.html` in the browser and toggle on the responsive design mode. If you're doing the latter, you may need to toggle the `hidden` classes manually and fix the relative paths of the fonts and images in `popup.css`.

I took some liberties here to align it with the relay site, and am happy to iterate on the changes either in this PR or as a followup.

Notable changes include:
- Adding a media query that takes into the fact that the popup in the desktop is hardcoded to a height of --panelHeight (300px) and basically checked if the viewport is bigger than 301px, then made everything bigger and aligned for a mobile screen.
- Added the bottom border for the "sign up" link since it is not obvious in mobile (don't feel too strongly about this change)

Before it is mobile responsive (old):

<img width="455" alt="Screen Shot 2020-05-03 at 9 59 58 AM" src="https://user-images.githubusercontent.com/1190888/80916148-f4958480-8d24-11ea-854c-e1df7b39a8bc.png">

With the changes (new):

<img width="455" alt="Screen Shot 2020-05-03 at 10 02 43 AM" src="https://user-images.githubusercontent.com/1190888/80916203-40e0c480-8d25-11ea-8d3a-a5a6c04e925b.png">

<img width="455" alt="Screen Shot 2020-05-03 at 10 05 14 AM" src="https://user-images.githubusercontent.com/1190888/80916320-f4e24f80-8d25-11ea-8c4a-efafe5b69c86.png">

<img width="455" alt="Screen Shot 2020-05-03 at 10 07 36 AM" src="https://user-images.githubusercontent.com/1190888/80916354-22c79400-8d26-11ea-8e43-8ac636e2656c.png">

<img width="455" alt="Screen Shot 2020-05-03 at 10 08 20 AM" src="https://user-images.githubusercontent.com/1190888/80916360-29560b80-8d26-11ea-82c5-b5e0351f36c0.png">
