### PR TITLE
fix #1126 replies for FXA's with plus addressing

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -410,3 +410,12 @@ class Reply(models.Model):
     lookup = models.CharField(max_length=255, blank=False, db_index=True)
     encrypted_metadata = models.TextField(blank=False)
     created_at = models.DateField(auto_now_add=True, null=False)
+
+    @property
+    def address(self):
+        return self.relay_address or self.domain_address
+
+    @property
+    def owner_has_premium(self):
+        profile = self.address.user.profile_set.first()
+        return profile.has_premium

--- a/emails/views.py
+++ b/emails/views.py
@@ -413,11 +413,13 @@ def _handle_reply(from_address, message_json):
     (lookup_key, encryption_key) = _get_keys_from_headers(mail['headers'])
     reply_record = _get_reply_record_from_lookup_key(lookup_key)
     address = reply_record.address
-    stripped_reply_record_address = _strip_localpart_tag(
-        address.user.email
-    )
+    reply_record_email = address.user.email
+    stripped_reply_record_address = _strip_localpart_tag(reply_record_email)
 
-    if stripped_from_address is stripped_reply_record_address:
+    if (
+        (from_address is reply_record_email) or
+        (stripped_from_address is stripped_reply_record_address)
+    ):
         # This is a Relay user replying to an external sender;
         # verify they are premium
         if not reply_record.owner_has_premium:


### PR DESCRIPTION
strip the localpart "tags" before checking that the From: value
is a valid premium Relay user.

also some new convenient Reply properties, and some refactoring of
_handle_reply code into some sub-functions:

_get_keys_from_headers, _get_reply_record_from_lookup_key, and
_strip_localpart_tag