### PR TITLE
Fix #971 - Add border-radius and box shadow to error message

### DIFF
--- a/privaterelay/templates/includes/messages.html
+++ b/privaterelay/templates/includes/messages.html
@@ -1,7 +1,7 @@
 {% if messages %}
 	{% for message in messages %}
-		<div class="messages home-messages">
-			<div{% if message.tags %} class="{{ message.tags }}" {% else %} class="" {% endif %}>
+		<div class="messages">
+			<div{% if message.tags %} class="message-wrapper {{ message.tags }}" {% else %} class="" {% endif %}>
 				<div class="js-notification">
 					<span>{{ message }}</span>
 					<button class="flx center-value dismiss js-dismiss">

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -2291,22 +2291,31 @@ input.input-has-error {
   width: 100%;
   padding: $spacing-lg $spacing-md 0 $spacing-md;
   margin: 0 auto;
-}
 
-.messages > div {
-  background-color: $color-grey-50
-}
+  span {
+    color: $color-white;
+    text-align: center;
+    width: 100%;
+    font-weight: 600;
+  }
 
-.messages .success {
-  background-color: $color-success;
-  border-radius: $border-radius-md;
-  box-shadow: var(--dropShadowLight);
-}
+  path {
+    fill: $color-white;
+  }
 
-.messages .error {
-  background-color: $color-error;
-  border-radius: $border-radius-md;
-  box-shadow: var(--dropShadowLight);
+  .message-wrapper {
+    border-radius: $border-radius-md;
+    box-shadow: var(--dropShadowLight);
+  }
+
+  .success {
+    background-color: $color-success;
+  }
+
+  .error {
+    background-color: $color-error;
+  }
+
 }
 
 ul.messages {
@@ -2344,15 +2353,4 @@ ul.messages {
     fill: $color-white !important; 
   }
 
-}
-
-.home-messages span {
-  color: $color-white;
-  text-align: center;
-  width: 100%;
-  font-weight: 600;
-}
-
-.home-messages path {
-  fill: $color-white;
 }

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -2305,6 +2305,8 @@ input.input-has-error {
 
 .messages .error {
   background-color: $color-error;
+  border-radius: $border-radius-md;
+  box-shadow: var(--dropShadowLight);
 }
 
 ul.messages {


### PR DESCRIPTION
Added `border-radius` and `box-shadow` to the `.error` class. 

Note: The color/box-shadow variable has yet to be updated to follow Protocol/Nebula convention. The Figma reference is dated at the moment.