### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!-- When fixing a bug: -->
+
+This PR fixes #<issue ID>.
+
+- [ ] l10n dependencies have been merged, if any.
+- [ ] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
+- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
+
+<!-- When adding a new feature: -->
+
+# New feature description
+
+# Checklist
+
+- [ ] l10n dependencies have been merged, if any.
+- [ ] All acceptance criteria are met.
+- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,12 @@
+<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->
+
 <!-- When fixing a bug: -->
 
 This PR fixes #<issue ID>.
 
 - [ ] l10n dependencies have been merged, if any.
 - [ ] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
+- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
 - [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
 
 <!-- When adding a new feature: -->
@@ -14,4 +17,5 @@ This PR fixes #<issue ID>.
 
 - [ ] l10n dependencies have been merged, if any.
 - [ ] All acceptance criteria are met.
+- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
 - [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).


### PR DESCRIPTION
I keep forgetting to check things before I submit a PR. This adds a checklist based on [the template of a project I worked on previously](https://github.com/inrupt/solid-client-js/blob/main/.github/pull_request_template.md), intended only as a reminder for yourself (i.e. as far as I'm concerned, people can just remove whatever's not relevant to their PR, which could be the entire template). And of course, we can always update this template in the future.

Let me know what you think.