### PR TITLE
Updating circleci config to user dockerhub auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ jobs:
   build:
     docker:
       - image: docker:stable-git
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     working_directory: /dockerflow
     steps:
       - checkout
@@ -42,6 +45,9 @@ jobs:
   test:
     docker:
       - image: docker:18.02.0-ce
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     steps:
       - setup_remote_docker
       - restore_cache:
@@ -57,6 +63,9 @@ jobs:
   deploy:
     docker:
       - image: docker:18.02.0-ce
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     steps:
       - setup_remote_docker
       - restore_cache:
@@ -105,4 +114,4 @@ workflows:
             tags:
               ignore: /addon-.*/
             branches:
-              only: master
+              only: main


### PR DESCRIPTION
Regarding: https://support.circleci.com/hc/en-us/articles/360050623311-Docker-Hub-rate-limiting-FAQ

Before this change we were getting warning messages in CircleCI mentioned in the support FAQ:
```
Warning: No authentication provided, using CircleCI credentials for pulls from Docker Hub.
```

After this change, the CircleCI run no longer shows this warning. Taken from the example here: https://github.com/mozilla-services/Dockerflow/blob/8aa28daed38aa55de42e9248e1e0ac4bac33b0c8/.circleci/config.yml

Closes https://github.com/mozilla/fx-private-relay/issues/711