### PR TITLE
Move the subdomain extension to the next line

### DIFF
--- a/privaterelay/templates/includes/modal-domain-registration-confirmation.html
+++ b/privaterelay/templates/includes/modal-domain-registration-confirmation.html
@@ -8,8 +8,8 @@
     <div class="c-modal-header t-domain-registration-hero">
       <div class="c-modal-header-content">
         <span class="c-modal-header-headline"><img src="{% static 'images/icon-green-check.svg' %}" aria-hidden="true" alt="check mark"> {% ftlmsg 'modal-domain-register-good-news' %}</span>
-        <h3><strong class="js-modal-domain-registration-confirmation-domain-preview"></strong><span class="js-modal-domain-registration-confirmation-domain-ending"></span></h3>
-        <span class="c-modal-header-headline">{% ftlmsg 'modal-domain-register-available' subdomain='' %}</span>
+        <h3><strong class="js-modal-domain-registration-confirmation-domain-preview"></strong></h3>
+        <span class="c-modal-header-headline"><span class="js-modal-domain-registration-confirmation-domain-ending"> </span>{% ftlmsg 'modal-domain-register-available' subdomain='' %}</span>
       </div>
     </div>
 
@@ -38,8 +38,8 @@
     <div class="c-modal-header t-domain-registration-hero">
       <div class="c-modal-header-content">
         <span class="c-modal-header-headline"><img src="{% static 'images/icon-check-green.svg' %}" aria-hidden="true" alt="check mark">{% ftlmsg 'modal-domain-register-success-title' %}</span>
-        <h3><strong class="js-modal-domain-registration-confirmation-domain-preview"></strong><span class="js-modal-domain-registration-confirmation-domain-ending"></span></h3>
-        <span class="c-modal-header-headline">{% ftlmsg 'modal-domain-register-success' subdomain='' %}</span>
+        <h3><strong class="js-modal-domain-registration-confirmation-domain-preview"></strong></h3>
+        <span class="c-modal-header-headline"><span class="js-modal-domain-registration-confirmation-domain-ending"> </span>{% ftlmsg 'modal-domain-register-success' subdomain='' %}</span>
       </div>
     </div>
 


### PR DESCRIPTION
This ensures maximum space for the user's chosen subdomain. Note
that we're currently abusing FTL, setting the `subdomain` variable
in `modal-domain-register-success` to an empty string and then just
stuffing the actual chosen subdomain in front of it. This will
break in languages where the chosen subdomain should not be the
first word, but is the result of not loading the language strings
client-side and thus not being able to substitute in variables
generated on the client-side. This was already the case, and this
commit keeps it that way.