### PR TITLE
Update email display name

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -444,6 +444,6 @@ def _generate_relay_From(original_from_address):
     relay_display_name, relay_from_address = parseaddr(
         settings.RELAY_FROM_ADDRESS
     )
-    return relay_from_address, '%s via Firefox Private Relay' % (
+    return relay_from_address, '%s [via Relay]' % (
         original_from_address
     )


### PR DESCRIPTION
# About this PR
Update the display name of forwarded emails from `Company Name <email-sent@from.com> via Firefox Private Relay` to `Company Name <email-sent@from.com> [via Relay]`. For example: `﻿Pocket <noreply@getpocket.com> via Firefox Private Relay` to `Pocket <noreply@getpocket.com> [via Relay]`