### PR TITLE
Display error message on profile redirect

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -50,8 +50,10 @@ class Profile(models.Model):
     @staticmethod
     def subdomain_available(subdomain):
         bad_word = has_bad_words(subdomain)
-        taken = len(Profile.objects.filter(subdomain=subdomain)) > 0
-        return not bad_word and not taken
+        taken = Profile.objects.filter(subdomain=subdomain).count() > 0
+        if not bad_word and not taken:
+            raise CannotMakeSubdomainException(TRY_DIFFERENT_VALUE_ERR_MSG.format(f'{subdomain} subdomain'))
+        return True
 
     @property
     def num_active_address(self):

--- a/emails/models.py
+++ b/emails/models.py
@@ -51,7 +51,7 @@ class Profile(models.Model):
     def subdomain_available(subdomain):
         bad_word = has_bad_words(subdomain)
         taken = Profile.objects.filter(subdomain=subdomain).count() > 0
-        if not bad_word and not taken:
+        if bad_word or taken:
             raise CannotMakeSubdomainException(TRY_DIFFERENT_VALUE_ERR_MSG.format(f'{subdomain} subdomain'))
         return True
 

--- a/emails/models.py
+++ b/emails/models.py
@@ -52,7 +52,7 @@ class Profile(models.Model):
         bad_word = has_bad_words(subdomain)
         taken = Profile.objects.filter(subdomain=subdomain).count() > 0
         if bad_word or taken:
-            raise CannotMakeSubdomainException(TRY_DIFFERENT_VALUE_ERR_MSG.format(f'{subdomain} subdomain'))
+            raise CannotMakeSubdomainException('error-subdomain-not-available')
         return True
 
     @property
@@ -149,12 +149,12 @@ class Profile(models.Model):
 
     def add_subdomain(self, subdomain):
         if not self.has_unlimited:
-            raise CannotMakeSubdomainException(NOT_PREMIUM_USER_ERR_MSG.format('set a subdomain'))
+            raise CannotMakeSubdomainException('error-premium-set-subdomain')
         if self.subdomain is not None:
-            raise CannotMakeSubdomainException('You cannot change your subdomain.')
+            raise CannotMakeSubdomainException('error-premium-cannot-change-subdomain')
         subdomain_available = Profile.subdomain_available(subdomain)
         if not subdomain or not subdomain_available:
-            raise CannotMakeSubdomainException(TRY_DIFFERENT_VALUE_ERR_MSG.format('Subdomain'))
+            raise CannotMakeSubdomainException('error-subdomain-not-available')
         self.subdomain = subdomain
         self.save()
         return subdomain

--- a/emails/models.py
+++ b/emails/models.py
@@ -51,9 +51,7 @@ class Profile(models.Model):
     def subdomain_available(subdomain):
         bad_word = has_bad_words(subdomain)
         taken = Profile.objects.filter(subdomain=subdomain).count() > 0
-        if bad_word or taken:
-            raise CannotMakeSubdomainException('error-subdomain-not-available')
-        return True
+        return not bad_word and not taken
 
     @property
     def num_active_address(self):

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -382,7 +382,7 @@ class ProfileTest(TestCase):
         try:
             non_premium_profile.add_subdomain(subdomain)
         except CannotMakeSubdomainException as e:
-            assert e.message == NOT_PREMIUM_USER_ERR_MSG.format('set a subdomain')
+            assert e.message == 'error-premium-set-subdomain'
             return
         self.fail("Should have raised CannotMakeSubdomainException")
 
@@ -405,7 +405,7 @@ class ProfileTest(TestCase):
         try:
             premium_profile.add_subdomain(subdomain)
         except CannotMakeSubdomainException as e:
-            assert e.message == 'You cannot change your subdomain.'
+            assert e.message == 'error-premium-cannot-change-subdomain'
             return
         self.fail("Should have raised CannotMakeSubdomainException")
 
@@ -426,7 +426,7 @@ class ProfileTest(TestCase):
         try:
             premium_profile.add_subdomain(subdomain)
         except CannotMakeSubdomainException as e:
-            assert e.message == TRY_DIFFERENT_VALUE_ERR_MSG.format('Subdomain')
+            assert e.message == 'error-subdomain-not-available'
             return
         self.fail("Should have raised CannotMakeSubdomainException")
 

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -131,7 +131,9 @@ class RelayAddressTest(TestCase):
         assert relay_address.get_domain_display() == 'MOZMAIL_DOMAIN'
         assert relay_address.domain_value == 'test.com'
 
