### PR TITLE
Fix #1305 - Improve error handling in premium plan language map

### DIFF
--- a/privaterelay/templatetags/relay_tags.py
+++ b/privaterelay/templatetags/relay_tags.py
@@ -36,7 +36,10 @@ def get_premium_country_lang(accept_lang):
     cc = lang_parts[1] if len(lang_parts) == 2 else lang_parts[0]
     cc = cc.lower()
     if cc in settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING.keys():
-        return cc, lang
+        languages = settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING[cc]
+        if lang in languages.keys():
+            return cc, lang
+        return cc, list(languages.keys())[0]
     return 'us', 'en'
 
 @register.simple_tag


### PR DESCRIPTION
When searching for the right premium plan for the users' language-country-combination, so far only the presence of the country code, not the language is being checked.
As demonstrated in #1305, this can cause a `KeyError` in case the language code cannot be found inside the country code dict. I slightly modified the logic here so that the first language of the country is being taken as a fallback.

Also, I was wondering: Should I go ahead and add Welsh to the dict? Technically it shouldn't be needed and I was a bit surprised to see USD as the currency for GB [here](https://github.com/mozilla/fx-private-relay/blob/f061179d9846d78ac188245a97fa528d5acb8116/privaterelay/settings.py#L334). Is that intended?

Btw, I would be extremely grateful if you could add the `hacktoberfest-accepted` badge to my PRs so that they can be counted for Hacktoberfest ❤️ Thx!