### PR TITLE
fix #1093 mpp #971: just check for presence of fxa_refresh url param

### DIFF
--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -71,7 +71,7 @@ def faq(request):
 def profile(request):
     if (not request.user or request.user.is_anonymous):
         return redirect(reverse('fxa_login'))
-    if request.GET.get('fxa_refresh') == 1:
+    if 'fxa_refresh' in request.GET:
         fxa = _get_fxa(request)
         _handle_fxa_profile_change(fxa)
     relay_addresses = RelayAddress.objects.filter(user=request.user).order_by(


### PR DESCRIPTION
Wow, this fixes a long-standing bug we've had in local dev environments too.

To test:

1. On local dev environment, go thru premium purchase flow
2. When you get back to http://127.0.0.1:8000/accounts/profile/?fxa_refresh=1 ...
   * It should automatically refresh your FXA data, detect your premium subscription, and update the page accordingly