### PR TITLE
ALPHA_INVITE_TOKEN env var to enable invite links

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -30,6 +30,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # defaulting to blank to be production-broken by default
 SECRET_KEY = config('SECRET_KEY', None, cast=str)
 
+ALPHA_INVITE_TOKEN = config('ALPHA_INVITE_TOKEN', default=None)
+MAX_ACTIVE_ACCOUNTS = config('MAX_ACTIVE_ACCOUNTS', default=1500, cast=int)
+
 DEBUG = config('DEBUG', False, cast=bool)
 
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()

--- a/privaterelay/signals.py
+++ b/privaterelay/signals.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 
+from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.contrib.auth.models import User
 
 from .models import Invitations
 
@@ -13,15 +15,47 @@ ALLOWED_SIGNUP_DOMAINS = [
 def invitations_only(sender, **kwargs):
     sociallogin = kwargs['sociallogin']
     email = sociallogin.account.extra_data['email']
+
+    # Mozilla domain FXA's should always be allowed
     domain_part = email.split('@')[1]
     for allowed_domain in ALLOWED_SIGNUP_DOMAINS:
         if domain_part == allowed_domain:
             return True
+
+    # Explicit invitations for an email address can get in
     try:
         active_invitation = Invitations.objects.get(email=email, active=True)
+        if not active_invitation.date_redeemed:
+            active_invitation.date_redeemed = datetime.now()
+            active_invitation.save()
+        return True
+
     except Invitations.DoesNotExist:
-        raise PermissionDenied
-    if not active_invitation.date_redeemed:
-        active_invitation.date_redeemed = datetime.now()
-        active_invitation.save()
-    return True
+        # If we're not doing token-based invites; reject immediately
+        if not settings.ALPHA_INVITE_TOKEN:
+            raise PermissionDenied
+
+        # Token inviations are subject to max accounts limit
+        active_accounts_count = User.objects.count()
+        if active_accounts_count >= settings.MAX_ACTIVE_ACCOUNTS:
+            raise PermissionDenied("There are too many active accounts on "
+                                   "Relay. Please try again later.")
+
+        # Must have visited the invitation link which put the token in their
+        # session
+        if 'alpha_token' not in kwargs['request'].session:
+            raise PermissionDenied(
+                "You must visit the invitation link in your invite email "
+                "before signing up for Relay.")
+
+        # Check the token in their session matches the setting
+        session_token = kwargs['request'].session['alpha_token']
+        if (session_token == settings.ALPHA_INVITE_TOKEN):
+            Invitations.objects.create(
+                email=email, active=True, date_redeemed=datetime.now()
+            )
+            del kwargs['request'].session['alpha_token']
+            return True
+
+    # Deny-by-default in case the logic above missed anything
+    raise PermissionDenied

--- a/privaterelay/templates/socialaccount/authentication_error.html
+++ b/privaterelay/templates/socialaccount/authentication_error.html
@@ -4,7 +4,11 @@
 <main id="profile-main" class="flx env-bg container bg-light dashboard-container" data-api-token="{{ user.profile_set.first.api_token }}">
   <div class="appear-smoothly flx flx-col al-cntr jst-cntr auth-error-wrapper">
     <div class="flx flx-col al-cntr jst-cntr auth-error">
-        <p class="ff-Met no-active-aliases text-center">Sorry, the Private Relay Beta is currently by invitation only. Please check again later.</p>
+        {% if error_message %}
+            <p class="ff-Met no-active-aliases text-center">{{ error_message }}</p>
+        {% else %}
+            <p class="ff-Met no-active-aliases text-center">Sorry, the Private Relay Beta is currently by invitation only. Please check again later.</p>
+        {% endif %}
       </div>
   </div>
 </main>

--- a/privaterelay/urls.py
+++ b/privaterelay/urls.py
@@ -13,8 +13,6 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from decouple import config
-
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
@@ -33,7 +31,8 @@ urlpatterns = [
 
     path('accounts/profile/', views.profile, name='profile'),
     path('accounts/', include('allauth.urls')),
-    path('', views.home),
+    path('invitation/', views.invitation, name='invitation'),
+    path('', views.home, name='home'),
 ]
 
 if settings.ADMIN_ENABLED:


### PR DESCRIPTION
To test:

1. Leave `ALPHA_INVITE_TOKEN` empty and try to sign up with a non-Mozilla email address.
   * It should NOT work.
2. Set `ALPHA_INVITE_TOKEN` to some string e.g., `unsafe-invite-token-for-local`
3. Restart `runserver`
4. Try to sign up with a non-matching url: http://127.0.0.1:8000/invitation?alpha_token=not-right
   * It should NOT work.
5. Try to sign up with the right url: http://127.0.0.1:8000/invitation?alpha_token=unsafe-invite-token-for-local
   * It should work.
6. Set `MAX_ACTIVE_ACCOUNTS` to a lower number e.g., `1`
7. Restart `runserver`
8. Try to sign up with the right url: http://127.0.0.1:8000/invitation?alpha_token=unsafe-invite-token-for-local
   * It should NOT work.