### PR TITLE
Fix #1238 - Unify banner logic

### DIFF
--- a/privaterelay/templates/includes/banners.html
+++ b/privaterelay/templates/includes/banners.html
@@ -26,7 +26,7 @@
       {% if not user_profile.server_storage %}
         <div id="sync-labels" class="c-notification-banner c-data-notification-banner t-warning is-hidden">
           <div class="dismiss-wrapper">
-            <button class="notification-dismiss js-data-collection-dismiss"><img src="{% static 'images/x-close.svg' %}"></button>
+            <button id= "data-collection-dismiss" class="notification-dismiss"><img src="{% static 'images/x-close.svg' %}"></button>
           </div>
           <div class="notification-banner-bg">
             <div class="notification-banner-content">

--- a/privaterelay/templates/includes/premium_onboarding.html
+++ b/privaterelay/templates/includes/premium_onboarding.html
@@ -3,7 +3,7 @@
 {% ftlconf bundle='privaterelay.ftl_bundles.main' %}
 
 <div id="premiumOnboarding" class="c-premium-onboarding is-hidden">
-    <button class="c-premium-onboarding-dismiss js-premium-onboarding-dismiss"><img src="{% static 'images/x-close.svg' %}" alt="Close"></button>
+    <button id="premiumOnboardingDismiss" class="c-premium-onboarding-dismiss"><img src="{% static 'images/x-close.svg' %}" alt="Close"></button>
 
     <div class="mzp-l-content mzp-t-content-xl">
         <div class="c-premium-onboarding-headlines">

--- a/privaterelay/templates/includes/vpn-promo-banner.html
+++ b/privaterelay/templates/includes/vpn-promo-banner.html
@@ -3,7 +3,7 @@
 {% load ftl %}
 {% ftlconf bundle='privaterelay.ftl_bundles.main' %}
 
-<div id="vpnPromoBanner" class="vpn-promo-banner closed">
+<div id="vpnPromoBanner" class="vpn-promo-banner is-hidden">
 	<div class="vpn-promo-banner-wrapper">
 		<img alt="Mozilla VPN" class="vpn-promo-logo" src="{% static 'images/logos/mozilla-vpn.svg' %}"/>
 		<div class="vpn-promo-copy">

--- a/static/scss/partials/vpn-promo.scss
+++ b/static/scss/partials/vpn-promo.scss
@@ -24,7 +24,7 @@ body {
     }
 }
 
-.vpn-promo-banner.closed {
+.vpn-promo-banner.is-hidden {
     max-height: 0;
 }
 
@@ -32,11 +32,11 @@ body {
     display: none;
 }
 
-.vpn-promo-banner.closed + .micro-survey-banner {
+.vpn-promo-banner.is-hidden + .micro-survey-banner {
     display: block;
 }
 
-.vpn-promo-banner.closed + .micro-survey-banner.is-hidden {
+.vpn-promo-banner.is-hidden + .micro-survey-banner.is-hidden {
     display: none;
 }
   


### PR DESCRIPTION
This solves #1238 by creating a single function called `bannerLogic` that unifies the logic of the three banners that set a cookie when dismissed.
The VPN banner is doing some extra things (e.g. calling Google Analytics), so (additionally to what @maxxcrawford mentioned in the issue) I added callbacks for the banner functions which should allow for a bit more flexibility. Also renamed the VPN banner's `closed` class to `is-hidden` to be consistent with the other banners. 