### PR TITLE
Move web-ext settings into config file

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "build": "web-ext build && mv ../static/downloads/addon/latest/firefox_relay-*.zip ../static/downloads/addon/latest/firefox_relay.zip && npm run build:clean",
+    "build": "web-ext build && npm run build:clean",
     "build:clean": "git checkout manifest.json js/background.js popup.html",
     "build:dev": "npm run build:clean && sed -i '' 's/:8000//g'  manifest.json js/background.js popup.html && sed -i '' 's@http://127.0.0.1@https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net@g' manifest.json js/background.js popup.html && npm run build",
     "build:stage": "npm run build:clean && sed -i '' 's/:8000//g'  manifest.json js/background.js popup.html && sed -i '' 's@http://127.0.0.1@https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net@g' manifest.json js/background.js popup.html && npm run build",

--- a/extension/package.json
+++ b/extension/package.json
@@ -8,13 +8,15 @@
   },
   "devDependencies": {},
   "scripts": {
+    "build": "web-ext build && mv ../static/downloads/addon/latest/firefox_relay-*.zip ../static/downloads/addon/latest/firefox_relay.zip && npm run build:clean",
     "build:clean": "git checkout manifest.json js/background.js popup.html",
-    "build": "web-ext build --ignore-files .DS_Store README.* package.json package-lock.json sequence-diagram.* --overwrite-dest -s . -a ../static/downloads/addon/latest/ && mv ../static/downloads/addon/latest/firefox_relay-*.zip ../static/downloads/addon/latest/firefox_relay.zip",
-    "build:dev": "npm run build:clean && sed -i '' 's/:8000//g'  manifest.json js/background.js popup.html && sed -i '' 's@http://127.0.0.1@https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net@g'  manifest.json js/background.js popup.html && web-ext build --ignore-files .DS_Store README.* package.json package-lock.json sequence-diagram.* --overwrite-dest -s . -a ../static/downloads/addon/latest/ && mv ../static/downloads/addon/latest/firefox_relay-*.zip ../static/downloads/addon/latest/firefox_relay.zip && npm run build:clean",
-    "build:stage": "npm run build:clean && sed -i '' 's/:8000//g'  manifest.json js/background.js popup.html && sed -i '' 's@http://127.0.0.1@https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net@g'  manifest.json js/background.js popup.html && web-ext build --ignore-files .DS_Store README.* package.json package-lock.json sequence-diagram.* --overwrite-dest -s . -a ../static/downloads/addon/latest/ && mv ../static/downloads/addon/latest/firefox_relay-*.zip ../static/downloads/addon/latest/firefox_relay.zip && npm run build:clean",
-    "build:prod": "npm run build:clean && sed -i '' 's/:8000//g'  manifest.json js/background.js popup.html && sed -i '' 's@http://127.0.0.1@https://relay.firefox.com@g'  manifest.json js/background.js popup.html && web-ext build --ignore-files .DS_Store README.* package.json package-lock.json sequence-diagram.* --overwrite-dest -s . -a ../static/downloads/addon/latest/ && mv ../static/downloads/addon/latest/firefox_relay-*.zip ../static/downloads/addon/latest/firefox_relay.zip && npm run build:clean",
+    "build:dev": "npm run build:clean && sed -i '' 's/:8000//g'  manifest.json js/background.js popup.html && sed -i '' 's@http://127.0.0.1@https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net@g' manifest.json js/background.js popup.html && npm run build",
+    "build:stage": "npm run build:clean && sed -i '' 's/:8000//g'  manifest.json js/background.js popup.html && sed -i '' 's@http://127.0.0.1@https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net@g' manifest.json js/background.js popup.html && npm run build",
+    "build:prod": "npm run build:clean && sed -i '' 's/:8000//g'  manifest.json js/background.js popup.html && sed -i '' 's@http://127.0.0.1@https://relay.firefox.com@g' manifest.json js/background.js popup.html && npm run build",
+    "lint": "web-ext lint",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mozilla/fx-private-relay.git"

--- a/extension/web-ext-config.js
+++ b/extension/web-ext-config.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ module.exports = {
+  // Global options:
+  sourceDir: ".",
+  artifactsDir: "../static/downloads/addon/latest/",
+  verbose: false,
+
+  // Command options:
+  build: {
+    overwriteDest: true,
+  },
+
+  ignoreFiles: [
+    ".DS_Store",
+    "README.*",
+    "package.json",
+    "package-lock.json",
+    "sequence-diagram.*",
+    "web-ext-config.js"
+  ],
+};

--- a/extension/web-ext-config.js
+++ b/extension/web-ext-config.js
@@ -5,7 +5,6 @@
  module.exports = {
   // Global options:
   sourceDir: ".",
-  artifactsDir: "../static/downloads/addon/latest/",
   verbose: false,
 
   // Command options:


### PR DESCRIPTION
Moves a bunch of duplicated <kbd>web-ext</kbd> configs into a separate config file to avoid duplicating in 3-4 places.
If you object to yet another new file, I think we can add it as a nested key in the extension/package.json.

Can't think of a better way yet to avoid using `sed` for string substitutions, unless we use Nunjucks/Liquid/lodash for simple templates (and then a combination of gitignore+web-ext ignoreFiles).