### PR TITLE
Replicate behavior for emails with attachments

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -389,6 +389,8 @@ def _get_all_contents(email_message):
         histogram_if_enabled(
             'attachment.count_per_email', len(attachments)
         )
+        if text_content and html_content is None:
+            html_content = urlize_and_linebreaks(text_content)
     else:
         if email_message.get_content_type() == 'text/plain':
             text_content = email_message.get_content()

--- a/emails/views.py
+++ b/emails/views.py
@@ -326,7 +326,7 @@ def _sns_message(message_json):
             'update the forwarding settings in your dashboard.\n'
             '{extra_msg}---Begin Email---\n'
         ).format(
-            relay_address=display_email, extra_msg=attachment_not_supported
+            relay_address=to_address, extra_msg=attachment_not_supported
         )
         wrapped_text = relay_header_text + text_content
         message_body['Text'] = {'Charset': 'UTF-8', 'Data': wrapped_text}

--- a/emails/views.py
+++ b/emails/views.py
@@ -371,15 +371,16 @@ def _get_all_contents(email_message):
     if email_message.is_multipart():
         for part in email_message.walk():
             try:
-                if part.get_content_type() == 'text/plain':
-                    text_content = part.get_content()
-                if part.get_content_type() == 'text/html':
-                    html_content = part.get_content()
                 if part.is_attachment():
                     att_name, att = (
                         _get_attachment(part)
                     )
                     attachments[att_name] = att
+                    continue
+                if part.get_content_type() == 'text/plain':
+                    text_content = part.get_content()
+                if part.get_content_type() == 'text/html':
+                    html_content = part.get_content()
             except KeyError:
                 # log the un-handled content type but don't stop processing
                 logger.error(

--- a/emails/views.py
+++ b/emails/views.py
@@ -390,7 +390,7 @@ def _get_all_contents(email_message):
         histogram_if_enabled(
             'attachment.count_per_email', len(attachments)
         )
-        if text_content and html_content is None:
+        if text_content is not None and html_content is None:
             html_content = urlize_and_linebreaks(text_content)
     else:
         if email_message.get_content_type() == 'text/plain':


### PR DESCRIPTION
# About this PR
When there is an attachment on the email AND the email only has the text body, the text body is not duplicated to the html body to be wrapped by the Relay headers. Also, since the text attachment has the same content-type as the text body, the email's body can be overwritten by the content of the text attachment.

# Acceptance Criteria
- [ ] Text only email with attachment is relayed with the HTML body as well
- [ ] Broken text-only body header with HTML tags on the Relay address is displayed properly as text only
- [ ] Text only email with text attachment is relayed properly

# Practical Test
## Check that email with text only and attachment(s) is relayed with the HTML body
1. Send an email to a Relay address with text only and attachment(s)
2. Check that email relayed has the proper HTML header wrapping the text body

## Check that the text render of the email has the text version of Relay address
1. Send an email to a Relay address
2. Check the text/plain part of the email and confirm that the Relay address on the header DOES NOT contain HTML tags

## Check that text-only email with text attachment is relayed properly
1. Send an email to a Relay address with text-only body and text attachment
2. Check that the relayed email contains the proper text on the body and the text attachment is relayed properly.
