### PR TITLE
Make settings screen stretch full page height

### DIFF
--- a/privaterelay/templates/base.html
+++ b/privaterelay/templates/base.html
@@ -30,15 +30,17 @@
     <meta name="twitter:description" content="{% ftlmsg 'meta-description' %}">
     <meta name="twitter:image" content="{{request.scheme}}://{{request.META.HTTP_HOST}}{% static 'images/share-relay.jpg' %}">
   </head>
-  <body class="{% with request.user.profile_set.first as user_profile %}{% if user_profile.has_premium %}is-premium{% endif %}{% endwith %}" data-fxa-settings-url="{{ settings.FXA_SETTINGS_URL }}" data-site-origin="{{ settings.SITE_ORIGIN }}" data-google-analytics-id="{{ settings.GOOGLE_ANALYTICS_ID }}" data-debug="{{ settings.DEBUG }}">
-    {% include "includes/modal-delete.html" %}
-    {% include "includes/modal-domain-registration-confirmation.html" %}
-    {% include "includes/header.html" %}
-    <firefox-private-relay-addon data-user-logged-in="{{ request.user.is_authenticated }}" data-addon-installed="false"></firefox-private-relay-addon>
-    {% block content %}
-    {% endblock %}
+  <body class="{% with request.user.profile_set.first as user_profile %}{% if user_profile.has_premium %}is-premium{% endif %}{% endwith %} {% if request.resolver_match.url_name == "faq" %}is-dark{% endif %}" data-fxa-settings-url="{{ settings.FXA_SETTINGS_URL }}" data-site-origin="{{ settings.SITE_ORIGIN }}" data-google-analytics-id="{{ settings.GOOGLE_ANALYTICS_ID }}" data-debug="{{ settings.DEBUG }}">
+    <div class="c-layout-wrapper">
+      {% include "includes/modal-delete.html" %}
+      {% include "includes/modal-domain-registration-confirmation.html" %}
+      {% include "includes/header.html" %}
+      <firefox-private-relay-addon data-user-logged-in="{{ request.user.is_authenticated }}" data-addon-installed="false"></firefox-private-relay-addon>
+      {% block content %}
+      {% endblock %}
 
-    {% include "includes/footer.html" %}
+      {% include "includes/footer.html" %}
+    </div>
 
     {% block javascript %}
     {% endblock %}

--- a/privaterelay/templates/faq.html
+++ b/privaterelay/templates/faq.html
@@ -6,48 +6,50 @@
 
 {% block content %}
   <div class="c-body-wrapper t-dark">
