### PR TITLE
Fix #1332 - Z-index issue on mobile onboarding

### DIFF
--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -401,7 +401,7 @@ firefox-private-relay-addon[data-addon-installed="true"] + firefox-private-relay
     width: 100%;
     text-align: center;
     position: sticky;
-    z-index: 2;
+    z-index: 1;
     bottom: 0;
     box-shadow: $box-shadow-sm;
 


### PR DESCRIPTION
Testing steps: 
Pre-req: Premium  account, not completed onboarding

- Open dashboard page (Should have onboarding present) 
- Click bento menu item 🍱  in navigation to open Glocal menu.
- Expected: It should be ABOVE  all onboarding UI

Preview: 

![image](https://user-images.githubusercontent.com/2692333/140829529-96549415-a64c-4e3d-a64f-645d5bd3066a.png)
