### PR TITLE
Fix #361 Display helpful message to stranded users

### DIFF
--- a/privaterelay/signals.py
+++ b/privaterelay/signals.py
@@ -74,4 +74,5 @@ def invitations_only(sender, **kwargs):
                 return True
 
     # Deny-by-default in case the logic above missed anything
-    raise PermissionDenied
+    raise PermissionDenied("Please check again later to be invited on "
+                           "Private Relay.")

--- a/privaterelay/signals.py
+++ b/privaterelay/signals.py
@@ -59,8 +59,10 @@ def invitations_only(sender, **kwargs):
             # their session
             if 'alpha_token' not in kwargs['request'].session:
                 raise PermissionDenied(
-                    "You must visit the invitation link in your invite email "
-                    "before signing up for Relay.")
+                    "Private Relay is currently invite-only. "
+                    "If you received an invitation email, "
+                    "you must visit the invitation link in your invite email "
+                    "to sign up for Relay.")
 
             # Check the token in their session matches the setting
             session_token = kwargs['request'].session['alpha_token']
@@ -74,5 +76,7 @@ def invitations_only(sender, **kwargs):
                 return True
 
     # Deny-by-default in case the logic above missed anything
-    raise PermissionDenied("Please check again later to be invited on "
-                           "Private Relay.")
+    raise PermissionDenied(
+        "Private Relay is currently invite-only. "
+        "Please check back again later to join the wait-list."
+    )


### PR DESCRIPTION
# About this PR
When the alpha testing and waitlist is not turned on the users who try to login get an empty page. We want to display a "helpful" message to user to check back later.

# Acceptance Criteria
- [x] When the alpha token and waitlist is not set, user is displayed with a message to come back later

# Practical Tests
## Check that the user gets no message when alpha token and waitlist is not set
1. Do not get the changes from this PR and go to .env file and set the `ALPHA_INVITE_TOKEN` AND `WAITLIST_OPEN` to empty string
2. Run server and login with FXA
3. Check that you are redirected to `http://127.0.0.1:8000/accounts/fxa/login/callback/?code=...` link and the page looks like the following:
<img width="1000" alt="Screen Shot 2020-05-27 at 12 01 10 PM" src="https://user-images.githubusercontent.com/25109943/83050222-d7955e00-a011-11ea-9945-59f04a0b0101.png">

## Check that the user gets a message when alpha token and waitlist is not set
1. Get the changes from this PR and leave the .env file as it was on previous test
2. Run server and login with FXA
3. Check that you are redirected to `http://127.0.0.1:8000/accounts/fxa/login/callback/?code=...` link and the page looks the same but is now displaying a message.

#
Fix #361