### PR TITLE
Fix #977 - Add tooltip to avatar icon

### DIFF
--- a/privaterelay/locales/en-US/app.ftl
+++ b/privaterelay/locales/en-US/app.ftl
@@ -34,6 +34,7 @@ logo-alt= { -brand-name-firefox-relay }
 nav-menu = Menu
 nav-home = Home
 label-open-menu = Open menu
+avatar-tooltip = Profile
 
 # FAQ stands for Frequently Asked Questions. The intent of this page is to answer commonly asked questions.
 nav-faq = FAQ

--- a/privaterelay/templates/includes/login.html
+++ b/privaterelay/templates/includes/login.html
@@ -19,7 +19,7 @@
 	{% else %}
 		{% get_social_accounts request.user as accounts %}
 		<glocal-menu class="glocal-menu">
-			<button class="avatar-wrapper" aria-label="{% ftlmsg 'label-open-menu' %}">
+			<button class="avatar-wrapper" aria-label="{% ftlmsg 'label-open-menu' %}" title="{% ftlmsg 'avatar-tooltip' %}">
 				<img class="avatar" src="{{ avatar }}" alt="{% ftlmsg 'nav-profile-image-alt' %}" />
 			</button>
 			<div class="glocal-menu-wrapper">


### PR DESCRIPTION
Preview:
![image](https://user-images.githubusercontent.com/13066134/128778934-d093b50d-89f6-4faa-a936-b66e4a11dee3.png)


Note: Discussed with Chris about what to add as the tooltip, he suggest `Profile` since its just alt-text.