### PR TITLE
add micro-survey-banner with nps and pmf questions

### DIFF
--- a/privaterelay/templates/base.html
+++ b/privaterelay/templates/base.html
@@ -16,7 +16,7 @@
     <link rel="shortcut icon" href="{%  static 'images/favicon.ico' %}">
     <link rel=”apple-touch-icon” href="{% static 'images/logos/relay-logo-dark-200.png' %}">
   </head>
-  <body data-fxa-settings-url="{{ settings.FXA_SETTINGS_URL }}" data-site-origin="{{ settings.SITE_ORIGIN }}" data-google-analytics-id="{{ settings.GOOGLE_ANALYTICS_ID }}">
+  <body data-fxa-settings-url="{{ settings.FXA_SETTINGS_URL }}" data-site-origin="{{ settings.SITE_ORIGIN }}" data-google-analytics-id="{{ settings.GOOGLE_ANALYTICS_ID }}" data-debug="{{ settings.DEBUG }}">
     <firefox-private-relay-addon data-addon-installed="false"></firefox-private-relay-addon>
     {% include "includes/modal.html" %}
     {% include "includes/header.html" %}

--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -11,9 +11,18 @@
     </div>
   {% elif not request.user.is_anonymous %}
     <div id="micro-survey-banner" class="micro-survey-banner">
-      {% now "s" as now_second %}
-      {% if now_second|divisibleby:2 %}
+      {% now "U" as now_second %}
+      {% if now_second|last == "1" or now_second|last == "6" %}
         <span id="micro-survey-prompt" data-survey-type="nps">On a scale from 1-10, how likely are you to recommend Relay to a friend or colleague?</span>
+        <ul id="micro-survey-options"></ul>
+      {% elif now_second|last == "2" or now_second|last == "7" %}
+        <span id="micro-survey-prompt" data-survey-type="usability">Is Relay easy to use?</span>
+        <ul id="micro-survey-options"></ul>
+      {% elif now_second|last == "3" or now_second|last == "8" %}
+        <span id="micro-survey-prompt" data-survey-type="credibility">Do you feel confident using Relay?</span>
+        <ul id="micro-survey-options"></ul>
+      {% elif now_second|last == "4" or now_second|last == "9" %}
+        <span id="micro-survey-prompt" data-survey-type="appearance">Does Relay have a clean and simple presentation?</span>
         <ul id="micro-survey-options"></ul>
       {% else %}
         <span id="micro-survey-prompt" data-survey-type="pmf">How would you feel if you could no longer use Relay?</span>

--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -9,6 +9,17 @@
     <div class="recruitment-banner">
       <a id="recruitment-banner" class="text-link" href="{{ settings.RECRUITMENT_BANNER_LINK }}" target="_blank" rel="noopener noreferrer" data-ga="send-ga-funnel-pings" data-event-category="Recruitment" data-event-label="{{ settings.RECRUITMENT_BANNER_TEXT }}">{{ settings.RECRUITMENT_BANNER_TEXT }}</a>
     </div>
+  {% elif not request.user.is_anonymous %}
+    <div id="micro-survey-banner" class="micro-survey-banner">
+      {% now "s" as now_second %}
+      {% if now_second|divisibleby:2 %}
+        <span id="micro-survey-prompt" data-survey-type="nps">On a scale from 1-10, how likely are you to recommend Relay to a friend or colleague?</span>
+        <ul id="micro-survey-options"></ul>
+      {% else %}
+        <span id="micro-survey-prompt" data-survey-type="pmf">How would you feel if you could no longer use Relay?</span>
+        <ul id="micro-survey-options"></ul>
+      {% endif %}
+    </div>
   {% endif %}
 
   <div class="flx flx-row spc-btwn row-full-width header-top">

--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -14,19 +14,19 @@
       {% now "U" as now_second %}
       {% if now_second|last == "1" or now_second|last == "6" %}
         <span id="micro-survey-prompt" data-survey-type="nps">On a scale from 1-10, how likely are you to recommend Relay to a friend or colleague?</span>
