### PR TITLE
Fix #910 - Update "Create New Alias" logic for max-alias users

### DIFF
--- a/privaterelay/templates/includes/dashboard-filter.html
+++ b/privaterelay/templates/includes/dashboard-filter.html
@@ -28,17 +28,35 @@
         <form action="{% url 'emails-index' %}" class="dash-create" method="POST">
             <input type="hidden" name="api_token" value="{{ user_profile.api_token }}">
             {% if user_profile.at_max_free_aliases and not user_profile.has_unlimited %}
-            <a
-                href="{{ settings.FXA_SUBSCRIPTIONS_URL }}/products/{{ settings.PREMIUM_PROD_ID }}?plan={{ settings.PREMIUM_PRICE_ID }}"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="btn btn-blue--ghost"
-                data-event-label="Upgrade"
+
+                {% if settings.PREMIUM_ENABLED %}
+                    <a
+                        href="{{ settings.FXA_SUBSCRIPTIONS_URL }}/products/{{ settings.PREMIUM_PROD_ID }}?plan={{ settings.PREMIUM_PRICE_ID }}"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="btn btn-blue--ghost"
+                        data-event-label="Upgrade"
+                    >
+                    <span class="generate-new-alias-text">
+                        {% ftlmsg 'profile-label-upgrade' %}
+                    </span>
+                    </a>
+
+                {% else %}
+
+                    <button 
+                disabled
+                type="submit"
+                class="blue-btn-states dash-create-new-relay flx al-cntr jst-cntr btn-disabled"
+                title="{% ftlmsg 'profile-label-generate-new-alias' %}"
+                value="{% ftlmsg 'profile-label-generate-new-alias' %}"
             >
+              <span class="generate-new-relay-icon"></span>
               <span class="generate-new-alias-text">
-                {% ftlmsg 'profile-label-upgrade' %}
-              </span>
-            </a>
+              {% ftlmsg 'profile-label-generate-new-alias' %}</span>
+            </button>
+
+                {% endif %}
 
             {% else %}
             <button

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -385,6 +385,7 @@ button:active {
 
 .btn-disabled {
   opacity: 0.9;
+  cursor: not-allowed;
 }
 
 .sign-in {


### PR DESCRIPTION
Add additional logic to only show 'Get unlimited button' to PREMIUM_ENABLED flagged env

## Testing:

**Premium turned OFF**

- Set ENV variable `PREMIUM_ENABLED` to `False`
- Log into Relay on production
- Create 5/maximum alises
- **Expected**: "Generate New Alias" button should be visible but dimmed/disabled.

**Premium turned ON**
- Set ENV variable `PREMIUM_ENABLED` to `True`
- Log into Relay on production
- Create 5/maximum alises
- **Expected**: Button reads "Get unlimited aliases" and links to FXA
