### PR TITLE
Fix #928 - Revise summary dashboard stats to stretch according to the tallest item

### DIFF
--- a/static/scss/pages/dashboard.scss
+++ b/static/scss/pages/dashboard.scss
@@ -43,6 +43,9 @@
     padding: 0 $spacing-xs;
     border-right: 1px solid #ECECEC;
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
 
     span {
         display: block;


### PR DESCRIPTION
Related to MPP-588

This PR fixes issues where the summary dashboard stats wrap. This fixes a secondary issue where the stats wrap in other languages too! 🗺️ 

**Reviewer note: The class names for this section are not Protcol'd. Please disregard.** 

Preview: 

![Sep-08-2021 10-41-36](https://user-images.githubusercontent.com/2692333/132541351-eaf4d067-7762-47fd-a725-d0c6360c0cbb.gif)
