### PR TITLE
Only hide add-on-related banners by default

### DIFF
--- a/privaterelay/templates/includes/banners.html
+++ b/privaterelay/templates/includes/banners.html
@@ -41,9 +41,9 @@
       {% endif %}
     {% endwith %}
   {% endif %}
-  <div class="dashboard-banners invisible">
+  <div class="dashboard-banners">
     <div class="flx hide-750">
-      <div class="banner-gradient-bg addon">
+      <div class="banner-gradient-bg addon invisible">
         <div class="download-fx-banner banner-content flx flx-row hidden">
           <div class="banner-fx-logo banner-logo"></div>
           <div class="banner-copy flx flx-col">

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -303,25 +303,25 @@ function showBannersIfNecessary() {
 
   const browserIsFirefox = /firefox|FxiOS/i.test(navigator.userAgent);
 
-  const dashboardBanners = document.querySelector(".dashboard-banners");
-  if (!dashboardBanners) {
+  const addonBanners = document.querySelector(".dashboard-banners .addon");
+  if (!addonBanners) {
     return;
   }
 
   const showBanner = (bannerEl) => {
     setTimeout(()=> {
       bannerEl.classList.remove("hidden");
-      dashboardBanners.classList.remove("invisible");
+      addonBanners.classList.remove("invisible");
     }, 500);
     return;
   };
 
   if (!browserIsFirefox) {
-    const firefoxBanner = dashboardBanners.querySelector(".download-fx-banner");
+    const firefoxBanner = addonBanners.querySelector(".download-fx-banner");
     showBanner(firefoxBanner);
     return;
   }
-  const relayAddonBanner = dashboardBanners.querySelector(".install-addon-banner");
+  const relayAddonBanner = addonBanners.querySelector(".install-addon-banner");
   return showBanner(relayAddonBanner);
 }
 

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -879,14 +879,6 @@ input:focus::placeholder {
 }
 
 
-
-.dashboard-banners.invisible {
-    transition: all .2s ease;
-    opacity: 0;
-    padding: 0;
-    max-height: 0;
-}
-
 .dashboard-banners.drop-shadow {
     box-shadow: 0 12px 18px 2px rgba(34,0,51,.04),0 6px 22px 4px rgba(7,48,114,.12),0 6px 10px -4px rgba(14,13,26,.12);
 }


### PR DESCRIPTION
Fixes #1285.

I'm making lots of assumptions here about what the existing code meant to do, so please review thoroughly.

It seems like the entirety of div.dashboard-banneres was hidden by default and only shown after
we could be sure whether the add-on was installed, presumably to
show the banners related to either installing the add-on or
installing Firefox.

This was problematic because there were other banners in there,
specifically the banner to register your own custom subdomain. By
hiding that by default, anchor links pointing to that banner did
not work. And since that banner should be shown regardless of
whether the add-on is installed or not, I modified the code to show
that banner by default and only hide the add-on-related banners
until we've determined whether the add-on is installed.