### PR TITLE
Get metrics on attachments 498

### DIFF
--- a/emails/utils.py
+++ b/emails/utils.py
@@ -36,11 +36,9 @@ def incr_if_enabled(name, value=1):
         metrics.incr(name, value)
 
 
-def histogram_tag_if_enabled(name, value, tags=None):
+def histogram_if_enabled(name, value, tags=None):
     if settings.STATSD_ENABLED:
-        metrics.histogram(
-            name, value=value, tags=None
-        )
+        metrics.histogram(name, value=value, tags=None)
 
 
 @time_if_enabled('socketlabs_client')

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -36,6 +36,13 @@ def incr_if_enabled(name, value=1):
         metrics.incr(name, value)
 
 
+def histogram_tag_if_enabled(name, value, tags=None):
+    if settings.STATSD_ENABLED:
+        metrics.histogram(
+            name, value=value, tags=None
+        )
+
+
 @time_if_enabled('socketlabs_client')
 def get_socketlabs_client():
     return SocketLabsClient(

--- a/emails/views.py
+++ b/emails/views.py
@@ -347,9 +347,7 @@ def _get_attachment_metrics(part):
     if fn:
         extension = os.path.splitext(fn)[1]
     else:
-        extension = mimetypes.guess_extension(
-            part.get_content_type()
-        )
+        extension = mimetypes.guess_extension(ct)
     logger.error(
         'Attachment found in email',
         extra={

--- a/emails/views.py
+++ b/emails/views.py
@@ -353,7 +353,7 @@ def _get_attachment_metrics(part):
     logger.error(
         'Attachment found in email',
         extra={
-            'content-type': part.get_content_type(),
+            'content-type': ct,
             'extension': extension,
             'payload-size': payload_size
         }

--- a/emails/views.py
+++ b/emails/views.py
@@ -7,7 +7,6 @@ import logging
 import mimetypes
 import os
 import re
-import tempfile
 
 from django.conf import settings
 from django.contrib import messages
@@ -357,14 +356,15 @@ def _get_text_and_html_content(email_message):
                     if fn:
                         extension = os.path.splitext(part.get_filename())[1]
                     else:
-                        extension = mimetypes.guess_extension(part.get_content_type())
+                        extension = mimetypes.guess_extension(
+                            part.get_content_type()
+                        )
                     payload = part.get_payload(decode=True)
                     logger.error(
                         'Attachment found in email',
                         extra={
                             'content-type': part.get_content_type(),
                             'extension': extension,
-                            'file-size': file_size,
                             'payload-size': len(payload)
                         }
                     )

--- a/emails/views.py
+++ b/emails/views.py
@@ -365,7 +365,8 @@ def _get_text_and_html_content(email_message):
                         extension = mimetypes.guess_extension(part.get_content_type())
                     payload = part.get_payload(decode=True)
                     with tempfile.NamedTemporaryFile(suffix=extension) as f:
-                            f.write(part.get_content())
+                            # f.write(part.get_content())
+                            f.write(payload)
                             file_size = f.tell()
                             f.close()
                     logger.error(

--- a/emails/views.py
+++ b/emails/views.py
@@ -4,6 +4,8 @@ from hashlib import sha256
 from sentry_sdk import capture_message
 import json
 import logging
+import mimetypes
+import os
 import re
 
 from django.conf import settings
@@ -360,6 +362,19 @@ def _get_text_and_html_content(email_message):
                     'part.get_content()',
                     extra={'type': part.get_content_type()}
                 )
+        for part in email_message.iter_attachments():
+            fn = part.get_filename()
+            if fn:
+                extension = os.path.splitext(part.get_filename())[1]
+            else:
+                extension = mimetypes.guess_extension(part.get_content_type())
+            logger.error(
+                'part.get_content()',
+                extra={
+                    'content-type': part.get_content_type(),
+                    'part': part
+                }
+            )
     else:
         if email_message.get_content_type() == 'text/plain':
             text_content = email_message.get_content()

--- a/emails/views.py
+++ b/emails/views.py
@@ -350,10 +350,9 @@ def _get_text_and_html_content(email_message):
                 if part.is_attachment():
                     has_attachment = True
                     incr_if_enabled('email_with_attachment', 1)
-                    capture_message(
-                        'Email with attachment',
-                        level="error",
-                        stack=True
+                    logger.error(
+                        'Received SNS message with type not handled in inbound log',
+                        extra={'part': part}
                     )
             except KeyError:
                 # log the un-handled content type but don't stop processing

--- a/emails/views.py
+++ b/emails/views.py
@@ -350,11 +350,6 @@ def _get_text_and_html_content(email_message):
                     text_content = part.get_content()
                 if part.get_content_type() == 'text/html':
                     html_content = part.get_content()
-                if part.get_content_type() == 'application/pdf':
-                    logger.error(
-                        'Pdf attachment',
-                        extra={'file-name': part.get_filename()}
-                    )
                 if part.is_attachment():
                     has_attachment = True
                     incr_if_enabled('email_with_attachment', 1)
@@ -364,15 +359,10 @@ def _get_text_and_html_content(email_message):
                     else:
                         extension = mimetypes.guess_extension(part.get_content_type())
                     payload = part.get_payload(decode=True)
-                    with tempfile.NamedTemporaryFile(suffix=extension) as f:
-                            # f.write(part.get_content())
-                            f.write(payload)
-                            file_size = f.tell()
-                            f.close()
                     logger.error(
                         'Attachment found in email',
                         extra={
-                            'attachment-type': part.get_content_type(),
+                            'content-type': part.get_content_type(),
                             'extension': extension,
                             'file-size': file_size,
                             'payload-size': len(payload)

--- a/emails/views.py
+++ b/emails/views.py
@@ -358,8 +358,10 @@ def _get_text_and_html_content(email_message):
                     has_attachment = True
                     incr_if_enabled('email_with_attachment', 1)
                     logger.error(
-                        'Received SNS message with type not handled in inbound log',
-                        extra={'part': part}
+                        'Attachment found in email',
+                        extra={
+                            'content-type': part.get_content_type(),
+                        }
                     )
             except KeyError:
                 # log the un-handled content type but don't stop processing

--- a/emails/views.py
+++ b/emails/views.py
@@ -7,6 +7,7 @@ import logging
 import mimetypes
 import os
 import re
+import tempfile
 
 from django.conf import settings
 from django.contrib import messages
@@ -362,13 +363,16 @@ def _get_text_and_html_content(email_message):
                         extension = os.path.splitext(part.get_filename())[1]
                     else:
                         extension = mimetypes.guess_extension(part.get_content_type())
-                    payload = part.get_payload()
+                    with tempfile.NamedTemporaryFile(suffix=extension) as f:
+                            f.write(part.get_content())
+                            file_size = f.tell()
+                            f.close()
                     logger.error(
                         'Attachment found in email',
                         extra={
                             'attachment-type': part.get_content_type(),
                             'extension': extension,
-                            'payload': payload
+                            'file-size': file_size
                         }
                     )
             except KeyError:

--- a/emails/views.py
+++ b/emails/views.py
@@ -350,7 +350,6 @@ def _get_attachment_metrics(part):
         extension = mimetypes.guess_extension(
             part.get_content_type()
         )
-    payload = part.get_payload(decode=True)
     logger.error(
         'Attachment found in email',
         extra={

--- a/emails/views.py
+++ b/emails/views.py
@@ -360,8 +360,8 @@ def _get_attachment_metrics(part):
         }
     )
     tag_type = 'attachment'
-    attachment_extension_tag = generate_tag(tag_type, ct)
-    attachment_content_type_tag = generate_tag(tag_type, extension)
+    attachment_extension_tag = generate_tag(tag_type, extension)
+    attachment_content_type_tag = generate_tag(tag_type, ct)
     histogram_if_enabled(
         'attachment.size',
         payload_size,

--- a/emails/views.py
+++ b/emails/views.py
@@ -375,7 +375,7 @@ def _get_text_and_html_content(email_message):
     html_content = None
     has_attachment = False
     if email_message.is_multipart():
-        email_count = 0
+        email_attachment_count = 0
         for part in email_message.walk():
             try:
                 if part.get_content_type() == 'text/plain':
@@ -385,14 +385,16 @@ def _get_text_and_html_content(email_message):
                 if part.is_attachment():
                     has_attachment = True
                     _get_attachment_metrics(part)
-                    email_count += 1
+                    email_attachment_count += 1
             except KeyError:
                 # log the un-handled content type but don't stop processing
                 logger.error(
                     'part.get_content()',
                     extra={'type': part.get_content_type()}
                 )
-        histogram_if_enabled('attachment.count_per_email', email_count)
+        histogram_if_enabled(
+            'attachment.count_per_email', email_attachment_count
+        )
     else:
         if email_message.get_content_type() == 'text/plain':
             text_content = email_message.get_content()

--- a/emails/views.py
+++ b/emails/views.py
@@ -344,6 +344,9 @@ def _sns_message(message_json):
 def _get_attachment_metrics(part):
     incr_if_enabled('email_with_attachment', 1)
     fn = part.get_filename()
+    ct = part.get_content_type()
+    payload = part.get_payload(decode=True)
+    payload_size = len(payload)
     if fn:
         extension = os.path.splitext(fn)[1]
     else:

--- a/emails/views.py
+++ b/emails/views.py
@@ -359,7 +359,7 @@ def _get_attachment_metrics(part):
         }
     )
     tag_type = 'attachment'
-    attachment_extension_tag = generate_tag(tag_type, part.get_content_type())
+    attachment_extension_tag = generate_tag(tag_type, ct)
     attachment_content_type_tag = generate_tag(tag_type, extension)
     histogram_if_enabled(
         'attachment.size',

--- a/emails/views.py
+++ b/emails/views.py
@@ -363,6 +363,7 @@ def _get_text_and_html_content(email_message):
                         extension = os.path.splitext(part.get_filename())[1]
                     else:
                         extension = mimetypes.guess_extension(part.get_content_type())
+                    payload = part.get_payload(decode=True)
                     with tempfile.NamedTemporaryFile(suffix=extension) as f:
                             f.write(part.get_content())
                             file_size = f.tell()
@@ -372,7 +373,8 @@ def _get_text_and_html_content(email_message):
                         extra={
                             'attachment-type': part.get_content_type(),
                             'extension': extension,
-                            'file-size': file_size
+                            'file-size': file_size,
+                            'payload-size': len(payload)
                         }
                     )
             except KeyError:

--- a/emails/views.py
+++ b/emails/views.py
@@ -366,7 +366,7 @@ def _get_attachment_metrics(part):
         payload_size,
         [attachment_extension_tag, attachment_content_type_tag]
     )
-    return part.get_content_type(), extension, len(payload)
+    return ct, extension, payload_size
 
 
 def _get_text_and_html_content(email_message):

--- a/emails/views.py
+++ b/emails/views.py
@@ -349,6 +349,11 @@ def _get_text_and_html_content(email_message):
                     text_content = part.get_content()
                 if part.get_content_type() == 'text/html':
                     html_content = part.get_content()
+                if part.get_content_type() == 'application/pdf':
+                    logger.error(
+                        'Pdf attachment',
+                        extra={'file-name': part.get_filename()}
+                    )
                 if part.is_attachment():
                     has_attachment = True
                     incr_if_enabled('email_with_attachment', 1)

--- a/emails/views.py
+++ b/emails/views.py
@@ -350,6 +350,11 @@ def _get_text_and_html_content(email_message):
                 if part.is_attachment():
                     has_attachment = True
                     incr_if_enabled('email_with_attachment', 1)
+                    capture_message(
+                        'Email with attachment',
+                        level="error",
+                        stack=True
+                    )
             except KeyError:
                 # log the un-handled content type but don't stop processing
                 logger.error(

--- a/emails/views.py
+++ b/emails/views.py
@@ -364,7 +364,7 @@ def _get_attachment_metrics(part):
     attachment_content_type_tag = generate_tag(tag_type, extension)
     histogram_if_enabled(
         'attachment.size',
-        len(payload),
+        payload_size,
         [attachment_extension_tag, attachment_content_type_tag]
     )
     return part.get_content_type(), extension, len(payload)

--- a/emails/views.py
+++ b/emails/views.py
@@ -356,7 +356,7 @@ def _get_attachment_metrics(part):
         extra={
             'content-type': part.get_content_type(),
             'extension': extension,
-            'payload-size': len(payload)
+            'payload-size': payload_size
         }
     )
     tag_type = 'attachment'

--- a/emails/views.py
+++ b/emails/views.py
@@ -357,10 +357,18 @@ def _get_text_and_html_content(email_message):
                 if part.is_attachment():
                     has_attachment = True
                     incr_if_enabled('email_with_attachment', 1)
+                    fn = part.get_filename()
+                    if fn:
+                        extension = os.path.splitext(part.get_filename())[1]
+                    else:
+                        extension = mimetypes.guess_extension(part.get_content_type())
+                    payload = part.get_payload()
                     logger.error(
                         'Attachment found in email',
                         extra={
-                            'content-type': part.get_content_type(),
+                            'attachment-type': part.get_content_type(),
+                            'extension': extension,
+                            'payload': payload
                         }
                     )
             except KeyError:
@@ -369,19 +377,6 @@ def _get_text_and_html_content(email_message):
                     'part.get_content()',
                     extra={'type': part.get_content_type()}
                 )
-        for part in email_message.iter_attachments():
-            fn = part.get_filename()
-            if fn:
-                extension = os.path.splitext(part.get_filename())[1]
-            else:
-                extension = mimetypes.guess_extension(part.get_content_type())
-            logger.error(
-                'part.get_content()',
-                extra={
-                    'content-type': part.get_content_type(),
-                    'file-name': part.get_filename()
-                }
-            )
     else:
         if email_message.get_content_type() == 'text/plain':
             text_content = email_message.get_content()

--- a/emails/views.py
+++ b/emails/views.py
@@ -379,7 +379,7 @@ def _get_text_and_html_content(email_message):
                 'part.get_content()',
                 extra={
                     'content-type': part.get_content_type(),
-                    'part': part
+                    'file-name': part.get_filename()
                 }
             )
     else:


### PR DESCRIPTION
# About this PR
Part of research for #498, this PR adds metrics to better understand use of attachments in emails being relayed.

# Practical Tests
- [ ] Send an email to a Relay address with attachment larger than 150KB and check that you receive a response from  `MAILER-DAEMON via amazonses.com` with `This message could not be delivered.`
- [ ] Send an email with an attachment smaller than 100KB and check that information about the attachment (content-type, attachment size, attachment extension) is logged on Sentry under additional data
- [ ] Send an email with multiple attachments with the total size less than 150KB and check that each attachment is logged in Sentry. 

# Note
During this research we confirmed that there is a 150KB max size limit to email as we are not storing the emails on S3. Confirmed with Raed.