### PR TITLE
Fix #1347 – Update Dashboard Domain Registration form to mirror Onboarding form 

### DIFF
--- a/static/js/domain-registration.js
+++ b/static/js/domain-registration.js
@@ -174,8 +174,6 @@
                 
                 switch (e.target.parentFormHTMLElement.id) {
                     case "domainRegistration":
-                        // domainRegistration.modal.close();
-                        // domainRegistration.showSuccess(e.target.parentFormRequestedDomain);
                         domainRegistration.modal.showSuccessState(e.target.parentFormRequestedDomain,{ "form": "dashboard" });
                         break;
                     case "onboardingDomainRegistration":

--- a/static/js/domain-registration.js
+++ b/static/js/domain-registration.js
@@ -174,37 +174,50 @@
                 
                 switch (e.target.parentFormHTMLElement.id) {
                     case "domainRegistration":
-                        domainRegistration.modal.close();
-                        domainRegistration.showSuccess(e.target.parentFormRequestedDomain);
+                        // domainRegistration.modal.close();
+                        // domainRegistration.showSuccess(e.target.parentFormRequestedDomain);
+                        domainRegistration.modal.showSuccessState(e.target.parentFormRequestedDomain,{ "form": "dashboard" });
                         break;
                     case "onboardingDomainRegistration":
-                        domainRegistration.modal.showSuccessState(e.target.parentFormRequestedDomain);
+                        domainRegistration.modal.showSuccessState(e.target.parentFormRequestedDomain, { "form": "onboarding" });
                         break;
                 }
-
-                // TODO: Submit form and catch success state changes to the modal for multi-step onboarding form
                 
             },
-            showSuccessState: (domain)=> {
+            showSuccessState: (domain, {form})=> {
                 const modalRegistrationForm = document.querySelector(".js-domain-registration-form");
                 const modalRegistrationSuccessState = document.querySelector(".js-domain-registration-success");
                 modalRegistrationForm.classList.add("is-hidden");
                 modalRegistrationSuccessState.classList.remove("is-hidden");
 
-                const modalContinue = document.querySelector(".js-modal-domain-registration-continue");
-                modalContinue.addEventListener("click", domainRegistration.modal.close, false);
-
                 const domainPreview = document.querySelector(".js-premium-onboarding-domain-registration-preview");
                 domainPreview.textContent = domain + ".mozmail.com";
 
-                const onboardingDomainRegistration = document.querySelector(".js-premium-onboarding-domain-registration-form");
-                onboardingDomainRegistration.classList.add("is-hidden");
-                onboardingDomainRegistration.nextElementSibling.classList.add("is-visible");
+                const modalContinue = document.querySelector(".js-modal-domain-registration-continue");
 
-                const onboardingDomainRegistrationActionButtons = document.querySelectorAll(".c-premium-onboarding-action-step-2 button");
-                onboardingDomainRegistrationActionButtons.forEach( button => {
-                    button.classList.toggle("is-hidden");
-                });
+                if (form === "onboarding") {
+                    modalContinue.addEventListener("click", domainRegistration.modal.close, false);
+                    
+                    const onboardingDomainRegistration = document.querySelector(".js-premium-onboarding-domain-registration-form");
+                    onboardingDomainRegistration.classList.add("is-hidden");
+                    onboardingDomainRegistration.nextElementSibling.classList.add("is-visible");
+
+                    const onboardingDomainRegistrationActionButtons = document.querySelectorAll(".c-premium-onboarding-action-step-2 button");
+                    onboardingDomainRegistrationActionButtons.forEach( button => {
+                        button.classList.toggle("is-hidden");
+                    });
+                }
+
+                if (form === "dashboard") {
+                    modalContinue.addEventListener("click", ()=>{
+                        location.reload();
+                    }, false);
+                }
+
+
+
+
+ 
             }
         },
         showError: (requestedDomain) => {


### PR DESCRIPTION
Risk: Medium/High

This PR revises the logic on how the domain registration form behaves on the dashboard page (as opposed to the form during onboarding). This handles both forms the same, except on the success modal frame: 

On the dashboard: 
- Clicking continue refreshes the page (which hides the modal, form AND updates the domain callout under the user's name)

On the onboarding flow: 
- Resets the continue button at the bottom
- Updates the form to a "success" state 

Revise domain registration form success state logic to work the same on the dashboard and onboarding process

## Testing

- Register/create subdomain through both onboarding and dashboard forms. Be sure to also try to register a failing domain first to make sure error messages display correctly too. 

## Screenshots

Onboarding / After Clicking Continue on "Success" modal: 
<img width="916" alt="image" src="https://user-images.githubusercontent.com/2692333/141208297-a585ac6b-56ec-4654-83e0-12d1c31e19dc.png">
