### PR TITLE
Fix #925 - Make CTA text visible on banners

### DIFF
--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -1705,6 +1705,7 @@ input.input-has-error {
 
 .banner-link:focus {
   box-shadow: var(--buttonFocus);
+  color: var(--blue4);
   outline: none;
 }
 


### PR DESCRIPTION
Added color property to :focus selector so that the links stay visible. 

