### PR TITLE
Position "Copied!" label to the right of the alias

### DIFF
--- a/privaterelay/templates/profile.html
+++ b/privaterelay/templates/profile.html
@@ -122,7 +122,7 @@
                   data-id="{{ relay_address.id }}"
                   data-clipboard-text="{{ relay_address.full_address }}"
                   class="relay-address click-copy  hide-mobile ff-Met xflx jst-cntr al-cntr">
-                    {{ relay_address.full_address }}
+                    <span class="relay-address--label">{{ relay_address.full_address }}</span>
                     <span class="alias-copied-icon"></span>
                     <span class="alias-copied-message">{% ftlmsg 'profile-label-copied' %}</span>
                 </button>
@@ -153,7 +153,7 @@
               data-id="{{ relay_address.id }}"
               data-clipboard-text="{{ relay_address.full_address }}"
               class="relay-address click-copy ff-Met jst-cntr al-cntr">
-                {{ relay_address.full_address }}
+                <span class="relay-address--label">{{ relay_address.full_address }}</span>
                 <span class="alias-copied-icon"></span>
                 <span class="alias-copied-message">{% ftlmsg 'profile-label-copied' %}</span>
             </button>
@@ -236,7 +236,7 @@
                   data-id="{{ domain_address.id }}"
                   data-clipboard-text="{{ domain_address.full_address }}"
                   class="relay-address click-copy  hide-mobile ff-Met xflx jst-cntr al-cntr">
-                    {{ domain_address.full_address }}
+                    <span class="relay-address--label">{{ domain_address.full_address }}</span>
                     <span class="alias-copied-icon"></span>
                     <span class="alias-copied-message">{% ftlmsg 'profile-label-copied' %}</span>
                 </button>
@@ -267,7 +267,7 @@
               data-id="{{ domain_address.id }}"
               data-clipboard-text="{{ domain_address.full_address }}"
               class="relay-address click-copy ff-Met xflx jst-cntr al-cntr">
-                {{ domain_address.full_address }}
+                <span class="relay-address--label">{{ domain_address.full_address }}</span>
                 <span class="alias-copied-icon"></span>
                 <span class="alias-copied-message">{% ftlmsg 'profile-label-copied' %}</span>
             </button>

--- a/static/scss/pages/dashboard.scss
+++ b/static/scss/pages/dashboard.scss
@@ -216,14 +216,6 @@
     flex-wrap: nowrap;
     max-width: 100%;
 
-    .relay-address {
-        display: none;
-
-        @media #{$mq-md} {
-            display: block;
-        }
-    }
-
     .additional-notes.show-label + button {
         margin-top: 0;
     }

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -413,15 +413,12 @@ table {
     text-align: left;
     border: none;
     font-weight: 600;
-    cursor: default;
     height: 100%; /* expand clickable area of relay address */
-    display: block;
-    position: relative;
+    display: flex;
     max-width: 100%;
     text-overflow: ellipsis;
     overflow: hidden;
     border-radius: 0;
-    padding: 2px 70px 2px 0; /* makes room for click to copy icon and copied message */
     color: $color-grey-60;
     white-space: nowrap;
 }
@@ -429,7 +426,10 @@ table {
 .relay-address:hover,
 .relay-address:focus {
     opacity: .75;
-    text-decoration: underline;
+
+    .relay-address--label {
+        text-decoration: underline;
+    }
 }
 
 .relay-address:active {
@@ -443,15 +443,6 @@ table {
 .alias-copied-fadeout .alias-copied-message {
     animation-duration: 4s;
     animation-name: fadeOut;
-    animation-fill-mode: forwards;
-}
-
-.alias-copied-fadeout .alias-copied-icon {
-    opacity: 0;
-    animation-delay: 3s;
-    animation-duration: .1s;
-    animation-name: fadeOut;
-    animation-direction: reverse;
     animation-fill-mode: forwards;
 }
 
@@ -472,17 +463,12 @@ table {
     background-image: url("/static/images/copy-to-clipboard.svg");
     background-repeat: no-repeat;
     background-size: contain;
-    top: 0;
-    right: 48px;
-    bottom: 3px;
-    margin: auto;
+    margin-left: $spacing-sm;
 }
 
 .alias-copied-icon,
 .alias-copied-message {
     display: inline-block;
-    position: absolute;
-    top: 0;
     pointer-events: none;
 }
 
@@ -490,11 +476,11 @@ table {
     visibility: hidden;
     font-family: "Inter", Arial, Helvetica, sans-serif;
     background-color: $color-violet-30;
+    margin-left: $spacing-sm;
     padding: 2px 4px;
     border-radius: 4px;
     color: $color-white;
     font-size: 14px;
-    right: 0;
     transition: opacity 2s ease-out;
 }
 


### PR DESCRIPTION
Fixes #1138.

It used to be absolutely positioned to the right of the alias,
presumably to prevent the underline when hovering the button from
also underlining the copy icon by taking it out of the flow.
However, although the label was positioned to the right of the
label, it did so based on the center point of the label, resulting
in it overlapping the alias if the label was longer (like in other
languages).

This reworks that to just only place the underline under the alias
when hovering, and just positioning the "Copied!" label to the
right of the copy icon. The copy icon also no longer disappears.

Old:

https://user-images.githubusercontent.com/4251/135629070-db3d26d4-768b-424a-ab94-344aa73eca07.mp4

New:

https://user-images.githubusercontent.com/4251/135629091-bac13eb7-5aa3-4b43-8cca-eb0fd41dddd4.mp4

