### PR TITLE
fix address header encoding for python 3.7.9

### DIFF
--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -1,3 +1,6 @@
+from email.utils import parseaddr
+
+from django.conf import settings
 from django.test import TestCase
 
 from emails.utils import generate_relay_From
@@ -5,16 +8,33 @@ from emails.utils import generate_relay_From
 
 class FormattingToolsTest(TestCase):
     def setUp(self):
-        self.original_from_address = '"foö bär" <foo@bar.com>'
+        _, self.relay_from = parseaddr(settings.RELAY_FROM_ADDRESS)
 
     def test_generate_relay_From_with_umlaut(self):
-        with self.settings(RELAY_FROM_ADDRESS='relay@relay.firefox.com'):
-            relay_from_address, relay_from_display = generate_relay_From(
-                self.original_from_address
-            )
+        original_from_address = '"foö bär" <foo@bar.com>'
+        formatted_from_address = generate_relay_From(original_from_address)
 
         expected_encoded_display_name = (
             '=?utf-8?b?IiJmb8O2IGLDpHIiIDxmb29AYmFyLmNvbT4gW3ZpYSBSZWxheV0i?='
         )
-        assert relay_from_address == 'relay@relay.firefox.com'
-        assert relay_from_display == expected_encoded_display_name
+        expected_formatted_from = '%s %s' % (
+            expected_encoded_display_name, '<%s>' % self.relay_from
+        )
+        assert formatted_from_address == expected_formatted_from
+
+    def test_generate_relay_From_with_really_long_address(self):
+        original_from_address = ''.join((
+            'a really long from address that is more ',
+            'than 78 characters because rfc2822 says to start inserting wrap',
+            'characters that could be unsafe <evil@evil.com>',
+        ))
+        formatted_from_address = generate_relay_From(original_from_address)
+
+        expected_encoded_display_name = (
+            '=?utf-8?q?=22a_really_long_from_address_that'
+            '__=2E=2E=2E_=5Bvia_Relay=5D=22?='
+        )
+        expected_formatted_from = '%s %s' % (
+            expected_encoded_display_name, '<%s>' % self.relay_from
+        )
+        assert formatted_from_address == expected_formatted_from

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.6
+python-3.7.9


### PR DESCRIPTION
What does all this mean?

We are now truncating the `From:` address when it is longer than 36 characters. So something like:

`For quality discount Gamestop stock, be sure to visit evil.com <scam@evil.com>`

to:

`For quality discount Gamestop st [via Relay] <relay@relay.firefox.com>`


The gross details ...

python 3.7.6 has a problem in the way that it handles email address headers. (https://bugs.python.org/issue39073)

it’s fixed in 3.7.8+. but the fix is to disallow `\n` or `\r` characters in email address headers. ok, fair enough …

when we use the `Header` `encode()` method, it follows RFC 2822 and auto-wraps headers at 78 chars …. wait for it … BY ADDING `\n` CHARS! so our encoding is busted in 3.7.9.

so, after trying a bunch of values in the test, I truncated the original From address we receive to 32 chars so we don’t end up with a `\n` char in there.