### PR TITLE
Add client-side validation of the subdomain name

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -43,6 +43,8 @@ def valid_available_subdomain(subdomain, *args, **kwargs):
     # valid subdomains:
     #   can't start or end with a hyphen
     #   must be 1-63 alphanumeric characters and/or hyphens
+    # Make sure to keep this aligned with the `pattern` attribute
+    # of form#domainRegistration>input in banners.html:
     valid_subdomain_pattern = re.compile('^(?!-)[A-Za-z0-9-]{1,63}(?<!-)$')
     valid = valid_subdomain_pattern.match(subdomain) is not None
     #   can't have "bad" words in them

--- a/privaterelay/templates/includes/banners.html
+++ b/privaterelay/templates/includes/banners.html
@@ -76,6 +76,8 @@
                       name="subdomain"
                       minlength="1"
                       maxlength="63"
+                      {% comment %} Make sure to keep this regex aligned with the one in valid_available_subdomain() in models.py {% endcomment %}
+                      pattern="^(?!-)[A-Za-z0-9-]{1,63}(?<!-)$"
                     >
                     <input class="btn btn--gray" type="submit" value="{% ftlmsg 'banner-choose-subdomain-submit' %}">
                 </form>


### PR DESCRIPTION
Fixes #939.

Although UX-wise, the `pattern` attribute doesn't give great user
feedback in terms of telling them what they're doing wrong, the
status quo is that they'll get a 500 error, so this is somewhat
better.