### PR TITLE
Make total stats order consistent with alias stats

### DIFF
--- a/privaterelay/templates/profile.html
+++ b/privaterelay/templates/profile.html
@@ -60,8 +60,8 @@
       </div>
       <ul class="mpp-dashbaord-header-stats">
         <li><span class="label">{% ftlmsg 'profile-stat-label-aliases-used' %}</span> <span>{{relay_addresses|length}}</span> </li>
-        <li><span class="label">{% ftlmsg 'profile-stat-label-forwarded' %}</span> <span>{{user_profile.emails_forwarded}}</span> </li>
         <li><span class="label">{% ftlmsg 'profile-stat-label-blocked' %}</span> <span>{{user_profile.emails_blocked}}</span> </li>
+        <li><span class="label">{% ftlmsg 'profile-stat-label-forwarded' %}</span> <span>{{user_profile.emails_forwarded}}</span> </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Fixes #1094.

In other words, Blocked comes before Forwarded in both the stats at
the top of the page as well as in the stats to the right of a
single alias. They're in the same order in the designs.

Before:

![image](https://user-images.githubusercontent.com/4251/133066383-77781838-294a-46f1-9a12-71a6b919ce6c.png)

After:

![image](https://user-images.githubusercontent.com/4251/133066346-9a8a7ab3-8b3b-48c9-b8a3-b7b12346a2a8.png)
