### PR TITLE
Handle errors properly on Emails

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -16,7 +16,7 @@ emails_config = apps.get_app_config('emails')
 
 BounceStatus = namedtuple('BounceStatus', 'paused type')
 
-NOT_PREMIUM_USER_ERR_MSG = 'You must be a premium subscriber to set a subdomain.'
+NOT_PREMIUM_USER_ERR_MSG = 'You must be a premium subscriber to {}.'
 TRY_DIFFERENT_VALUE_ERR_MSG = '{} could not be created, try using a different value.'
 
 
@@ -114,7 +114,7 @@ class Profile(models.Model):
 
     def add_subdomain(self, subdomain):
         if not self.has_unlimited:
-            raise CannotMakeSubdomainException(NOT_PREMIUM_USER_ERR_MSG)
+            raise CannotMakeSubdomainException(NOT_PREMIUM_USER_ERR_MSG.format('set a subdomain'))
         if self.subdomain is not None:
             raise CannotMakeSubdomainException('You cannot change your subdomain.')
         subdomain_exists = Profile.objects.filter(subdomain=subdomain)
@@ -205,7 +205,10 @@ class RelayAddress(models.Model):
             user_profile.at_max_free_aliases
             and not user_profile.has_unlimited
         ):
-            raise CannotMakeAddressException(NOT_PREMIUM_USER_ERR_MSG)
+            hit_limit = f'make more than {settings.MAX_NUM_FREE_ALIASES} alises'
+            raise CannotMakeAddressException(
+                NOT_PREMIUM_USER_ERR_MSG.format(hit_limit)
+            )
         if num_tries >= 5:
             raise CannotMakeAddressException
         relay_address = RelayAddress.objects.create(user=user_profile.user)
@@ -253,7 +256,9 @@ class DomainAddress(models.Model):
 
     def make_domain_address(user_profile, address=None, made_via_email=False):
         if not user_profile.has_unlimited:
-            raise CannotMakeAddressException(NOT_PREMIUM_USER_ERR_MSG)
+            raise CannotMakeAddressException(
+                NOT_PREMIUM_USER_ERR_MSG.format('create subdomain aliases')
+            )
 
         user_subdomain = Profile.objects.get(user=user_profile.user).subdomain
         if not user_subdomain:

--- a/emails/models.py
+++ b/emails/models.py
@@ -205,7 +205,7 @@ class RelayAddress(models.Model):
             user_profile.at_max_free_aliases
             and not user_profile.has_unlimited
         ):
-            hit_limit = f'make more than {settings.MAX_NUM_FREE_ALIASES} alises'
+            hit_limit = f'make more than {settings.MAX_NUM_FREE_ALIASES} aliases'
             raise CannotMakeAddressException(
                 NOT_PREMIUM_USER_ERR_MSG.format(hit_limit)
             )
@@ -267,7 +267,7 @@ class DomainAddress(models.Model):
             )
 
         address_contains_badword = False
-        if address is None:
+        if not address:
             # FIXME: if the alias is randomly generated and has bad words
             # we should retry like make_relay_address does
             # not fixing this now because not sure randomly generated

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -89,7 +89,9 @@ class RelayAddressTest(TestCase):
             for i in range(settings.MAX_NUM_FREE_ALIASES + 1):
                 RelayAddress.make_relay_address(self.user_profile)
         except CannotMakeAddressException as e:
-            assert e.message == NOT_PREMIUM_USER_ERR_MSG
+            assert e.message == NOT_PREMIUM_USER_ERR_MSG.format(
+                f'make more than {settings.MAX_NUM_FREE_ALIASES} aliases'
+            )
             relay_addresses = RelayAddress.objects.filter(
                 user=self.user_profile.user
             ).values_list("address", flat=True)
@@ -331,7 +333,7 @@ class ProfileTest(TestCase):
         try:
             non_premium_profile.add_subdomain(subdomain)
         except CannotMakeSubdomainException as e:
-            assert e.message == NOT_PREMIUM_USER_ERR_MSG
+            assert e.message == NOT_PREMIUM_USER_ERR_MSG.format('set a subdomain')
             return
         self.fail("Should have raised CannotMakeSubdomainException")
 
