### PR TITLE
Make the word filter wider

### DIFF
--- a/static/scss/components/filter-bar.scss
+++ b/static/scss/components/filter-bar.scss
@@ -60,6 +60,7 @@
         position: relative;
         z-index: 0;
         transition: padding-right .2s ease-out;
+        width: $content-sm;
 
         &.is-filtered,
         &:focus {


### PR DESCRIPTION
In some languages the placeholder is rather long, so his gives it
more opportunity to be fully visible.

Fixes #1136, for good this time I hope.