### PR TITLE
fix stage DeletedAddress.MultipleObjectsReturned

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -286,6 +286,9 @@ def _sns_message(message_json):
                 'Received email for unknown address.',
                 extra={'to_address': to_address}
             )
+        except DeletedAddress.MultipleObjectsReturned:
+            # not sure why this happens on stage but let's handle it
+            incr_if_enabled('email_for_deleted_address_multiple', 1)
         return HttpResponse("Address does not exist", status=404)
 
     # first see if this user is over bounce limits


### PR DESCRIPTION
Only seeing this on stage. Maybe bad or corrupted data there from before we did proper data integrity checks? https://sentry.prod.mozaws.net/operations/fx-private-relay-stage/issues/10374815/?query=is%3Aunresolved

Or maybe we've created multiple records for `relay@stage.fxprivaterelay.nonprod.cloudops.mozgcp.net` at different times in the past?