### PR TITLE
fix ProtonMail delivery

### DIFF
--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -14,7 +14,7 @@ class FormattingToolsTest(TestCase):
             )
 
         expected_encoded_display_name = (
-            '=?utf-8?b?IlwiZm/DtiBiw6RyXCIgPGZvb0BiYXIuY29tPiBbdmlhIFJlbGF5XSI=?='
+            '=?utf-8?b?IiJmb8O2IGLDpHIiIDxmb29AYmFyLmNvbT4gW3ZpYSBSZWxheV0i?='
         )
         assert relay_from_address == 'relay@relay.firefox.com'
         assert relay_from_display == expected_encoded_display_name

--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -14,7 +14,7 @@ class FormattingToolsTest(TestCase):
             )
 
         expected_encoded_display_name = (
-            '=?utf-8?b?ImZvw7YgYsOkciIgPGZvb0BiYXIuY29tPiBbdmlhIFJlbGF5XQ==?='
+            '=?utf-8?b?IlwiZm/DtiBiw6RyXCIgPGZvb0BiYXIuY29tPiBbdmlhIFJlbGF5XSI=?='
         )
         assert relay_from_address == 'relay@relay.firefox.com'
         assert relay_from_display == expected_encoded_display_name

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -182,6 +182,6 @@ def generate_relay_From(original_from_address):
         settings.RELAY_FROM_ADDRESS
     )
     display_name = Header(
-        '%s [via Relay]' % (original_from_address), 'UTF-8'
+        '"' + quote('%s [via Relay]' % (original_from_address)) + '"', 'UTF-8'
     )
     return relay_from_address, display_name.encode()

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -182,6 +182,6 @@ def generate_relay_From(original_from_address):
         settings.RELAY_FROM_ADDRESS
     )
     display_name = Header(
-        '"' + quote('%s [via Relay]' % (original_from_address)) + '"', 'UTF-8'
+        '"%s [via Relay]"' % (original_from_address), 'UTF-8'
     )
     return relay_from_address, display_name.encode()


### PR DESCRIPTION
Turns out we just needed to restore `"` around the whole `From` value. 

This branch is already on [the dev site](https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/), if you want to test it out there.