### PR TITLE
Fix #958 - Add focus effect to avatar icon

### DIFF
--- a/static/scss/partials/glocal-menu.scss
+++ b/static/scss/partials/glocal-menu.scss
@@ -46,8 +46,8 @@ glocal-menu {
   transition: all 0.2s ease;
 }
 
-.avatar-wrapper:hover {
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 1), 0 0 0px 5px rgba(255, 255, 255, .3);
+.avatar-wrapper:hover, .avatar-wrapper:focus {
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 1), 0 0 0px 5px rgba(255, 255, 255, .3    );
   transition: all 0.2s ease;
 }
 

--- a/static/scss/partials/glocal-menu.scss
+++ b/static/scss/partials/glocal-menu.scss
@@ -47,7 +47,7 @@ glocal-menu {
 }
 
 .avatar-wrapper:hover, .avatar-wrapper:focus {
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 1), 0 0 0px 5px rgba(255, 255, 255, .3    );
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 1), 0 0 0px 5px rgba(255, 255, 255, .3);
   transition: all 0.2s ease;
 }
 


### PR DESCRIPTION
Pressing tab now shows the `:focus` effect for the avatar icon, and remains when selected.

Demo/Preview:

https://user-images.githubusercontent.com/13066134/127700716-a3306a83-9d68-491b-9626-e8f70fe0adbf.mov

