### PR TITLE
🛑 DNM: Use new string for the email attachment limit

### DIFF
--- a/privaterelay/templates/includes/alias-stats.html
+++ b/privaterelay/templates/includes/alias-stats.html
@@ -14,7 +14,7 @@
   <span class="forwarding-description stat-description">
     {% ftlmsg 'profile-forwarded-copy' %}
     <p>
-      <strong>{% ftlmsg 'profile-forwarded-note' %}</strong> {% ftlmsg 'profile-forwarded-note-copy' size='10' unit='MB' %}
+      <strong>{% ftlmsg 'profile-forwarded-note' %}</strong> {% ftlmsg 'profile-forwarded-note-copy-v2' size='10' unit='MB' %}
     </p>
   </span>
 </div>


### PR DESCRIPTION
~Do not merge until this is merged: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/29~

Builds on #1231, so only 5cc08e2 is relevant for this PR.