### PR TITLE
Fix #956 - Shift main wrapper down when mobile menu is toggled

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -235,17 +235,14 @@ function addEventListeners() {
     });
   }
 
-  function readExpandedHeight() {
-    const mobileMenuWrapperLinks = document.querySelector(".mobile-menu-links");
-    const mobileMenuWrapperLinksHeight = mobileMenuWrapperLinks.offsetHeight;
-    return mobileMenuWrapperLinksHeight;
-}
 
-function moveDownMainContainer(setMenuLinksHeightVal, mainWrapper) {
+function moveDownMainContainer(setMenuLinksHeightVal) {
+
+  const mainWrapper = document.querySelector("main");
   
-  const moveDownBy = parseInt(setMenuLinksHeightVal) + 70;
-  console.log(moveDownBy);
+  const moveDownBy = parseInt(setMenuLinksHeightVal);
 
+  console.log(moveDownBy);
 
   if (mainWrapper.style.marginTop == 0 || mainWrapper.style.marginTop == "0px" ) {
     mainWrapper.style.marginTop = moveDownBy + "px";
@@ -253,20 +250,25 @@ function moveDownMainContainer(setMenuLinksHeightVal, mainWrapper) {
   else {
     mainWrapper.style.marginTop = 0;
   }
+
 }
-
   const mobileMenuWrapper = document.querySelector(".mobile-menu");
-  if (mobileMenuWrapper) {
-    const mobileMenuButton = document.querySelector(".mobile-menu-toggle");
 
-    const mainWrapper = document.querySelector("main");
+  if (mobileMenuWrapper) {
+
+    const mobileMenuWrapperLinks = document.querySelector(".mobile-menu-links");
+
+    const mobileMenuButton = document.querySelector(".mobile-menu-toggle");
 
     mobileMenuButton.addEventListener("click", () => {
       mobileMenuWrapper.classList.toggle("menu-open");
-      const setMenuLinksHeightVal = setTimeout(readExpandedHeight, 1000);
-      setTimeout(moveDownMainContainer, 1200, setMenuLinksHeightVal, mainWrapper);
-     });
 
+      setTimeout(() => {
+        const mobileMenuWrapperLinksHeight = mobileMenuWrapperLinks.offsetHeight;
+        moveDownMainContainer(mobileMenuWrapperLinksHeight);
+      }, 100);
+
+     });
 
   }
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -238,9 +238,21 @@ function addEventListeners() {
   const mobileMenuWrapper = document.querySelector(".mobile-menu");
   if (mobileMenuWrapper) {
     const mobileMenuButton = document.querySelector(".mobile-menu-toggle");
+
+    const mainWrapper = document.querySelector("main");
+    const mobileMenuWrapperHeight = mobileMenuWrapper.offsetHeight + 24;
+    
     mobileMenuButton.addEventListener("click", () => {
       mobileMenuWrapper.classList.toggle("menu-open");
-    });
+
+      if (mainWrapper.style.marginTop == 0 || mainWrapper.style.marginTop == "0px" ) {
+        mainWrapper.style.marginTop = mobileMenuWrapperHeight + "px";
+      }
+      else {
+        mainWrapper.style.marginTop = 0;
+      }
+     });
+
   }
 
   document.querySelectorAll(".js-dismiss").forEach(btn => {
@@ -257,6 +269,7 @@ function hasParent(el, selector) {
   }
   return null;
 }
+
 
 function handleLegacyAddonLabels(legacyNoteElem) {
   const legacyNote = legacyNoteElem.textContent;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -240,7 +240,7 @@ function moveDownMainContainer(setMenuLinksHeightVal) {
   const mainWrapper = document.querySelector("main");
   const moveDownBy = parseInt(setMenuLinksHeightVal);
 
-  if (mainWrapper.style.marginTop == 0 || mainWrapper.style.marginTop == "0px" ) {
+  if (mainWrapper.style.marginTop === 0 || mainWrapper.style.marginTop === "0px" ) {
     mainWrapper.style.marginTop = moveDownBy + "px";
   }
   else {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -235,23 +235,38 @@ function addEventListeners() {
     });
   }
 
+  function readExpandedHeight() {
+    const mobileMenuWrapperLinks = document.querySelector(".mobile-menu-links");
+    const mobileMenuWrapperLinksHeight = mobileMenuWrapperLinks.offsetHeight;
+    return mobileMenuWrapperLinksHeight;
+}
+
+function moveDownMainContainer(setMenuLinksHeightVal, mainWrapper) {
+  
+  const moveDownBy = parseInt(setMenuLinksHeightVal) + 70;
+  console.log(moveDownBy);
+
+
+  if (mainWrapper.style.marginTop == 0 || mainWrapper.style.marginTop == "0px" ) {
+    mainWrapper.style.marginTop = moveDownBy + "px";
+  }
+  else {
+    mainWrapper.style.marginTop = 0;
+  }
+}
+
   const mobileMenuWrapper = document.querySelector(".mobile-menu");
   if (mobileMenuWrapper) {
     const mobileMenuButton = document.querySelector(".mobile-menu-toggle");
 
     const mainWrapper = document.querySelector("main");
-    const mobileMenuWrapperHeight = mobileMenuWrapper.offsetHeight + 24;
-    
+
     mobileMenuButton.addEventListener("click", () => {
       mobileMenuWrapper.classList.toggle("menu-open");
-
-      if (mainWrapper.style.marginTop == 0 || mainWrapper.style.marginTop == "0px" ) {
-        mainWrapper.style.marginTop = mobileMenuWrapperHeight + "px";
-      }
-      else {
-        mainWrapper.style.marginTop = 0;
-      }
+      const setMenuLinksHeightVal = setTimeout(readExpandedHeight, 1000);
+      setTimeout(moveDownMainContainer, 1200, setMenuLinksHeightVal, mainWrapper);
      });
+
 
   }
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -238,11 +238,12 @@ function addEventListeners() {
 
 function moveDownMainContainer(setMenuLinksHeightVal) {
   const mainWrapper = document.querySelector("main");
-  const moveDownBy = parseInt(setMenuLinksHeightVal);
+  const moveDownBy = parseInt(setMenuLinksHeightVal, 10);
 
-  if (mainWrapper.style.marginTop === 0 || mainWrapper.style.marginTop === "0px" ) {
+  if (!mainWrapper.style.marginTop || mainWrapper.style.marginTop === "0px") {
     mainWrapper.style.marginTop = moveDownBy + "px";
   }
+
   else {
     mainWrapper.style.marginTop = 0;
   }
@@ -255,13 +256,14 @@ function moveDownMainContainer(setMenuLinksHeightVal) {
     const mobileMenuButton = document.querySelector(".mobile-menu-toggle");
    
     mobileMenuButton.addEventListener("click", () => {
-      mobileMenuWrapper.classList.toggle("menu-open");
+      // mobileMenuWrapper.classList.toggle("menu-open");
   
       setTimeout(() => {
         const mobileMenuWrapperLinksHeight = mobileMenuWrapperLinks.offsetHeight;
         moveDownMainContainer(mobileMenuWrapperLinksHeight);
       }, 100);
 
+      mobileMenuWrapper.classList.toggle("menu-open");
      });
 
   }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -237,12 +237,8 @@ function addEventListeners() {
 
 
 function moveDownMainContainer(setMenuLinksHeightVal) {
-
   const mainWrapper = document.querySelector("main");
-  
   const moveDownBy = parseInt(setMenuLinksHeightVal);
-
-  console.log(moveDownBy);
 
   if (mainWrapper.style.marginTop == 0 || mainWrapper.style.marginTop == "0px" ) {
     mainWrapper.style.marginTop = moveDownBy + "px";
@@ -255,14 +251,12 @@ function moveDownMainContainer(setMenuLinksHeightVal) {
   const mobileMenuWrapper = document.querySelector(".mobile-menu");
 
   if (mobileMenuWrapper) {
-
     const mobileMenuWrapperLinks = document.querySelector(".mobile-menu-links");
-
     const mobileMenuButton = document.querySelector(".mobile-menu-toggle");
-
+   
     mobileMenuButton.addEventListener("click", () => {
       mobileMenuWrapper.classList.toggle("menu-open");
-
+  
       setTimeout(() => {
         const mobileMenuWrapperLinksHeight = mobileMenuWrapperLinks.offsetHeight;
         moveDownMainContainer(mobileMenuWrapperLinksHeight);

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -294,9 +294,39 @@ button:active {
     margin: auto auto 0 0;
 }
 
-main,
-table {
+.dashboard-mpp-promo {
+    background: url("/static/images/polygon-background-small.png") center right no-repeat;
+    background-color: $color-white;
+    background-size: contain;
+}
+
+.dashboard-mpp-promo-container {
+    max-width: $content-xl;
+    margin: auto;
+    padding: $spacing-xl $spacing-lg;
+}
+
+.dashboard-mpp-promo-headline {
+    font-size: 1.75rem;
+    line-height: 2rem;
+    margin: 0 0 $spacing-sm;
+    padding: 0;
+    font-weight: 500;
+    max-width: $content-xs;
+    color: $color-black;
+
+    strong {
+        display: inline-block;
+    }
+}
+
+.dashboard-mpp-promo-container p {
+    max-width: $content-sm;
+}
+
+main, table {
     width: 100%;
+    transition: all .4s ease;
 }
 
 .relay-email-card {

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -326,7 +326,7 @@ button:active {
 
 main, table {
     width: 100%;
-    transition: all .4s ease;
+    transition: all .3s ease;
 }
 
 .relay-email-card {


### PR DESCRIPTION
This PR fixes #956, and pushes the main wrapper of the site down when the mobile menu is toggled.

Demo:

https://user-images.githubusercontent.com/13066134/148368494-48f9dbea-d530-41c6-b64e-35396816981a.mov


