### PR TITLE
Also disallow whitespace for domain alias labels

### DIFF
--- a/privaterelay/templates/profile.html
+++ b/privaterelay/templates/profile.html
@@ -266,6 +266,8 @@
                       aria-label="{% ftlmsg 'profile-label-edit' %}"
                       placeholder="{% ftlmsg 'profile-label-placeholder' %}"
                       class="relay-email-address-label js-relay-email-address-label ff-Met"
+                      {# Require at least one non-whitespace character:  #}
+                      pattern=".*\S.*"
                     >
                     <span class="saved-confirmation">{% ftlmsg 'profile-label-saved' %}</span>
                     <span class="input-error js-input-error" data-default-message="{% ftlmsg 'profile-label-save-error' %}"></span>


### PR DESCRIPTION
This is a followup on #1191, to also disallow whitespace-only for subdomain alias labels. (I feel like the similarities between custom and random aliases are greater than their differences, so hopefully at some point we can re-architecture this to make them use mostly the same code path to avoid errors like this.)