### PR TITLE
fix #789: show users when they are "bounce paused"

### DIFF
--- a/emails/tests/model_tests.py
+++ b/emails/tests/model_tests.py
@@ -1,12 +1,17 @@
+from datetime import datetime, timedelta, timezone
 from hashlib import sha256
 from unittest.mock import patch
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
 
 from model_bakery import baker
 
-from ..models import CannotMakeAddressException, DeletedAddress, RelayAddress
+from ..models import (
+    CannotMakeAddressException, DeletedAddress, RelayAddress,
+    Profile
+)
 
 
 class RelayAddressTest(TestCase):
@@ -45,3 +50,177 @@ class RelayAddressTest(TestCase):
         except CannotMakeAddressException:
             return
         self.fail("Should have raise CannotMakeAddressException")
+
+
+class ProfileTest(TestCase):
+    def setUp(self):
+        self.profile = baker.make(Profile)
+
+    def test_bounce_paused_no_bounces(self):
+        bounce_paused, bounce_type = self.profile.check_bounce_pause()
+
+        assert bounce_paused == False
+        assert bounce_type == ''
+
+    def test_bounce_paused_hard_bounce_pending(self):
+        self.profile.last_hard_bounce = (
+            datetime.now(timezone.utc) -
+            timedelta(days=settings.HARD_BOUNCE_ALLOWED_DAYS-1)
+        )
+        self.profile.save()
+
+        bounce_paused, bounce_type = self.profile.check_bounce_pause()
+
+        assert bounce_paused == True
+        assert bounce_type == 'hard'
+
+    def test_bounce_paused_soft_bounce_pending(self):
+        self.profile.last_soft_bounce = (
+            datetime.now(timezone.utc) -
+            timedelta(days=settings.SOFT_BOUNCE_ALLOWED_DAYS-1)
+        )
+        self.profile.save()
+
+        bounce_paused, bounce_type = self.profile.check_bounce_pause()
+
+        assert bounce_paused == True
+        assert bounce_type == 'soft'
+
+    def test_bounce_paused_hardd_and_soft_bounce_pending_shows_hard(self):
+        self.profile.last_hard_bounce = (
+            datetime.now(timezone.utc) -
+            timedelta(days=settings.HARD_BOUNCE_ALLOWED_DAYS-1)
+        )
+        self.profile.last_soft_bounce = (
+            datetime.now(timezone.utc) -
+            timedelta(days=settings.SOFT_BOUNCE_ALLOWED_DAYS-1)
+        )
+        self.profile.save()
+        bounce_paused, bounce_type = self.profile.check_bounce_pause()
+
+        assert bounce_paused == True
+        assert bounce_type == 'hard'
+
+    def test_bounce_paused_hard_bounce_over_resets_timer(self):
+        self.profile.last_hard_bounce = (
+            datetime.now(timezone.utc) -
+            timedelta(days=settings.HARD_BOUNCE_ALLOWED_DAYS+1)
+        )
+        self.profile.save()
+
+        assert self.profile.last_hard_bounce is not None
+
+        bounce_paused, bounce_type = self.profile.check_bounce_pause()
+
+        assert bounce_paused == False
+        assert bounce_type == ''
+        assert self.profile.last_hard_bounce == None
+
+    def test_bounce_paused_soft_bounce_over_resets_timer(self):
+        self.profile.last_soft_bounce = (
+            datetime.now(timezone.utc) -
+            timedelta(days=settings.SOFT_BOUNCE_ALLOWED_DAYS+1)
+        )
+        self.profile.save()
+
+        assert self.profile.last_soft_bounce is not None
+
+        bounce_paused, bounce_type = self.profile.check_bounce_pause()
+
+        assert bounce_paused == False
+        assert bounce_type == ''
+        assert self.profile.last_soft_bounce == None
+
+    def test_next_email_try_no_bounces_returns_today(self):
+        assert (
+            self.profile.next_email_try.date() ==
+            datetime.now(timezone.utc).date()
+        )
+
+    def test_next_email_try_hard_bounce_returns_proper_datemath(self):
+        last_hard_bounce = (
+            datetime.now(timezone.utc) -
+            timedelta(days=settings.HARD_BOUNCE_ALLOWED_DAYS-1)
+        )
+        self.profile.last_hard_bounce = last_hard_bounce
+        self.profile.save()
+
+        expected_next_try_date = last_hard_bounce + timedelta(
+            days=settings.HARD_BOUNCE_ALLOWED_DAYS
+        )
+        assert (
+            self.profile.next_email_try.date() == expected_next_try_date.date()
+        )
+
+    def test_next_email_try_soft_bounce_returns_proper_datemath(self):
+        last_soft_bounce = (
+            datetime.now(timezone.utc) -
+            timedelta(days=settings.SOFT_BOUNCE_ALLOWED_DAYS-1)
+        )
+        self.profile.last_soft_bounce = last_soft_bounce
+        self.profile.save()
+
+        expected_next_try_date = last_soft_bounce + timedelta(
+            days=settings.SOFT_BOUNCE_ALLOWED_DAYS
+        )
+        assert (
+            self.profile.next_email_try.date() == expected_next_try_date.date()
+        )
+
+    def test_next_email_try_hard_and_soft_bounce_returns_hard_datemath(self):
+        last_soft_bounce = (
+            datetime.now(timezone.utc) -
+            timedelta(days=settings.SOFT_BOUNCE_ALLOWED_DAYS-1)
+        )
+        self.profile.last_soft_bounce = last_soft_bounce
+        last_hard_bounce = (
+            datetime.now(timezone.utc) -
+            timedelta(days=settings.HARD_BOUNCE_ALLOWED_DAYS-1)
+        )
+        self.profile.last_hard_bounce = last_hard_bounce
+        self.profile.save()
+
+        expected_next_try_date = last_hard_bounce + timedelta(
+            days=settings.HARD_BOUNCE_ALLOWED_DAYS
+        )
+        assert (
+            self.profile.next_email_try.date() == expected_next_try_date.date()
+        )
+
+    def test_last_bounce_date_no_bounces_returns_None(self):
+        assert self.profile.last_bounce_date == None
+
+    def test_last_bounce_date_soft_bounce_returns_its_date(self):
+        last_soft_bounce = (
+            datetime.now(timezone.utc) -
+            timedelta(days=settings.SOFT_BOUNCE_ALLOWED_DAYS-1)
+        )
+        self.profile.last_soft_bounce = last_soft_bounce
+        self.profile.save()
+
+        assert self.profile.last_bounce_date == self.profile.last_soft_bounce
+
+    def test_last_bounce_date_hard_bounce_returns_its_date(self):
+        last_hard_bounce = (
+            datetime.now(timezone.utc) -
+            timedelta(days=settings.HARD_BOUNCE_ALLOWED_DAYS-1)
+        )
+        self.profile.last_hard_bounce = last_hard_bounce
+        self.profile.save()
+
+        assert self.profile.last_bounce_date == self.profile.last_hard_bounce
+
+    def test_last_bounce_date_hard_and_soft_bounces_returns_hard_date(self):
+        last_soft_bounce = (
+            datetime.now(timezone.utc) -
+            timedelta(days=settings.SOFT_BOUNCE_ALLOWED_DAYS-1)
+        )
+        self.profile.last_soft_bounce = last_soft_bounce
+        last_hard_bounce = (
+            datetime.now(timezone.utc) -
+            timedelta(days=settings.HARD_BOUNCE_ALLOWED_DAYS-1)
+        )
+        self.profile.last_hard_bounce = last_hard_bounce
+        self.profile.save()
+
+        assert self.profile.last_bounce_date == self.profile.last_hard_bounce