@@ -432,7 +434,7 @@ class DomainAddressTest(TestCase):
         try:
             DomainAddress.make_domain_address(non_preimum_user_profile)
         except CannotMakeAddressException as e:
-            assert e.message == NOT_PREMIUM_USER_ERR_MSG
+            assert e.message == NOT_PREMIUM_USER_ERR_MSG.format('create subdomain aliases')
             return
         self.fail("Should have raise CannotMakeAddressException")
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -103,8 +103,7 @@ def _index_POST(request):
                 return HttpResponse(e.message, status=402)
             messages.error(
                 request,
-                "You already have %s email addresses. Please upgrade." %
-                settings.MAX_NUM_FREE_ALIASES
+                e.message
             )
             return redirect('profile')
 

--- a/privaterelay/templates/includes/domain-alias-dashboard.html
+++ b/privaterelay/templates/includes/domain-alias-dashboard.html
@@ -6,20 +6,20 @@
   <div class="remaining-aliases-wrapper flx al-cntr jst-cntr hide-750"></div>
   <span class="remaining-aliases flx">
     <span class="num-remaining-aliases bold">
-      {{ relay_addresses|length }} aliases. You can make unlimited!
+      {{ domain_addresses|length }} aliases. You can make unlimited!
     </span>
   </span>
 </div>
 <div class="flx flx-row flx-end inset wrap-col-600">
   <form action="/emails/" class="dash-create" method="POST">
     <input type="hidden" name="api_token" value="{{ user_profile.api_token }}">
-    {% if user_profile.at_max_free_aliases and not user_profile.has_unlimited %}
+    {% if user_profile.has_unlimited and not user_profile.subdomain %}
     <button
         class="blue-btn-states dash-create-new-relay flx al-cntr jst-cntr btn-disabled"
-        title="You have reached the alias limit."
+        title="You must choose a subdomain before generating aliases."
         type="submit"
         value="Generate new alias"
-        data-event-label="Create New Relay Alias"
+        data-event-label="Create New Domain Alias"
     >
     {% else %}
     <button
@@ -27,7 +27,7 @@
         title="Generate new alias"
         type="submit"
         value="Generate new alias"
-        data-event-label="Create New Relay Alias"
+        data-event-label="Create New Domain Alias"
     >
     {% endif %}
     <span class="generate-new-relay-icon"></span>

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -113,7 +113,7 @@ def profile_subdomain(request):
     try:
         profile.add_subdomain(request.POST.get('subdomain', None))
     except CannotMakeSubdomainException as e:
-        message.error(request, e.message)
+        messages.error(request, e.message)
     return redirect(reverse('profile'))
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2274,3 +2274,49 @@ input.input-has-error {
     opacity: 1;
   }
 }
+
+.messages.home-messages {
+  background: var(--warningRed);
+}
+
+ul.messages {
+  max-height: 50px;
+  display: flex;
+  border-radius: 8px;
+  padding: 0;
+}
+
+.js-notification {
+  position: relative;
+  width: 100%;
+  padding: 1rem;
+  align-items: center;
+  display: flex;
+  
+  border-radius: 8px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.dismiss {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 1rem;
+  margin: auto;
+  outline: none;
+  border: none;
+  background: var(--lightestGray);
+  height: 32px;
+  width: 32px;
+  border-radius: 50%;
+  padding: 5px;
+}
+
+.home-messages span {
+  color: #fff;
+}
+
+.home-messages path {
+  fill: #fff;
+}


### PR DESCRIPTION
# About this PR
Fast follow to fix some dev tested errors on #808. Some fixes include:
- adding helpful messages on the disabled button
<img width="1282" alt="Screen Shot 2021-05-04 at 14 23 36" src="https://user-images.githubusercontent.com/25109943/117064209-8397fc80-aceb-11eb-9c75-aa0d18c3bd5f.png">

- making the errors be more helpful
- formatting errors on the profile page (has been broken since this [change](https://github.com/mozilla/fx-private-relay/commit/0b534d452255aadf23fa03a4b6e3cfabfdc4dbce#diff-a5ea33c888430601a659bcbef2da1944097953737f2606282efc13ca6e5fbaba))
![image (16)](https://user-images.githubusercontent.com/25109943/117066834-db843280-acee-11eb-8b21-e1bad443aca3.png)

