### PR TITLE
Fix #1173 - Disable delete button on modal close

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -128,6 +128,10 @@ function deleteAliasConfirmation(submitEvent) {
   checkbox.focus();
 
   const closeModal = () => {
+    const confirmDeleteModalActions =
+      confirmDeleteModal.querySelectorAll("button");
+    const deleteAnywayBtn = confirmDeleteModalActions[1];
+    deleteAnywayBtn.disabled = true;
     checkbox.checked = false;
     confirmDeleteModal.classList.remove("is-visible");
     trapFocusInModal("delete-modal", false);


### PR DESCRIPTION
Bug Fix for #1173 / https://mozilla-hub.atlassian.net/browse/MPP-1138

## Testing Steps

- Log into Relay
- Click "Delete" under any alias
- On modal, click checkbox
- **Expected:** Delete button turns RED, becoming active
- Dismiss modal (Click cancel, click outside of modal area, click esc kep) 
- Click on "Delete" again
- **Expected:** Delete button should be gray

## Screenshots: 

Active: 
<img width="663" alt="image" src="https://user-images.githubusercontent.com/2692333/138527346-c7814dc3-7b7a-4216-a185-3608e932906a.png">


Disabled:
<img width="629" alt="image" src="https://user-images.githubusercontent.com/2692333/138527343-892e4d9b-7a05-4f09-a85e-ef72d6f4b71e.png">
