### PR TITLE
Fix #1207 - Add privacy policy question to FAQs

### DIFF
--- a/privaterelay/templates/faq.html
+++ b/privaterelay/templates/faq.html
@@ -21,8 +21,6 @@
           <h2 class="faq-headline">{% ftlmsg 'faq-question-2-question' %}</h2>
           <p class="faq-answer js-set-href">{% ftlmsg 'faq-question-2-answer-html' url='https://addons.mozilla.org/firefox/addon/private-relay/' attrs='class="text-link" data-url="https://addons.mozilla.org/firefox/addon/private-relay/"' %}</p>
         </section>
-      </div>
-      <div class="faq-col flx flx-col">
         <section class="faq">
           <h2 class="faq-headline">{% ftlmsg 'faq-question-3-question' %}</h2>
           <p class="faq-answer">{% ftlmsg 'faq-question-3-answer' %}</p>
@@ -31,6 +29,8 @@
           <h2 class="faq-headline">{% ftlmsg 'faq-question-4-question' %}</h2>
           <p class="faq-answer js-set-href">{% ftlmsg 'faq-question-4-answer-html' url='https://github.com/mozilla/fx-private-relay/issues/99' attrs='class="text-link" data-url="https://github.com/mozilla/fx-private-relay/issues/99"' %}</p>
         </section>
+      </div>
+      <div class="faq-col flx flx-col">
         <section class="faq">
           <h2 class="faq-headline">{% ftlmsg 'faq-question-5-question' %}</h2>
           <p class="faq-answer">{% ftlmsg 'faq-question-5-answer' %}</p>
@@ -42,6 +42,10 @@
         <section class="faq">
           <h2 class="faq-headline">{% ftlmsg 'faq-question-7-question' %}</h2>
           <p class="faq-answer">{% ftlmsg 'faq-question-7-answer' size='150' unit='KB' %}</p>
+        </section>
+        <section class="faq">
+          <h2 class="faq-headline">{% ftlmsg 'faq-question-8-question' %}</h2>
+          <p class="faq-answer js-set-href">{% ftlmsg 'faq-question-8-answer-html' url='https://www.mozilla.org/privacy/firefox-relay/' attrs='class="text-link" data-url="https://www.mozilla.org/privacy/firefox-relay/"' %}</p>
         </section>
       </div>
     </div>


### PR DESCRIPTION
This PR adds a new question to the FAQ.

Depends on PR https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/24 

Link goes to: https://www.mozilla.org/privacy/firefox-relay/

Preview: 
<img width="774" alt="image" src="https://user-images.githubusercontent.com/2692333/137253560-3220a4ed-5961-448f-a685-9de921660af4.png">
