### PR TITLE
Hide category filter by default

### DIFF
--- a/privaterelay/templates/includes/dashboard-filter.html
+++ b/privaterelay/templates/includes/dashboard-filter.html
@@ -22,80 +22,82 @@
     <div class="c-filter-date hidden">
         <div class="c-filter-icon c-filter-icon-calendar"></div>
     </div>
-    <div class="c-filter-category">
+    <div class="c-filter-category {% if not user_profile.has_unlimited %} hidden {% endif %}">
+        {% if user_profile.has_unlimited %}
         <div class="c-filter-icon c-filter-icon-filter js-filter-category-toggle"></div>
-        <form class="c-filter-category-list">
-            <ul class="c-filter-category-types">
-                <li class="c-filter-category-type">
-                    <div class="mzp-c-choices">
-                        <div class="mzp-c-choice">
-                            <input
-                                data-category-type="active-aliases"
-                                data-parent-category="active"
-                                class="mzp-c-choice-control js-filter-category-checkbox"
-                                type="checkbox" name="Show active aliases"
-                                id="active-aliases"
-                                value=""
-                            >
-                            <label class="mzp-c-choice-label" for="active-aliases">{% ftlmsg 'profile-filter-category-option-active-aliases' %}</label>
+            <form class="c-filter-category-list">
+                <ul class="c-filter-category-types">
+                    <li class="c-filter-category-type">
+                        <div class="mzp-c-choices">
+                            <div class="mzp-c-choice">
+                                <input
+                                    data-category-type="active-aliases"
+                                    data-parent-category="active"
+                                    class="mzp-c-choice-control js-filter-category-checkbox"
+                                    type="checkbox" name="Show active aliases"
+                                    id="active-aliases"
+                                    value=""
+                                >
+                                <label class="mzp-c-choice-label" for="active-aliases">{% ftlmsg 'profile-filter-category-option-active-aliases' %}</label>
+                            </div>
                         </div>
-                    </div>
-                </li>
-                <li class="c-filter-category-type">
-                    <div class="mzp-c-choices">
-                        <div class="mzp-c-choice">
-                            <input
-                                data-category-type="disabled-aliases"
-                                data-parent-category="active"
-                                class="mzp-c-choice-control js-filter-category-checkbox"
-                                type="checkbox" name="Show disabled aliases"
-                                id="disabled-aliases"
-                                value=""
-                            >
-                            <label class="mzp-c-choice-label" for="disabled-aliases">{% ftlmsg 'profile-filter-category-option-disabled-aliases' %}</label>
+                    </li>
+                    <li class="c-filter-category-type">
+                        <div class="mzp-c-choices">
+                            <div class="mzp-c-choice">
+                                <input
+                                    data-category-type="disabled-aliases"
+                                    data-parent-category="active"
+                                    class="mzp-c-choice-control js-filter-category-checkbox"
+                                    type="checkbox" name="Show disabled aliases"
+                                    id="disabled-aliases"
+                                    value=""
+                                >
+                                <label class="mzp-c-choice-label" for="disabled-aliases">{% ftlmsg 'profile-filter-category-option-disabled-aliases' %}</label>
+                            </div>
                         </div>
-                    </div>
-                </li>
-                <li class="c-filter-category-type">
-                    <div class="mzp-c-choices">
-                        <div class="mzp-c-choice">
-                            <input
-                                data-category-type="relay-aliases"
-                                data-parent-category="domain"
-                                class="mzp-c-choice-control js-filter-category-checkbox"
-                                type="checkbox" name="Show relay aliases"
-                                id="relay-aliases"
-                                value=""
-                            >
-                            <label class="mzp-c-choice-label" for="relay-aliases">{% ftlmsg 'profile-filter-category-option-relay-aliases' %}</label>
+                    </li>
+                    <li class="c-filter-category-type">
+                        <div class="mzp-c-choices">
+                            <div class="mzp-c-choice">
+                                <input
+                                    data-category-type="relay-aliases"
+                                    data-parent-category="domain"
+                                    class="mzp-c-choice-control js-filter-category-checkbox"
+                                    type="checkbox" name="Show relay aliases"
+                                    id="relay-aliases"
+                                    value=""
+                                >
+                                <label class="mzp-c-choice-label" for="relay-aliases">{% ftlmsg 'profile-filter-category-option-relay-aliases' %}</label>
+                            </div>
                         </div>
-                    </div>
-                </li>
-                <li class="c-filter-category-type">
-                    <div class="mzp-c-choices">
-                        <div class="mzp-c-choice">
-                            <input
-                                data-category-type="domain-aliases"
-                                data-parent-category="domain"
-                                class="mzp-c-choice-control js-filter-category-checkbox"
-                                type="checkbox" name="Show domain-based aliases"
-                                id="domain-aliases"
-                                value=""
-                            >
-                            <label class="mzp-c-choice-label" for="domain-aliases">{% ftlmsg 'profile-filter-category-option-domain-based-aliases' %}</label>
+                    </li>
+                    <li class="c-filter-category-type">
+                        <div class="mzp-c-choices">
+                            <div class="mzp-c-choice">
+                                <input
+                                    data-category-type="domain-aliases"
+                                    data-parent-category="domain"
+                                    class="mzp-c-choice-control js-filter-category-checkbox"
+                                    type="checkbox" name="Show domain-based aliases"
+                                    id="domain-aliases"
+                                    value=""
+                                >
+                                <label class="mzp-c-choice-label" for="domain-aliases">{% ftlmsg 'profile-filter-category-option-domain-based-aliases' %}</label>
+                            </div>
                         </div>
