### PR TITLE
Fix #965 - Reset button/item count overlaps search input query on fil…

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -13,6 +13,7 @@
     "at-rule-no-unknown": null,
     "color-hex-case": "upper",
     "declaration-block-semicolon-newline-after": "always",
+    "function-url-quotes": "always",
     "indentation": 4,
     "no-descending-specificity": null,
     "number-leading-zero": "never",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint .",
     "lint:css": "stylelint static/scss/",
-    "lint:css-fix": "stylelint --fix static/scss/",
+    "lint:fix-css": "stylelint --fix static/scss/",
     "test": "echo \"Error: no test specified\" && exit 1"
   }
 }

--- a/privaterelay/templates/includes/dashboard-filter.html
+++ b/privaterelay/templates/includes/dashboard-filter.html
@@ -7,14 +7,16 @@
         <div class="c-filter-icon c-filter-icon-search js-filter-mobile-search-toggle"></div>
         <form class="js-filter-search-form c-filter-search-form" action="">
             <input class="c-filter-search-input js-filter-search-input " type="search" name="search" id="search" placeholder="{% ftlmsg 'profile-filter-search-placeholder' %}" >
-            <div class="c-filter-case-count">
-                <span class="js-filter-case-visible"></span>
-                /
-                <span class="js-filter-case-total"></span>
+            <div class="c-filter-search-controls">
+                <div class="c-filter-case-count">
+                    <span class="js-filter-case-visible"></span>
+                    /
+                    <span class="js-filter-case-total"></span>
+                </div>
+                <button aria-label="{% ftlmsg 'profile-label-reset' %}" type="reset" class="c-filter-reset js-filter-reset">
+                    <img alt="Reset" src="{% static '/images/x-close.svg' %}"/>
+                </button>
             </div>
-            <button aria-label="{% ftlmsg 'profile-label-reset' %}" type="reset" class="c-filter-reset js-filter-reset">
-                <img alt="Reset" src="{% static '/images/x-close.svg' %}"/>
-            </button>
         </form>
     </div>
     <div class="c-filter-date hidden">

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -530,5 +530,8 @@ function dismissSurvey() {
 	survey_banner.classList.toggle("is-hidden");
 }
 
-document.getElementById("survey-dismiss").addEventListener("click", dismissSurvey, false);
+if ( document.getElementById("survey-dismiss") ) {
+  document.getElementById("survey-dismiss").addEventListener("click", dismissSurvey, false);
+}
+
 

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -25,16 +25,23 @@
 
     filterToggleSearchInput.addEventListener("click", toggleAliasSearchBar, false);
 
