### PR TITLE
Remove attachments information on logger

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -346,14 +346,6 @@ def _get_attachment_metrics(part):
         extension = os.path.splitext(fn)[1]
     else:
         extension = mimetypes.guess_extension(ct)
-    logger.error(
-        'Attachment found in email',
-        extra={
-            'content-type': ct,
-            'extension': extension,
-            'payload-size': payload_size
-        }
-    )
     tag_type = 'attachment'
     attachment_extension_tag = generate_tag(tag_type, extension)
     attachment_content_type_tag = generate_tag(tag_type, ct)

--- a/emails/views.py
+++ b/emails/views.py
@@ -336,7 +336,7 @@ def _sns_message(message_json):
     )
 
 
-def _get_attachment_metrics(part):
+def _get_attachment(part):
     incr_if_enabled('email_with_attachment', 1)
     fn = part.get_filename()
     ct = part.get_content_type()
@@ -377,7 +377,7 @@ def _get_all_contents(email_message):
                     html_content = part.get_content()
                 if part.is_attachment():
                     att_name, att = (
-                        _get_attachment_metrics(part)
+                        _get_attachment(part)
                     )
                     attachments[att_name] = att
             except KeyError:


### PR DESCRIPTION
# About this PR
Now that we have metrics to gather data on attachments we can remove the logger for attachments metrics

# Acceptance Criteria
- [ ] Remove attachments metrics on the logger
- [ ] Update `_get_attachment_metrics` function to more descriptive function `_get_attachment` (#662)

#
Related to #613
Fix #662