### PR TITLE
Run linting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+
+env:
+  CI: true
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
+        # We're currently only linting, for which results shouldn't vary across OS's and Node versions:
+        os: [ubuntu-20.04]
+        node-version: [14.x]
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2.4.0
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run lint:js -- --max-warnings=0
+    - run: npm run lint:css


### PR DESCRIPTION
There's already a configuration for CircleCI, so we might want to move this there. However, the add-on's repository does have a GitHub Actions config, and this integrates better with GitHub (plus, I was already familiar with the syntax :) ), so created this as a first proposal.

This complements #1088 to avoid having to manually check for linting errors in PR reviews.