### PR TITLE
Messaging for attachment support and limits 596

### DIFF
--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -39,6 +39,9 @@
               <td width="100%" align="center" style="line-height: 150%;">
                 <p style="color: #363959; font-size: 13px; font-family: sans-serif; margin-top: 0; margin-bottom: 0;">
                   This message was forwarded from <span style="font-family: sans-serif; font-weight: bolder; color: #20123a; text-decoration: none; font-size: 13px;">{{ display_email|safe }}</span> by <a href="{{ SITE_ORIGIN }}" target="_blank" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">Firefox Relay</a>.
+                  {% if has_attachment %}
+                    <br>Emails with a maximum size of <b>150KB</b> have attachments support. To learn more check our <a href="{{ faq_page }}" target="_blank" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">FAQ page</a>.
+                  {% endif %}
                 </p>
               </td>
             </tr>

--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -40,7 +40,7 @@
                 <p style="color: #363959; font-size: 13px; font-family: sans-serif; margin-top: 0; margin-bottom: 0;">
                   This message was forwarded from <span style="font-family: sans-serif; font-weight: bolder; color: #20123a; text-decoration: none; font-size: 13px;">{{ display_email|safe }}</span> by <a href="{{ SITE_ORIGIN }}" target="_blank" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">Firefox Relay</a>.
                   {% if has_attachment %}
-                    <br>Emails with a maximum size of <b>150KB</b> have attachments support. To learn more check our <a href="{{ faq_page }}" target="_blank" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">FAQ page</a>.
+                    <br>Firefox Relay supports email forwarding (including attachments) of email up to 150KB in size. To learn more check our <a href="{{ faq_page }}" target="_blank" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">FAQ page</a>.
                   {% endif %}
                 </p>
               </td>

--- a/emails/views.py
+++ b/emails/views.py
@@ -315,6 +315,8 @@ def _sns_message(message_json):
             'email_to': to_address,
             'display_email': display_email,
             'SITE_ORIGIN': settings.SITE_ORIGIN,
+            'has_attachment': bool(attachments),
+            'faq_page': settings.SITE_ORIGIN + reverse('faq')
         })
         message_body['Html'] = {'Charset': 'UTF-8', 'Data': wrapped_html}
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -17,6 +17,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
+from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 
 from .context_processors import relay_from_domain
@@ -319,14 +320,17 @@ def _sns_message(message_json):
 
     if text_content:
         incr_if_enabled('email_with_text_content', 1)
-        attachment_not_supported = ''
+        attachment_msg = (
+            'Emails with a maximum size (including headers) of 150KB '
+            'have attachments support. To learn more visit {site}{faq}\n'
+        ).format(site=settings.SITE_ORIGIN, faq=reverse('faq'))
         relay_header_text = (
             'This email was sent to your alias '
             '{relay_address}. To stop receiving emails sent to this alias, '
             'update the forwarding settings in your dashboard.\n'
             '{extra_msg}---Begin Email---\n'
         ).format(
-            relay_address=display_email, extra_msg=attachment_not_supported
+            relay_address=display_email, extra_msg=attachment_msg
         )
         wrapped_text = relay_header_text + text_content
         message_body['Text'] = {'Charset': 'UTF-8', 'Data': wrapped_text}

--- a/privaterelay/templates/faq.html
+++ b/privaterelay/templates/faq.html
@@ -60,7 +60,7 @@
         <section class="faq">
           <h2 class="faq-headline">What if an email sent to my alias contains an attachment?</h2>
           <p class="faq-answer">
-            Attachments and emails larger than 150KB are not currently supported and will not be forwarded to your real email address. If an email containing an attachment is smaller than 150KB, the email will be forwarded without the attachment.
+            We now support attachment forwarding. However, there is a 150KB limit for email forwarding using Relay. Any emails larger than 150KB will not be forwarded.
           </p>
         </section>
       </div>

--- a/privaterelay/templates/includes/alias-stats.html
+++ b/privaterelay/templates/includes/alias-stats.html
@@ -9,5 +9,5 @@
 <div class="column-forwarded center-value relay-stat">
   <span class="relay-email-label card-small-text">Forwarded</span>
   <span class="email-value relay-stat-value num-forwarded">{{ relay_address.num_forwarded }}</span>
-  <span class="forwarding-description stat-description">Firefox Relay will send messages to your inbox when you select forwarding for this alias. <br /><span class="fwd-note"><span class="bold ff-Met">Note:</span> Attachments and emails larger than 150KB are not currently supported and will not be forwarded.</span></span>
+  <span class="forwarding-description stat-description">Firefox Relay will send messages to your inbox when you select forwarding for this alias. <br /><span class="fwd-note"><span class="bold ff-Met">Note:</span> Email (including attachments) larger than 150KB are not currently supported and will not be forwarded.</span></span>
 </div>

--- a/privaterelay/templates/profile.html
+++ b/privaterelay/templates/profile.html
@@ -145,6 +145,9 @@
             </div> <!-- end card-->
           </div> <!-- end relay-email-->
         {% endfor %}
+        <div> <!-- informtaion footer -->
+          Firefox Relay supports email forwarding (including attachments) of email up to 150KB in size
+        </div> <!-- end informtaion footer -->
       </div><!-- end dashboard-container -->
     </div>
   </div>


### PR DESCRIPTION
# About this PR
Update texts on forwarded email headers and FAQ page about attachment support and email size limit. This PR did not make changes to the existing hover text for "Forwarded" text on the dashboard as it was succinct enough to imply that the attachment may be supported. Current hover message reads:
<img width="363" alt="Screen Shot 2020-09-09 at 3 41 21 PM" src="https://user-images.githubusercontent.com/25109943/92652738-f9f67300-f2b2-11ea-9480-1ee8951621d9.png">

# Acceptance Criteria
- [ ] When attachment is delivered, we include a line in an header about supporting only up to 150KB email size
- [ ] FAQ has attachment support and relaying email only up to 150KB (bigger than this will get lost) message
- [ ] Fix #596