-        <ul id="micro-survey-options" class="micro-survey-options micro-survey-options-nps"></ul>
+        <ul id="micro-survey-options" class="micro-survey-options micro-survey-options-numeric"></ul>
       {% elif now_second|last == "2" or now_second|last == "7" %}
         <span id="micro-survey-prompt" data-survey-type="usability">Is Relay easy to use?</span>
-        <ul id="micro-survey-options" class="micro-survey-options micro-survey-options-pmf"></ul>
+        <ul id="micro-survey-options" class="micro-survey-options micro-survey-options-likert"></ul>
       {% elif now_second|last == "3" or now_second|last == "8" %}
-        <span id="micro-survey-prompt" data-survey-type="credibility">Do you feel confident using Relay?</span>
-        <ul id="micro-survey-options" class="micro-survey-options micro-survey-options-pmf"></ul>
+        <span id="micro-survey-prompt" data-survey-type="credibility">Do you feel Relay is trustworthy?</span>
+        <ul id="micro-survey-options" class="micro-survey-options micro-survey-options-likert"></ul>
       {% elif now_second|last == "4" or now_second|last == "9" %}
         <span id="micro-survey-prompt" data-survey-type="appearance">Does Relay have a clean and simple presentation?</span>
-        <ul id="micro-survey-options" class="micro-survey-options micro-survey-options-pmf"></ul>
+        <ul id="micro-survey-options" class="micro-survey-options micro-survey-options-likert"></ul>
       {% else %}
         <span id="micro-survey-prompt" data-survey-type="pmf">How would you feel if you could no longer use Relay?</span>
-        <ul id="micro-survey-options" class="micro-survey-options micro-survey-options-pmf"></ul>
+        <ul id="micro-survey-options" class="micro-survey-options micro-survey-options-likert"></ul>
       {% endif %}
     </div>
   {% endif %}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -431,24 +431,38 @@ header {
   transition: all 0.5s ease;
 }
 
-.recruitment-banner {
+.recruitment-banner, .micro-survey-banner {
   text-align: center;
   position: relative;
   padding: 1em;
 }
 
-#recruitment-banner {
+#micro-survey-options {
+  padding: 0;
+}
+
+.nps-bookend {
   color: #FFFFFF;
   text-decoration: none;
   font-family: var(--metropolis);
   display: inline-block;
+  padding: 0 1em;
 }
 
-#recruitment-banner:hover {
+#recruitment-banner, .micro-survey-option {
+  color: #FFFFFF;
+  text-decoration: none;
+  font-family: var(--metropolis);
+  display: inline-block;
+  padding: 0 1em;
+}
+
+#recruitment-banner:hover, .micro-survey-option:hover {
+  cursor: pointer;
   text-decoration: underline;
 }
 
