### PR TITLE
fix MPP-1030: default_server_storage function

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -62,6 +62,10 @@ def valid_available_subdomain(subdomain, *args, **kwargs):
     return True
 
 
+def default_server_storage():
+    return datetime.now(timezone.utc) > settings.PREMIUM_RELEASE_DATE
+
+
 class Profile(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     api_token = models.UUIDField(default=uuid.uuid4)
@@ -79,7 +83,7 @@ class Profile(models.Model):
         blank=True, null=True, unique=True, max_length=63, db_index=True,
         validators=[valid_available_subdomain]
     )
-    server_storage = models.BooleanField(default=False)
+    server_storage = models.BooleanField(default=default_server_storage)
 
     def __str__(self):
         return '%s Profile' % self.user

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -689,6 +689,21 @@ class ProfileTest(TestCase):
         profile = Profile.objects.get(user=user)
         assert profile.joined_before_premium_release is False
 
+    @override_settings(
+        PREMIUM_RELEASE_DATE=datetime.now(timezone.utc) + timedelta(days=1)
+    )
+    def test_user_created_before_premium_release_server_storage_False(self):
+        user = baker.make(User)
+        profile = Profile.objects.get(user=user)
+        assert not profile.server_storage
+
+    @override_settings(
+        PREMIUM_RELEASE_DATE=datetime.now(timezone.utc) - timedelta(days=1)
+    )
+    def test_user_created_after_premium_release_server_storage_True(self):
+        user = baker.make(User)
+        profile = Profile.objects.get(user=user)
+        assert profile.server_storage
 
 class DomainAddressTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
Update Profile model to use new default_server_storage callable function
to determine its default value. The function returns False before
premium release and True after premium release.