### PR TITLE
Fix #1286 - Add context with user profile to FAQ page when user is logged in

### DIFF
--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -65,7 +65,12 @@ def newlanding(request):
 
 
 def faq(request):
-    return render(request, 'faq.html')
+    context = {}
+    if (request.user and not request.user.is_anonymous):
+        context.update({
+            'user_profile': request.user.profile_set.first()
+        })
+    return render(request, 'faq.html', context)
 
 
 def profile(request):


### PR DESCRIPTION
This should fix #1286.
The FAQ page was lacking a context with the user profile when accessed by a logged in user, so it couldn't access the subscription status.