### PR TITLE
only call set_cookie if response available

### DIFF
--- a/privaterelay/signals.py
+++ b/privaterelay/signals.py
@@ -8,14 +8,14 @@ from emails.utils import incr_if_enabled
 @receiver(user_signed_up)
 def record_user_signed_up(request, user, **kwargs):
     incr_if_enabled('user_signed_up', 1)
-    kwargs.get('response').set_cookie(
-        'server_ga_event', 'user_signed_up', max_age=5
-    )
+    response = kwargs.get('response')
+    if response:
+        response.set_cookie('server_ga_event', 'user_signed_up', max_age=5)
 
 
 @receiver(user_logged_in)
 def record_user_logged_in(request, user, **kwargs):
     incr_if_enabled('user_logged_in', 1)
-    kwargs.get('response').set_cookie(
-        'server_ga_event', 'user_logged_in', max_age=5
-    )
+    response = kwargs.get('response')
+    if response:
+        response.set_cookie('server_ga_event', 'user_logged_in', max_age=5)


### PR DESCRIPTION
I'm not sure why the first sign-up signal is sometimes missing a `response` object, but need to prevent that causing errors.