### PR TITLE
refresh access tokens automatically, or log the user out

### DIFF
--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -1,7 +1,19 @@
+from datetime import datetime, timezone
 import time
 
 import markus
+from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
 
+from django.contrib.auth import logout
+from django.shortcuts import redirect
+from django.urls import reverse
+
+from allauth.socialaccount.models import SocialToken
+from allauth.socialaccount.providers.fxa.views import (
+    FirefoxAccountsOAuth2Adapter
+)
+
+from .views import _get_oauth2_session, update_social_token
 
 metrics = markus.get_metrics('fx-private-relay')
 
@@ -20,6 +32,19 @@ class FxAToRequest:
 
         if not fxa_account:
             return self.get_response(request)
+
+        social_token = SocialToken.objects.get(account=fxa_account)
+        # if the user's FXA access token has expired; try to get a new one
+        if social_token.expires_at < datetime.now(timezone.utc):
+            try:
+                client = _get_oauth2_session(fxa_account)
+                new_token = client.refresh_token(
+                    FirefoxAccountsOAuth2Adapter.access_token_url
+                )
+                update_social_token(social_token, new_token)
+            except CustomOAuth2Error:
+                logout(request)
+                return redirect(reverse('home'))
 
         request.fxa_account = fxa_account
         return self.get_response(request)

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -306,13 +306,7 @@ def _get_oauth2_session(social_account):
     social_token = social_account.socialtoken_set.first()
 
     def _token_updater(new_token):
-        social_token.token = new_token['access_token']
-        social_token.token_secret = new_token['refresh_token']
-        social_token.expires_at = (
-            datetime.now(timezone.utc) +
-            timedelta(seconds=int(new_token['expires_in']))
-        )
-        social_token.save()
+        update_social_token(social_token, new_token)
 
     client_id = social_token.app.client_id
     client_secret = social_token.app.secret
@@ -337,3 +331,12 @@ def _get_oauth2_session(social_account):
         auto_refresh_kwargs=extra, token_updater=_token_updater
     )
     return client
+
+def update_social_token(existing_social_token, new_oauth2_token):
+    existing_social_token.token = new_oauth2_token['access_token']
+    existing_social_token.token_secret = new_oauth2_token['refresh_token']
+    existing_social_token.expires_at = (
+        datetime.now(timezone.utc) +
+        timedelta(seconds=int(new_oauth2_token['expires_in']))
+    )
+    existing_social_token.save()


### PR DESCRIPTION
To test:

### Expired access token, VALID refresh token should automatically refresh
1. Sign in as a regular user
2. (In private window) Sign in to [the admin interface for social tokens](http://127.0.0.1:8000/admin/socialaccount/socialtoken/)
3. As the admin, go to the social token for the signed-in user
4. Change the "Expires at" field to "Today" and "Now" values
5. Go back to the regular user window and refresh
   * The page should refresh no problem - the expired access token should automatically be refreshed
6. In the admin interface, refresh the list of social tokens
   * The social token object for the user should have a new token value and a new expires at value

### Expired access token, REVOKED refresh token should sign out
1. In the account menu, click "Manage your Firefox Account" (should take you [here](https://accounts.stage.mozaws.net/settings))
2. Click "Connected Services"
3. Click "Sign out" in the "Firefox Private Relay local dev" entry
   * Note: you may need to refresh the page and click "Sign out" multiple times, as FXA's collapses multiple active sessions into 1 in the UI. Just keep refreshing and clicking "Sign out" until you've signed out of ALL of them.
4. Back on your local Relay, as the admin, go to the social token for the signed-in user
5. Change the "Expires at" field to "Today" and "Now" values
6. Go back to the regular user window and refresh
   * Your session should be signed out (because your access token is expired AND your refresh token is revoked)