### PR TITLE
Don't truncate label fields with placeholders

### DIFF
--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -585,7 +585,6 @@ input::placeholder,
 .relay-email-address-label:placeholder-shown {
     color: $color-grey-50;
     opacity: 1;
-    width: 192px;
 }
 
 input:focus::placeholder {


### PR DESCRIPTION
Otherwise, label fields without a value will have a different width
from those with a value.

Fixes #1223.

Note that this reverts part of #978, but since that was intended to prevent long alias names from expanding beyond the target width (which still works), I think this should be fine.