### PR TITLE
use accept language to show country-specific price

### DIFF
--- a/privaterelay/context_processors.py
+++ b/privaterelay/context_processors.py
@@ -2,6 +2,8 @@ from functools import lru_cache
 
 from django.conf import settings
 
+from .templatetags.relay_tags import premium_plan_price
+
 
 def django_settings(request):
     return {'settings': settings}
@@ -9,10 +11,12 @@ def django_settings(request):
 def common(request):
     fxa = _get_fxa(request)
     avatar = fxa.extra_data['avatar'] if fxa else None
+    accept_language = request.headers.get('Accept-Language', 'en-US')
     return {
         'avatar': avatar,
         'ftl_mode': 'server',
-        'accept_language': request.headers.get('Accept-Language', 'en-US')
+        'accept_language': accept_language,
+        'monthly_price': premium_plan_price(accept_language)
     }
 
 @lru_cache(maxsize=None)

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -282,7 +282,7 @@ PREMIUM_PLAN_ID_MATRIX = {
     "usd": {
         "en": {
             "id": "price_1JmRSRJNcmPzuWtRN9MG5cBy",
-            "price": "US$0.99"
+            "price": "$0.99"
         }
     }
 }

--- a/privaterelay/templates/newlanding/a/plans.html
+++ b/privaterelay/templates/newlanding/a/plans.html
@@ -21,8 +21,7 @@
                 <div class="c-option c-premium">
                     <img class="c-brand-title" src="{% static 'images/logos/logo-firefox-premium-relay.svg' %}">
                     <p class="c-price premium-price">
-                        <span class="c-price-number">$0.99</span>
-                        <span class="c-currency">{% ftlmsg 'landing-pricing-premium-price' monthly_price='USD' %}</span>
+                        <span class="c-price-number">{{ monthly_price }}</span>
                     </p>
                     <div class="c-features premium-list">
                         <ul class="c-list">
@@ -40,7 +39,7 @@
     
             <div class="c-pricing-text">
                 <div class="c-text">
-                    <h2 class="c-main-header">{% ftlmsg 'landing-pricing-headline' monthly_price='$0.99 USD' %}</h2>
+                    <h2 class="c-main-header">{% ftlmsg 'landing-pricing-headline' monthly_price=monthly_price %}</h2>
                     <p class="c-pricing-body">{% ftlmsg 'landing-pricing-body' %}</p>
                 </div>
             </div>

--- a/privaterelay/templates/newlanding/a/plans.html
+++ b/privaterelay/templates/newlanding/a/plans.html
@@ -1,3 +1,5 @@
+{% load relay_tags %}
+{% load socialaccount %}
 {% load static %}
 {% load ftl %}
 
@@ -13,7 +15,7 @@
                         <li>{% ftlmsg 'landing-pricing-free-feature-1' %}</li>
                         <li>{% ftlmsg 'landing-pricing-free-feature-2' %}</li>
                     </ul>
-                    <a class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg">
+                    <a class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg" href="{% provider_login_url 'fxa' process='login' %}">
                         {% ftlmsg 'landing-pricing-free-cta' %}
                     </a>
                 </div>
@@ -31,7 +33,7 @@
                             <li>{% ftlmsg 'landing-pricing-premium-feature-4' %}</li>
                         </ul>
                     </div>
-                    <a class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg">
+                    <a class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg" href="{% premium_subscribe_url accept_language %}" target="_blank" rel="noopener noreferrer">
                         {% ftlmsg 'nav-profile-sign-up' %}
                     </a>
                 </div>

--- a/privaterelay/templatetags/relay_tags.py
+++ b/privaterelay/templatetags/relay_tags.py
@@ -47,6 +47,11 @@ def premium_plan_id(accept_lang):
     return settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING[cc][lang]["id"]
 
 @register.simple_tag
+def premium_plan_price(accept_lang):
+    cc, lang = get_premium_country_lang(accept_lang)
+    return settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING[cc][lang]["price"]
+
+@register.simple_tag
 def premium_subscribe_url(accept_lang=None):
     plan_id = premium_plan_id(accept_lang)
     return f'{settings.FXA_SUBSCRIPTIONS_URL}/products/{settings.PREMIUM_PROD_ID}?plan={plan_id}'


### PR DESCRIPTION
To test:

1. Set browser language to en-US
2. Visit http://127.0.0.1:8000/
   * Expected: See price in $, with link to English $ plan:
<img width="1367" alt="image" src="https://user-images.githubusercontent.com/71928/138573507-069a6ef8-741f-44d3-b02f-99209cd9caec.png">

3. Set browser language to de
4. Visit http://127.0.0.1:8000/
   * Expected: See price in €, with link to German € plan:
<img width="1340" alt="image" src="https://user-images.githubusercontent.com/71928/138573533-9b1dccff-b1d7-4270-be86-ae0d666f7b53.png">

5. Set browser language to de
6. Visit http://127.0.0.1:8000/
   * Expected: See price in CHF, with link to German CHF plan:
<img width="1346" alt="image" src="https://user-images.githubusercontent.com/71928/138573559-b735625d-4d5b-4f27-9639-a9cbe1e7bb0a.png">