### PR TITLE
Problem joining waitlist 

### DIFF
--- a/emails/utils.py
+++ b/emails/utils.py
@@ -1,6 +1,7 @@
 import contextlib
 import markus
 import logging
+import json
 from socketlabs.injectionapi import SocketLabsClient
 
 from django.conf import settings
@@ -44,3 +45,9 @@ def urlize_and_linebreaks(text, autoescape=True):
         urlize(text, autoescape=autoescape),
         autoescape=autoescape
     )
+
+
+def get_post_data_from_request(request):
+    if request.content_type == 'application/json':
+        return json.loads(request.body)
+    return request.POST

--- a/emails/views.py
+++ b/emails/views.py
@@ -26,9 +26,11 @@ from django.views.decorators.csrf import csrf_exempt
 from .context_processors import relay_from_domain
 from .models import DeletedAddress, Profile, RelayAddress
 from .utils import (
+    get_post_data_from_request,
     get_socketlabs_client,
     socketlabs_send,
-    urlize_and_linebreaks)
+    urlize_and_linebreaks
+)
 from .sns import verify_from_sns, SUPPORTED_SNS_TYPES
 
 
@@ -36,15 +38,9 @@ logger = logging.getLogger('events')
 metrics = markus.get_metrics('fx-private-relay')
 
 
-def _get_data_from_request(request):
-    if request.content_type == 'application/json':
-        return json.loads(request.body)
-    return request.POST
-
-
 @csrf_exempt
 def index(request):
-    request_data = _get_data_from_request(request)
+    request_data = get_post_data_from_request(request)
     if (not request.user.is_authenticated and
         not request_data.get("api_token", False)
        ):
@@ -61,7 +57,7 @@ def _get_user_profile(request, api_token):
 
 
 def _index_POST(request):
-    request_data = _get_data_from_request(request)
+    request_data = get_post_data_from_request(request)
     api_token = request_data.get('api_token', None)
     if not api_token:
         raise PermissionDenied

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -155,11 +155,13 @@ def waitlist(request):
         if invitation.email != email:
             invitation.email = email
             invitation.save()
+        message = 'You were already on our waitlist!'
         status = 200
     except Invitations.DoesNotExist:
         Invitations.objects.create(fxa_uid=fxa_uid, email=email, active=False)
         status = 201
-    return JsonResponse({'email': email}, status=status)
+        message = 'You are added on our waitlist!'
+    return JsonResponse({'email': email, 'message': message}, status=status)
 
 
 @csrf_exempt

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -26,6 +26,7 @@ from allauth.socialaccount.providers.fxa.views import (
 )
 
 from emails.models import RelayAddress
+from emails.utils import get_post_data_from_request
 from .models import Invitations
 
 
@@ -138,9 +139,9 @@ def invitation(request):
 def waitlist(request):
     if not settings.WAITLIST_OPEN:
         raise PermissionDenied
-    json_body = json.loads(request.body)
-    email = json_body['email']
-    fxa_uid = json_body['fxa_uid']
+    request_data = get_post_data_from_request(request)
+    email = request_data['email']
+    fxa_uid = request_data['fxa_uid']
     if not email or not fxa_uid:
         return JsonResponse({}, status=400)
 


### PR DESCRIPTION
# About this PR
There are some cases where the JS is not properly packaging the post data to add the user to waitlist resulting in the error message on #491. This PR handles the post data as either a JSON or queryparam that causes [this](https://sentry.prod.mozaws.net/operations/fx-private-relay-prod/issues/8862456/?query=is%3Aunresolved) issue on Sentry.

# Practical Test
## BEFORE GETTING THE CHANGE
### Check that error happens when the user joins the waitlist while script is not loaded
1. Get a no script add-on
2. Go to http://127.0.0.1:8000/ and try to add yourself to waitlist. You may have to "trust"/"allow" the script for FXA.
3. Click the join waitlist button on the /accounts/fxa/... page
4. Check that you get an error: a "oops something went wrong" displayed on /account/..., (prod?), 500 server error on `/waitlist/` page(stage), or stack trace of the error on `/waitlist/` page (dev)

## AFTER GETTING THE CHANGE
### Check that error DOES NOT happen when the user joins the waitlist while script is not loaded
1. Get a no script add-on
2. Go to http://127.0.0.1:8000/ and try to add yourself to waitlist. You may have to "trust"/"allow" the script for FXA.
3. Click the join waitlist button on the /accounts/fxa/... page
4. Check that you are successfully added to the waitlist
