### PR TITLE
Fix #835 - Set profile name from FxA

### DIFF
--- a/privaterelay/templates/profile.html
+++ b/privaterelay/templates/profile.html
@@ -37,7 +37,11 @@
     <div class="mpp-dashbaord-header-container inset">
       <div class="mpp-dashbaord-header-title">
         <div class="mpp-dashbaord-header-name">
-          {% ftlmsg 'profile-label-welcome-html' email=request.user.email %}
+          {% if user_profile.display_name %}
+            {% ftlmsg 'profile-label-welcome-html' email=user_profile.display_name %}
+          {% else %}
+            {% ftlmsg 'profile-label-welcome-html' email=request.user.email %}
+          {% endif %}
         </div>
         {% if not user_profile.subdomain %}
           <div class="mpp-dashbaord-header-action">

--- a/static/scss/pages/dashboard.scss
+++ b/static/scss/pages/dashboard.scss
@@ -8,10 +8,12 @@
     width: 100%;
     word-wrap: break-word;
     padding-right: $spacing-sm;
+    @include text-body-xl;
 
     span {
         font-weight: 400;
         display: block;
+        @include text-body-md;
     }
 }
 

--- a/static/scss/pages/dashboard.scss
+++ b/static/scss/pages/dashboard.scss
@@ -8,11 +8,13 @@
     width: 100%;
     word-wrap: break-word;
     padding-right: $spacing-sm;
+
     @include text-body-xl;
 
     span {
         font-weight: 400;
         display: block;
+
         @include text-body-md;
     }
 }


### PR DESCRIPTION
Fixes MPP-405

Screenshot: 
With name set: 
![image](https://user-images.githubusercontent.com/2692333/133334330-a9dfcdfe-3894-4194-8e50-8917cfb00f13.png)

With no name set: 
![image](https://user-images.githubusercontent.com/2692333/133334402-8d50d748-12af-4005-b661-5022be8371c3.png)
 