### PR TITLE
Don't hide other banners with the collection one

### DIFF
--- a/privaterelay/templates/includes/banners.html
+++ b/privaterelay/templates/includes/banners.html
@@ -20,26 +20,27 @@
       </div>
     </div>
   </div>
-{% elif show_data_notification_banner %}
-  {% with request.user.profile_set.first as user_profile %}
-    {% if not user_profile.server_storage %}
-      <div id="sync-labels" class="c-notification-banner c-data-notification-banner t-warning is-hidden">
-        <div class="dismiss-wrapper">
-          <button class="notification-dismiss js-data-collection-dismiss"><img src="{% static 'images/x-close.svg' %}"></button>
-        </div>
-        <div class="notification-banner-bg">
-          <div class="notification-banner-content">
-            <div class="notification-banner-copy">
-              <p class="notification-banner-header">{% ftlmsg 'banner-label-data-notification-header' %}</p>
-              <p class="notification-banner-sub">{% ftlmsg 'banner-label-data-notification-body' %}</p>
-              <a class="notification-banner-link" href="/accounts/settings" rel="noopener noreferrer">{% ftlmsg 'banner-label-data-notification-cta' %}</a>
+{% else %}
+  {% if show_data_notification_banner %}
+    {% with request.user.profile_set.first as user_profile %}
+      {% if not user_profile.server_storage %}
+        <div id="sync-labels" class="c-notification-banner c-data-notification-banner t-warning is-hidden">
+          <div class="dismiss-wrapper">
+            <button class="notification-dismiss js-data-collection-dismiss"><img src="{% static 'images/x-close.svg' %}"></button>
+          </div>
+          <div class="notification-banner-bg">
+            <div class="notification-banner-content">
+              <div class="notification-banner-copy">
+                <p class="notification-banner-header">{% ftlmsg 'banner-label-data-notification-header' %}</p>
+                <p class="notification-banner-sub">{% ftlmsg 'banner-label-data-notification-body' %}</p>
+                <a class="notification-banner-link" href="/accounts/settings" rel="noopener noreferrer">{% ftlmsg 'banner-label-data-notification-cta' %}</a>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    {% endif %}
-  {% endwith %}
-{% else %}
+      {% endif %}
+    {% endwith %}
+  {% endif %}
   <div class="dashboard-banners invisible">
     <div class="flx hide-750">
       <div class="banner-gradient-bg addon">


### PR DESCRIPTION
Fixes #1241, fixes #1243.

The `if` for hiding the data notification banner was placed as an
`elif` after the last_bounce_type `if`, resulting in the regular
`else` no longer being hit. This meant that as long as the data
collection notification banner is active, the others wouldn't be
shown.