### PR TITLE
get_premium_country_lang: exact-match country & lang, or fall back to…

### DIFF
--- a/privaterelay/templatetags/relay_tags.py
+++ b/privaterelay/templatetags/relay_tags.py
@@ -36,7 +36,8 @@ def get_premium_country_lang(accept_lang):
     cc = lang_parts[1] if len(lang_parts) == 2 else lang_parts[0]
     cc = cc.lower()
     if cc in settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING.keys():
-        return cc, lang
+        if lang in settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING[cc].keys():
+            return cc, lang
     return 'us', 'en'
 
 @register.simple_tag


### PR DESCRIPTION
… "us", "en"

## To test
1. Set language to a combination that does NOT have an exact match in `PREMIUM_PLAN_ID_MATRIX` (e.g., French-Canada `fr-ca`)
2. Go to http://127.0.0.1:8000/
   * Should no longer see an error page!