### PR TITLE
Align menu links with sign out buttons

### DIFF
--- a/static/scss/partials/glocal-menu.scss
+++ b/static/scss/partials/glocal-menu.scss
@@ -144,10 +144,14 @@ glocal-menu {
     padding: $spacing-md var(--glocalPaddingUnit);
     width: 100%;
     background-color: rgba(255, 255, 255, 0);
+    color: $color-violet-90;
+    font-size: 14px;
 
     img {
-        padding: 0 $spacing-xs;
-        padding-right: $spacing-md;
+        display: inline-block;
+        width: var(--glocalSmallAvatarDimensions);
+        margin-right: 12px;
+        opacity: .9;
     }
 }
 


### PR DESCRIPTION
Old:

![image](https://user-images.githubusercontent.com/4251/137128020-550fb0d8-eea6-4108-b7f5-e1229b922eb8.png)

New (same colours and alignment):

![image](https://user-images.githubusercontent.com/4251/137127976-69d88b5e-1fdb-4740-a3d3-cee9f0a52a39.png)
