### PR TITLE
Fix #996 - Stop alias name from flickering

### DIFF
--- a/static/scss/partials/dashboard.scss
+++ b/static/scss/partials/dashboard.scss
@@ -185,10 +185,9 @@
 
 .c-alias-name {
     margin-left: $spacing-xs;
-    max-width: 100%;
+    max-width: $content-sm;
     height: 100%;
     flex-wrap: nowrap;
-    width: $content-sm;
 
     .additional-notes, .relay-address {
         text-overflow: ellipsis;


### PR DESCRIPTION
**Flickering on hover has stopped, check demo:**


https://user-images.githubusercontent.com/13066134/128577819-4b11e632-c05a-488b-9ab5-9c2a344097fd.mov


