### PR TITLE
Fix Apple Touch icon syntax, add SVG favicon

### DIFF
--- a/privaterelay/templates/base.html
+++ b/privaterelay/templates/base.html
@@ -11,8 +11,9 @@
     <meta name="description" content="{% ftlmsg 'meta-description' %}" />
     <title>{% ftlmsg 'meta-title' %}</title>
     <link rel="stylesheet" href="{% static 'css/app.css' %}">
+    <link rel="icon" type="image/svg+xml" href="{% static 'images/logos/relay-logo-dark.svg' %}">
     <link rel="shortcut icon" href="{%  static 'images/favicon.ico' %}">
-    <link rel=”apple-touch-icon” href="{% static 'images/logos/relay-logo-dark-200.png' %}">
+    <link rel="apple-touch-icon" href="{% static 'images/logos/relay-logo-dark-200.png' %}">
     
     <!-- Open Graph Tags -->
     <meta property="og:url" content="{{request.scheme}}://{{request.META.HTTP_HOST}}{{ request.path }}" />


### PR DESCRIPTION
The quotes for the Apple Touch Icon were of the wrong kind, leading to that not being recognised (e.g. in Firefox's Top Sites). I also added a reference to the SVG icon.