### PR TITLE
Addon fixes

### DIFF
--- a/extension/css/popup.css
+++ b/extension/css/popup.css
@@ -502,10 +502,6 @@ onboarding-panel p {
     font-size: 1rem;
   }
 
-  .message-copied {
-    font-size: 0.8rem;
-  }
-
   .text-link {
     border-bottom: 1px solid var(--relayInk);
   }

--- a/extension/css/relay.css
+++ b/extension/css/relay.css
@@ -71,6 +71,9 @@
   border-bottom: 1px solid rgba(0, 0, 0, 0) !important;
   justify-content: flex-start;
   display: flex;
+  width: 100%;
+  margin: 1rem auto 2rem 1rem;
+
 }
 
 fx-relay-logotype {
@@ -100,6 +103,19 @@ fx-relay-logomark {
   margin: auto;
   text-decoration: none;
   font-size: 16px;
+}
+
+.fx-relay-modal-manage-aliases {
+  margin-top: 2rem;
+  height: 48px;
+  border-top: 1px solid #eee;
+  width: 100% !important;
+  text-align: center !important;
+  display: flex !important;
+  justify-content: center !important;
+  align-content: center !important;
+  align-items: center !important;
+  text-decoration: none !important;
 }
 
 fx-relay-logotype,
@@ -132,7 +148,7 @@ fx-relay-logomark {
   min-width: 400px;
   background-color: rgba(255, 255, 255, 1);
   border-radius: 8px;
-  padding: 2rem 2rem calc(50px + 2rem) 2rem;
+  padding: 0;
   box-shadow: 0 7px 12px -3px rgba(28, 28, 29, 0.502);
   display: flex;
   flex-direction: column;
@@ -143,34 +159,14 @@ fx-relay-logomark {
   overflow: hidden;
 }
 
-.fx-relay-modal-message-alias-wrapper {
-  height: 48px;
-  margin-bottom: 12px;
-  font-size: 18px;
-  padding: 0 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  border-bottom: 1px solid #ededf0;
-}
-
 .fx-relay-modal-message {
-  font-size: 17px;
+  font-size: 18px !important;
+  max-width: 250px;
   line-height: 1.5;
   text-align: center;
   color: #2b1e44d6;
-  margin-bottom: 32px;
+  margin-bottom: 1rem;
   font-family: var(--InterUI);
-}
-
-.fx-relay-message-copied {
-  font-size: 12px;
-  background-color: var(--relayViolet);
-  border-radius: 2px;
-  padding: 3px 6px;
-  color: rgba(255, 255, 255, 1);
-  margin-left: 8px;
 }
 
 button.fx-relay-modal-close-button {
@@ -181,16 +177,8 @@ button.fx-relay-modal-close-button {
   background-color: var(--relayGrey20) !important;
   color: var(--relayInk) !important;
   font-size: 17px !important;
-  display: flex !important;
-  align-items: center !important;
-  text-align: center !important;
-  justify-content: center !important;
-  position: absolute !important;
-  bottom: 0 !important;
-  left: 0 !important;
-  right: 0 !important;
-  min-width: 100%;
-  width: 100%;
+  min-width: 100% !important;
+  width: 100% !important;
 }
 
 /* input icon & icon messaging */
@@ -388,14 +376,18 @@ button.fx-relay-button {
   box-shadow: none !important;
 }
 
-.fx-relay-button:hover{
+
+.fx-relay-new-tab:hover,
+.fx-relay-button:hover {
   background-color: var(--relayGrey20) !important;
 }
 
+.fx-relay-new-tab:focus,
 .fx-relay-button:focus {
   box-shadow: var(--relayButtonFocus);
 }
 
+.fx-relay-new-tab:active,
 .fx-relay-button:active {
   background-color: var(--relayGrey30) !important;
 }

--- a/extension/first-run.html
+++ b/extension/first-run.html
@@ -22,7 +22,7 @@
             <button title="" class="data-collection fx-relay-toggle"></button>
           </div>
           <p class="pref-p">Collecting interaction data when you do things like click the Relay icon in your toolbar or create a new alias helps us learn what is working well and where we can improve. You can always turn this off in the Settings panel.</p>
-          <button id="first-run-sign-in" class="first-run-sign-in open-oauth" data-event-label="first-run-sign-in">Sign In</button>
+          <button id="first-run-sign-in" class="first-run-sign-in open-oauth" data-event-label="first-run-sign-in">Sign Up / In</button>
         </div>
       </div>
     </main>

--- a/extension/js/add_input_icon.js
+++ b/extension/js/add_input_icon.js
@@ -172,7 +172,7 @@ async function addRelayIconToInput(emailInput) {
 
     if (!signedInUser) {
       const signUpMessageEl = createElementWithClassList("span", "fx-relay-menu-sign-up-message");
-      signUpMessageEl.textContent = "Visit the Firefox Relay website to sign in, create an account, or join the beta waitlist.";
+      signUpMessageEl.textContent = "Visit the Firefox Relay website to sign in or create an account.";
 
       relayInPageMenu.appendChild(signUpMessageEl);
       const signUpButton = createElementWithClassList("button", "fx-relay-menu-sign-up-btn");

--- a/extension/js/add_input_icon.js
+++ b/extension/js/add_input_icon.js
@@ -289,9 +289,18 @@ function getEmailInputsAndAddIcon() {
   }
 }
 
+async function areInputIconsEnabled() {
+  const { showInputIcons } = await browser.storage.local.get("showInputIcons");
+  if (!showInputIcons) {
+    browser.storage.local.set({ "showInputIcons" : "show-input-icons"})
+    return true;
+  }
+  return (showInputIcons === "show-input-icons");
+}
+
 (async function() {
-  const inputIconPref = await browser.storage.local.get("showInputIcons");
-  if (inputIconPref.showInputIcons !== "show-input-icons") {
+  const inputIconsAreEnabled = await areInputIconsEnabled();
+  if (!inputIconsAreEnabled) {
     return;
   }
   // Catch all immediately findable email inputs

--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -3,7 +3,6 @@ const RELAY_SITE_ORIGIN = "http://127.0.0.1:8000";
 browser.storage.local.set({ "maxNumAliases": 5 });
 browser.storage.local.set({ "showInputIcons": "show-input-icons" });
 browser.storage.local.set({ "relaySiteOrigin": RELAY_SITE_ORIGIN });
-browser.storage.local.set({ "fxaOauthFlow": `${RELAY_SITE_ORIGIN}/accounts/fxa/login/?process=login` });
 
 
 browser.runtime.onInstalled.addListener(async () => {

--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -1,7 +1,6 @@
 const RELAY_SITE_ORIGIN = "http://127.0.0.1:8000";
 
 browser.storage.local.set({ "maxNumAliases": 5 });
-browser.storage.local.set({ "showInputIcons": "show-input-icons" });
 browser.storage.local.set({ "relaySiteOrigin": RELAY_SITE_ORIGIN });
 
 

--- a/extension/js/fill_relay_address.js
+++ b/extension/js/fill_relay_address.js
@@ -1,4 +1,4 @@
-async function showModal(modalType, newAlias=null) {
+async function showModal(modalType) {
   const { relaySiteOrigin } = await browser.storage.local.get("relaySiteOrigin");
   const modalWrapper = document.createElement("div");
   modalWrapper.classList = ["fx-relay-modal-wrapper"];
@@ -16,57 +16,29 @@ async function showModal(modalType, newAlias=null) {
 
   modalContent.appendChild(logoWrapper);
 
-  const modalAliasWrapper = document.createElement("div");
-  modalAliasWrapper.classList = ["fx-relay-modal-message-alias-wrapper"];
-
-  if (modalType === "new-alias") { // New alias was created, but input wasn't found.
-    const modalAlias = document.createElement("span");
-    modalAlias.textContent = newAlias;
-    modalAlias.classList = ["relay-modal-alias"];
-
-    const purpleCopiedBlurb = document.createElement("span");
-    purpleCopiedBlurb.textContent = "Copied!";
-    purpleCopiedBlurb.classList = ["fx-relay-message-copied"];
-
-    [modalAlias, purpleCopiedBlurb].forEach(textEl => {
-      modalAliasWrapper.appendChild(textEl);
-    });
-
-    const modalMessage = document.createElement("span");
-    modalMessage.textContent = "You just created a new alias!";
-    modalMessage.classList = ["fx-relay-modal-message"];
-
-    [modalAliasWrapper, modalMessage].forEach(textEl => {
-      modalContent.appendChild(textEl);
-    });
-    window.navigator.clipboard.writeText(newAlias);
-  }
-
   const sendModalEvent = (evtAction, evtLabel) => {
     return sendRelayEvent("Modal", evtAction, evtLabel);
   };
 
-  if (modalType === "max-num-aliases") { // User has maxed out the number of allowed free aliases.
+  sendModalEvent("viewed-modal", "modal-max-aliases");
+  const modalMessage = document.createElement("span");
 
-    sendModalEvent("viewed-modal", "modal-max-aliases");
-    const modalMessage = document.createElement("span");
+  modalMessage.textContent = "You've reached the alias limit for our beta release.";
+  modalMessage.classList = ["fx-relay-modal-message"];
+  modalContent.appendChild(modalMessage);
 
-    modalMessage.textContent = "You've used all of your beta aliases.";
-    modalMessage.classList = ["fx-relay-modal-message"];
-    modalContent.appendChild(modalMessage);
+  const manageAliasesLink = document.createElement("a");
+  manageAliasesLink.textContent = "Manage All Aliases";
+  manageAliasesLink.classList = ["fx-relay-new-tab fx-relay-modal-manage-aliases"];
+  manageAliasesLink.href = `${relaySiteOrigin}?utm_source=fx-relay-addon&utm_medium=context-menu-modal&utm_campaign=beta&utm_content=manage-relay-addresses`;
 
-    const manageAliasesLink = document.createElement("a");
-    manageAliasesLink.textContent = "Manage All Aliases";
-    manageAliasesLink.classList = ["fx-relay-new-tab"];
-    manageAliasesLink.href = `${relaySiteOrigin}?utm_source=fx-relay-addon&utm_medium=context-menu-modal&utm_campaign=beta&utm_content=manage-relay-addresses`;
-
-    manageAliasesLink.addEventListener("click", async(e) => {
-      e.preventDefault();
-      sendModalEvent("click", "modal-manage-all-aliases-btn");
-      return await browser.tabs.create({ url: e.target.href });
-    });
-    modalContent.appendChild(manageAliasesLink);
-  }
+  manageAliasesLink.addEventListener("click", async(e) => {
+    e.preventDefault();
+    sendModalEvent("click", "modal-manage-all-aliases-btn");
+    return window.open(e.target.href);
+  });
+  modalContent.appendChild(manageAliasesLink);
+  
 
   const modalCloseButton = document.createElement("button");
   modalCloseButton.classList = ["fx-relay-modal-close-button"];
@@ -104,15 +76,11 @@ function fillInputWithAlias(emailInput, relayAlias) {
 
 browser.runtime.onMessage.addListener((message, sender, response) => {
   if (message.type === "fillTargetWithRelayAddress") {
-    // attempt to find the email input
     const emailInput = browser.menus.getTargetElement(message.targetElementId);
-    if (!emailInput) {
-      return showModal("new-alias", message.relayAddress);
-    }
     return fillInputWithAlias(emailInput, message.relayAddress);
   }
 
   if (message.type === "showMaxNumAliasesMessage") {
-    return showModal("max-num-aliases");
+    return showModal();
   }
 });

--- a/extension/js/first-run.js
+++ b/extension/js/first-run.js
@@ -3,7 +3,6 @@
 /* global enableDataOptOut */
 
 document.addEventListener("DOMContentLoaded", async () => {
-  const { fxaOauthFlow } = await browser.storage.local.get("fxaOauthFlow");
   const { relaySiteOrigin } = await browser.storage.local.get("relaySiteOrigin");
 
 
@@ -13,15 +12,12 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   enableDataOptOut();
 
-  // TODO Add FXA params, do metrics flow from extension?
-  const openFxaFlow = new URL(fxaOauthFlow, relaySiteOrigin);
-
   const oauthEntryPoints = document.querySelectorAll(".open-oauth");
   oauthEntryPoints.forEach(el => {
     el.addEventListener("click", (e) => {
       e.preventDefault();
       sendRelayEvent("First Run", "click", e.target.dataset.eventLabel);
-      return window.open(openFxaFlow);
+      return window.open(`${relaySiteOrigin}/accounts/profile?utm_source=fx-relay-addon&utm_medium=first-run&utm_campaign=beta&utm_content=first-run-sign-up-btn`);
     });
   });
 });

--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -169,11 +169,10 @@ async function popup() {
     });
   });
 
-  const { fxaOauthFlow } = await browser.storage.local.get("fxaOauthFlow");
   const { relaySiteOrigin } = await browser.storage.local.get("relaySiteOrigin");
 
   document.querySelectorAll(".login-link").forEach(loginLink => {
-    loginLink.href = fxaOauthFlow;
+    loginLink.href = `${relaySiteOrigin}/accounts/profile?utm_source=fx-relay-addon&utm_medium=popup&utm_campaign=beta&utm_content=popup-continue-btn`;
   });
 
   document.querySelectorAll(".dashboard-link").forEach(dashboardLink => {

--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -1,5 +1,6 @@
 /* global browser */
 /* global enableDataOptOut */
+/* global areInputIconsEnabled */
 
 function getOnboardingPanels() {
   return {
@@ -125,8 +126,9 @@ async function enableInputIconDisabling() {
   };
 
 
-  const areInputIconsEnabled = await browser.storage.local.get("showInputIcons");
-  stylePrefToggle(areInputIconsEnabled.showInputIcons);
+  const iconsAreEnabled = await areInputIconsEnabled();
+  const userIconChoice = iconsAreEnabled ? "show-input-icons" : "hide-input-icons";
+  stylePrefToggle(userIconChoice);
 
   inputIconVisibilityToggle.addEventListener("click", async() => {
     const userIconPreference = (inputIconVisibilityToggle.dataset.iconVisibilityOption === "disable-input-icon") ? "hide-input-icons" : "show-input-icons";

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="css/relay.css">
     <link rel="stylesheet" href="css/popup.css">
     <script src="/js/data-opt-out-toggle.js"></script>
+    <script src="js/add_input_icon.js"></script>
     <script src="js/popup.js"></script>
     <script src="js/metrics.js"></script>
   </head>


### PR DESCRIPTION
- Updates button text on post-install page
- Changes sign in links to use `/accounts/profile` so that users who are already signed in aren't taken back to the oauth flow.
- Fixes the "Manage All Aliases" link in the modal
- Prevents input icons from getting re-enabled on browser restarts