### PR TITLE
Prevent the landing hero section from expanding vertically to outrageous proportions…

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -226,7 +226,6 @@ button:active {
 }
 
 .home-hero {
-  min-height: 74vh;
   margin: 0 auto 6em auto;
   position: relative;
 }


### PR DESCRIPTION
Before:
<img width="1881" alt="Screen Shot 2020-08-07 at 2 54 39 PM" src="https://user-images.githubusercontent.com/22355127/89683489-3ef74600-d8be-11ea-96e9-614faf402492.png">

After:
<img width="2123" alt="Screen Shot 2020-08-07 at 2 56 13 PM" src="https://user-images.githubusercontent.com/22355127/89683475-39016500-d8be-11ea-93f2-f45a7d4b2b40.png">
