### PR TITLE
Align the tooltip with the hovered "i" icon

### DIFF
--- a/static/scss/pages/dashboard.scss
+++ b/static/scss/pages/dashboard.scss
@@ -109,7 +109,10 @@
 
     @media #{$mq-md} {
         right: auto;
-        left: $layout-lg;
+        // .mpp-action-tooltip-hover-wrapper:after (i.e. the triangle at the top)
+        // is $layout-sm from the left, so shift the whole thing that are to the
+        // left to make the arrow align with the "i" icon:
+        margin-left: -1 * $layout-sm;
     }
 }
 


### PR DESCRIPTION
Fixes #1167.

Unfortunately I'm not sure how it was initially intended to align and how it got misaligned, which makes me a bit uneasy, but this should make the "Create your domain" doorhanger hang on the icon it pop ups from again.

![image](https://user-images.githubusercontent.com/4251/140344919-d5105fa9-e3a9-480e-91cf-39e0dbd7c802.png)
