### PR TITLE
Multi-part Premium Onboarding UI Bug Fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
     },
   ],
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
   },
   root: true,
   rules: {

--- a/privaterelay/templates/includes/messages-frontend.html
+++ b/privaterelay/templates/includes/messages-frontend.html
@@ -1,6 +1,6 @@
 {% load ftl %}
 {% load relay_tags %}
-<div class="js-notification messages is-hidden">
+<div class="js-notification-html messages is-hidden">
 	<fluent 
 		data-error-subdomain-not-available="{% ftlmsg 'error-subdomain-not-available' unavailable_subdomain='REPLACE'  %}"
 		data-success-subdomain-registered="{% ftlmsg 'success-subdomain-registered' unavailable_subdomain='REPLACE'  %}"
@@ -11,7 +11,7 @@
 		<span>
 			<!-- Message -->
 		</span>
-		<button class="dismiss js-dismiss">
+		<button class="dismiss js-dismiss-html">
 			<svg class="x-close-icon" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
 		</button>
 	</div>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2,7 +2,7 @@
 
 function dismissNotification() {
 	const notification = document.querySelector(".js-notification");
-	notification.classList.toggle("is-hidden");
+	notification.classList.add("is-hidden");
 }
 
 if (typeof(sendGaPing) === "undefined") {

--- a/static/js/domain-registration.js
+++ b/static/js/domain-registration.js
@@ -76,7 +76,7 @@
 
                     // Dismiss error state if visible
                     const messages = document.querySelector(".js-notification");
-                    messages.classList.add("is-hidden");
+                    messages?.classList.add("is-hidden");
                     e.target.classList.remove("mzp-is-error");
                     domainRegistration.modal.open(e.target);
                 } else {
@@ -209,10 +209,13 @@
             }
         },
         showError: (requestedDomain) => {
-            const messages = document.querySelector(".js-notification");
+            const messagesDjango = document.querySelector(".js-notification");
+            const messages = document.querySelector(".js-notification-html");
             const messageWrapper = messages.querySelector(".message-wrapper");
             const messageWrapperSpan = messageWrapper.querySelector("span");
             const messageFluent = messages.querySelector("fluent");
+            
+            messagesDjango?.classList.add("is-hidden");
             messages.classList.remove("is-hidden");
             messageWrapper.classList.remove("success");
             messageWrapper.classList.add("error");
@@ -221,6 +224,12 @@
             let message = messageFluent.dataset.errorSubdomainNotAvailable;
             message = message.replace("REPLACE", requestedDomain); 
             messageWrapperSpan.textContent = message;
+
+            const messagesDismissButton = document.querySelector(".js-dismiss-html");
+            messagesDismissButton.addEventListener("click", ()=> {
+                messages.classList.add("is-hidden");
+            });
+
         },
         showSuccess: (requestedDomain) => {
             const messages = document.querySelector(".js-notification");

--- a/static/js/domain-registration.js
+++ b/static/js/domain-registration.js
@@ -69,13 +69,13 @@
                 const requestedDomain = currentForm.querySelector(".js-subdomain-value").value.toLowerCase();
                 currentForm.querySelector(".js-subdomain-value").value = requestedDomain;
                 const domainCanBeRegistered = await domainRegistration.checkIfDomainIsSafeAndAvailable(requestedDomain);               
-
+                const messages = document.querySelector(".js-notification");
+                const messagesHtml = document.querySelector(".js-notification-html");
 
                 if (domainCanBeRegistered) {
-
                     // Dismiss error state if visible
-                    const messages = document.querySelector(".js-notification");
-                    messages?.classList.add("is-hidden");
+                    messages?.classList.add("is-hidden"); 
+                    messagesHtml?.classList.add("is-hidden");
                     e.target.classList.remove("mzp-is-error");
                     domainRegistration.modal.open(e.target);
                 } else {

--- a/static/js/domain-registration.js
+++ b/static/js/domain-registration.js
@@ -65,10 +65,9 @@
             onSubmit: async (e) => {
                 e.preventDefault();
 
-                
-
                 const currentForm = e.target;
-                const requestedDomain = currentForm.querySelector(".js-subdomain-value").value;
+                const requestedDomain = currentForm.querySelector(".js-subdomain-value").value.toLowerCase();
+                currentForm.querySelector(".js-subdomain-value").value = requestedDomain;
                 const domainCanBeRegistered = await domainRegistration.checkIfDomainIsSafeAndAvailable(requestedDomain);               
 
 


### PR DESCRIPTION
This PR solves two issues flagged by QA yesterday: 

- [#1332](https://github.com/mozilla/fx-private-relay/issues/1332) / [MPP-1335](https://mozilla-hub.atlassian.net/browse/MPP-1335)
- [#1337](https://github.com/mozilla/fx-private-relay/issues/1337) / [MPP-1339](https://mozilla-hub.atlassian.net/browse/MPP-1339)

Testing: 

## Test 1: Double-notifications Fix

_Pre-requisites for both tests below:_
- Premium account
- Onboarding is visible
- NO Subdomain set

- Log into Relay
- **Expected:** Green "Logged in" message should be visible
- Go to Step 2 of Onboarding (Domain Registration) 
- Try to register a previously registered domain (test, etc) OR a bad word (butt) 
- **Expected:** You should only get ONE message, with the correct error message ("The domain @### is not available…"). 
- Extra Steps: You should be able to dismiss the message, search for another error-causing domain, and see the new erro message. 

## Test 2: Double-notifications Fix
- Log into Relay
- Go to Step 2 of Onboarding (Domain Registration) 
- Try to register an available domain with mixed/all capitals (MoZiLlAaa,  MyDomain, MAILMAILMAIL, etc.)
- **Expected:** The search input value is converted to lowercase on submit, the preview modals are shown in lowercase. 