### PR TITLE
More clickable "Generate New Alias" button

### DIFF
--- a/extension/css/relay.css
+++ b/extension/css/relay.css
@@ -203,9 +203,9 @@ button.fx-relay-modal-close-button {
   background-color: var(--relayGrey10);
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
   position: absolute;
-  padding-top: 24px;
+  align-content: center;
+  padding-top: 20px;
   padding-left: 0;
   padding-right: 0;
   padding-bottom: 0;
@@ -225,6 +225,7 @@ button.fx-relay-modal-close-button {
   height: 20px;
   width: 20px;
   background: var(--relayGrey10);
+  z-index: -1;
   transform: rotate(45deg);
 }
 
@@ -246,40 +247,37 @@ button.fx-relay-modal-close-button {
 }
 
 .fx-relay-menu-remaining-aliases {
-  font-size: 13px;
+  font-size: 14px;
   padding: 0 24px;
-  margin-bottom: 40px;
   color: var(--relayInk70);
+  text-align: center;
+  margin-top: 8px;
+  margin-bottom: 24px;
+  font-weight: 600 !important;
 }
 
 button.fx-relay-menu-sign-up-btn,
-.fx-relay-menu-dashboard-link,
-.fx-relay-menu button.fx-relay-menu-generate-alias-btn {
-  font-size: 14px;
+.fx-relay-menu-dashboard-link {
+  font-size: 15px;
   border: 1px solid rgba(0, 0, 0, 0);
   border-color: rgba(0, 0, 0, 0);
   outline: none;
   width: 100%;
   min-width: 100%;
-  border-radius: 2px;
   font-family: var(--relayMetropolis) !important;
   color: var(--relayInk) !important;
   display: flex;
   min-height: auto;
   box-shadow: none;
   box-sizing: border-box;
-}
-
-.fx-relay-menu-sign-up-btn,
-.fx-relay-menu-dashboard-link {
   background-color: var(--relayGrey20) !important;
-  border-top: 1px solid var(--relayGrey30);
   text-align: center;
   justify-content: center;
   padding: 12px 24px;
   pointer-events: all;
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
+  text-decoration: none !important;
 }
 
 .fx-relay-menu-dashboard-link {
@@ -287,31 +285,35 @@ button.fx-relay-menu-sign-up-btn,
 }
 
 button.fx-relay-menu-generate-alias-btn {
-  background-color: var(--relayGrey10) !important;
-  text-align: left !important;
-  justify-content: flex-start !important;
-  padding-top: 4px !important;
-  padding-bottom: 4px !important;
-  padding-left: 24px !important;
-  padding-right: 24px !important;
+  background-color: var(--relayBlue3) !important;
+  padding-top: 12px !important;
+  padding-bottom: 12px !important;
+  padding-left: 28px !important;
+  padding-right: 28px !important;
+  max-width: 260px;
+  width: 100%;
   font-family: var(--relayMetropolis) !important;
-  color: var(--relayInk) !important;
-  font-weight: 600 !important;
+  color: rgba(255, 255, 255, 1) !important;
   border: none !important;
-  border-radius: 0 !important;
+  border-radius: 2px !important;
+  font-size: 16px !important;
+  margin: auto !important;
+  text-align: center !important;
+  font-weight: 500 !important;
 }
 
 button.fx-relay-menu-generate-alias-btn[disabled] {
   pointer-events: none;
-  opacity: 0.5;
+  background-color: var(--relayGrey20) !important;
+  color: var(--relayGrey50) !important;
 }
 
 .fx-relay-menu button.fx-relay-menu-generate-alias-btn:hover {
-  background-color: var(--relayGrey20) !important;
+  background-color: var(--relayBlueHover) !important;
 }
 
 .fx-relay-menu button.fx-relay-menu-generate-alias-btn:active {
-  background-color: var(--relayGrey30) !important;
+  background-color: var(--relayBlueActive) !important;
 }
 
 .fx-relay-menu-sign-up-btn:hover,
@@ -334,9 +336,10 @@ button.fx-relay-menu-generate-alias-btn[disabled] {
 }
 
 .fx-relay-menu-sign-up-message {
-  font-size: 12px;
+  font-size: 14px;
   max-width: 200px;
   display: inline-block;
+  line-height: 1.3;
   margin: auto auto 24px auto;
 }
 

--- a/extension/js/add_input_icon.js
+++ b/extension/js/add_input_icon.js
@@ -196,7 +196,7 @@ async function addRelayIconToInput(emailInput) {
     sendInPageEvent("viewed-menu", "authenticated-user-input-menu")
     // Create "Generate Relay Address" button
     const generateAliasBtn = createElementWithClassList("button", "fx-relay-menu-generate-alias-btn");
-    generateAliasBtn.textContent = "Generate new alias";
+    generateAliasBtn.textContent = "Generate New Alias";
 
 
 


### PR DESCRIPTION
A more clickable "Generate new alias" (now "Generate New Alias") button:
<img width="339" alt="Screen Shot 2020-07-22 at 6 03 55 PM" src="https://user-images.githubusercontent.com/22355127/88237842-c483c080-cc45-11ea-8e5f-4c41145d881e.png">
