### PR TITLE
Inform users attachment not supported for 498

### DIFF
--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -37,7 +37,12 @@
           <table width="100%" style="max-width:700px; text-align: center; border-collapse: collapse;">
             <tr>
               <td width="100%" align="center" style="line-height: 150%;">
-                <p style="color: #363959; font-size: 13px; font-family: sans-serif; margin-top: 0; margin-bottom: 0;">This message was forwarded from <span style="font-family: sans-serif; font-weight: bolder; color: #20123a; text-decoration: none; font-size: 13px;">{{ display_email|safe }}</span> by <a href="{{ SITE_ORIGIN }}" target="_blank" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">Firefox Relay</a>.</p>
+                <p style="color: #363959; font-size: 13px; font-family: sans-serif; margin-top: 0; margin-bottom: 0;">
+                  This message was forwarded from <span style="font-family: sans-serif; font-weight: bolder; color: #20123a; text-decoration: none; font-size: 13px;">{{ display_email|safe }}</span> by <a href="{{ SITE_ORIGIN }}" target="_blank" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">Firefox Relay</a>.
+                  {% if has_attachment %}
+                    <br>Relay detected an attachment, but attachments are currently <b>not</b> supported.
+                  {% endif %}
+                </p>
               </td>
             </tr>
           </table>

--- a/emails/views.py
+++ b/emails/views.py
@@ -296,6 +296,7 @@ def _sns_message(message_json):
             'email_to': to_address,
             'display_email': display_email,
             'SITE_ORIGIN': settings.SITE_ORIGIN,
+            'has_attachment': has_attachment,
         })
         message_body['Html'] = {'Charset': 'UTF-8', 'Data': wrapped_html}
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -302,10 +302,20 @@ def _sns_message(message_json):
 
     if text_content:
         incr_if_enabled('email_with_text_content', 1)
-        relay_header_text = ('This email was sent to your alias '
+        attachment_not_supported = ''
+        if has_attachment:
+            attachment_not_supported = (
+                'Relay detected an attachment, but attachments are currently '
+                'NOT supported.\n'
+            )
+        relay_header_text = (
+            'This email was sent to your alias '
             '{relay_address}. To stop receiving emails sent to this alias, '
             'update the forwarding settings in your dashboard.\n'
-            '---Begin Email---\n').format(relay_address=display_email)
+            '{extra_msg}---Begin Email---\n'
+        ).format(
+            relay_address=display_email, extra_msg=attachment_not_supported
+        )
         wrapped_text = relay_header_text + text_content
         message_body['Text'] = {'Charset': 'UTF-8', 'Data': wrapped_text}
 


### PR DESCRIPTION
# About this PR
Warn users when Relay forwards emails with attachment that attachment is not currently supported and fix flake8 errors on emails/views.py