### PR TITLE
Fix MPP-1355: Update support contact string on FAQs page

### DIFF
--- a/privaterelay/templates/faq.html
+++ b/privaterelay/templates/faq.html
@@ -77,7 +77,7 @@
                   <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-turned-off' %}</li>
                   <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-delay' %}</li>
                 </ul>
-                <p>{% ftlmsg 'faq-question-missing-emails-answer-b-html' url='https://accounts.firefox.com/support/' attrs='class="text-link" data-url="https://accounts.firefox.com/support/"' %}</p>
+                <p>{% ftlmsg 'faq-question-missing-emails-answer-support-site-html' url='https://support.mozilla.org/products/relay/' attrs='class="text-link" data-url="https://support.mozilla.org/products/relay/"' %}</p>
               </div>
             </section>
             <section class="faq" id="faq-use-cases">

--- a/privaterelay/templates/faq.html
+++ b/privaterelay/templates/faq.html
@@ -90,7 +90,7 @@
             <section class="faq" id="faq-rejections">
               <h2 class="faq-headline">{% ftlmsg 'faq-question-2-question' %}</h2>
               <p class="faq-answer js-set-href">
-                {% ftlmsg 'faq-question-2-answer-v2-html' url='https://addons.mozilla.org/firefox/addon/private-relay/' attrs='class="text-link" data-url="https://addons.mozilla.org/firefox/addon/private-relay/"' %}
+                {% ftlmsg 'faq-question-2-answer-v3-html' url='https://addons.mozilla.org/firefox/addon/private-relay/' attrs='class="text-link" data-url="https://addons.mozilla.org/firefox/addon/private-relay/"' %}
               </p>
             </section>
             <section class="faq" id="faq-spam">
@@ -108,11 +108,11 @@
             </section>
             <section class="faq" id="faq-replies">
               <h2 class="faq-headline">{% ftlmsg 'faq-question-4-question' %}</h2>
-              <p class="faq-answer">{% ftlmsg 'faq-question-4-answer-v2' %}</p>
+              <p class="faq-answer">{% ftlmsg 'faq-question-4-answer-v3' %}</p>
             </section>
             <section class="faq" id="faq-subdomain-question">
               <h2 class="faq-headline">{% ftlmsg 'faq-question-subdomain-characters-question' %}</h2>
-              <p class="faq-answer">{% ftlmsg 'faq-question-subdomain-characters-answer' %}</p>
+              <p class="faq-answer">{% ftlmsg 'faq-question-subdomain-characters-answer-v2' %}</p>
             </section>
             <section class="faq" id="faq-browser-support">
               <h2 class="faq-headline">{% ftlmsg 'faq-question-browser-support-question' %}</h2>
@@ -135,7 +135,7 @@
             <section class="faq" id="faq-attachments">
               <h2 class="faq-headline">{% ftlmsg 'faq-question-attachments-question' %}</h2>
               <p class="faq-answer">
-                {% ftlmsg 'faq-question-attachments-answer' size='150' unit='KB' %}
+                {% ftlmsg 'faq-question-attachments-answer-v2' size='150' unit='KB' %}
               </p>
             </section>
             <section class="faq" id="faq-unsubscribe-domain">


### PR DESCRIPTION
~L10N Dependency: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/45~

This PR also incorporated additional FAQ changes from @Vinnl: https://github.com/mozilla/fx-private-relay/pull/1356

## Screenshot

<img width="632" alt="image" src="https://user-images.githubusercontent.com/2692333/141204614-ee647a6b-b4fc-41ce-a6f7-8d0d5ea4fe1f.png">
