### PR TITLE
Prevent focused .btn-blue--ghosts being unreadable

### DIFF
--- a/static/scss/components/buttons.scss
+++ b/static/scss/components/buttons.scss
@@ -24,7 +24,17 @@
     color: $color-blue-50;
     background: none;
 
-    &:hover {
+    &:focus,
+    &:active,
+    &:visited:focus,
+    &:visited:active {
+        color: $color-blue-50;
+        outline: none;
+        box-shadow: var(--buttonFocus);
+    }
+
+    &:hover,
+    &:visited:hover {
         color: $color-white;
         background-color: $color-blue-50;
     }


### PR DESCRIPTION
Fixes #974.

They would become white-on-transparent when focused/active due to the default styling
of visited links.