### PR TITLE
Fix #929 - Add class to fix iOS display of search close button

### DIFF
--- a/static/scss/components/filter-bar.scss
+++ b/static/scss/components/filter-bar.scss
@@ -184,6 +184,8 @@
     outline: 0;
     appearance: none;
     border: 0;
+    position: relative;
+    padding: 0;
 
     img {
         width: 1rem;


### PR DESCRIPTION
This PR fixes MPP-589

Preview: 

<img width="442" alt="image" src="https://user-images.githubusercontent.com/2692333/132413423-43d44ea5-7d50-45df-a768-6deeabb7e545.png">
