### PR TITLE
Check bucket and object key None

### DIFF
--- a/emails/utils.py
+++ b/emails/utils.py
@@ -310,6 +310,8 @@ def get_message_content_from_s3(bucket, object_key):
 
 
 def remove_message_from_s3(bucket, object_key):
+    if bucket is None or object_key is None:
+        return False
     try:
         s3_client = apps.get_app_config('emails').s3_client
         response = s3_client.delete_object(

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -310,11 +310,12 @@ def _get_bucket_and_key_from_s3_json(message_json):
 
 def get_message_content_from_s3(bucket, object_key):
     try:
-        s3_client = apps.get_app_config('emails').s3_client
-        streamed_s3_object = s3_client.get_object(
-            Bucket=bucket, Key=object_key
-        ).get('Body')
-        return streamed_s3_object.read()
+        if bucket and object_key:
+            s3_client = apps.get_app_config('emails').s3_client
+            streamed_s3_object = s3_client.get_object(
+                Bucket=bucket, Key=object_key
+            ).get('Body')
+            return streamed_s3_object.read()
     except ClientError as e:
         logger.error('s3_client_error_get_email', extra=e.response['Error'])
     raise S3ClientException('Failed to fetch email from S3')

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -313,8 +313,8 @@ def remove_message_from_s3(bucket, object_key):
     try:
         s3_client = apps.get_app_config('emails').s3_client
         response = s3_client.delete_object(
-            Bucket=bucket,
-            Key=object_key
+            Bucket=None,
+            Key=None
         )
         return response.get('DeleteMarker')
     except ClientError as e:

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -313,8 +313,8 @@ def remove_message_from_s3(bucket, object_key):
     try:
         s3_client = apps.get_app_config('emails').s3_client
         response = s3_client.delete_object(
-            Bucket=None,
-            Key=None
+            Bucket=bucket,
+            Key=object_key
         )
         return response.get('DeleteMarker')
     except ClientError as e:

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -288,9 +288,20 @@ class S3ClientException(Exception):
         self.message = message
 
 
-def _get_bucket_and_key_from_s3_json(message_json_receipt):
+def _get_bucket_and_key_from_s3_json(message_json):
     bucket = None
     object_key = None
+    if 'receipt' in message_json and 'action' in message_json['receipt']:
+        message_json_receipt = message_json['receipt']
+    else:
+        # TODO: sns inbound notification does not have 'receipt'
+        # we need to look into this more
+        logger.error(
+            'sns_inbound_message_without_receipt',
+            extra={'message_json_keys': message_json.keys()}
+        )
+        return None, None
+
     if 'S3' in message_json_receipt['action']['type']:
         bucket = message_json_receipt['action']['bucketName']
         object_key = message_json_receipt['action']['objectKey']

--- a/emails/views.py
+++ b/emails/views.py
@@ -385,8 +385,8 @@ def _sns_message(message_json):
     )
 
     # only remove message from S3 if the email was stored in S3
-    if 'receipt' in message_json and 'action' in message_json['receipt']:
-        bucket, object_key = _get_bucket_and_key_from_s3_json( message_json['receipt'])
+    bucket, object_key = _get_bucket_and_key_from_s3_json(message_json)
+    if bucket and object_key:
         remove_message_from_s3(bucket, object_key)
 
     return response
@@ -565,9 +565,11 @@ def _handle_bounce(message_json):
 
 def _get_text_html_attachments(message_json):
     if 'content' in message_json:
+        # email content in sns message
         message_content = message_json['content'].encode('utf-8')
-    elif 'receipt' in message_json and 'action' in message_json['receipt']:
-        bucket, object_key = _get_bucket_and_key_from_s3_json( message_json['receipt'])
+    else:
+        # assume email content in S3
+        bucket, object_key = _get_bucket_and_key_from_s3_json(message_json)
         message_content = get_message_content_from_s3(bucket, object_key)
         histogram_if_enabled(
             'relayed_email.size',


### PR DESCRIPTION
# About this PR
Increase on 500s on our service because when email is being sent with sns only infrastructure the app code tried to delete a non-existing object in S3 as seen in [this Sentry error](https://sentry.prod.mozaws.net/operations/fx-private-relay-dev/issues/13761319/?query=is%3Aunresolved). Meaning, even if the email is sent with email content in the sns-inbound notification message, there is still the `receipt` field in the message_json which tricks the code into thinking an object exists in S3. And since our service returns a 500 to the SNS, SNS tries to resend the email resulting in same email being relayed repeatedly. Fix is to check for `None` for the bucket and object key before any S3 request is ran.

# Acceptance Criteria
- [ ] No more 500s from `TypeError` mentioned [here](https://sentry.prod.mozaws.net/operations/fx-private-relay-dev/issues/13761319/?query=is%3Aunresolved)
- [ ] Email is not repeatedly relayed