### PR TITLE
Remove test flags

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -7,7 +7,6 @@ SECRET_KEY=unsafe-secret-key-for-dev-envs
 ADMIN_ENABLED=
 DEBUG=True
 DJANGO_INTERNAL_IPS=127.0.0.1, localhost
-TEST_MOZMAIL=False
 RELAY_FIREFOX_DOMAIN="relay.firefox.com"
 MOZMAIL_DOMAIN="mozmail.com"
 SENTRY_DSN=""

--- a/emails/models.py
+++ b/emails/models.py
@@ -460,7 +460,6 @@ class RelayAddress(models.Model):
                 if valid_address(self.address, self.domain):
                     break
                 self.address = address_default()
-            self.domain = get_domain_from_env_vars_and_profile(self.user)
             profile = self.user.profile_set.first()
             profile.update_abuse_metric(address_created=True)
         return super().save(*args, **kwargs)
@@ -500,14 +499,6 @@ def valid_address(address, domain):
     ):
         return False
     return True
-
-
-def get_domain_from_env_vars_and_profile(user):
-    user_profile = user.profile_set.first()
-    domain = DOMAINS.get('RELAY_FIREFOX_DOMAIN')
-    if user_profile.has_premium or settings.TEST_MOZMAIL:
-        domain = DOMAINS.get('MOZMAIL_DOMAIN')
-    return get_domain_numerical(domain)
 
 
 class DeletedAddress(models.Model):

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -67,13 +67,13 @@ class MiscEmailModelsTest(TestCase):
     def test_is_blocklisted_without_blocked_words(self):
         assert not is_blocklisted('non-blocked-word')
 
-    @override_settings(TEST_MOZMAIL=False, RELAY_FIREFOX_DOMAIN='firefox.com')
+    @override_settings(RELAY_FIREFOX_DOMAIN='firefox.com')
     def test_address_hash_without_subdomain_domain_firefox(self):
         address = 'aaaaaaaaa'
         expected_hash = sha256(f'{address}'.encode('utf-8')).hexdigest()
         assert address_hash(address, domain='firefox.com') == expected_hash
 
-    @override_settings(TEST_MOZMAIL=False, RELAY_FIREFOX_DOMAIN='firefox.com')
+    @override_settings(RELAY_FIREFOX_DOMAIN='firefox.com')
     def test_address_hash_without_subdomain_domain_not_firefoxz(self):
         non_default = 'test.com'
         address = 'aaaaaaaaa'
@@ -185,14 +185,11 @@ class RelayAddressTest(TestCase):
         assert relay_address.get_domain_display() == 'MOZMAIL_DOMAIN'
         assert relay_address.domain_value == 'test.com'
 
-    @override_settings(
-        TEST_MOZMAIL=False, RELAY_FIREFOX_DOMAIN=TEST_DOMAINS['RELAY_FIREFOX_DOMAIN']
-    )
     @patch('emails.models.DOMAINS', TEST_DOMAINS)
     def test_delete_adds_deleted_address_object(self):
         relay_address = baker.make(RelayAddress, user=self.user)
         address_hash = sha256(
-            relay_address.address.encode('utf-8')
+            relay_address.full_address.encode('utf-8')
         ).hexdigest()
         relay_address.delete()
         deleted_count = DeletedAddress.objects.filter(

--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -67,13 +67,13 @@ class FormattingToolsTest(TestCase):
         )
         assert formatted_from_address == expected_formatted_from
 
-    @override_settings(ON_HEROKU=True, SITE_ORIGIN='https://test.com', TEST_MOZMAIL=False)
-    def test_get_email_domain_from_settings_on_heroku_test_mozmail_false(self):
+    @override_settings(ON_HEROKU=True, SITE_ORIGIN='https://test.com')
+    def test_get_email_domain_from_settings_on_heroku(self):
         email_domain = get_email_domain_from_settings()
         assert 'mail.test.com' == email_domain
 
-    @override_settings(ON_HEROKU=False, SITE_ORIGIN='https://test.com', TEST_MOZMAIL=False)
-    def test_get_email_domain_from_settings_not_on_heroku_test_mozmail_false(self):
+    @override_settings(ON_HEROKU=False, SITE_ORIGIN='https://test.com')
+    def test_get_email_domain_from_settings_not_on_heroku(self):
         email_domain = get_email_domain_from_settings()
         assert 'test.com' == email_domain
 

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -93,7 +93,6 @@ class GetAddressTest(TestCase):
 
     @patch('emails.models.DOMAINS', TEST_DOMAINS)
     @patch('emails.views.get_domains_from_settings')
-    @override_settings(TEST_MOZMAIL=True)
     def test_get_address_with_relay_address(self, domains_mocked):
         domains_mocked.return_value = TEST_DOMAINS
         local_portion = 'foo'

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -366,8 +366,6 @@ HARD_BOUNCE_ALLOWED_DAYS = config('HARD_BOUNCE_ALLOWED_DAYS', 30, cast=int)
 
 WSGI_APPLICATION = 'privaterelay.wsgi.application'
 
-TEST_MOZMAIL = config('TEST_MOZMAIL', False, cast=bool)
-
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 


### PR DESCRIPTION
# About this PR
We used to use the flag `TEST_MOZMAIL` to make sure that mozmail.com domain was only being used by premium users. Since we want this as a default behavior and is now being set using the `default_domain_numerical` we should remove all references to the `TEST_MOZMAIL`.

# Acceptance Criteria
- [x] All users are use mozmail.com domain on Relay and Domain addresses
- [x] mozmail.com domain is ONLY dependent on the `PREMIUM_RELEASE_DATE` (if now is later than `PREMIUM_RELEASE_DATE` mozmail.com should be used otherwise `relay.firefox.com` should be used

#
We should remove any env set for `TEST_MOZMAIL` on Stage and Prod
Need to do further cleaning later to remove flags for gating premium features with `PREMIUM_RELEASE_DATE`