### PR TITLE
restore c-currency span to show /month

### DIFF
--- a/privaterelay/templates/newlanding/a/plans.html
+++ b/privaterelay/templates/newlanding/a/plans.html
@@ -24,6 +24,7 @@
                     <img class="c-brand-title" src="{% static 'images/logos/logo-firefox-premium-relay.svg' %}">
                     <p class="c-price premium-price">
                         <span class="c-price-number">{{ monthly_price }}</span>
+                        <span class="c-currency">{% ftlmsg 'landing-pricing-premium-price' monthly_price='' %}</span>
                     </p>
                     <div class="c-features premium-list">
                         <ul class="c-list">


### PR DESCRIPTION
Since the monthly price is already in the `c-price-number` span, I'm calling `ftlmsg` with monthly_price='' so we don't duplicate it:

## en-US
<img width="447" alt="image" src="https://user-images.githubusercontent.com/71928/138595771-a5477db7-eb05-4176-92c7-1f40df1aa066.png">

## de
<img width="454" alt="image" src="https://user-images.githubusercontent.com/71928/138595870-25e18b6c-c144-43a5-bd57-7d78f1cdf27d.png">

## de-CH
<img width="448" alt="image" src="https://user-images.githubusercontent.com/71928/138595880-953fff21-5ab9-4af3-b36e-3bd079dd5b75.png">
