### PR TITLE
ENH: significantly reduce size of Docker image using multi-stage builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,41 @@
-FROM python:3.7.6
-
-RUN apt-get update && apt-get -y install libpq-dev
-RUN pip install --upgrade pip
-
-RUN groupadd --gid 10001 app && \
-    useradd -g app --uid 10001 --shell /usr/sbin/nologin --create-home --home-dir /app app
+FROM python:3.7.6 AS builder
 
 WORKDIR /app
 
-EXPOSE 8000
-
-USER app
+RUN python -m venv ./python-venv
+ENV PATH="/app/python-venv/bin:$PATH"
+RUN python -m pip install --upgrade --no-cache-dir pip setuptools wheel
 
 COPY . /app
 COPY .env-dist /app/.env
 
-RUN pip install -r requirements.txt
+RUN apt-get update \
+    && apt-get install --yes libpq-dev \
+    && python -m pip install --no-cache-dir -r requirements.txt
 
+# Create final image.
+FROM python:3.7.6-slim
+
+RUN groupadd --gid 10001 app && \
+    useradd -g app --uid 10001 --shell /usr/sbin/nologin --create-home --home-dir /app app
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        libpq5 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+USER app
+WORKDIR /app
+
+COPY --chown=app --from=builder /app /app
+
+ENV PATH="/app/python-venv/bin:$PATH"
 RUN mkdir -p /app/staticfiles
 RUN python manage.py collectstatic --no-input -v 2
 
-ENTRYPOINT ["/app/.local/bin/gunicorn"]
+EXPOSE 8000
+
+ENTRYPOINT ["gunicorn"]
 
 CMD ["--config", "gunicorn.conf", "privaterelay.wsgi:application"]


### PR DESCRIPTION
Dependencies are compiled and installed in the first stage into a virtual environment, made with python's standard venv. In the second stage, a slim python docker image is used (e.g., no compilers), and the virtual environment is copied into the second stage. The result is a docker image with a size of 341 MB (uncompressed) vs 1.13 GB before this commit.