### PR TITLE
fix drf permissions attributes so unauthorized access returns 4xx

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -31,7 +31,7 @@ class SaveToRequestUser:
 
 class RelayAddressViewSet(SaveToRequestUser, viewsets.ModelViewSet):
     serializer_class = RelayAddressSerializer
-    permissions_classes = [permissions.IsAuthenticated, IsOwner]
+    permission_classes = [permissions.IsAuthenticated, IsOwner]
 
     def get_queryset(self):
         return RelayAddress.objects.filter(user=self.request.user)
@@ -39,7 +39,7 @@ class RelayAddressViewSet(SaveToRequestUser, viewsets.ModelViewSet):
 
 class DomainAddressViewSet(SaveToRequestUser, viewsets.ModelViewSet):
     serializer_class = DomainAddressSerializer
-    permissions_classes = [permissions.IsAuthenticated, IsOwner]
+    permission_classes = [permissions.IsAuthenticated, IsOwner]
 
     def get_queryset(self):
         return DomainAddress.objects.filter(user=self.request.user)
@@ -47,7 +47,7 @@ class DomainAddressViewSet(SaveToRequestUser, viewsets.ModelViewSet):
 
 class ProfileViewSet(viewsets.ModelViewSet):
     serializer_class = ProfileSerializer
-    permissions_classes = [permissions.IsAuthenticated, IsOwner]
+    permission_classes = [permissions.IsAuthenticated, IsOwner]
 
     def get_queryset(self):
         return Profile.objects.filter(user=self.request.user)

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -401,7 +401,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ],
-    'DEFAULT_PERMISSIONS_CLASSES': [
+    'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated'
     ],
     'DEFAULT_RENDERER_CLASSES': DRF_RENDERERS,


### PR DESCRIPTION
our api ModelViewSets have restricted data access using queryset
filter(user=request.user), but this makes un-authenticated or
un-authorized requests trigger a 5xx error instead of a proper 4xx
error.

this fixes the DRF global setting, and our ModelViewSets permission
attribute to properly enforce all 3 layers of access control:

1. (Global) User must be authenticated
2. (Model-level) User must be authenticated owner of the object
3. (Queryset-level) User can only see their own data

## To test:

`curl -sD - -o /dev/null http://127.0.0.1:8000/api/v1/profiles/16/`

Expected result:

`HTTP/1.1 401 Unauthorized`

Previous result:

`HTTP/1.1 500 Internal Server Error`