### PR TITLE
Add a partial for notifications

### DIFF
--- a/privaterelay/templatetags/notification.py
+++ b/privaterelay/templatetags/notification.py
@@ -1,0 +1,41 @@
+from django import template
+
+register = template.Library()
+
+def do_notification(parser, token):
+    nodelist = parser.parse(('endnotification',))
+    parser.delete_first_token()
+    _tag_name, level = token.split_contents()
+    return NotificationNode(nodelist, level[1:-1])
+
+class NotificationNode(template.Node):
+    def __init__(self, nodelist, level):
+        self.nodelist = nodelist
+        self.level = 'info'
+        if (level == 'warning'):
+            self.level = 'warning'
+
+    def render(self, context):
+        content = self.nodelist.render(context)
+
+        theme = 't-info'
+        if (self.level == 'warning'):
+            theme = 't-warning'
+
+        # Note: the img[src] is currently root-relative; not sure how to make that use {% static %}:
+        output = '''
+            <div class="c-data-notification-banner js-notification {theme}">
+                <div class="dismiss-wrapper">
+                    <button class="data-notification-dismiss js-dismiss"><img src="/static/images/x-close.svg" alt="Close"></button>
+                </div>
+                <div class="data-notification-banner-bg">
+                    <div class="data-notification-banner-content">
+                        <div class="data-notification-banner-copy">
+                            {notification_content}
+                        </div>
+                    </div>
+                </div>
+            </div>'''.format(notification_content=content, theme=theme)
+        return output
+
+register.tag('notification', do_notification)

--- a/static/images/icon-orange-info.svg
+++ b/static/images/icon-orange-info.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM11 15H9V9H11V15ZM11 7H9V5H11V7Z" fill="#FFA436"/>
+</svg>


### PR DESCRIPTION
OK, so there are multiple places we need notifications, and they've got a rather elaborate HTML structure. I tried to turn the banner as @codemist made it (in https://github.com/mozilla/fx-private-relay/pull/1154/) into a reusable template, but obviously not knowing Python nor Django it's probably not ideal - hence y'all as reviewers :)

This is how it's used:

```
{% load notification %}

{% notification 'warning' %}

          <p class="data-notification-banner-header">Allow data collection for future features</p>
          <p class="data-notification-banner-sub">This data will allow you to label your aliases with the sites where they're generated and used in a future release. You can allow this data collection in “Settings.”</p>

{% endnotification %}
```

What I don't like is that you still have to know the HTML to use for the header and the body, but I couldn't see how to pass template tags (specifically `{% ftlmsg %}` as arguments to other template tags.