### PR TITLE
Consider domain aliases where relevant

### DIFF
--- a/privaterelay/templates/profile.html
+++ b/privaterelay/templates/profile.html
@@ -90,11 +90,11 @@
       {% include "includes/banners.html" %}
 
 
-      {% if relay_addresses %}      
+      {% if relay_addresses or domain_addresses %}
         {% include "includes/dashboard-filter.html" %}
       {% endif %}
 
-      {% if relay_addresses|length == 0 %}
+      {% if relay_addresses|length == 0 and domain_addresses|length == 0 %}
         {% include "includes/dashboard_onboarding.html" %}
       {% endif %}
 


### PR DESCRIPTION
Fixes #1264.

Two elements were dependent on aliases being created or not, but
they only checked for Relay addresses, not domain addresses.