### PR TITLE
bump version number to 1.4.6

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Firefox Relay",
-  "version": "1.4.5",
+  "version": "1.4.6",
 
   "description": "Firefox Relay makes it easy to create email aliases that forward to your real inbox. Use it to protect your online accounts from hackers and unwanted messages.",
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fx-private-relay",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Firefox Relay",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Bumping the version number so we can make a new release to AMO and get our label changed from "Experimental" to "By Firefox"