-	function filterInputWatcher(e) {
+	function filterInputWatcher(input) {
 
-		const query = e.target.value.toLowerCase();
+        let query = input;
+        
+        if (input.target) {
+            query = input.target.value.toLowerCase();
+        }   
 
         // Reset filter if the input is empty, however, do not steal focus to input
         if (query === "") resetFilter({focus: false});
 
+        // Add class to keep the reset button visible while a query has been entered
+        filterInput.classList.add("is-filtered");
+
 		// Hide all cases
 		aliases.forEach(alias => {
-            alias.style.display = "none";
+            alias.classList.add("is-hidden");
         });
 
         // Fix GitHub/#966: Create temporary array of objects containing labels and their parent `.js-alias` DOM element
@@ -61,13 +68,13 @@
         for (const alias of matchListEmailAddresses) {
             let index = filterEmailAddresses.indexOf(alias);
             if (index >= 0) {
-                aliasCollection[index].style.display = "block";
+                aliasCollection[index].classList.remove("is-hidden");
             }
         }
 
         // Show aliases with labels that match the search query
         for (const result of matchListAliasLabels) {        
-            result.alias.style.display = "block";
+            result.alias.classList.remove("is-hidden");
         }
 
 	}
@@ -117,7 +124,7 @@
 
         // Hide the search function and end early if the user has no aliases created. 
         if (aliases.length < 1) {
-            filterForm.style.display = "none";
+            filterForm.classList.add("is-hidden");
             return;
         }
 
@@ -149,6 +156,12 @@
         filterLabelVisibleCases.textContent = aliases.length;
         filterLabelTotalCases.textContent = aliases.length;
 
+        // Filter aliases on page load if the search already has a query in it. 
+        if (filterInput.value) {
+            toggleAliasSearchBar(); 
+            filterInputWatcher(filterInput.value);
+        }
+
 		filterInput.addEventListener("input", filterInputWatcher, false);
         filterInput.addEventListener("keydown", e => {
           if(e.keyIdentifier=="U+000A"||e.keyIdentifier=="Enter"||e.keyCode==13){
@@ -166,10 +179,11 @@
     function resetFilter(opts) {
         filterLabelVisibleCases.textContent = aliases.length;
         filterLabelTotalCases.textContent = aliases.length;
+        filterInput.classList.remove("is-filtered");
         filterInput.value = "";
 
         aliases.forEach(alias => {
-            alias.style.display = "block";
+            alias.classList.remove("is-hidden");
         });
 
         if (opts && opts.focus) {

--- a/static/scss/components/filter-bar.scss
+++ b/static/scss/components/filter-bar.scss
@@ -46,21 +46,29 @@
     input[type="search"] {
         background-image: url(/static/images/icon-search.svg);
         margin-bottom: 0;
-        padding-right: 1.75rem;
-        &:focus + .c-filter-case-count {
-            opacity: .5;
-        }
-        &:focus + .c-filter-case-count + .c-filter-reset {
+        padding-right: 90px;
+        position: relative;
+        z-index: 0;
+        &:focus + .c-filter-search-controls {
             opacity: 1;
         }
     }
 
+    .c-filter-search-controls {
+        position: absolute;
+        right: $spacing-sm;
+        display: flex;
+        align-items: center;
+        height: 100%;
+        top: 0;
+        z-index: 1;
+        opacity: 0;
+        transition: opacity .2s ease-out;
+    }
+
     .c-filter-case-count {
         display: flex;
-        opacity: 0;
-        position: absolute;
-        right: 2.5rem;
-        top: 0;
+        margin-right: $spacing-sm;
         align-items: center;
         height: 100%;
         transition: opacity .2s ease-out;
@@ -141,10 +149,6 @@
     outline: 0;
     appearance: none;
     border: 0;
-    position: absolute;
-    right: .5rem;
-    top: .5rem;
-    opacity: 0;
 
     img {
         width: 1rem;

--- a/static/scss/components/filter-bar.scss
+++ b/static/scss/components/filter-bar.scss
@@ -2,6 +2,12 @@
     display: flex;
     align-items: center;
     margin-bottom: $spacing-md;
+
+    .c-filter-search-form {
+        &.is-hidden {
+            display: none;
+        }
+    }
     
     &.is-search-active {
         margin-bottom: 4.5rem;
@@ -19,6 +25,7 @@
             width: 100%;
         }
     }
+    
 
     @media screen and (min-width: 768px) {
         justify-content: flex-end;
@@ -43,14 +50,21 @@
         position: relative;
     }
 
-    input[type="search"] {
-        background-image: url(/static/images/icon-search.svg);
+    .c-filter-search-input {
+        background-image: url("/static/images/icon-search.svg");
         margin-bottom: 0;
         padding-right: 90px;
         position: relative;
         z-index: 0;
+        &.is-filtered + .c-filter-search-controls {
+            opacity: 1;
+        }
+
         &:focus + .c-filter-search-controls {
             opacity: 1;
+        }
+        &:focus, &:hover {
+            background-image: url("/static/images/icon-search-blue.svg");
         }
     }
 
@@ -114,23 +128,24 @@
 
 .c-filter-icon-search {
     background-size: auto 1.25rem;
-    background-image: url(/static/images/icon-search.svg);
+    background-image: url("/static/images/icon-search.svg");
     &.is-enabled, &:hover {
-        background-image: url(/static/images/icon-search-blue.svg);        
+        background-image: url("/static/images/icon-search-blue.svg");        
     }
 }
 
 .c-filter-icon-calendar {
-    background-image: url(/static/images/icon-calendar.svg);
+    background-image: url("/static/images/icon-calendar.svg");
     &.is-enabled, &:hover {
-        background-image: url(/static/images/icon-calendar-blue.svg);        
+        background-image: url("/static/images/icon-calendar-blue.svg");        
     }
 }
 
 .c-filter-icon-filter {
-    background-image: url(/static/images/icon-filter.svg);
+    background-image: url("/static/images/icon-filter.svg");
+           
     &.is-enabled, &:hover {
-        background-image: url(/static/images/icon-filter-blue.svg);        
+        background-image: url("/static/images/icon-filter-blue.svg");        
     }
 }
 

--- a/static/scss/partials/dashboard.scss
+++ b/static/scss/partials/dashboard.scss
@@ -172,6 +172,9 @@
     &.is-enabled {
         background-color: $color-white;
     }
+    &.is-hidden {
+        display: none;
+    }
 }
 
 .c-alias-main-info {

--- a/static/scss/partials/header.scss
+++ b/static/scss/partials/header.scss
@@ -178,7 +178,7 @@ header {
     position: absolute;
     display: flex;
     align-items: center;
-    background-image: url(/static/images/arrowhead-white.svg);
+    background-image: url("/static/images/arrowhead-white.svg");
     background-repeat: no-repeat;
     background-position: center;
     top: 0;
@@ -336,7 +336,7 @@ header {
     }
 
     .mobile-menu-label::after {
-        background-image: url(/static/images/arrowhead.svg);
+        background-image: url("/static/images/arrowhead.svg");
     }
 
     @media screen and (max-width: 690px) {

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -394,7 +394,7 @@ ul {
 }
 
 .dashboard-mpp-promo {
-    background: url(/static/images/polygon-background-small.png) center right no-repeat;
+    background: url("/static/images/polygon-background-small.png") center right no-repeat;
     background-color: $color-white;
     background-size: contain;
 }
@@ -506,7 +506,7 @@ table {
 .alias-copied-icon {
     width: 18px;
     height: 18px;
-    background-image: url(/static/images/copy-to-clipboard.svg);
+    background-image: url("/static/images/copy-to-clipboard.svg");
     background-repeat: no-repeat;
     background-size: contain;
     top: 0;

--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -36,7 +36,7 @@
 }
 
 .c-onboarding-step-number {
-    background: url(/static/images/dashboard-onboarding/shield.svg) center center no-repeat;
+    background: url("/static/images/dashboard-onboarding/shield.svg") center center no-repeat;
     background-size: contain;
     width: 100%;
     height: 45px;


### PR DESCRIPTION
This PR fixes: 
- Issue where the reset button/item count overlaps search input query on filter bar
- Use case where user refreshes page while items are being filtered
  - Including showing the search bar on mobile 
- Use case where a user has filtered aliases and is not focused on the search query input but wants to reset
- Protocol / JS optimizations 
- Issue where page throws JS error bc element is not visible 

STR: 
- Go to Relay dashboard
- Enter long string (longer than the width of the input box) into the search filter bar
-  **Expected:** The input should "stop" before the `X/X` number of items visible/total. 
