### PR TITLE
Fix category filter logic

### DIFF
--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -36,11 +36,10 @@
             // "relay-aliases"– Only show aliases that have been generated from the dashboard/add-on 
             // "domain-aliases"– Only show aliases that were created with a unique subdomain. 
             const matchesCategoryFilters = (
-                activeCategoryFilters.length === 0 ||
-                (activeCategoryFilters.includes("active-aliases") && aliasContainer.classList.contains("is-enabled")) ||
-                (activeCategoryFilters.includes("disabled-aliases") && !aliasContainer.classList.contains("is-enabled")) ||
-                (activeCategoryFilters.includes("relay-aliases") && aliasContainer.classList.contains("is-relay-alias")) ||
-                (activeCategoryFilters.includes("domain-aliases") && aliasContainer.classList.contains("is-domain-alias"))
+                (!activeCategoryFilters.includes("active-aliases") || aliasContainer.classList.contains("is-enabled")) &&
+                (!activeCategoryFilters.includes("disabled-aliases") || !aliasContainer.classList.contains("is-enabled")) &&
+                (!activeCategoryFilters.includes("relay-aliases") || aliasContainer.classList.contains("is-relay-alias")) &&
+                (!activeCategoryFilters.includes("domain-aliases") || aliasContainer.classList.contains("is-domain-alias"))
             );
 
             if (matchesSearchFilter && matchesCategoryFilters) {


### PR DESCRIPTION
Fixes #1166.

Looks like I got my boolean logic messed up the first time around :sweat_smile: Now, instead of saying an element matches the category filter if one of them is enabled and it matches, now _every_ filter should either not be enabled or match.