### PR TITLE
bug 1685570 - Fx85 omits Origin from addon requests

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -84,7 +84,7 @@ def _index_POST(request):
             user=user_profile.user
         )
         if locked_profile.num_active_address >= settings.MAX_NUM_FREE_ALIASES:
-            if 'moz-extension' in request.headers.get('Origin', ''):
+            if not settings.SITE_ORIGIN in request.headers.get('Origin', ''):
                 return HttpResponse('Payment Required', status=402)
             messages.error(
                 request, "You already have 5 email addresses. Please upgrade."
@@ -92,7 +92,7 @@ def _index_POST(request):
             return redirect('profile')
         relay_address = RelayAddress.make_relay_address(locked_profile.user)
 
-    if 'moz-extension' in request.headers.get('Origin', ''):
+    if not settings.SITE_ORIGIN in request.headers.get('Origin', ''):
         address_string = '%s@%s' % (
             relay_address.address, relay_from_domain(request)['RELAY_DOMAIN']
         )


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1685570 ...

Firefox 85+ is sending `Origin: null` in HTTP requests from add-ons. Our back-end code looks for `Origin: moz-extension://...` to send a JSON response back to add-on requests. This is breaking the addon button functionality in Firefox 85+ (release since Jan 26).

Instead of looking for `moz-extension` in the requests, we can look to see that `Origin` is *NOT* the site origin. (This change has no effect on the auth check - that's a different check that the request includes a proper api token.)