### PR TITLE
Only show domain tooltip when there is none yet

### DIFF
--- a/privaterelay/templates/profile.html
+++ b/privaterelay/templates/profile.html
@@ -45,20 +45,19 @@
         </div>
         {% if not user_profile.subdomain %}
           <div class="mpp-dashbaord-header-action">
-            <button class="mpp-action-link"> <img class="margin-right" src="/static/images/icon-check.svg" alt=""> {% ftlmsg 'profile-label-create-domain' %}</button>
-          </div>
-        {% else %}
-          <div class="mpp-dashbaord-header-action">
-            <div class="mpp-action-link mpp-action-tooltip">
-              {% ftlmsg 'profile-label-domain' %} {{ user_profile.subdomain }}
-              <img class="margin-left" src="/static/images/icon-info.svg" alt="informtaion">
+            <div class="mpp-action-tooltip">
+              <button class="mpp-action-link"><img class="margin-right" src="/static/images/icon-check.svg" alt=""> {% ftlmsg 'profile-label-create-domain' %}</button>
+              <img class="margin-left" src="/static/images/icon-info.svg" alt="">
               <div class="mpp-action-tooltip-hover">
                 <div class="mpp-action-tooltip-hover-wrapper">
                   {% ftlmsg 'profile-label-domain-tooltip' %}
                 </div>
               </div>
             </div>
-            
+          </div>
+        {% else %}
+          <div class="mpp-dashbaord-header-action">
+            {% ftlmsg 'profile-label-domain' %} <samp>{{ user_profile.subdomain }}</samp>
           </div>
         {% endif %}
       </div>

--- a/static/scss/pages/dashboard.scss
+++ b/static/scss/pages/dashboard.scss
@@ -140,6 +140,7 @@
 }
 
 .mpp-action-tooltip {
+    display: flex;
     position: relative;
     z-index: 1;
     


### PR DESCRIPTION
Fixes #1105.

The tooltip says "Create your unique and custom email domain", so it is only
relevant when the user doesn't have a domain yet.

Since I didn't know what to put in the tooltip for when the user _does_ have a domain, I just removed it there altogether. It looks like this now:

![image](https://user-images.githubusercontent.com/4251/133619995-fad4a24b-b1cf-45a1-9495-87c5cd36ec5a.png)

We can of course re-add it when we have appropriate content there later.