--- a/privaterelay/templates/includes/banners.html
+++ b/privaterelay/templates/includes/banners.html
@@ -1,3 +1,15 @@
+    {% if last_bounce_type %}
+<div class="dashboard-banners flx hide-750">
+  <div class="banner-gradient-bg">
+    <div class="bounced-email-banner banner-content flx flx-row">
+      <div class="banner-copy flx flx-col">
+        <p class="banner-hl ff-Met">Relay couldn't deliver your email.</p>
+        <p class="banner-sub">We are currently unable to send email to {{ request.user.email }}. We received a <em>{{ last_bounce_type }}</em> "bounce" from your email provider when trying to forward emails to you. This can happen if Relay couldn't connect to your email provider, or if your mailbox was full. We will try again on {{ next_email_try|date:"SHORT_DATETIME_FORMAT" }}</p>
+      </div>
+    </div>
+  </div>
+</div>
+    {% else %}
 <div class="dashboard-banners flx invisible hide-750">
   <div class="banner-gradient-bg">
     <div class="download-fx-banner banner-content flx flx-row hidden">
@@ -18,3 +30,4 @@
     </div>
   </div>
 </div>
+    {% endif %}

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -64,10 +64,18 @@ def profile(request):
     )
     fxa_account = request.user.socialaccount_set.filter(provider='fxa').first()
     avatar = fxa_account.extra_data['avatar'] if fxa_account else None
+    context = {'relay_addresses': relay_addresses, 'avatar': avatar}
 
-    return render(request, 'profile.html', {
-        'relay_addresses': relay_addresses, 'avatar': avatar
-    })
+    profile = request.user.profile_set.first()
+    bounce_status = profile.check_bounce_pause()
+    if bounce_status.paused:
+        context.update({
+            'last_bounce_type': bounce_status.type,
+            'last_bounce_date': profile.last_bounce_date,
+            'next_email_try': profile.next_email_try
+        })
+
+    return render(request, 'profile.html', context)
 
 
 def version(request):


### PR DESCRIPTION
This adds a new banner on the user dashboard to show them when they are "bounce paused":

- When we received a bounce from their address
- What type of bounce it was
- When we will try to resume delivering email to their address

For examples ...

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/71928/107421877-202d7280-6ae0-11eb-92a9-7fdb5e62c7b7.png">
<img width="1072" alt="image" src="https://user-images.githubusercontent.com/71928/107422206-57038880-6ae0-11eb-9778-7e31b407c5ce.png">

Also refactors a lot of the bounce logic into the `Profile` model; tests incoming.

Note: need to check delivery and bounce recording thru the dev server again since this refactors that code which is hard to test.