### PR TITLE
Support utf8 in headers 523

### DIFF
--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -10,7 +10,8 @@ class FormattingToolsTest(TestCase):
     def test_generate_relay_From_with_umlaut(self):
         with self.settings(RELAY_FROM_ADDRESS='relay@relay.firefox.com'):
             relay_from_address, relay_from_display = generate_relay_From(
-                self.original_from_address)
+                self.original_from_address
+            )
 
         expected_encoded_display_name = (
             '=?utf-8?b?ImZvw7YgYsOkciIgPGZvb0BiYXIuY29tPiBbdmlhIFJlbGF5XQ==?='

--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -1,0 +1,19 @@
+from django.test import TestCase
+
+from emails.utils import generate_relay_From
+
+
+class FormattingToolsTest(TestCase):
+    def setUp(self):
+        self.original_from_address = '"foö bär" <foo@bar.com>'
+
+    def test_generate_relay_From_with_umlaut(self):
+        with self.settings(RELAY_FROM_ADDRESS='relay@relay.firefox.com'):
+            relay_from_address, relay_from_display = generate_relay_From(
+                self.original_from_address)
+
+        expected_encoded_display_name = (
+            '=?utf-8?b?ImZvw7YgYsOkciIgPGZvb0BiYXIuY29tPiBbdmlhIFJlbGF5XQ==?='
+        )
+        assert relay_from_address == 'relay@relay.firefox.com'
+        assert relay_from_display == expected_encoded_display_name

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -1,5 +1,6 @@
 import contextlib
 from datetime import datetime, timezone
+from email.header import Header
 from email.headerregistry import Address
 from email.utils import parseaddr
 import json
@@ -99,6 +100,7 @@ def generate_relay_From(original_from_address):
     relay_display_name, relay_from_address = parseaddr(
         settings.RELAY_FROM_ADDRESS
     )
-    return relay_from_address, '%s [via Relay]' % (
-        original_from_address
+    encoded_original_address = Header(
+        '%s [via Relay]' % (original_from_address), 'UTF-8'
     )
+    return relay_from_address, encoded_original_address

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -100,7 +100,7 @@ def generate_relay_From(original_from_address):
     relay_display_name, relay_from_address = parseaddr(
         settings.RELAY_FROM_ADDRESS
     )
-    encoded_original_address = Header(
+    display_name = Header(
         '%s [via Relay]' % (original_from_address), 'UTF-8'
     )
-    return relay_from_address, encoded_original_address
+    return relay_from_address, display_name.encode()

--- a/emails/views.py
+++ b/emails/views.py
@@ -296,7 +296,7 @@ def _sns_message(message_json):
     from_address = parseaddr(mail['commonHeaders']['from'])[1]
     subject = mail['commonHeaders'].get('subject', '')
     email_message = message_from_string(
-        message_json['content'] # , policy=policy.default
+        message_json['content'], policy.EmailPolicy(utf8=False)
     )
 
     text_content, html_content, has_attachment = _get_text_and_html_content(

--- a/emails/views.py
+++ b/emails/views.py
@@ -419,6 +419,8 @@ def _get_text_and_html_content(email_message):
         if email_message.get_content_type() == 'text/plain':
             text_content = email_message.get_content()
             html_content = urlize_and_linebreaks(email_message.get_content())
+            payload_text = email_message.get_payload(decode=True)
+            decoded_payload_text = email_message.decode()
             logger.error(
                 'Decode text content (non-multipart)',
                 extra={

--- a/emails/views.py
+++ b/emails/views.py
@@ -296,7 +296,7 @@ def _sns_message(message_json):
     from_address = parseaddr(mail['commonHeaders']['from'])[1]
     subject = mail['commonHeaders'].get('subject', '')
     email_message = message_from_string(
-        message_json['content'], policy=policy.default
+        message_json['content'] # , policy=policy.default
     )
 
     text_content, html_content, has_attachment = _get_text_and_html_content(

--- a/emails/views.py
+++ b/emails/views.py
@@ -380,6 +380,16 @@ def _get_text_and_html_content(email_message):
             try:
                 if part.get_content_type() == 'text/plain':
                     text_content = part.get_content()
+                    payload_text = part.get_payload(decode=True)
+                    decoded_payload_text = payload_text.decode()
+                    logger.error(
+                        'Decode text content',
+                        extra={
+                            'text-content' : text_content,
+                            'payload': payload_text,
+                            'decoded-content': decoded_payload_text
+                        }
+                    )
                 if part.get_content_type() == 'text/html':
                     html_content = part.get_content()
                     content = part.get_payload(decode=True)

--- a/emails/views.py
+++ b/emails/views.py
@@ -382,6 +382,16 @@ def _get_text_and_html_content(email_message):
                     text_content = part.get_content()
                 if part.get_content_type() == 'text/html':
                     html_content = part.get_content()
+                    content = part.get_payload(decode=True)
+                    decoded_content = content.decode()
+                    logger.error(
+                        'Decode HTML content'
+                        {
+                            'html-content' : html_content,
+                            'content': content,
+                            'decoded-content': decoded_content
+                        }
+                    )
                 if part.is_attachment():
                     has_attachment = True
                     _get_attachment_metrics(part)

--- a/emails/views.py
+++ b/emails/views.py
@@ -1,5 +1,5 @@
 from email import message_from_string, policy
-from email.utils import parseaddr, _string_transform
+from email.utils import parseaddr
 from hashlib import sha256
 from sentry_sdk import capture_message
 import json

--- a/emails/views.py
+++ b/emails/views.py
@@ -419,6 +419,14 @@ def _get_text_and_html_content(email_message):
         if email_message.get_content_type() == 'text/plain':
             text_content = email_message.get_content()
             html_content = urlize_and_linebreaks(email_message.get_content())
+            logger.error(
+                'Decode text content (non-multipart)',
+                extra={
+                    'text-content' : text_content,
+                    'payload': payload_text,
+                    'decoded-content': decoded_payload_text
+                }
+            )
         if email_message.get_content_type() == 'text/html':
             html_content = email_message.get_content()
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -385,8 +385,8 @@ def _get_text_and_html_content(email_message):
                     content = part.get_payload(decode=True)
                     decoded_content = content.decode()
                     logger.error(
-                        'Decode HTML content'
-                        {
+                        'Decode HTML content',
+                        extra={
                             'html-content' : html_content,
                             'content': content,
                             'decoded-content': decoded_content


### PR DESCRIPTION
# About this PR
On #523 a user pointed out that UTF-8 encoding is not properly handled on the From display name. This PR ensures that the utf-8 is used on the From display name.

# Acceptance Criteria
- [ ] From display name properly handles UTF-8 encoding
- [ ] Fix #523

# Practical Tests
## Check that umlauts are supported on From, Subject, and Body of the relayed email
1. Send an email to a relay address with umlauts on the From, Subject, and Body
2. Check that you get an email without the umlauts being broken (UTF-8 is properly encoded on the string)
3. Repeat this test with different email clients as the sender with umlauts on their username, in the email subject, and in the body:
- [ ] Yahoo Mail
- [ ] Gmail
- [ ] ProtonMail 
- [ ] AOL Mail
- [ ] Outlook
- [ ] Thunderbird

While testing, I would like information on the following headers:
```
Content-Type
Content-Transfer-Encoding
```
Often times you can get this information from a given email client by clicking for more details/see original/view headers on the email that was relayed.
For example, if you are an FXA user with ProtonMail as your primary email, then when you receive the email via Relay, when you open the email click on the "More" button. Then from the drop down of options click on the "View headers" and search for `Content-Type` and `Content-Transfer-Encoding`