### PR TITLE
Fix #1295 - Wrong target when clicking plus next to FAQ accordion

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -640,9 +640,10 @@ function scrollToSubdomainRegistrationAndShowErrorState() {
 const faqQuestion = document.querySelectorAll(".c-faq-question");
 
 function showFAQAnswer(elem) {
-  if (elem.target.getAttribute("aria-expanded") === "true") {
-    elem.target.setAttribute("aria-expanded", "false");
-    document.getElementById(elem.target.getAttribute("aria-controls")).hidden = true;
+  const expandButton = elem.querySelector("button");
+  if (expandButton.getAttribute("aria-expanded") === "true") {
+    expandButton.setAttribute("aria-expanded", "false");
+    document.getElementById(expandButton.getAttribute("aria-controls")).hidden = true;
     return;
   }
 
@@ -652,12 +653,11 @@ function showFAQAnswer(elem) {
     document.getElementById(expandButton.getAttribute("aria-controls")).hidden = true;
   });
 
-  elem.target.setAttribute("aria-expanded", "true");
-  document.getElementById(elem.target.getAttribute("aria-controls")).hidden = false;
-  return;
+  expandButton.setAttribute("aria-expanded", "true");
+  document.getElementById(expandButton.getAttribute("aria-controls")).hidden = false;
 }
 
 faqQuestion.forEach(item => {
   const expandButton = item.querySelector("button");
-  expandButton.addEventListener("click", showFAQAnswer, false);
+  expandButton.addEventListener("click", () => showFAQAnswer(item), false);
 });


### PR DESCRIPTION
Hey!

I had a look at #1295 and noticed that there is something not quite right with the way onclick handler worked.
Because the handler was looking for a button inside of the onclick target, the query couldn't be resolved when that target was the span with the icon, not the question container itself.

I modified the handler slightly so that it is always running with the question container as a root element, no matter what the onclick target was. 

Let me know what you think! :)