### PR TITLE
Multiple invitations object found fix

### DIFF
--- a/privaterelay/management/commands/invite_beta_user.py
+++ b/privaterelay/management/commands/invite_beta_user.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 from django.core.validators import validate_email
 
-from ...models import Invitations
+from ...models import Invitations, get_invitation
 
 
 class Command(BaseCommand):
@@ -15,9 +15,7 @@ class Command(BaseCommand):
         validate_email(email)
 
         try:
-            existing_invitation = Invitations.objects.get(
-                email=email, active=False
-            )
+            existing_invitation = get_invitation(email=email, active=False)
             existing_invitation.active = True
             existing_invitation.save(update_fields=['active'])
         except Invitations.DoesNotExist:

--- a/privaterelay/management/commands/invite_beta_user.py
+++ b/privaterelay/management/commands/invite_beta_user.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 from django.core.validators import validate_email
 
-from ...models import Invitations, get_invitation
+from ...models import get_invitation, Invitations
 
 
 class Command(BaseCommand):

--- a/privaterelay/management/commands/invite_monitor_waitlist.py
+++ b/privaterelay/management/commands/invite_monitor_waitlist.py
@@ -11,7 +11,7 @@ from django.core.management.base import BaseCommand
 from django.template.loader import render_to_string
 
 from emails.utils import get_socketlabs_client, socketlabs_send
-from ...models import Invitations, get_invitation, MonitorSubscriber
+from ...models import get_invitation, Invitations, MonitorSubscriber
 
 
 logger = logging.getLogger('events')

--- a/privaterelay/management/commands/invite_monitor_waitlist.py
+++ b/privaterelay/management/commands/invite_monitor_waitlist.py
@@ -11,7 +11,7 @@ from django.core.management.base import BaseCommand
 from django.template.loader import render_to_string
 
 from emails.utils import get_socketlabs_client, socketlabs_send
-from ...models import Invitations, MonitorSubscriber
+from ...models import Invitations, get_invitation, MonitorSubscriber
 
 
 logger = logging.getLogger('events')
@@ -82,9 +82,10 @@ class Command(BaseCommand):
         invites_sent = 0
         for invitee in monitor_waitlist:
             try:
