### PR TITLE
Fix #918 - Add Color to Settings Hover State

### DIFF
--- a/static/scss/partials/glocal-menu.scss
+++ b/static/scss/partials/glocal-menu.scss
@@ -103,6 +103,7 @@ glocal-menu {
 .glocal-fxa-settings-link:hover,
 .glocal-fxa-settings-link:focus {
   text-decoration: underline;
+  color: var(--grey50);
 }
 
 .glocal-fxa-settings-link:active {


### PR DESCRIPTION
I added a color property to the hover state, perhaps this may get it to become visible. It works fine locally. 


