### PR TITLE
Fix #806 - Fade out copied success message after 5 seconds

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -653,15 +653,33 @@ table {
 }
 
 .relay-address.alias-copied {
-  opacity: 1 !important;
   text-decoration: none !important;
 }
 
-
-.relay-address.alias-copied.alias-copied-fadeout .alias-copied-message {
-  opacity: 0 !important;
+.alias-copied-fadeout .alias-copied-message {
+  animation-duration: 4s;
+  animation-name: fadeOut;
+  animation-fill-mode: forwards;
 }
 
+.alias-copied-fadeout .alias-copied-icon {
+  opacity: 0;
+  animation-delay: 3s;
+  animation-duration: 0.1s;
+  animation-name: fadeOut;
+  animation-direction: reverse;
+  animation-fill-mode: forwards;
+}
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
 
 .alias-copied-icon {
   width: 18px;
@@ -683,12 +701,7 @@ table {
   pointer-events: none;
 }
 
-.alias-copied .alias-copied-icon {
-  display: none;
-}
-
-.alias-copied-message,
-.alias-copied .alias-copied-icon {
+.alias-copied-message {
   visibility: hidden;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -657,6 +657,12 @@ table {
   text-decoration: none !important;
 }
 
+
+.relay-address.alias-copied.alias-copied-fadeout .alias-copied-message {
+  opacity: 0 !important;
+}
+
+
 .alias-copied-icon {
   width: 18px;
   height: 18px;
@@ -694,6 +700,7 @@ table {
   color: var(--white);
   font-size: 14px;
   right: 0;
+  transition: opacity 2s ease-out;
 }
 
 .alias-copied .alias-copied-message {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -91,27 +91,19 @@ async function sendForm(formAction, formData) {
 function copyToClipboardAndShowMessage(triggeringEl) {
   const aliasCopyBtn = triggeringEl;
   const previouslyCopiedAlias = document.querySelector(".alias-copied");
-  
-  if (previouslyCopiedAlias) {
+
+  if (previouslyCopiedAlias || previouslyCopiedAlias == triggeringEl) {
     previouslyCopiedAlias.classList.remove("alias-copied", "alias-copied-fadeout");
     previouslyCopiedAlias.title = "Copy alias to clipboard";
   }
-  
-  aliasCopyBtn.classList.add("alias-copied");
-  aliasCopyBtn.title="Alias copied to clipboard";
 
-  // Countdown timer to fade out the "Copied" message after 5 seconds of being displayed
-  let copyMessageCountdown = 0;
-  const copyMessageCountdownInterval = setInterval(function() {
-      copyMessageCountdown++;
-      if (copyMessageCountdown == 5) {
-          aliasCopyBtn.classList.add("alias-copied-fadeout");
-      } else if (copyMessageCountdown == 7) {
-          aliasCopyBtn.classList.remove("alias-copied", "alias-copied-fadeout");
-          aliasCopyBtn.title = "Copy alias to clipboard";
-          clearInterval(copyMessageCountdownInterval);
-      }
-  }, 1000);
+  setTimeout(() => { 
+    triggeringEl.classList.add("alias-copied", "alias-copied-fadeout");
+    triggeringEl.title="Alias copied to clipboard";
+   }, 10);
+
+  
+  
 
   return;
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -91,12 +91,28 @@ async function sendForm(formAction, formData) {
 function copyToClipboardAndShowMessage(triggeringEl) {
   const aliasCopyBtn = triggeringEl;
   const previouslyCopiedAlias = document.querySelector(".alias-copied");
+  
   if (previouslyCopiedAlias) {
-    previouslyCopiedAlias.classList.remove("alias-copied");
+    previouslyCopiedAlias.classList.remove("alias-copied", "alias-copied-fadeout");
     previouslyCopiedAlias.title = "Copy alias to clipboard";
   }
+  
   aliasCopyBtn.classList.add("alias-copied");
   aliasCopyBtn.title="Alias copied to clipboard";
+
+  // Countdown timer to fade out the "Copied" message after 5 seconds of being displayed
+  let copyMessageCountdown = 0;
+  const copyMessageCountdownInterval = setInterval(function() {
+      copyMessageCountdown++;
+      if (copyMessageCountdown == 5) {
+          aliasCopyBtn.classList.add("alias-copied-fadeout");
+      } else if (copyMessageCountdown == 7) {
+          aliasCopyBtn.classList.remove("alias-copied", "alias-copied-fadeout");
+          aliasCopyBtn.title = "Copy alias to clipboard";
+          clearInterval(copyMessageCountdownInterval);
+      }
+  }, 1000);
+
   return;
 }
 


### PR DESCRIPTION
## Testing

1. Go to http://127.0.0.1:8000/accounts/profile/
2. Create multiple aliases
3. Click copy.
4. **Expected**: Message should fade out and reset to copy symbol after 5 seconds. 
5. **Expected**: Clicking copy on multiple messages should reset the other email _(matches current functionality) _

Screenshot: 
<img width="314" alt="image" src="https://user-images.githubusercontent.com/2692333/115472059-a364f600-a1fe-11eb-8130-334374191a68.png">

Fading away: 
<img width="310" alt="image" src="https://user-images.githubusercontent.com/2692333/115472147-e2934700-a1fe-11eb-8105-3195adcd74cf.png">

