### PR TITLE
Redis env var

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -254,12 +254,12 @@ DATABASES = {
     )
 }
 
-REDIS_CACHE_URL = config('REDIS_CACHE_URL', '', cast=str)
-if REDIS_CACHE_URL:
+REDIS_URL = config('REDIS_URL', '', cast=str)
+if REDIS_URL:
     CACHES = {
         "default": {
             "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": REDIS_CACHE_URL,
+            "LOCATION": REDIS_URL,
             "OPTIONS": {
                 "CLIENT_CLASS": "django_redis.client.DefaultClient",
             }
@@ -267,12 +267,6 @@ if REDIS_CACHE_URL:
     }
     SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
     SESSION_CACHE_ALIAS = 'default'
-
-    # When running on heroku we need to ignore invalid TLS certs
-    # https://devcenter.heroku.com/articles/heroku-redis#connecting-in-django
-    if ON_HEROKU:
-        CACHES['default']['OPTIONS']['CONNECTION_POOL_KWARGS'] = {"ssl_cert_reqs": None}
-
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -268,6 +268,12 @@ if REDIS_CACHE_URL:
     SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
     SESSION_CACHE_ALIAS = 'default'
 
+    # When running on heroku we need to ignore invalid TLS certs
+    # https://devcenter.heroku.com/articles/heroku-redis#connecting-in-django
+    if ON_HEROKU:
+        CACHES['default']['OPTIONS']['CONNECTION_POOL_KWARGS'] = {"ssl_cert_reqs": None}
+
+
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators
 


### PR DESCRIPTION
In order to work better with Heroku, we should change `REDIS_CACHE_URL` to `REDIS_URL`: https://devcenter.heroku.com/articles/heroku-redis#connecting-in-django

Confirmed this is working by logging into dev, and seeing a new key was created with redis-cli.