### PR TITLE
Disallow whitespace-only labels

### DIFF
--- a/privaterelay/templates/profile.html
+++ b/privaterelay/templates/profile.html
@@ -135,6 +135,8 @@
                       aria-label="{% ftlmsg 'profile-label-edit' %}"
                       placeholder="{% ftlmsg 'profile-label-placeholder' %}"
                       class="relay-email-address-label js-relay-email-address-label ff-Met"
+                      {# Require at least one non-whitespace character:  #}
+                      pattern=".*\S.*"
                     >
                     <span class="saved-confirmation">{% ftlmsg 'profile-label-saved' %}</span>
                     <span class="input-error js-input-error" data-default-message="{% ftlmsg 'profile-label-save-error' %}"></span>

--- a/static/js/labels.js
+++ b/static/js/labels.js
@@ -94,7 +94,10 @@
         });
 
         labelInputElement.addEventListener("focusout", async () => {
-            await saveLabel(labelInputElement, aliasId, type);
+            const isValid = labelForm.reportValidity();
+            if (isValid) {
+                await saveLabel(labelInputElement, aliasId, type);
+            }
         });
         labelInputElement.addEventListener("focus", () => {
             labelInputElement.classList.remove("input-has-error");


### PR DESCRIPTION
Fixes https://github.com/mozilla/fx-private-relay-add-on/issues/104.

Using the `pattern` attribute doesn't provide a particularly
helpful error message, but since it's pretty clear what you're
doing wrong if you're only inserting whitespace, and also not
something people often do, I think that's probably fine.