### PR TITLE
Add back /month copy to premium pricing plan box

### DIFF
--- a/privaterelay/templates/newlanding/a/plans.html
+++ b/privaterelay/templates/newlanding/a/plans.html
@@ -24,6 +24,7 @@
                     <img class="c-brand-title" src="{% static 'images/logos/logo-firefox-premium-relay.svg' %}">
                     <p class="c-price premium-price">
                         <span class="c-price-number">{{ monthly_price }}</span>
+                        <span class="c-currency">{% ftlmsg 'landing-pricing-premium-price' monthly_price="" %}</span>
                     </p>
                     <div class="c-features premium-list">
                         <ul class="c-list">


### PR DESCRIPTION
Reverts a change from https://github.com/mozilla/fx-private-relay/pull/1276/files

Preview: 

EN: 
<img width="403" alt="image" src="https://user-images.githubusercontent.com/2692333/138578568-b6823e85-cd71-441c-b193-1434f532de4a.png">

DE: 
<img width="365" alt="image" src="https://user-images.githubusercontent.com/2692333/138578600-df7dd412-e566-461b-94a9-38502e9ff3cb.png">