-    <main class="flx flx-col container faqs-wrapper">
-      <h1 class="faqs-headline">{% ftlmsg 'faq-headline' %}</h1>
-      <div class="faqs flx flx-row spc-btwn">
-        <div class="faq-col flx flx-col">
-          <section class="faq">
-            <h2 class="faq-headline">{% ftlmsg 'faq-question-1-question' %}</h2>
-            <p class="faq-answer js-set-href">
-              {% ftlmsg 'faq-question-1-answer-a' %}
-              <br/><br/>
-              {% ftlmsg 'faq-question-1-answer-b-html' url='https://addons.mozilla.org/firefox/addon/private-relay/' attrs='class="text-link" data-url="https://addons.mozilla.org/firefox/addon/private-relay/"' %}
-            </p>
-          </section>
-          <section class="faq">
-            <h2 class="faq-headline">{% ftlmsg 'faq-question-2-question' %}</h2>
-            <p class="faq-answer js-set-href">{% ftlmsg 'faq-question-2-answer-html' url='https://addons.mozilla.org/firefox/addon/private-relay/' attrs='class="text-link" data-url="https://addons.mozilla.org/firefox/addon/private-relay/"' %}</p>
-          </section>
-        </div>
-        <div class="faq-col flx flx-col">
-          <section class="faq">
-            <h2 class="faq-headline">{% ftlmsg 'faq-question-3-question' %}</h2>
-            <p class="faq-answer">{% ftlmsg 'faq-question-3-answer' %}</p>
-          </section>
-          <section class="faq">
-            <h2 class="faq-headline">{% ftlmsg 'faq-question-4-question' %}</h2>
-            <p class="faq-answer js-set-href">{% ftlmsg 'faq-question-4-answer-html' url='https://github.com/mozilla/fx-private-relay/issues/99' attrs='class="text-link" data-url="https://github.com/mozilla/fx-private-relay/issues/99"' %}</p>
-          </section>
-          <section class="faq">
-            <h2 class="faq-headline">{% ftlmsg 'faq-question-5-question' %}</h2>
-            <p class="faq-answer">{% ftlmsg 'faq-question-5-answer' %}</p>
-          </section>
-          <section class="faq">
-            <h2 class="faq-headline">{% ftlmsg 'faq-question-6-question' %}</h2>
-            <p class="faq-answer">{% ftlmsg 'faq-question-6-answer' %}</p>
-          </section>
-          <section class="faq">
-            <h2 class="faq-headline">{% ftlmsg 'faq-question-7-question' %}</h2>
-            <p class="faq-answer">{% ftlmsg 'faq-question-7-answer' size='150' unit='KB' %}</p>
-          </section>
-          <section class="faq">
-            <h2 class="faq-headline">{% ftlmsg 'faq-question-8-question' %}</h2>
-            <p class="faq-answer js-set-href">{% ftlmsg 'faq-question-8-answer-html' url='https://www.mozilla.org/privacy/firefox-relay/' attrs='class="text-link" data-url="https://www.mozilla.org/privacy/firefox-relay/"' %}</p>
-          </section>
+    <main class="faqs-wrapper">
+      <div class="flx flx-col container faqs-container">
+        <h1 class="faqs-headline">{% ftlmsg 'faq-headline' %}</h1>
+        <div class="faqs flx flx-row spc-btwn">
+          <div class="faq-col flx flx-col">
+            <section class="faq">
+              <h2 class="faq-headline">{% ftlmsg 'faq-question-1-question' %}</h2>
+              <p class="faq-answer js-set-href">
+                {% ftlmsg 'faq-question-1-answer-a' %}
+                <br/><br/>
+                {% ftlmsg 'faq-question-1-answer-b-html' url='https://addons.mozilla.org/firefox/addon/private-relay/' attrs='class="text-link" data-url="https://addons.mozilla.org/firefox/addon/private-relay/"' %}
+              </p>
+            </section>
+            <section class="faq">
+              <h2 class="faq-headline">{% ftlmsg 'faq-question-2-question' %}</h2>
+              <p class="faq-answer js-set-href">{% ftlmsg 'faq-question-2-answer-html' url='https://addons.mozilla.org/firefox/addon/private-relay/' attrs='class="text-link" data-url="https://addons.mozilla.org/firefox/addon/private-relay/"' %}</p>
+            </section>
+          </div>
+          <div class="faq-col flx flx-col">
+            <section class="faq">
+              <h2 class="faq-headline">{% ftlmsg 'faq-question-3-question' %}</h2>
+              <p class="faq-answer">{% ftlmsg 'faq-question-3-answer' %}</p>
+            </section>
+            <section class="faq">
+              <h2 class="faq-headline">{% ftlmsg 'faq-question-4-question' %}</h2>
+              <p class="faq-answer js-set-href">{% ftlmsg 'faq-question-4-answer-html' url='https://github.com/mozilla/fx-private-relay/issues/99' attrs='class="text-link" data-url="https://github.com/mozilla/fx-private-relay/issues/99"' %}</p>
+            </section>
+            <section class="faq">
+              <h2 class="faq-headline">{% ftlmsg 'faq-question-5-question' %}</h2>
+              <p class="faq-answer">{% ftlmsg 'faq-question-5-answer' %}</p>
+            </section>
+            <section class="faq">
+              <h2 class="faq-headline">{% ftlmsg 'faq-question-6-question' %}</h2>
+              <p class="faq-answer">{% ftlmsg 'faq-question-6-answer' %}</p>
+            </section>
+            <section class="faq">
+              <h2 class="faq-headline">{% ftlmsg 'faq-question-7-question' %}</h2>
+              <p class="faq-answer">{% ftlmsg 'faq-question-7-answer' size='150' unit='KB' %}</p>
+            </section>
+            <section class="faq">
+              <h2 class="faq-headline">{% ftlmsg 'faq-question-8-question' %}</h2>
+              <p class="faq-answer js-set-href">{% ftlmsg 'faq-question-8-answer-html' url='https://www.mozilla.org/privacy/firefox-relay/' attrs='class="text-link" data-url="https://www.mozilla.org/privacy/firefox-relay/"' %}</p>
+            </section>
+          </div>
         </div>
       </div>
     </main>

--- a/static/scss/pages/faq.scss
+++ b/static/scss/pages/faq.scss
@@ -1,3 +1,7 @@
+.faqs-wrapper {
+    background-image: var(--darkBlueGradient);
+}
+
 .faqs {
     column-width: $content-sm;
     column-gap: $spacing-2xl;
@@ -35,7 +39,7 @@
 
 @media screen and #{$mq-lg} {
 
-    .faqs-wrapper {
+    .faqs-container {
         max-width: $content-xl;
     }
 

--- a/static/scss/pages/settings.scss
+++ b/static/scss/pages/settings.scss
@@ -1,4 +1,5 @@
 .settings-main {
+    flex-grow: 2;
 
     .c-settings-headline {
         @include text-title-2xs;

--- a/static/scss/partials/header.scss
+++ b/static/scss/partials/header.scss
@@ -260,7 +260,7 @@ header {
 }
 
 
-.is-premium {
+.is-premium:not(.is-dark) {
 
     header {
         background: $color-white;

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -5,6 +5,7 @@
 html {
     font-size: 100%;
     scroll-behavior: smooth;
+    height: 100%;
 
     @media (prefers-reduced-motion) {
 
@@ -19,7 +20,7 @@ body {
     font-family: "Inter", Helvetica Neue, Helvetica, Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    min-height: 100vh;
+    height: 100%;
     display: flex;
     flex-direction: column;
     margin: 0;
@@ -180,6 +181,12 @@ button:active {
     border: 0;
 }
 
+.c-layout-wrapper {
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+}
+
 .bold {
     font-weight: 700;
 }
@@ -265,7 +272,6 @@ button:active {
 }
 
 .dashboard-container {
-    height: 100%;
     background-color: $color-mpp-background;
     background-color: $color-grey-05;
     padding-left: 0;


### PR DESCRIPTION
The main changes is that everything is now wrapped in a flex `.layout-wrapper`, so that a child of it can set `flex-grow: 2` to fill out the full height of the page.

However, this meant that the gradient set on `body` was now the height of the viewport, which means it didn't fully cover the FAQs. So I've removed that gradient, and instead wrapped the FAQs in an element with that background directly. That left the header not having the background colour, which I solved by adding an `is-dark` class to the body for the FAQs, and prevented the premium styles from applying if that class was present.