### PR TITLE
Wrap alias label input in a form

### DIFF
--- a/privaterelay/templates/profile.html
+++ b/privaterelay/templates/profile.html
@@ -108,9 +108,11 @@
               <div class="relay-email-row card-top-row inset">
                 <!-- alias label -->
                 <div class="additional-notes">
-                  <input data-label="" type="text" maxlength="50" value="" aria-label="{% ftlmsg 'profile-label-edit' %}" class="relay-email-address-label ff-Met">
-                  <span class="saved-confirmation">{% ftlmsg 'profile-label-saved' %}</span>
-                  <span class="input-error"></span>
+                  <form class="relay-email-address-label-form">
+                    <input data-label="" type="text" maxlength="50" value="" aria-label="{% ftlmsg 'profile-label-edit' %}" class="relay-email-address-label ff-Met">
+                    <span class="saved-confirmation">{% ftlmsg 'profile-label-saved' %}</span>
+                    <span class="input-error"></span>
+                  </form>
                 </div>
 
                 <button title="{% ftlmsg 'profile-label-click-to-copy' %}"
@@ -218,9 +220,11 @@
               <div class="relay-email-row card-top-row xflx xflx-row inset">
                 <!-- alias label -->
                 <div class="additional-notes">
-                  <input data-label="" type="text" maxlength="50" value="" aria-label="{% ftlmsg 'profile-label-edit' %}" class="relay-email-address-label ff-Met">
-                  <span class="saved-confirmation">{% ftlmsg 'profile-label-saved' %}</span>
-                  <span class="input-error"></span>
+                  <form action="" class="relay-email-address-label-form">
+                    <input data-label="" type="text" maxlength="50" value="" aria-label="{% ftlmsg 'profile-label-edit' %}" class="relay-email-address-label ff-Met">
+                    <span class="saved-confirmation">{% ftlmsg 'profile-label-saved' %}</span>
+                    <span class="input-error"></span>
+                  </form>
                 </div>
 
                 <button title="{% ftlmsg 'profile-label-click-to-copy' %}"


### PR DESCRIPTION
This should allow submitting it by pressing Enter, and might better
assist screen readers. Note that this will break versions of the add-on that do not include