### PR TITLE
eventValue determines NPS segment; not array index

### DIFF
--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -168,10 +168,10 @@ function analyticsSurveyLogic() {
         li.dataset.eventCategory = "NPS Survey";
         li.dataset.eventAction = "submitted";
         li.dataset.eventValue = option + 1;
-        if (option <= 6) {
+        if (li.dataset.eventValue <= 6) {
           li.dataset.eventLabel = "detractor";
           li.dataset.npsValue = -1;
-        } else if (option <= 8) {
+        } else if (li.dataset.eventValue <= 8) {
           li.dataset.eventLabel = "passive";
           li.dataset.npsValue = 0;
         } else {


### PR DESCRIPTION
We run a Net Promoter Score micro-survey in the site banner for signed-in users. (i.e., "How likely are you to recommend ...")

We disabled this banner while we ran the VPN banner instead.

When I [restored this banner](https://github.com/mozilla/fx-private-relay/pull/975), I thought I was also fixing the NPS value logic. (In NPS, 9-10 is considered a "promoter", 7-8 is a "passive", and 1-6 is a "detractor"). But, the code was looking at the value of the `option` variable, which is the array index value - i.e., it starts at 0 and goes to 9, not 10.

But when I looked at the Google Analytics report for NPS, I saw the *average* score for promoters was 10.00! As if there were ZERO people picking "9" in the survey.

So, this fixes the code to use the real event value (i.e., the 1-10 value) rather than the array index value to determine if the choice is "promoter", "passive", or "detractor".