### PR TITLE
Get display name from profile

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -101,6 +101,12 @@ class Profile(models.Model):
         return self.user.socialaccount_set.filter(provider='fxa').first()
 
     @property
+    def display_name(self):
+        # if display name is not set on FxA the
+        # displayName key will not exist on the extra_data
+        return self.fxa.extra_data.get('displayName')
+
+    @property
     def has_unlimited(self):
         # FIXME: as we don't have all the tiers defined we are over-defining
         # this to mark the user as a premium user as well

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -381,6 +381,26 @@ class ProfileTest(TestCase):
             return
         self.fail("Should have raised CannotMakeSubdomainException")
 
+    def test_display_name_exists(self):
+        display_name = 'Display Name'
+        social_account = baker.make(
+            SocialAccount,
+            provider='fxa',
+            extra_data={'displayName': display_name}
+        )
+        profile = Profile.objects.get(user=social_account.user)
+        assert profile.display_name == display_name
+
+    def test_display_name_does_not_exist(self):
+        social_account = baker.make(
+            SocialAccount,
+            provider='fxa',
+            extra_data={}
+        )
+        profile = Profile.objects.get(user=social_account.user)
+        assert profile.display_name == None
+        
+
 
 class DomainAddressTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
# About this PR
According to FxA document on keys and values returned for a given profile [here](https://github.com/mozilla/fxa/blob/main/packages/fxa-profile-server/docs/API.md#get-v1profile), the display name is under the extra data of a Social Account authorized from FxA. However, if display name is not set, the `displayName` key will not show up on the `extra_data`.

#
Related to #872