### PR TITLE
Only hide add-on banner with the add-on installed

### DIFF
--- a/privaterelay/templates/base.html
+++ b/privaterelay/templates/base.html
@@ -29,10 +29,10 @@
     <meta name="twitter:image" content="{{request.scheme}}://{{request.META.HTTP_HOST}}{% static 'images/share-relay.jpg' %}">
   </head>
   <body class="{% with request.user.profile_set.first as user_profile %}{% if user_profile.has_unlimited %}is-premium{% endif %}{% endwith %}" data-fxa-settings-url="{{ settings.FXA_SETTINGS_URL }}" data-site-origin="{{ settings.SITE_ORIGIN }}" data-google-analytics-id="{{ settings.GOOGLE_ANALYTICS_ID }}" data-debug="{{ settings.DEBUG }}">
-    <firefox-private-relay-addon data-addon-installed="false"></firefox-private-relay-addon>
     {% include "includes/modal-delete.html" %}
     {% include "includes/modal-domain-registration-confirmation.html" %}
     {% include "includes/header.html" %}
+    <firefox-private-relay-addon data-addon-installed="false"></firefox-private-relay-addon>
     {% block content %}
     {% endblock %}
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -309,7 +309,6 @@ function showBannersIfNecessary() {
   const bg = dashboardBanners.querySelector(".banner-gradient-bg");
   const showBanner = (bannerEl) => {
     setTimeout(()=> {
-      bg.style.minHeight = "101px";
       bannerEl.classList.remove("hidden");
       dashboardBanners.classList.remove("invisible");
     }, 500);

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -300,9 +300,6 @@ function showBannersIfNecessary() {
   }
 
   const browserIsFirefox = /firefox|FxiOS/i.test(navigator.userAgent);
-  if (browserIsFirefox && isRelayAddonInstalled()) {
-    return;
-  }
 
   const dashboardBanners = document.querySelector(".dashboard-banners");
   if (!dashboardBanners) {
@@ -312,11 +309,9 @@ function showBannersIfNecessary() {
   const bg = dashboardBanners.querySelector(".banner-gradient-bg");
   const showBanner = (bannerEl) => {
     setTimeout(()=> {
-      if (!isRelayAddonInstalled()) {
-        bg.style.minHeight = "101px";
-        bannerEl.classList.remove("hidden");
-        dashboardBanners.classList.remove("invisible");
-      }
+      bg.style.minHeight = "101px";
+      bannerEl.classList.remove("hidden");
+      dashboardBanners.classList.remove("invisible");
     }, 500);
     return;
   };

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -1021,6 +1021,11 @@ input:focus::placeholder {
     transition: all .3s ease;
 }
 
+/* Don't show the "Install the add-on" banner if the add-on is active: */
+firefox-private-relay-addon[data-addon-installed="true"] + firefox-private-relay-addon-data + main .dashboard-banners .addon {
+    display: none;
+}
+
 .banner-hl {
     font-size: 1.25rem;
     font-weight: 700;


### PR DESCRIPTION
Fixes #868, fixes #935.

This required a bit of code archeology, so I'm not sure if I
correctly interpreted the original intentions of the code, but it
seems like we used to only have a banner suggesting the
installation of the add-on, which then got updated to hide
.dashboard-banners when the add-on was installed. Over time, more
banners were added ("download Firefox", "upgrade to Premium"), but
those were all stashed inside .dashboard-banners, which got
hidden when the add-on was installed. Additionally, it seems the
banners are supposed to appear on the page a little bit after page
load? Or maybe that is to give the add-on time to load.

Either way, I now opted to revert the code that hides
.dashboard-banners if the add-on is installed (and thus now only
makes it appear after a delay of half a second). Instead, the
add-on banner specifically is hidden using CSS only, using a
selector that only matches when the add-on has set
`data-addon-installed` to true in `<firefox-private-relay-addon>`.