### PR TITLE
Align on toolchain versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,9 @@
     "lint:css": "stylelint static/scss/",
     "lint:fix-css": "stylelint --fix static/scss/",
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "volta": {
+    "node": "12.22.6",
+    "npm": "6.14.15"
   }
 }


### PR DESCRIPTION
@codemist @maxxcrawford if you both also install [Volta](https://volta.sh/), we can be sure that we're all on the same versions of Node and npm, and hence that we won't have endless back-and-forth changes to `package-lock.json` when different people are on different versions :)

(I set it to Node 12 because that's what the README says, although the Dockerfile uses Node 14. On which version shall we align?)