### PR TITLE
add endpoint for checking subdomain availability

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -40,6 +40,12 @@ class Profile(models.Model):
     def __str__(self):
         return '%s Profile' % self.user
 
+    @staticmethod
+    def subdomain_available(subdomain):
+        bad_word = has_bad_words(subdomain)
+        taken = len(Profile.objects.filter(subdomain=subdomain)) > 0
+        return not bad_word and not taken
+
     @property
     def num_active_address(self):
         return RelayAddress.objects.filter(user=self.user).count()
@@ -137,8 +143,8 @@ class Profile(models.Model):
             raise CannotMakeSubdomainException(NOT_PREMIUM_USER_ERR_MSG.format('set a subdomain'))
         if self.subdomain is not None:
             raise CannotMakeSubdomainException('You cannot change your subdomain.')
-        subdomain_exists = Profile.objects.filter(subdomain=subdomain)
-        if not subdomain or has_bad_words(subdomain) or subdomain_exists:
+        subdomain_available = Profile.subdomain_available(subdomain)
+        if not subdomain or not subdomain_available:
             raise CannotMakeSubdomainException(TRY_DIFFERENT_VALUE_ERR_MSG.format('Subdomain'))
         self.subdomain = subdomain
         self.save()

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -381,6 +381,24 @@ class ProfileTest(TestCase):
             return
         self.fail("Should have raised CannotMakeSubdomainException")
 
+    def test_subdomain_available_bad_word_returns_False(self):
+        assert Profile.subdomain_available('angry') == False
+
+    def test_subdomain_available_taken_returns_False(self):
+        premium_user = baker.make(User)
+        random_sub = random.choice(
+            settings.SUBSCRIPTIONS_WITH_UNLIMITED.split(',')
+        )
+        baker.make(
+            SocialAccount,
+            user=premium_user,
+            provider='fxa',
+            extra_data={'subscriptions': [random_sub]}
+        )
+        premium_profile = Profile.objects.get(user=premium_user)
+        premium_profile.add_subdomain('thisisfine')
+        assert Profile.subdomain_available('thisisfine') == False
+
     def test_display_name_exists(self):
         display_name = 'Display Name'
         social_account = baker.make(


### PR DESCRIPTION
To test:

1. http://127.0.0.1:8000/accounts/profile/subdomain?subdomain=<subdomain-to-check>
   * Note: if your browser session isn't signed in, it should return an error
2. Also verify that you can still register a new subdomain