### PR TITLE
Fix #1123 - Disable Upgrade CTA Button when user is already premium

### DIFF
--- a/privaterelay/templates/includes/dashboard-filter.html
+++ b/privaterelay/templates/includes/dashboard-filter.html
@@ -103,7 +103,7 @@
         <!-- Button -->
         <form action="{% url 'emails-index' %}" class="dash-create" method="POST">
             <input type="hidden" name="api_token" value="{{ user_profile.api_token }}">
-            {% if user_profile.at_max_free_aliases and not user_profile.has_unlimited %}
+            {% if user_profile.at_max_free_aliases and not user_profile.has_premium %}
                 {% if settings.PREMIUM_ENABLED %}
                     <a
                         href="{{ settings.FXA_SUBSCRIPTIONS_URL }}/products/{{ settings.PREMIUM_PROD_ID }}?plan={{ settings.PREMIUM_PRICE_ID }}"
@@ -130,19 +130,6 @@
                         </span>
                     </button>
                 {% endif %}
-            {% else %}
-                <button
-                    class="blue-btn-states dash-create-new-relay flx al-cntr jst-cntr"
-                    title="{% ftlmsg 'profile-label-generate-new-alias' %}"
-                    type="submit"
-                    value="{% ftlmsg 'profile-label-generate-new-alias' %}"
-                    data-event-label="Create New Relay Alias"
-                >
-                    <span class="generate-new-relay-icon"></span>
-                    <span class="generate-new-alias-text">
-                        {% ftlmsg 'profile-label-generate-new-alias' %}
-                    </span>
-                </button>
             {% endif %}
         </form>
     </div>

--- a/privaterelay/templates/includes/dashboard-filter.html
+++ b/privaterelay/templates/includes/dashboard-filter.html
@@ -130,6 +130,19 @@
                         </span>
                     </button>
                 {% endif %}
+            {% else %}
+            <button
+                class="blue-btn-states dash-create-new-relay flx al-cntr jst-cntr"
+                title="{% ftlmsg 'profile-label-generate-new-alias' %}"
+                type="submit"
+                value="{% ftlmsg 'profile-label-generate-new-alias' %}"
+                data-event-label="Create New Relay Alias"
+            >
+                <span class="generate-new-relay-icon"></span>
+                <span class="generate-new-alias-text">
+                    {% ftlmsg 'profile-label-generate-new-alias' %}
+                </span>
+            </button>
             {% endif %}
         </form>
     </div>


### PR DESCRIPTION
This removes the upgrade CTA button along the search container when the user is already premium.

Demo: https://drive.google.com/file/d/1--A9qCgsAKJV-gdpsGLP-ADfp6Q6p-Px/view?usp=sharing