### PR TITLE
Add add-on data attr if subdomain is set

### DIFF
--- a/privaterelay/templates/profile.html
+++ b/privaterelay/templates/profile.html
@@ -18,6 +18,13 @@
   data-fxa-subscriptions-url="{{ settings.FXA_SUBSCRIPTIONS_URL }}" 
   data-premium-prod-id="{{ settings.PREMIUM_PROD_ID }}" 
   data-premium-price-id="{{ settings.PREMIUM_PRICE_ID }}" 
+  {% if settings.PREMIUM_ENABLED %}
+    {% with request.user.profile_set.first as user_profile %}
+      {% if user_profile.subdomain %}
+        data-premium-subdomain-set="true"
+      {% endif %}
+    {% endwith %}
+  {% endif %}
 >
 </firefox-private-relay-addon-data>
 


### PR DESCRIPTION
Expected: 
If you're a user who is premium AND logged in AND have registered a subdomain, then the data-attr `data-premium-subdomain-set` will be set to `true` in the `firefox-private-relay-addon-data` custom element. 

Otherwise, that data-attr will not exist in the `firefox-private-relay-addon-data` element. 
