### PR TITLE
fix #1157: use == instead of "is" for checking relay user email

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -417,8 +417,8 @@ def _handle_reply(from_address, message_json):
     stripped_reply_record_address = _strip_localpart_tag(reply_record_email)
 
     if (
-        (from_address is reply_record_email) or
-        (stripped_from_address is stripped_reply_record_address)
+        (from_address == reply_record_email) or
+        (stripped_from_address == stripped_reply_record_address)
     ):
         # This is a Relay user replying to an external sender;
         # verify they are premium


### PR DESCRIPTION
The reply code checks to see if the reply is coming from an email address that matches an existing Relay user. But it was using `is` which evaluates to `False` even when the values ARE equal. This means that Relay assumes (maybe another bug to dig into and fix?) the sender is the external party sending their reply.