### PR TITLE
Only make room for filter controls when needed

### DIFF
--- a/static/scss/components/filter-bar.scss
+++ b/static/scss/components/filter-bar.scss
@@ -57,14 +57,16 @@
     .c-filter-search-input {
         background-image: url("/static/images/icon-search.svg");
         margin-bottom: 0;
-        padding-right: 90px;
         position: relative;
         z-index: 0;
+        transition: padding-right .2s ease-out;
 
-        &.is-filtered + .c-filter-search-controls {
-            opacity: 1;
+        &.is-filtered,
+        &:focus {
+            padding-right: 90px;
         }
 
+        &.is-filtered + .c-filter-search-controls,
         &:focus + .c-filter-search-controls {
             opacity: 1;
         }


### PR DESCRIPTION
Fixes #1136, whitespace in the word filter input:

![image](https://user-images.githubusercontent.com/4251/136383997-9a1fe808-f2a5-42ff-9942-d2b160869913.png)

With this change, the search field expands to make room for the filter counts:

https://user-images.githubusercontent.com/4251/136384059-15c20dcb-8414-4491-a54f-050e3b3426db.mp4


