### PR TITLE
for #308: Display proper exception message

### DIFF
--- a/privaterelay/templates/socialaccount/authentication_error.html
+++ b/privaterelay/templates/socialaccount/authentication_error.html
@@ -43,6 +43,8 @@
               </div>
             </div>
           </div>
+        {% elif auth_error.exception.args %}
+          <p class="ff-Met no-active-aliases text-center text-light">{{ auth_error.exception.args | first }}</p>
         {% endif %}
       {% endif %}
     </div>


### PR DESCRIPTION
# About this PR
Fix #308

# Practical Tests
## Check that too many active users message shows up properly
1. Change the var `MAX_ACTIVE_ACCOUNTS` in .env file to be less than the number of active users
2. Set the `ALPHA_INVITE_TOKEN` as `unsafe-invite-token-for-local` in .env
3. Runserver and login
4. Check that you get the message:
<img width="1495" alt="Screen Shot 2020-05-15 at 2 06 42 PM" src="https://user-images.githubusercontent.com/25109943/82087428-afbf0580-96b5-11ea-993c-0052440cab55.png">

## Check that visit invitations link message shows up properly
1. Change the `MAX_ACTIVE_ACCOUNTS` .env file so the the number of active users is higher than the current active users
2. Runserver and login
3. Check that you get the message:
<img width="1495" alt="Screen Shot 2020-05-15 at 2 06 00 PM" src="https://user-images.githubusercontent.com/25109943/82087448-b9486d80-96b5-11ea-87a4-f5d8c02d9ccd.png">

