### PR TITLE
couple allauth settings to make relay sso work

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -348,6 +348,9 @@ SOCIALACCOUNT_PROVIDERS = {
 }
 
 SOCIALACCOUNT_EMAIL_VERIFICATION = 'none'
+ACCOUNT_USERNAME_REQUIRED=False
+SOCIALACCOUNT_AUTO_SIGNUP=True
+
 
 FXA_SETTINGS_URL = config('FXA_SETTINGS_URL', 'https://accounts.firefox.com/settings')
 FXA_SUBSCRIPTIONS_URL = config('FXA_SUBSCRIPTIONS_URL', 'https://accounts.firefox.com/subscriptions')


### PR DESCRIPTION
Monitor -> Relay SSO is working on local & dev servers, but not on stage.

The problem on stage relay is it kicks into allauth’s “pick a username” flow when my local relay doesn’t do that. 😕  (screenshot below)

It could be that our local relay FXA OAuth client is getting enough data to automatically pick a username for the user and our stage FXA OAuth client isn’t, or something else is going on and I’m not sure what it is.

BUT, I may have a couple allauth settings we can add to stage relay to see if it fixes the issue …
```
ACCOUNT_USERNAME_REQUIRED=False
SOCIALACCOUNT_AUTO_SIGNUP=True
```

These don't affect the regular Relay sign up/in flow on my local, but they may fix the SSO on stage.

![image](https://user-images.githubusercontent.com/71928/131004970-60384f86-4dc0-455c-b759-032d5c089245.png)
