### PR TITLE
Update footer links

### DIFF
--- a/privaterelay/templates/includes/footer.html
+++ b/privaterelay/templates/includes/footer.html
@@ -4,8 +4,8 @@
 		<img alt="Mozilla" class="block w-24" src="{% static 'images/mozilla.svg' %}"/>
 	</a>
 	<nav class="flx flx-wrap al-cntr">
-		<a class="footer-link" href="#">SUMO</a>
-		<a class="footer-link" href="#">Legal</a>
+    <a class="footer-link" href="https://www.mozilla.org/about/legal/" target="_blank" rel="noopener noreferrer">Legal</a>
+    <a class="footer-link" href="https://www.mozilla.org/privacy/" target="_blank" rel="noopener noreferrer">Privacy</a>
 		<a class="footer-link" href="https://github.com/mozilla/fx-private-relay" rel="noopener noreferrer" target="_blank" aria-label="Link to the Firefox Relay GitHub repository.">
 			<img class="GitHub-logo" alt="GitHub logo" src="{% static 'images/GitHub.svg' %}" />
 		</a>


### PR DESCRIPTION
This removes the SUMO footer link and adds generic Mozilla Privacy and Legal links while we're waiting for confirmation that `https://www.mozilla.org/privacy/firefox-private-relay/` and `https://www.mozilla.org/about/legal/terms/firefox-private-relay/` are live and have been updated to drop the word "private". Fixes #289 