### PR TITLE
Ignore deploying release tags that end in -addon.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,6 @@ workflows:
             - test
           filters:
             tags:
-              ignore: /.*-addon/
+              ignore: /addon-.*/
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,6 @@ workflows:
             - test
           filters:
             tags:
-              only: /.*/
+              ignore: /.*-addon/
             branches:
               only: master


### PR DESCRIPTION
This is for bug [1653644](https://bugzilla.mozilla.org/show_bug.cgi?id=1653644). See configuration [documentation](https://circleci.com/docs/2.0/configuration-reference/#section=configuration).