### PR TITLE
Fix #963 - Set path of vpnBannerDismissed cookie to root

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -512,7 +512,7 @@ function vpnBannerLogic() {
     setCookie: function() {
       const date = new Date();
       date.setTime(date.getTime() + 30*24*60*60*1000);
-      document.cookie = "vpnBannerDismissed=true; expires=" + date.toUTCString();
+      document.cookie = "vpnBannerDismissed=true; expires=" + date.toUTCString() + "; path=/";
     },
     show: function() {
       vpnPromoBanner.classList.remove("closed");


### PR DESCRIPTION
Hey there,

First of all, cool product! :)

I just had a look at #963 and saw that you're not specifying the path of the `vpnBannerDismissed` cookie.
Since the cookie path defaults to the current one, the VPN banner will show up again because it's only available in `/accounts/profile/` (in the scenario described in the issue, but should also work the other way around and on the other pages). 
I've updated the `setCookie` function to create the cookie for the entire domain.