-.recruitment-banner::after {
+.recruitment-banner::after, .micro-survey-banner::after {
   height: 1px;
   background: var(--fxGradient);
   content: "";
@@ -1834,6 +1848,10 @@ input.input-has-error {
 @media screen and (max-width: 800px) {
   .relay-stat {
     margin-left: 2em;
+  }
+
+  #micro-survey-banner {
+    display: none;
   }
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -464,7 +464,7 @@ header {
 }
 
 
-.micro-survey-options-nps .micro-survey-option {
+.micro-survey-options-numeric .micro-survey-option {
     width: 2.5rem;
     height: 2.5rem;
     display: flex;
@@ -473,7 +473,7 @@ header {
 }
 
 
-.micro-survey-options-pmf .micro-survey-option {
+.micro-survey-options-likert .micro-survey-option {
     padding: 0.5rem 0.75rem;
 }
 

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -156,10 +156,10 @@ function analyticsSurveyLogic() {
       notLikely.textContent = "Not likely";
       notLikely.classList = "nps-bookend";
       surveyOptions.appendChild(notLikely);
-      [...Array(11).keys()].forEach(option => {
+      [...Array(10).keys()].forEach(option => {
         const li = document.createElement("li");
         li.classList = "micro-survey-option";
-        li.textContent = option;
+        li.textContent = option + 1;
         li.dataset.eventCategory = "NPS Survey";
         li.dataset.eventAction = "submitted";
         li.dataset.eventValue = option;

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -153,7 +153,7 @@ function analyticsSurveyLogic() {
       notLikely.textContent = "Not likely";
       notLikely.classList = "nps-bookend";
       surveyOptions.appendChild(notLikely);
-      Array.from([...Array(10).keys()], (x, i) => i + 1).forEach(option => {
+      [...Array(11).keys()].forEach(option => {
         const li = document.createElement("li");
         li.classList = "micro-survey-option";
         li.textContent = option;
@@ -210,6 +210,28 @@ function analyticsSurveyLogic() {
         li.dataset.ga = "send-ga-funnel-pings";
         li.addEventListener("click", setSurveyedCookie);
         surveyOptions.appendChild(li);
+      });
+      break;
+    }
+    case "usability":
+    case "credibility":
+    case "appearance": {
+      const options = [
+        "Strongly disagree", "Disagree", "Agree", "Strongly agree"
+      ];
+      let eventValue = 1;
+      options.forEach(option => {
+        const li = document.createElement("li");
+        li.classList = "micro-survey-option";
+        li.textContent = option;
+        li.dataset.eventCategory = "PMF Survey";
+        li.dataset.eventAction = "submitted";
+        li.dataset.eventLabel = option;
+        li.dataset.eventValue = eventValue;
+        li.dataset.ga = "send-ga-funnel-pings";
+        li.addEventListener("click", setSurveyedCookie);
+        surveyOptions.appendChild(li);
+        eventValue++;
       });
       break;
     }

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -219,6 +219,17 @@ function analyticsSurveyLogic() {
     case "usability":
     case "credibility":
     case "appearance": {
+      let countMetric = "metric4";
+      let rankMetric = "metric5";
+      if (surveyType === "credibility") {
+        countMetric = "metric6";
+        rankMetric = "metric7";
+      }
+      if (surveyType === "appearance") {
+        countMetric = "metric8";
+        rankMetric = "metric9";
+      }
+
       const options = [
         "Strongly disagree", "Disagree", "Unsure", "Agree", "Strongly agree"
       ];
@@ -227,14 +238,28 @@ function analyticsSurveyLogic() {
         const li = document.createElement("li");
         li.classList = "micro-survey-option";
         li.textContent = option;
-        li.dataset.eventCategory = "PMF Survey";
+        li.dataset.eventCategory = "SUPR-Q Survey";
         li.dataset.eventAction = "submitted";
         li.dataset.eventLabel = option;
         li.dataset.eventValue = eventValue;
         li.dataset.ga = "send-ga-funnel-pings";
         li.addEventListener("click", setSurveyedCookie);
-        surveyOptions.appendChild(li);
-        eventValue++;
+        li.addEventListener("click", (evt) => {
+          const eventData = li.dataset;
+          const gaFieldsObject = {
+              [countMetric]: 1,
+              [rankMetric]: eventData.eventValue
+          };
+          ga("send", "event",
+            eventData.eventCategory,
+            eventData.eventAction,
+            eventData.eventLabel,
+            eventData.eventValue,
+            gaFieldsObject
+          );
+          surveyOptions.appendChild(li);
+          eventValue++;
+        });
       });
       break;
     }

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -220,7 +220,7 @@ function analyticsSurveyLogic() {
     case "credibility":
     case "appearance": {
       const options = [
-        "Strongly disagree", "Disagree", "Agree", "Strongly agree"
+        "Strongly disagree", "Disagree", "Unsure", "Agree", "Strongly agree"
       ];
       let eventValue = 1;
       options.forEach(option => {

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -173,7 +173,6 @@ function analyticsSurveyLogic() {
           li.dataset.eventLabel = "promoter";
           li.dataset.npsValue = 1;
         }
-        li.dataset.ga = "send-ga-funnel-pings";
         li.addEventListener("click", (evt) => {
           const eventData = li.dataset;
           ga("send", "event",
@@ -210,8 +209,16 @@ function analyticsSurveyLogic() {
         li.dataset.eventCategory = "PMF Survey";
         li.dataset.eventAction = "submitted";
         li.dataset.eventLabel = option;
-        li.dataset.ga = "send-ga-funnel-pings";
         li.addEventListener("click", setSurveyedCookie);
+        li.addEventListener("click", (evt) => {
+          const eventData = li.dataset;
+          ga("send", "event",
+            eventData.eventCategory,
+            eventData.eventAction,
+            eventData.eventLabel,
+            eventData.eventValue,
+          );
+        });
         surveyOptions.appendChild(li);
       });
       break;
@@ -238,11 +245,10 @@ function analyticsSurveyLogic() {
         const li = document.createElement("li");
         li.classList = "micro-survey-option";
         li.textContent = option;
-        li.dataset.eventCategory = "SUPR-Q Survey";
+        li.dataset.eventCategory = `SUPR-Q Survey ${surveyType}`;
         li.dataset.eventAction = "submitted";
         li.dataset.eventLabel = option;
         li.dataset.eventValue = eventValue;
-        li.dataset.ga = "send-ga-funnel-pings";
         li.addEventListener("click", setSurveyedCookie);
         li.addEventListener("click", (evt) => {
           const eventData = li.dataset;
@@ -257,9 +263,9 @@ function analyticsSurveyLogic() {
             eventData.eventValue,
             gaFieldsObject
           );
-          surveyOptions.appendChild(li);
-          eventValue++;
         });
+        eventValue++;
+        surveyOptions.appendChild(li);
       });
       break;
     }
@@ -272,10 +278,15 @@ function analyticsSurveyLogic() {
 // Check for DoNotTrack header before running GA script
 
 if (!_dntEnabled()) {
+  const jsPath = document.body.dataset.debug ? "analytics_debug.js" : "analytics.js";
   (function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments);},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m);
-    })(window,document,"script","https://www.google-analytics.com/analytics.js","ga");
+    })(window,document,"script",`https://www.google-analytics.com/${jsPath}`,"ga");
+
+  if (document.body.dataset.debug) {
+    window.ga_debug = {trace: true};
+  }
     ga("create", document.body.dataset.googleAnalyticsId);
     ga("set", "anonymizeIp", true);
     ga("set", "transport", "beacon");

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -163,10 +163,10 @@ function analyticsSurveyLogic() {
         li.dataset.eventCategory = "NPS Survey";
         li.dataset.eventAction = "submitted";
         li.dataset.eventValue = option + 1;
-        if (option < 7) {
+        if (option < 6) {
           li.dataset.eventLabel = "detractor";
           li.dataset.npsValue = -1;
-        } else if (option < 9) {
+        } else if (option < 8) {
           li.dataset.eventLabel = "passive";
           li.dataset.npsValue = 0;
         } else {

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -162,7 +162,7 @@ function analyticsSurveyLogic() {
         li.textContent = option + 1;
         li.dataset.eventCategory = "NPS Survey";
         li.dataset.eventAction = "submitted";
-        li.dataset.eventValue = option;
+        li.dataset.eventValue = option + 1;
         if (option < 7) {
           li.dataset.eventLabel = "detractor";
           li.dataset.npsValue = -1;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -216,12 +216,12 @@ function resetBodyPadding() {
 }
 
 function recruitmentLogic() {
-  const recruitmentBannerLink = document.querySelector('#recruitment-banner');
+  const recruitmentBannerLink = document.querySelector("#recruitment-banner");
   if (!recruitmentBannerLink) {
     return;
   }
 
-  const recruited = document.cookie.split('; ').some((item) => item.trim().startsWith('recruited='));
+  const recruited = document.cookie.split("; ").some((item) => item.trim().startsWith("recruited="));
   if (recruited) {
     recruitmentBannerLink.parentElement.remove();
     return;


### PR DESCRIPTION
Adds a new banner along the top of the site for micro-surveys to track our NPS and PMF scores. The logic is essentially:

* If we're running a survey *recruitment* banner, that takes precedence over everything
* Else, flip a digital 50/50 coin and show either the NPS question or the PMF question
* If a user has answered either micro-survey in the last 30 days, don't show the survey again