-                    </div>
-                </li>
-            </ul>
-            <div class="c-filter-category-buttons">
-                <button type="reset" class="mzp-c-button mzp-t-md mzp-t-neutral js-filter-category-reset">
-                    {% ftlmsg 'profile-label-reset' %}
-                </button>
-                <button type="submit" class="mzp-c-button mzp-t-md mzp-t-product js-filter-category-apply">
-                    {% ftlmsg 'profile-label-apply' %}
-                </button>
-            </div>
-        </form>
+                    </li>
+                </ul>
+                <div class="c-filter-category-buttons">
+                    <button type="reset" class="mzp-c-button mzp-t-md mzp-t-neutral js-filter-category-reset">
+                        {% ftlmsg 'profile-label-reset' %}
+                    </button>
+                    <button type="submit" class="mzp-c-button mzp-t-md mzp-t-product js-filter-category-apply">
+                        {% ftlmsg 'profile-label-apply' %}
+                    </button>
+                </div>
+            </form>
+        {% endif %}
     </div>
     <div class="c-filter-action">
         <!-- Button -->

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -251,8 +251,6 @@
         }
     }
 
-    filterToggleCategoryInput.addEventListener("click", toggleAliasCategoryBar, false);
-
     const filterCategory = {
         init: () => {
             filterToggleCategoryButtonApply.addEventListener("click", filterCategory.apply, false);
@@ -425,6 +423,8 @@
         }
     }
 
-    filterCategory.init();
-
+    if (filterToggleCategoryInput) {
+        filterToggleCategoryInput.addEventListener("click", toggleAliasCategoryBar, false);
+        filterCategory.init();
+    }
 })();

--- a/static/scss/partials/dashboard.scss
+++ b/static/scss/partials/dashboard.scss
@@ -208,16 +208,12 @@
     flex-wrap: nowrap;
     max-width: 100%;
 
-    .additional-notes {
-        text-overflow: ellipsis;
-        flex-direction: row;
-        position: relative;
-        margin: auto auto 0 0;
-        max-width: $content-xs;
-    }
-
     .relay-address {
         display: none;
+
+        @media #{$mq-md} {
+            display: block;
+        }
     }
 
     .additional-notes.show-label + button {
@@ -246,25 +242,17 @@
         border: 0;
         margin: 0;
         list-style: inherit;
-    }
-
-    input[type="text"] {
-        max-width: $content-xs;
-        min-width: auto;
+        min-width: 100%;
     }
 
     @media screen and (max-width: $screen-sm) {
-        
+
         input {
             width: auto;
         }
     }
+    
     @media #{$mq-md} {
-
-        .relay-address {
-            display: block;
-        }
-
         margin-left: 0;
     }
 }
@@ -411,4 +399,34 @@
         justify-content: flex-start;
     }
 
+}
+
+
+.show-label.additional-notes {
+    visibility: visible;
+    pointer-events: all;
+    display: flex;
+}
+
+.additional-notes {
+    display: none;
+    text-overflow: ellipsis;
+    flex-direction: row;
+    position: relative;
+    margin: auto auto 0 0;
+    max-width: $content-xs;
+
+    &::after {
+        content: "";
+        min-width: 16px;
+        min-height: 16px;
+        margin-left: -$spacing-lg;
+        display: inline-block;
+        background: url("/static/images/edit.svg");
+        background-repeat: no-repeat;
+        background-position: center center;
+        pointer-events: none;
+        background-size: contain;
+        opacity: .6;
+    }
 }

--- a/static/scss/partials/dashboard.scss
+++ b/static/scss/partials/dashboard.scss
@@ -251,7 +251,6 @@
             width: auto;
         }
     }
-    
     @media #{$mq-md} {
         margin-left: 0;
     }

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -751,26 +751,6 @@ input:focus::placeholder {
     opacity: 0;
 }
 
-.show-label.additional-notes {
-    visibility: visible;
-    pointer-events: all;
-    display: flex;
-}
-
-.additional-notes::after {
-    content: "";
-    min-width: 16px;
-    min-height: 16px;
-    margin-left: -24px;
-    display: inline-block;
-    background: url("/static/images/edit.svg");
-    background-repeat: no-repeat;
-    background-position: center center;
-    pointer-events: none;
-    background-size: contain;
-    opacity: .6;
-}
-
 .user-created-label::after {
     opacity: 0;
 }


### PR DESCRIPTION
This PR addresses two issues: 

- Only show alias label/edit input when add-on is detected
- Only show the category filter bar if the user is premium 

Screenshows: 

### Alias labels

With add-on installed: 
<img width="803" alt="image" src="https://user-images.githubusercontent.com/2692333/131390992-3d89991d-3dfd-49e8-8aec-69e0bc318a50.png">

Without add-on installed:
<img width="833" alt="image" src="https://user-images.githubusercontent.com/2692333/131391036-f04a4a31-c4f1-4f56-aa69-842dc0cabc95.png">

### Category filter

As premium user: 
<img width="554" alt="image" src="https://user-images.githubusercontent.com/2692333/131391236-8d1a3976-8724-45de-9ce3-6630d12cbef3.png">


As normal user (no filter bar): 
<img width="946" alt="image" src="https://user-images.githubusercontent.com/2692333/131391126-e6fa1713-6dcf-41bb-b51e-70648b47ea70.png">

