### PR TITLE
Client-side validation of subdomain length

### DIFF
--- a/privaterelay/templates/includes/banners.html
+++ b/privaterelay/templates/includes/banners.html
@@ -66,7 +66,16 @@
                 <p>{% ftlmsg 'banner-choose-subdomain-copy' %}</p>
                 <form id="domainRegistration" method="post" action="{% url 'profile_subdomain' %}">
                     {% csrf_token %}
-                    <input class="js-subdomain-value" data-domain="{{ MOZMAIL_DOMAIN }}" required type="text" placeholder="{% ftlmsg 'banner-choose-subdomain-input-placeholder' %}" name="subdomain">
+                    <input
+                      class="js-subdomain-value"
+                      data-domain="{{ MOZMAIL_DOMAIN }}"
+                      required
+                      type="text"
+                      placeholder="{% ftlmsg 'banner-choose-subdomain-input-placeholder' %}"
+                      name="subdomain"
+                      minlength="1"
+                      maxlength="63"
+                    >
                     <input class="btn btn--gray" type="submit" value="{% ftlmsg 'banner-choose-subdomain-submit' %}">
                 </form>
                 <p class="warning">{% ftlmsg 'banner-choose-subdomain-warning' %}</p>


### PR DESCRIPTION
Validate subdomain length on the client-side as well, to align with the validation from #1107. I didn't add a `pattern` match since that won't generally result in helpful error messages.

@groovecoder I noticed you set a min length of 1 character, so I mirrored that, but I was thinking that maybe we should start with a higher min length? We can always lower the min length later, but otherwise there might be a scramble for the short domain names, and possibly names that are easily confused with others.