### PR TITLE
Update invitation email fields and additional user logic

### DIFF
--- a/privaterelay/management/commands/invite_monitor_waitlist.py
+++ b/privaterelay/management/commands/invite_monitor_waitlist.py
@@ -97,6 +97,7 @@ class Command(BaseCommand):
                 print("Creating invitation for %s" % invitee.primary_email)
                 invitation = Invitations.objects.create(
                     email=invitee.primary_email,
+                    fxa_uid=invitee.fxa_uid,
                     active=True,
                     date_added=datetime.now(),
                     date_redeemed=None

--- a/privaterelay/models.py
+++ b/privaterelay/models.py
@@ -20,4 +20,5 @@ class MonitorSubscriber(models.Model):
         managed = False
 
     primary_email = models.CharField(max_length=255)
+    fxa_uid = models.CharField(max_length=255)
     waitlists_joined = JSONField()

--- a/privaterelay/signals.py
+++ b/privaterelay/signals.py
@@ -5,6 +5,8 @@ from django.core.exceptions import PermissionDenied
 from django.contrib.auth.models import User
 from django.db.models import Q
 
+from allauth.socialaccount.models import SocialAccount
+
 from .models import Invitations
 
 
@@ -23,6 +25,13 @@ def invitations_only(sender, **kwargs):
     for allowed_domain in ALLOWED_SIGNUP_DOMAINS:
         if domain_part == allowed_domain:
             return True
+
+    # Accounts that have already used Private Relay should always be allowed
+    try:
+        SocialAccount.objects.get(uid=fxa_uid)
+        return True
+    except SocialAccount.DoesNotExist:
+        pass
 
     # Explicit invitations for an email address can get in
     try:

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -245,9 +245,9 @@ def _handle_fxa_delete(authentic_jwt, social_account, event_key):
 def _update_invitation(authentic_jwt, old_email, new_email):
     try:
         invitation = Invitations.objects.get(
-            fxa_uid=authentic_jwt['sub'] | email=old_email)
-            invitation.email = new_email
-            invitation.save()
+            Q(fxa_uid=authentic_jwt['sub']) | Q(email=old_email))
+        invitation.email = new_email
+        invitation.save()
         logger.info('fxa_rp_event', extra={
             'fxa_uid': authentic_jwt['sub'],
             'updated_invitation_objects': invitation,

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -216,6 +216,9 @@ def _handle_fxa_profile_change(authentic_jwt, social_account, event_key):
         'event_key': event_key,
         'real_address': sha256(new_email.encode('utf-8')).hexdigest(),
     })
+
+    _update_invitation(authentic_jwt, social_account.user.email, new_email)
+
     social_account.extra_data = extra_data
     social_account.save()
     social_account.user.email = new_email
@@ -237,6 +240,21 @@ def _handle_fxa_delete(authentic_jwt, social_account, event_key):
         'deleted_user_objects': deleted_user_objects,
         'deleted_invitation_objects': deleted_invitation_objects,
     })
+
+
+def _update_invitation(authentic_jwt, old_email, new_email):
+    try:
+        invitation = Invitations.objects.get(
+            fxa_uid=authentic_jwt['sub'] | email=old_email)
+            invitation.email = new_email
+            invitation.save()
+        logger.info('fxa_rp_event', extra={
+            'fxa_uid': authentic_jwt['sub'],
+            'updated_invitation_objects': invitation,
+        })
+        return invitation
+    except Invitations.DoesNotExist:
+        pass
 
 
 def _delete_invitation(authentic_jwt):


### PR DESCRIPTION
# About this PR
If a previously authenticated and verified FXA user changes their email address, the user cannot access Relay due to the login in `signals.py`. We should update this logic to allow any users previously allowed in Relay by checking a value that does not change (like FXA id). Similarly, a user who is listed under waitlist may not get an email if the primary email is changed but not reflected in `Invitiations`
Fix #378 