### PR TITLE
Use translated copy button tooltips

### DIFF
--- a/privaterelay/templates/profile.html
+++ b/privaterelay/templates/profile.html
@@ -114,6 +114,8 @@
                 </div>
 
                 <button title="{% ftlmsg 'profile-label-click-to-copy' %}"
+                  data-ftl-click-to-copy="{% ftlmsg 'profile-label-click-to-copy' %}"
+                  data-ftl-copy-confirmation="{% ftlmsg 'profile-label-copy-confirmation' %}"
                   data-id="{{ relay_address.id }}"
                   data-clipboard-text="{{ relay_address.address }}@{{ relay_address.domain_value }}"
                   class="relay-address click-copy  hide-mobile ff-Met xflx jst-cntr al-cntr">
@@ -143,6 +145,8 @@
 
           <div class="c-alias-copy">
             <button title="{% ftlmsg 'profile-label-click-to-copy' %}"
+              data-ftl-click-to-copy="{% ftlmsg 'profile-label-click-to-copy' %}"
+              data-ftl-copy-confirmation="{% ftlmsg 'profile-label-copy-confirmation' %}"
               data-id="{{ relay_address.id }}"
               data-clipboard-text="{{ relay_address.address }}@{{ relay_address.domain_value }}"
               class="relay-address click-copy ff-Met jst-cntr al-cntr">
@@ -224,6 +228,8 @@
                 </div>
 
                 <button title="{% ftlmsg 'profile-label-click-to-copy' %}"
+                  data-ftl-click-to-copy="{% ftlmsg 'profile-label-click-to-copy' %}"
+                  data-ftl-copy-confirmation="{% ftlmsg 'profile-label-copy-confirmation' %}"
                   data-id="{{ domain_address.id }}"
                   data-clipboard-text="{{ domain_address.address }}@{% user_email_domain user_profile %}"
                   class="relay-address click-copy  hide-mobile ff-Met xflx jst-cntr al-cntr">
@@ -253,6 +259,8 @@
 
           <div class="c-alias-copy">
             <button title="{% ftlmsg 'profile-label-click-to-copy' %}"
+              data-ftl-click-to-copy="{% ftlmsg 'profile-label-click-to-copy' %}"
+              data-ftl-copy-confirmation="{% ftlmsg 'profile-label-copy-confirmation' %}"
               data-id="{{ domain_address.id }}"
               data-clipboard-text="{{ domain_address.address }}@{% user_email_domain user_profile %}"
               class="relay-address click-copy ff-Met xflx jst-cntr al-cntr">

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -68,7 +68,7 @@ async function sendForm(formAction, formData) {
 
 function copyToClipboardAndShowMessage(triggeringEl) {
   triggeringEl.classList.add("alias-copied", "alias-copied-fadeout");
-  triggeringEl.title="Alias copied to clipboard";
+  triggeringEl.title = triggeringEl.dataset.ftlCopyConfirmation;
 
   setTimeout(() => {
     // When the fade-out animation is done (it takes four seconds),
@@ -76,7 +76,7 @@ function copyToClipboardAndShowMessage(triggeringEl) {
     // every time the alias is being hidden and reshown (i.e. when a filter
     // is applied and removed again).
     triggeringEl.classList.remove("alias-copied", "alias-copied-fadeout");
-    triggeringEl.title = "Copy alias to clipboard";
+    triggeringEl.title = triggeringEl.dataset.ftlClickToCopy;
   }, 4 * 1000);
   
   


### PR DESCRIPTION
Fixes #1104.

Uses localised strings for the reverted tooltips of the copy button. https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/10 should be merged first (@maxxcrawford who does that?).