### PR TITLE
Only show summary stats when there are aliases

### DIFF
--- a/privaterelay/templates/profile.html
+++ b/privaterelay/templates/profile.html
@@ -33,7 +33,7 @@
   <div class="messages-profile">
     {% include "includes/messages.html" %}
   </div>
-  {% if user_profile.has_premium %}
+  {% if user_profile.has_premium and user_profile.num_active_address > 0 %}
   <div class="mpp-dashbaord-header">
     <div class="mpp-dashbaord-header-container inset">
       <div class="mpp-dashbaord-header-title">

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -258,6 +258,7 @@ button:active {
     max-width: $content-xl;
     margin: auto;
     justify-content: flex-start;
+    padding-top: $spacing-md;
     padding-bottom: $layout-xl;
     padding-left: $spacing-md;
     padding-right: $spacing-md;


### PR DESCRIPTION
This makes the onboarding less overwhelming.