### PR TITLE
Remove unused vars, enable in lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,7 @@ module.exports = {
     "linebreak-style": ["error", "unix"],
     "no-console": ["error", { "allow": ["warn", "error"] }],
     "no-prototype-builtins": "off",
-    "no-unused-vars": ["warn", { vars: "all", args: "none", ignoreRestSiblings: false }],
+    "no-unused-vars": ["warn", { vars: "all", args: "all", ignoreRestSiblings: false }],
     quotes: ["error", "double", { avoidEscape: true }],
     semi: ["off", "always"],
   },

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -178,7 +178,7 @@ function analyticsSurveyLogic() {
           li.dataset.eventLabel = "promoter";
           li.dataset.npsValue = 1;
         }
-        li.addEventListener("click", (evt) => {
+        li.addEventListener("click", () => {
           const eventData = li.dataset;
           ga("send", "event",
             eventData.eventCategory,
@@ -222,7 +222,7 @@ function analyticsSurveyLogic() {
         li.dataset.eventAction = "submitted";
         li.dataset.eventLabel = optionEventLabels[optionBuildIndex];
         li.addEventListener("click", setSurveyedCookie);
-        li.addEventListener("click", (evt) => {
+        li.addEventListener("click", () => {
           const eventData = li.dataset;
           ga("send", "event",
             eventData.eventCategory,
@@ -272,7 +272,7 @@ function analyticsSurveyLogic() {
         li.dataset.eventLabel = optionEventLabels[optionBuildIndex];
         li.dataset.eventValue = eventValue;
         li.addEventListener("click", setSurveyedCookie);
-        li.addEventListener("click", (evt) => {
+        li.addEventListener("click", () => {
           const eventData = li.dataset;
           const gaFieldsObject = {
               [countMetric]: 1,

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -142,7 +142,7 @@ function deleteAliasConfirmation(submitEvent) {
   // Enable "Delete Anyway" button once the checkbox has been clicked.
   const confirmDeleteModalActions = confirmDeleteModal.querySelectorAll("button");
   const deleteAnywayBtn = confirmDeleteModalActions[1];
-  checkbox.addEventListener("change", (e) => {
+  checkbox.addEventListener("change", () => {
     if (checkbox.checked) {
       deleteAnywayBtn.disabled = false;
       return;
@@ -278,7 +278,7 @@ function watchForInstalledAddon() {
     childList: true, // catches legacy addons modifying .relay-email-address-note els
 	};
 
-  const patrollerDuties = (mutations, mutationPatroller) => {
+  const patrollerDuties = (mutations) => {
     for (const mutation of mutations) {
       // handle legacy addon labeling
       if (mutation.type === "childList" && mutation.target.classList.contains("relay-email-address-note")) {

--- a/static/js/domain-registration.js
+++ b/static/js/domain-registration.js
@@ -120,7 +120,7 @@
                 document.removeEventListener("keydown", domainRegistration.modal.close, false);
 
             },
-            formSubmit: async (e) => {
+            formSubmit: async () => {
                 const modalConfirmCheckbox = document.querySelector(".js-modal-domain-registration-confirmation-checkbox");
 
                 if (!modalConfirmCheckbox.checked) {

--- a/static/js/fx-bento.js
+++ b/static/js/fx-bento.js
@@ -138,7 +138,7 @@ class FirefoxApps extends HTMLElement {
       return;
     };
 
-    this._closeBento = (event) => {
+    this._closeBento = () => {
       this._active = false;
       this.handleBentoFocusTrap();
       window.removeEventListener("resize", this.handleBentoHeight);


### PR DESCRIPTION
Instead of manually checking (e.g.
https://github.com/mozilla/fx-private-relay/pull/1082#discussion_r704475602),
we can just have the computer do it for us :)