-    @override_settings(TEST_MOZMAIL=False, RELAY_FIREFOX_DOMAIN=TEST_DOMAINS['RELAY_FIREFOX_DOMAIN'])
+    @override_settings(
+        TEST_MOZMAIL=False, RELAY_FIREFOX_DOMAIN=TEST_DOMAINS['RELAY_FIREFOX_DOMAIN']
+    )
     @patch('emails.models.DOMAINS', TEST_DOMAINS)
     @patch('emails.models.DEFAULT_DOMAIN', TEST_DOMAINS['RELAY_FIREFOX_DOMAIN'])
     def test_delete_adds_deleted_address_object(self):

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -128,7 +128,10 @@ class GetAddressTest(TestCase):
     @patch('emails.models.DOMAINS', TEST_DOMAINS)
     @patch('emails.views.get_domains_from_settings')
     @patch('emails.views.incr_if_enabled')
-    def test_get_address_with_relay_address_does_not_exist(self, incr_mocked, domains_mocked):
+    @patch('emails.views.logger')
+    def test_get_address_with_relay_address_does_not_exist(
+        self, logging_mocked, incr_mocked, domains_mocked
+    ):
         domains_mocked.return_value = TEST_DOMAINS
         try:
             _get_address(

--- a/emails/views.py
+++ b/emails/views.py
@@ -23,7 +23,6 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 
-from .context_processors import relay_from_domain
 from .models import (
     address_hash,
     CannotMakeAddressException,
@@ -35,7 +34,6 @@ from .models import (
 )
 from .utils import (
     get_domains_from_settings,
-    get_email_domain_from_settings,
     get_post_data_from_request,
     incr_if_enabled,
     histogram_if_enabled,

--- a/privaterelay/templates/includes/messages.html
+++ b/privaterelay/templates/includes/messages.html
@@ -1,11 +1,18 @@
+{% load ftl %}
+{% load relay_tags %}
 {% if messages %}
 	{% for message in messages %}
 		<div class="js-notification messages">
 			<div{% if message.tags %} class="message-wrapper {{ message.tags }}" {% else %} class="" {% endif %}>
+				{% message_in_fluent message.message as in_fluent %}
+				{% if in_fluent %}
+					<span>{% ftlmsg message.message subdomain=user_profile.subdomain unavailable_subdomain=message.extra_tags %}</span>
+				{% else %}
 					<span>{{ message }}</span>
 					<button class="dismiss js-dismiss">
 						<svg class="x-close-icon" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
 					</button>
+				{% endif %}
 			</div>
 		</div>
 	{% endfor %}

--- a/privaterelay/templatetags/relay_tags.py
+++ b/privaterelay/templatetags/relay_tags.py
@@ -15,3 +15,14 @@ def remaining_free_aliases(aliases):
 def user_email_domain(user_profile):
     mail_domain = get_email_domain_from_settings()
     return "%s.%s" % (user_profile.subdomain, mail_domain)
+
+@register.simple_tag
+def message_in_fluent(message):
+    ftl_messages = [
+        'success-subdomain-registered',
+        'error-subdomain-not-available',
+        'error-premium-cannot-change-subdomain',
+        'error-premium-set-subdomain',
+        'error-premium-check-subdomain'
+    ]
+    return message in ftl_messages

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -108,12 +108,13 @@ def profile_subdomain(request):
     profile = request.user.profile_set.first()
     if not profile.has_unlimited:
         raise CannotMakeSubdomainException(NOT_PREMIUM_USER_ERR_MSG.format('check a subdomain'))
-    if request.method == 'GET':
-        subdomain = request.GET.get('subdomain', None)
-        available = Profile.subdomain_available(subdomain)
-        return JsonResponse({'available':available})
     try:
-        profile.add_subdomain(request.POST.get('subdomain', None))
+        if request.method == 'GET':
+            subdomain = request.GET.get('subdomain', None)
+            available = Profile.subdomain_available(subdomain)
+            return JsonResponse({'available': available})
+        else:
+            profile.add_subdomain(request.POST.get('subdomain', None))
     except CannotMakeSubdomainException as e:
         messages.error(request, e.message)
     return redirect(reverse('profile'))

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -115,6 +115,9 @@ def profile_subdomain(request):
             return JsonResponse({'available': available})
         else:
             profile.add_subdomain(request.POST.get('subdomain', None))
+        messages.success(
+            request, f'Your domain @{profile.subdomain} has been created.'
+        )
     except CannotMakeSubdomainException as e:
         messages.error(request, e.message)
     return redirect(reverse('profile'))

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -112,6 +112,8 @@ def profile_subdomain(request):
         if request.method == 'GET':
             subdomain = request.GET.get('subdomain', None)
             available = Profile.subdomain_available(subdomain)
+            if not available:
+                raise CannotMakeSubdomainException('error-subdomain-not-available')
             return JsonResponse({'available': available})
         else:
             subdomain = request.POST.get('subdomain', None)

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -107,19 +107,20 @@ def profile_subdomain(request):
         return redirect(reverse('fxa_login'))
     profile = request.user.profile_set.first()
     if not profile.has_unlimited:
-        raise CannotMakeSubdomainException(NOT_PREMIUM_USER_ERR_MSG.format('check a subdomain'))
+        raise CannotMakeSubdomainException('error-premium-check-subdomain')
     try:
         if request.method == 'GET':
             subdomain = request.GET.get('subdomain', None)
             available = Profile.subdomain_available(subdomain)
             return JsonResponse({'available': available})
         else:
-            profile.add_subdomain(request.POST.get('subdomain', None))
+            subdomain = request.POST.get('subdomain', None)
+            profile.add_subdomain(subdomain)
         messages.success(
-            request, f'Your domain @{profile.subdomain} has been created.'
+            request, 'success-subdomain-registered'
         )
     except CannotMakeSubdomainException as e:
-        messages.error(request, e.message)
+        messages.error(request, e.message, subdomain)
     return redirect(reverse('profile'))
 
 


### PR DESCRIPTION
# About this PR
In order for frontend to give user the ability to check that the subdomain exists, we want to display the error message on the profile banner if the subdomain is not available. Also, if the subdomain is available and the user subsequently registers the subdomain successfully we should display a success message when the user is redirected to profile page.

# Acceptance Criteria
- [x] Subdomain that is unavailable should display an error message on profile banner
- [x] If user already has a subdomain and tries to register another one, error message should be displayed on profile banner
- [x] Subdomain that is successfully registered should display a success message on profile banner
- [x] Error message is on fluent ecosystem to be translated: `error-premium-check-subdomain`, `error-subdomain-not-available`
- [x] Success message is on fluent ecosystem to be translated: `success-subdomain-registered`

# STR
## Subdomain that is not allowed should display an error message on profile banner
1. Get a premium subscription
2. Go to profile and register for a subdomain `poop`
3. Check that you get the following error:
<img width="1233" alt="Screen Shot 2021-09-10 at 11 21 32" src="https://user-images.githubusercontent.com/25109943/132886625-2f068d57-0aa2-41b4-8361-4e8666523213.png">

## Subdomain that is unavailable should display an error message on profile banner
1. Get a premium subscription
2. Go to profile and register for a subdomain that was already registered before
3. Check that you get the following error:
<img width="1233" alt="Screen Shot 2021-09-10 at 11 21 32" src="https://user-images.githubusercontent.com/25109943/132886625-2f068d57-0aa2-41b4-8361-4e8666523213.png">

## Subdomain that is successfully registered should display a success message on profile banner
1. Get a premium subscription
2. Go to profile and register for a valid subdomain
3. Check that you get the following success message:
<img width="1243" alt="Screen Shot 2021-09-10 at 11 21 55" src="https://user-images.githubusercontent.com/25109943/132886814-c7348caf-f5fc-4622-b57e-c196c72bcb2e.png">

##  Subdomain registration while the user already has one display error message on profile banner
1. Get a premium subscription
2. Go to profile page
3. Open another profile page and register for a valid subdomain
4. Go to the profile page that still has the field to register for a subdomain
5. Register a subdomain and check that you get the following error message:
<img width="1248" alt="Screen Shot 2021-09-10 at 11 23 17" src="https://user-images.githubusercontent.com/25109943/132887019-7f701c60-91e9-4ebc-8378-8fdfea213b94.png">

#
Related to #1027
Related to https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/9
Completes [MPP-855](https://mozilla-hub.atlassian.net/browse/MPP-855)
Completes [MPP-871](https://mozilla-hub.atlassian.net/browse/MPP-871)