### PR TITLE
Fix #898 - Update VPN promo banner copy

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,42 +3,36 @@ const sass = require("gulp-sass");
 const del = require("del");
 
 // directory for building LESS, SASS, and bundles
-const buildDir = "static/scss/libs/protocol/";
-const finalDir = "static/css/";
+const buildDir = "./static/scss/libs/protocol/";
+const finalDir = "./static/css/";
 
-function clean(cb) {
-    del([
+function clean() {
+    return del([
         finalDir
     ]);
-    cb();
 }
 
-function reset(cb) {
-    del([
+function reset() {    
+    return del([
         finalDir,
         buildDir,
     ]);
-    cb();
 }
 
-function styles(cb) {
-    src("static/scss/app.scss")
+function styles() {
+    return src("./static/scss/app.scss")
         .pipe(sass().on("error", sass.logError))
         .pipe(dest(finalDir));
-
-    cb();
 }
 
-function assetsCopy(cb) {
-    src(["node_modules/@mozilla-protocol/core/protocol/**/*"]).pipe(dest(buildDir));
-    cb();
+function assetsCopy() { 
+    return src(["./node_modules/@mozilla-protocol/core/protocol/**/*"]).pipe(dest(buildDir));
 }
 
 exports.build = series(reset, assetsCopy, styles);
-
 exports.default = series(
     clean, assetsCopy, styles, function() {
         // You can use a single task
-        watch("static/scss/**/*.scss", { ignoreInitial: false }, series(clean, styles));
+        watch("./static/scss/**/*.scss", { ignoreInitial: false }, series(clean, styles));
     }
 );

--- a/privaterelay/locales/en-US/app.ftl
+++ b/privaterelay/locales/en-US/app.ftl
@@ -250,6 +250,6 @@ survey-option-not-likely = Not likely
 vpn-promo-headline = Now’s the time to boost your safety online.
 vpn-promo-copy = { -brand-name-mozilla }’s Virtual Private Network helps shield your internet connection from hackers and spies. 
 vpn-promo-cta = Get { -brand-name-mozilla-vpn }
-vpn-promo-price-headline = Introductory offer ends soon: $4.99/month for { -brand-name-mozilla-vpn }
-vpn-promo-price-copy = Now's the time to protect your device against hackers and prying eyes.
-vpn-promo-price-disclaimer = Offer only available in the United States, United Kingdom, Canada, New Zealand, Malaysia, and Singapore
+
+vpn-promo-price-headline = Now’s the time to boost your safety online.
+vpn-promo-price-copy = Mozilla’s Virtual Private Network helps shield your internet connection from hackers and spies.

--- a/privaterelay/locales/en-US/app.ftl
+++ b/privaterelay/locales/en-US/app.ftl
@@ -247,9 +247,6 @@ survey-option-not-likely = Not likely
 
 ## VPN Promo Banner
 
-vpn-promo-headline = Now’s the time to boost your safety online.
-vpn-promo-copy = { -brand-name-mozilla }’s Virtual Private Network helps shield your internet connection from hackers and spies. 
+vpn-promo-headline = Save 50% with a full year subscription
+vpn-promo-copy = Protect your online data—and choose a VPN subscription plan that works for you.
 vpn-promo-cta = Get { -brand-name-mozilla-vpn }
-
-vpn-promo-price-headline = Now’s the time to boost your safety online.
-vpn-promo-price-copy = Mozilla’s Virtual Private Network helps shield your internet connection from hackers and spies.

--- a/privaterelay/templates/includes/vpn-promo-banner.html
+++ b/privaterelay/templates/includes/vpn-promo-banner.html
@@ -9,9 +9,8 @@
 		<div class="vpn-promo-copy">
 			<strong>{% ftlmsg 'vpn-promo-price-headline' %}</strong>
 			<span>{% ftlmsg 'vpn-promo-price-copy' %}</span>
-			<small>{% ftlmsg 'vpn-promo-price-disclaimer' %}</small>
 		</div>
-		<a class="vpn-promo-cta" href="https://www.mozilla.org/products/vpn/?utm_source=relay&utm_medium=banner&utm_campaign=intro-pricing">{% ftlmsg 'vpn-promo-cta' %}</a>
+		<a class="vpn-promo-cta" href="https://www.mozilla.org/products/vpn/?utm_source=relay&utm_medium=banner&utm_campaign=mozillavpn-relay-top-banner">{% ftlmsg 'vpn-promo-cta' %}</a>
 		<button id="vpnPromoCloseButton" type="button" name="button" data-event-category="vpn-promo-close"><img src="{% static 'images/x-close-black.svg' %}"/></button>
 	</div>
 </div>

--- a/privaterelay/templates/includes/vpn-promo-banner.html
+++ b/privaterelay/templates/includes/vpn-promo-banner.html
@@ -7,8 +7,8 @@
 	<div class="vpn-promo-banner-wrapper">
 		<img alt="Mozilla VPN" class="vpn-promo-logo" src="{% static 'images/logos/mozilla-vpn.svg' %}"/>
 		<div class="vpn-promo-copy">
-			<strong>{% ftlmsg 'vpn-promo-price-headline' %}</strong>
-			<span>{% ftlmsg 'vpn-promo-price-copy' %}</span>
+			<strong>{% ftlmsg 'vpn-promo-headline' %}</strong>
+			<span>{% ftlmsg 'vpn-promo-copy' %}</span>
 		</div>
 		<a class="vpn-promo-cta" href="https://www.mozilla.org/products/vpn/?utm_source=private-relay&utm_medium=banner&utm_campaign=relay-banner">{% ftlmsg 'vpn-promo-cta' %}</a>
 		<button id="vpnPromoCloseButton" type="button" name="button" data-event-category="vpn-promo-close"><img src="{% static 'images/x-close-black.svg' %}"/></button>

--- a/privaterelay/templates/includes/vpn-promo-banner.html
+++ b/privaterelay/templates/includes/vpn-promo-banner.html
@@ -10,7 +10,7 @@
 			<strong>{% ftlmsg 'vpn-promo-price-headline' %}</strong>
 			<span>{% ftlmsg 'vpn-promo-price-copy' %}</span>
 		</div>
-		<a class="vpn-promo-cta" href="https://www.mozilla.org/products/vpn/?utm_source=relay&utm_medium=banner&utm_campaign=mozillavpn-relay-top-banner">{% ftlmsg 'vpn-promo-cta' %}</a>
+		<a class="vpn-promo-cta" href="https://www.mozilla.org/products/vpn/?utm_source=private-relay&utm_medium=banner&utm_campaign=relay-banner">{% ftlmsg 'vpn-promo-cta' %}</a>
 		<button id="vpnPromoCloseButton" type="button" name="button" data-event-category="vpn-promo-close"><img src="{% static 'images/x-close-black.svg' %}"/></button>
 	</div>
 </div>

--- a/static/scss/partials/vpn-promo.scss
+++ b/static/scss/partials/vpn-promo.scss
@@ -40,23 +40,23 @@ body {
 }
 
 .vpn-promo-banner-wrapper {
-  max-width: 1000px;
+  max-width: $content-lg;
   margin: 0 auto;
-  padding: 1rem 2rem;
+  padding: $spacing-md $spacing-xl;
   text-align: center;
 }
 
 .vpn-promo-logo {
   display: block;
   max-width: 122px;
-  margin: 0 auto 1rem;
+  margin: 0 auto $spacing-md;
 }
 
 .vpn-promo-copy {
   text-align: center;
   font-size: 1rem;
-  max-width: 320px;
-  margin: 0 auto 1rem;
+  max-width: $content-sm;
+  margin: 0 auto $spacing-md;
   line-height: 1.2rem;
   color: var(--inkDark);
 }
@@ -64,15 +64,6 @@ body {
 .vpn-promo-copy strong, .vpn-promo-copy span {
   display: block;
   margin: 0 0 2px;
-}
-
-.vpn-promo-copy small {
-  padding-top: 2px;
-  display: block;
-  font-size: 0.65rem;
-  margin: 0 auto;
-  line-height: normal;
-  font-style: italic;
 }
 
 .vpn-promo-banner a {
@@ -85,8 +76,8 @@ body {
   font-size: 1.125rem;
   font-weight: bold;
   line-height: 1.5rem;
-  padding: 0.5rem 1rem;
-  margin-bottom: 1rem;
+  padding: $spacing-sm $spacing-md;
+  margin-bottom: $spacing-md;
   position: relative;
   text-decoration: none;
   transition: background-color 0.15s ease, color 0.15s ease;
@@ -103,7 +94,7 @@ body {
   -moz-appearance: none;
   -webkit-appearance: none;
   position: absolute;
-  top: 0.5rem;
+  top: $spacing-sm;
   right: 0;
   border: none;
   outline: none;
@@ -134,6 +125,8 @@ body {
 
   .vpn-promo-copy {
     flex-shrink: 2;
+    max-width: none;
+    padding: 0 $spacing-md;
   }
 
   .vpn-promo-copy strong {
@@ -160,32 +153,23 @@ body {
     }
     padding-top: 10rem;
   }
-
-  .vpn-promo-copy small {
-    max-width: 400px;
-  }
-
 }
 
 @media screen and (min-width: 800px) {
   .vpn-promo-copy {
-    max-width: none;
-    padding: 0 1rem;
+    padding: 0 $spacing-md;
   }
 
   .vpn-banner-visible main {
     padding-top: 5rem;
   }
   
-  .vpn-promo-copy small {
-    max-width: none;
-  }
 }
 
 @media screen and (min-width: 960px) {
   .vpn-promo-banner button {
-    top: 0.25rem;
-    right: 0.25rem;
+    top: $spacing-xs;
+    right: $spacing-xs;
   }
   .vpn-promo-banner a {
     flex-shrink: 0;

--- a/static/scss/partials/vpn-promo.scss
+++ b/static/scss/partials/vpn-promo.scss
@@ -11,10 +11,6 @@ body {
   display: none;
 }
 
-// .vpn-banner-visible .micro-survey-banner {
-//   display: none;
-// }
-
 .vpn-promo-banner {
   background-color: var(--background);
   font-family: "Metropolis", sans-serif;
@@ -125,7 +121,6 @@ body {
 
   .vpn-promo-copy {
     flex-shrink: 2;
-    max-width: none;
     padding: 0 $spacing-md;
   }
 

--- a/static/scss/partials/vpn-promo.scss
+++ b/static/scss/partials/vpn-promo.scss
@@ -95,6 +95,7 @@ body {
   border: none;
   outline: none;
   display: block;
+  background-color: transparent;
 }
 
 .vpn-promo-banner button:hover img {


### PR DESCRIPTION
### ⚠️  **NOTE: DO NOT MERGE/DEPLOY UNTIL TUESDAY, JULY 13TH** ⚠️

This PR removes the current pricing promo from the VPN banner. The new strings match what is also on Monitor. 

**Note that because this app is not currently localized, this promo will appear to ALL USERS, only in English.** 

Preview: 
![image](https://user-images.githubusercontent.com/2692333/125337335-7d8a5180-e314-11eb-9dee-609d02a3d364.png)


## Testing

- Clear any previous cookies for `mozgcp.net` if you have tested this this banner previously) 
- Go to homepage (https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/) 
- **Expected:** See VPN banner at top of the page with the following text: 
  - Headline: _Now’s the time to boost your safety online._
  - Body copy: _Mozilla’s Virtual Private Network helps shield your internet connection from hackers and spies._ 