### PR TITLE
Add attribution correlate emails being sent from Relay

### DIFF
--- a/emails/utils.py
+++ b/emails/utils.py
@@ -82,6 +82,7 @@ def ses_send_raw_email(
             RawMessage={
                 'Data': msg_with_attachments.as_string(),
             },
+            ConfigurationSetName=settings.AWS_SES_CONFIGSET,
         )
         incr_if_enabled('ses_send_raw_email', 1)
 


### PR DESCRIPTION
# About this PR
To correlate emails being sent from Relay, specifically as opposed to other services at Mozilla, we need to add `ConfigurationSetName`. Just like `ses_send_email`, `send_raw_email` also has the `ConfigurationSetName` argument ([document here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses.html#SES.Client.send_raw_email)) to attribution email sends.