### PR TITLE
Fix #1059 - Revise category filter buttons to wrap if necessary

### DIFF
--- a/static/scss/components/filter-bar.scss
+++ b/static/scss/components/filter-bar.scss
@@ -241,13 +241,18 @@
 }
 
 .c-filter-category-buttons {
-    padding: $spacing-md $spacing-md 0;
+    padding: $spacing-md $spacing-md 0 0;
     width: 100%;
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;
+    flex-direction: row;
+    align-items: stretch;
 }
 
 .c-filter-category-buttons button {
     margin-bottom: $spacing-md;
+    margin-left: $spacing-md;
+    width: auto;
+    flex: 1;
 }

--- a/static/scss/components/filter-bar.scss
+++ b/static/scss/components/filter-bar.scss
@@ -236,9 +236,18 @@
     }
 }
 
+.c-filter-category-types {
+    margin-bottom: 0;
+}
+
 .c-filter-category-buttons {
-    padding: 0 $spacing-md $spacing-md;
+    padding: $spacing-md $spacing-md 0;
     width: 100%;
     display: flex;
     justify-content: space-between;
+    flex-wrap: wrap;
+}
+
+.c-filter-category-buttons button {
+    margin-bottom: $spacing-md;
 }


### PR DESCRIPTION
This PR fixes MPP-869

This PR refactors how the padding/wrapping works on the category filter menu. If there is not enough room to fit both buttons, it wraps to the next line, but maintains the expected spacing/margins. 

## Screenshots

German (edit): 
<img width="336" alt="image" src="https://user-images.githubusercontent.com/2692333/133165393-e92c0faa-8547-4757-8f46-0479abed3c54.png">

English: 
<img width="354" alt="image" src="https://user-images.githubusercontent.com/2692333/132536721-77e9aa47-ac7d-420c-a5ba-0d53c3c836ab.png">
