### PR TITLE
Fix text color on authentication error page

### DIFF
--- a/privaterelay/templates/socialaccount/authentication_error.html
+++ b/privaterelay/templates/socialaccount/authentication_error.html
@@ -4,7 +4,7 @@
 <main id="profile-main" class="flx env-bg container bg-light dashboard-container" data-api-token="{{ user.profile_set.first.api_token }}">
   <div class="appear-smoothly flx flx-col al-cntr jst-cntr auth-error-wrapper">
     <div class="flx flx-col al-cntr jst-cntr auth-error">
-        <p class="ff-Met no-active-aliases text-center">Sorry, the Private Relay Beta is currently by invitation only. Please check again later.</p>
+        <p class="ff-Met no-active-aliases text-center txt-white">Sorry, the Private Relay Beta is currently by invitation only. Please check again later.</p>
       </div>
   </div>
 </main>


### PR DESCRIPTION
If an uninvited user tries to sign in to Firefox Private Relay, all they see is a black envelope because the text on top is also black:
![image](https://user-images.githubusercontent.com/3108640/81022436-9ad3ae00-8e3b-11ea-9eec-90fad4dc8363.png)

In this PR I changed the color of the text to white so that it appears as expected:
![image](https://user-images.githubusercontent.com/3108640/81022486-ba6ad680-8e3b-11ea-9c13-5e0a8a791fe4.png)