### PR TITLE
Add email header and From address formatting to SES inbound logic

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from email import message_from_string, policy
 from email.utils import parseaddr
+import email.headerregistry import Address
 from hashlib import sha256
 import json
 import logging
@@ -265,6 +266,9 @@ def _sns_message(message_json):
     })
 
     relay_from_address, relay_from_display = _generate_relay_From(from_address)
+    formatted_from_address = str(
+        Address(relay_from_display, addr_spec=relay_from_address)
+    )
 
     ses_client = boto3.client('ses', region_name=settings.AWS_REGION)
     try:
@@ -277,7 +281,7 @@ def _sns_message(message_json):
                 },
                 'Subject': {'Charset': 'UTF-8', 'Data': subject},
             },
-            Source='{0} <{1}>'.format(relay_from_display, relay_from_address),
+            Source=formatted_from_address,
             ConfigurationSetName=settings.AWS_SES_CONFIGSET,
         )
         logger.debug('ses_sent_response', extra=ses_response['MessageId'])

--- a/emails/views.py
+++ b/emails/views.py
@@ -264,6 +264,8 @@ def _sns_message(message_json):
         'SITE_ORIGIN': settings.SITE_ORIGIN,
     })
 
+    relay_from_address, relay_from_display = _generate_relay_From(from_address)
+
     ses_client = boto3.client('ses', region_name=settings.AWS_REGION)
     try:
         ses_response = ses_client.send_email(
@@ -275,7 +277,7 @@ def _sns_message(message_json):
                 },
                 'Subject': {'Charset': 'UTF-8', 'Data': subject},
             },
-            Source=settings.RELAY_FROM_ADDRESS,
+            Source='{0} <{1}>'.format(relay_from_display, relay_from_address),
             ConfigurationSetName=settings.AWS_SES_CONFIGSET,
         )
         logger.debug('ses_sent_response', extra=ses_response['MessageId'])

--- a/emails/views.py
+++ b/emails/views.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from email import message_from_string, policy
 from email.utils import parseaddr
-import email.headerregistry import Address
+from email.headerregistry import Address
 from hashlib import sha256
 import json
 import logging


### PR DESCRIPTION
# About this PR
Fix #375. Email header and from address was not formatted into email. Wrapping/formatting the email sender (From) in SES was derived from the formatting seen on this [doc](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-using-sdk-python.html).

# Acceptance Criteria
- [x] Header is displayed properly
- [x] From address is formatted properly

# Expected Behavior
Email should look like:
<img width="1146" alt="Screen Shot 2020-06-03 at 1 28 59 PM" src="https://user-images.githubusercontent.com/25109943/83805161-fbd9e600-a674-11ea-8519-c9d18634332e.png">