### PR TITLE
Don't let .mzp-l-content overlap dismiss button

### DIFF
--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -78,6 +78,7 @@
 
     .mzp-l-content {
         padding: $spacing-lg $spacing-lg;
+        position: initial;
     }
 }
 
@@ -131,7 +132,6 @@
     padding: 0;
     cursor: pointer;
     display: block;
-    z-index: 5;
     transition: transform .3s ease-in;
 
     &:hover {


### PR DESCRIPTION
Fixes #1172.

The z-index already did that, but then made the dismiss button
in turn overlap the header. This just removes the relative
positioning from .mzp-l-content, which it doesn't seem to need (at
least not here).