### PR TITLE
Fix #1136 - Add ellipsis overflow to filter bar input

### DIFF
--- a/static/scss/components/filter-bar.scss
+++ b/static/scss/components/filter-bar.scss
@@ -72,6 +72,10 @@
         &:focus, &:hover {
             background-image: url("/static/images/icon-search-blue.svg");
         }
+
+        &::placeholder {
+            text-overflow: ellipsis;
+        }
     }
 
     .c-filter-search-controls {


### PR DESCRIPTION
Fixes #1136 by adding ellipsis overflow to the placeholder of the filter bar. Keeps the placeholder from being cut-off.