### PR TITLE
Remove template filter that breaks html

### DIFF
--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -47,7 +47,7 @@
     <table width="100%; padding: 0; margin: 0;">
       <tr>
         <td width="100%">
-          {{ original_html|linebreaks|safe }}
+          {{ original_html|safe }}
         </td>
       </tr>
     </table>


### PR DESCRIPTION
#About this PR
After pushing #454, we broke emails with content-type `html`.

# Acceptance Criteria
- [ ] Emails with html content is not broken