### PR TITLE
Fix #1330 - Change contact tool tip to match menu

### DIFF
--- a/privaterelay/templates/settings.html
+++ b/privaterelay/templates/settings.html
@@ -22,7 +22,7 @@
           href="{{ settings.FXA_SUPPORT_URL }}?utm_source={{ settings.SITE_ORIGIN }}"
           target="_blank"
           rel="noopener noreferrer"
-          title="{% ftlmsg 'settings-meta-contact-tooltip' %}"
+          title="{% ftlmsg 'nav-profile-contact-tooltip' %}"
           class="glocal-fxa-settings-link"
         >
         <img src="{% static 'images/icon-message-purple.svg' %}" alt="">


### PR DESCRIPTION
@Vinnl Just checking here that the 'Contact Us' on the settings page is only available for Premium users?