### PR TITLE
Set display-name of From header to quoted-string

### DIFF
--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -14,7 +14,7 @@ class FormattingToolsTest(TestCase):
             )
 
         expected_encoded_display_name = (
-            '=?utf-8?b?ImZvw7YgYsOkciIgPGZvb0BiYXIuY29tPiBbdmlhIFJlbGF5XQ==?='
+            '=?utf-8?b?IlwiZm/DtiBiw6RyXCIgPGZvb0BiYXIuY29tPiBbdmlhIFJlbGF5XSI=?='
         )
         assert relay_from_address == 'relay@relay.firefox.com'
         assert relay_from_display == expected_encoded_display_name

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -182,6 +182,6 @@ def generate_relay_From(original_from_address):
         settings.RELAY_FROM_ADDRESS
     )
     display_name = Header(
-        '%s [via Relay]' % (original_from_address), 'UTF-8'
+        '"' + quote('%s [via Relay]' % (original_from_address)) + '"', 'UTF-8'
     )
     return relay_from_address, display_name.encode()


### PR DESCRIPTION
Follow up on: #683 

> Looked further into it and found this is discussed more precisely at <https://tools.ietf.org/html/rfc2047#section-5>.
> The From header sent by the relay always contains `[` `]` `<` and `>` in its display name. For this reason I believe it should indeed be a quoted-string, before it gets encoded.
> 
> Before the support-utf8-in-headers commit, the quotes would always get added by [this piece of code](https://github.com/python/cpython/blob/3.8/Lib/email/headerregistry.py#L96).

This MR offers to always transform the display name of the From header into a quoted-string before being word-encoded.