### PR TITLE
Treat warnings as errors in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ COPY .stylelintrc.json ./
 COPY static ./static/
 RUN npm install
 RUN ./node_modules/.bin/gulp build
-RUN npm run lint
+RUN npm run lint:js -- --max-warnings=0
+RUN npm run lint:css
 
 FROM python:3.7.9
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -165,18 +165,6 @@ function deleteAliasConfirmation(submitEvent) {
 	});
 }
 
-// Checks for changes made to <firefox-private-relay-addon></firefox-private-relay-add-on> by the addon.
-function isRelayAddonInstalled() {
-  const installationIndicator = document.querySelector("firefox-private-relay-addon");
-	return (installationIndicator.dataset.addonInstalled === "true" || isAddonInstallInLocalStorage());
-}
-
-
-// Looks for previously saved installation note in localStorage
-function isAddonInstallInLocalStorage() {
-	return (localStorage && localStorage.getItem("fxRelayAddonInstalled"));
-}
-
 function toggleAliasCardDetailsVisibility(aliasCard) {
   const detailsWrapper = aliasCard.querySelector(".js-alias-details");
   detailsWrapper.classList.toggle("is-visible");
@@ -305,7 +293,6 @@ function showBannersIfNecessary() {
     return;
   }
 
-  const bg = dashboardBanners.querySelector(".banner-gradient-bg");
   const showBanner = (bannerEl) => {
     setTimeout(()=> {
       bannerEl.classList.remove("hidden");


### PR DESCRIPTION
While warnings shouldn't interrupt your flow during development, I think it
would be good not to accumulate too many of them by resolving them
before merging to `main`. (But feel free to reject if you don't agree :) )