-                invitation = Invitations.objects.get(
+                invitation = get_invitation(
                     email=invitee.primary_email,
-                    active=True,
+                    fxa_uid=invitee.fxa_uid,
+                    active=True
                 )
                 if invitation.date_redeemed:
                     print(

--- a/privaterelay/management/commands/invite_monitor_waitlist.py
+++ b/privaterelay/management/commands/invite_monitor_waitlist.py
@@ -45,14 +45,23 @@ class Command(BaseCommand):
                     invitee.save(update_fields=['waitlists_joined'])
                     continue
             except Invitations.DoesNotExist:  # no invitation
-                print("Creating invitation for %s" % invitee.primary_email)
-                invitation = Invitations.objects.create(
-                    email=invitee.primary_email,
-                    fxa_uid=invitee.fxa_uid,
-                    active=True,
-                    date_added=datetime.now(),
-                    date_redeemed=None
-                )
+                try:
+                    invitation = get_invitation(
+                        email=invitee.primary_email,
+                        fxa_uid=invitee.fxa_uid,
+                        active=False
+                    )
+                    invitation.active = True
+                    invitation.save()
+                except Invitations.DoesNotExist:  # no invitation
+                    print("Creating invitation for %s" % invitee.primary_email)
+                    invitation = Invitations.objects.create(
+                        email=invitee.primary_email,
+                        fxa_uid=invitee.fxa_uid,
+                        active=True,
+                        date_added=datetime.now(),
+                        date_redeemed=None
+                    )
 
             print("Sending invite email to %s" % invitee.primary_email)
             response = email_invited_user(invitation, invitee)

--- a/privaterelay/models.py
+++ b/privaterelay/models.py
@@ -14,6 +14,24 @@ class Invitations(models.Model):
         return 'Invitation for %s' % self.email
 
 
+def get_invitation(email=None, fxa_uid=None, active=False):
+    invitations = Invitations.objects.filter(
+        Q(email=email) | Q(fxa_uid=fxa_uid), active=active
+    ).order_by('date_added')
+    if invitation.count() < 1:
+        raise Invitations.DoesNotExist
+    invitations = list(invitations)
+    oldest_invitation = invitations.pop(0)
+    for invite in invitations:
+        if oldest_invitation.email != invite.email:
+            oldest_invitation.email = invite.email
+        if oldest_invitation.fxa_uid != invite.fxa_uid:
+            oldest_invitation.fxa_uid = invite.fxa_uid
+        invite.delete()
+    oldest_invitation.save(update_fields=['email', 'fxa_uid'])
+    return oldest_invitation
+
+
 class MonitorSubscriber(models.Model):
     class Meta:
         db_table = 'subscribers'

--- a/privaterelay/models.py
+++ b/privaterelay/models.py
@@ -18,7 +18,7 @@ def get_invitation(email=None, fxa_uid=None, active=False):
     invitations = Invitations.objects.filter(
         Q(email=email) | Q(fxa_uid=fxa_uid), active=active
     ).order_by('date_added')
-    if invitation.count() < 1:
+    if invitations.count() < 1:
         raise Invitations.DoesNotExist
     invitations = list(invitations)
     oldest_invitation = invitations.pop(0)

--- a/privaterelay/models.py
+++ b/privaterelay/models.py
@@ -27,9 +27,9 @@ def get_invitation(email=None, fxa_uid=None, active=False):
     invitations = list(invitations)
     oldest_invitation = invitations.pop(0)
     for invite in invitations:
-        if oldest_invitation.email != invite.email:
+        if invite.email and oldest_invitation.email != invite.email:
             oldest_invitation.email = invite.email
-        if oldest_invitation.fxa_uid != invite.fxa_uid:
+        if  invite.fxa_uid and oldest_invitation.fxa_uid != invite.fxa_uid:
             oldest_invitation.fxa_uid = invite.fxa_uid
         invite.delete()
     oldest_invitation.save(update_fields=['email', 'fxa_uid'])

--- a/privaterelay/models.py
+++ b/privaterelay/models.py
@@ -1,5 +1,6 @@
 from django.contrib.postgres.fields import JSONField
 from django.db import models
+from django.db.models import Q
 
 
 class Invitations(models.Model):
@@ -15,11 +16,14 @@ class Invitations(models.Model):
 
 
 def get_invitation(email=None, fxa_uid=None, active=False):
+    local_args = locals()
     invitations = Invitations.objects.filter(
         Q(email=email) | Q(fxa_uid=fxa_uid), active=active
     ).order_by('date_added')
     if invitations.count() < 1:
-        raise Invitations.DoesNotExist
+        raise Invitations.DoesNotExist(
+            'get_invitation found no invitation for args: %s' % local_args
+        )
     invitations = list(invitations)
     oldest_invitation = invitations.pop(0)
     for invite in invitations:

--- a/privaterelay/signals.py
+++ b/privaterelay/signals.py
@@ -55,7 +55,7 @@ def invitations_only(sender, **kwargs):
         return True
 
     except Invitations.DoesNotExist:
-        waitlist_invite = = get_invitation(
+        waitlist_invite = get_invitation(
             email=email, fxa_uid=fxa_uid, active=False
         )
         inactive_invitation = waitlist_invite.first()

--- a/privaterelay/signals.py
+++ b/privaterelay/signals.py
@@ -7,7 +7,7 @@ from django.db.models import Q
 
 from allauth.socialaccount.models import SocialAccount
 
-from .models import Invitations
+from .models import Invitations, get_invitation
 
 
 ALLOWED_SIGNUP_DOMAINS = [
@@ -43,8 +43,8 @@ def invitations_only(sender, **kwargs):
 
     # Explicit invitations for an email address can get in
     try:
-        active_invitation = Invitations.objects.get(
-            Q(email=email) | Q(fxa_uid=fxa_uid), active=True
+        active_invitation = get_invitation(
+            email=email, fxa_uid=fxa_uid, active=True
         )
         if not active_invitation.fxa_uid:
             active_invitation.fxa_uid = fxa_uid
@@ -55,8 +55,8 @@ def invitations_only(sender, **kwargs):
         return True
 
     except Invitations.DoesNotExist:
-        waitlist_invite = Invitations.objects.filter(
-            Q(email=email) | Q(fxa_uid=fxa_uid), active=False
+        waitlist_invite = = get_invitation(
+            email=email, fxa_uid=fxa_uid, active=False
         )
         inactive_invitation = waitlist_invite.first()
 

--- a/privaterelay/signals.py
+++ b/privaterelay/signals.py
@@ -7,7 +7,7 @@ from django.db.models import Q
 
 from allauth.socialaccount.models import SocialAccount
 
-from .models import Invitations, get_invitation
+from .models import get_invitation, Invitations
 
 
 ALLOWED_SIGNUP_DOMAINS = [

--- a/privaterelay/signals.py
+++ b/privaterelay/signals.py
@@ -3,7 +3,6 @@ from datetime import datetime, timezone
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.models import User
-from django.db.models import Q
 
 from allauth.socialaccount.models import SocialAccount
 
@@ -55,10 +54,13 @@ def invitations_only(sender, **kwargs):
         return True
 
     except Invitations.DoesNotExist:
-        waitlist_invite = get_invitation(
-            email=email, fxa_uid=fxa_uid, active=False
-        )
-        inactive_invitation = waitlist_invite.first()
+        try:
+            waitlist_invite = get_invitation(
+                email=email, fxa_uid=fxa_uid, active=False
+            )
+            inactive_invitation = waitlist_invite.first()
+        except Invitations.DoesNotExist:
+            inactive_invitation = None
 
         # Not mozilla domain; no invitation
         if settings.WAITLIST_OPEN:

--- a/privaterelay/signals.py
+++ b/privaterelay/signals.py
@@ -55,10 +55,9 @@ def invitations_only(sender, **kwargs):
 
     except Invitations.DoesNotExist:
         try:
-            waitlist_invite = get_invitation(
+            inactive_invitation = get_invitation(
                 email=email, fxa_uid=fxa_uid, active=False
             )
-            inactive_invitation = waitlist_invite
         except Invitations.DoesNotExist:
             inactive_invitation = None
 

--- a/privaterelay/signals.py
+++ b/privaterelay/signals.py
@@ -58,7 +58,7 @@ def invitations_only(sender, **kwargs):
             waitlist_invite = get_invitation(
                 email=email, fxa_uid=fxa_uid, active=False
             )
-            inactive_invitation = waitlist_invite.first()
+            inactive_invitation = waitlist_invite
         except Invitations.DoesNotExist:
             inactive_invitation = None
 

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -28,7 +28,7 @@ from allauth.socialaccount.providers.fxa.views import (
 
 from emails.models import RelayAddress
 from emails.utils import get_post_data_from_request
-from .models import Invitations
+from .models import Invitations, get_invitation
 
 
 FXA_PROFILE_CHANGE_EVENT = (
@@ -147,8 +147,8 @@ def waitlist(request):
         return JsonResponse({}, status=400)
 
     try:
-        invitation =  Invitations.objects.get(
-            Q(fxa_uid=fxa_uid) | Q(email=email), active=False
+        invitation = get_invitation(
+            email=email, fxa_uid=fxa_uid, active=False
         )
         if not invitation.fxa_uid:
             invitation.fxa_uid = fxa_uid

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -14,7 +14,6 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.db import connections
-from django.db.models import Q
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render, redirect
 from django.urls import reverse


### PR DESCRIPTION
# About this PR
Currently, we use `get()` on the queryset to retrieve existing `Invitations` which can result into the error stated in #488. 

# Acceptance Criteria
- [ ] handle multiple invitations in  `invite_beta_user`
- [x] handle multiple invitations in `invitations_only` signal
- [x] handle multiple invitations in `waitlist` view
- [x] handle multiple invitations in `invite_monitor_waitlist` command
- [x] keep the oldest invitation and delete new ones

###
## Nice to have:
- [ ] Constrain email and fxa_uid to be unique on `Invitations`?