### PR TITLE
fix settings page header label

### DIFF
--- a/privaterelay/templates/settings.html
+++ b/privaterelay/templates/settings.html
@@ -64,7 +64,7 @@
       <form action="#" class="js-settings-form mzp-c-form" data-profile-id="{{ user_profile.id }}">
         <div class="c-settings-form--field">
           <h2 class="mzp-c-form-subheading c-settings-form--heading">
-            {% ftlmsg 'setting-label-collection-heading' %}
+            {% ftlmsg 'setting-label-collection-heading-v2' %}
           </h2>
           <div class="mzp-c-choices c-settings-form--choices">
             <div class="mzp-c-choice">


### PR DESCRIPTION
Stage is missing the settings page header label:
![image](https://user-images.githubusercontent.com/71928/137034210-e90d3df7-70b4-4161-a20d-8dce7163b6ad.png)


Looks like the message ID was changed to `-v2`.