### PR TITLE
add client-side setPremiumSubscribeUrlsByCountry function

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -74,6 +74,7 @@ CSP_CONNECT_SRC = (
     "'self'",
     'https://www.google-analytics.com/',
     'https://accounts.firefox.com',
+    'https://location.services.mozilla.com',
 )
 CSP_DEFAULT_SRC = ("'self'",)
 CSP_SCRIPT_SRC = (

--- a/privaterelay/templates/includes/banners/default-banners.html
+++ b/privaterelay/templates/includes/banners/default-banners.html
@@ -41,7 +41,7 @@
                 <div class="banner-copy flx flx-col">
                     <p class="banner-hl ff-Met">{% ftlmsg 'banner-upgrade-headline' %}</p>
                     <p class="banner-sub">{% ftlmsg 'banner-upgrade-copy' %}</p>
-                    <a class="banner-link ff-Met" target="_blank" rel="noopener noreferrer"
+                    <a class="banner-link ff-Met js-purchase-premium" target="_blank" rel="noopener noreferrer"
                         href="{% premium_subscribe_url accept_language %}" data-ga="send-ga-pings"
                         data-event-category="Purchase Button" data-event-label="profile-banner-promo"
                         data-cookie-for-server="clicked-purchase">

--- a/privaterelay/templates/includes/dashboard-filter.html
+++ b/privaterelay/templates/includes/dashboard-filter.html
@@ -110,7 +110,7 @@
                         href="{% premium_subscribe_url accept_language %}"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="btn btn-blue--ghost"
+                        class="btn btn-blue--ghost js-purchase-premium"
                         data-ga="send-ga-pings"
                         data-event-category="Purchase Button"
                         data-event-label="profile-create-alias-upgrade-promo"

--- a/privaterelay/templates/includes/domain-alias-dashboard.html
+++ b/privaterelay/templates/includes/domain-alias-dashboard.html
@@ -10,7 +10,7 @@
         <p>
           {% ftlmsg 'banner-pack-upgrade-copy' %}
         </p>
-        <a  class="btn btn--blue" target="_blank" rel="noopener noreferrer"
+        <a  class="btn btn--blue js-purchase-premium" target="_blank" rel="noopener noreferrer"
             href="{% premium_subscribe_url accept_language %}"
             data-ga="send-ga-pings"
             data-event-category="Purchase Button"

--- a/privaterelay/templates/newlanding/a/plans.html
+++ b/privaterelay/templates/newlanding/a/plans.html
@@ -44,7 +44,7 @@
                         </ul>
                     </div>
                     <a
-                        class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg"
+                        class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg js-purchase-premium"
                         href="{% premium_subscribe_url accept_language %}"
                         target="_blank" rel="noopener noreferrer"
                         data-ga="send-ga-pings"

--- a/privaterelay/templatetags/relay_tags.py
+++ b/privaterelay/templatetags/relay_tags.py
@@ -29,12 +29,14 @@ def message_in_fluent(message):
     return message in ftl_messages
 
 
-def get_premium_country_lang(accept_lang):
+def get_premium_country_lang(accept_lang, cc=None):
     lang = accept_lang.split(',')[0]
     lang_parts = lang.split("-") if lang and "-" in lang else [lang]
     lang = lang_parts[0].lower()
-    cc = lang_parts[1] if len(lang_parts) == 2 else lang_parts[0]
-    cc = cc.lower()
+    if cc is None:
+        cc = lang_parts[1] if len(lang_parts) == 2 else lang_parts[0]
+        cc = cc.lower()
+
     if cc in settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING.keys():
         languages = settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING[cc]
         if lang in languages.keys():
@@ -43,18 +45,18 @@ def get_premium_country_lang(accept_lang):
     return 'us', 'en'
 
 @register.simple_tag
-def premium_plan_id(accept_lang):
+def premium_plan_id(accept_lang, cc=None):
     if settings.PREMIUM_PRICE_ID_OVERRIDE:
         return settings.PREMIUM_PRICE_ID_OVERRIDE
-    cc, lang = get_premium_country_lang(accept_lang)
+    cc, lang = get_premium_country_lang(accept_lang, cc)
     return settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING[cc][lang]["id"]
 
 @register.simple_tag
-def premium_plan_price(accept_lang):
-    cc, lang = get_premium_country_lang(accept_lang)
+def premium_plan_price(accept_lang, cc=None):
+    cc, lang = get_premium_country_lang(accept_lang, cc)
     return settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING[cc][lang]["price"]
 
 @register.simple_tag
-def premium_subscribe_url(accept_lang=None):
-    plan_id = premium_plan_id(accept_lang)
+def premium_subscribe_url(accept_lang=None, cc=None):
+    plan_id = premium_plan_id(accept_lang, cc)
     return f'{settings.FXA_SUBSCRIPTIONS_URL}/products/{settings.PREMIUM_PROD_ID}?plan={plan_id}'

--- a/privaterelay/urls.py
+++ b/privaterelay/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     path('fxa-rp-events', views.fxa_rp_events),
     path('metrics-event', views.metrics_event),
 
+    path('premium_subscribe_url', views.premium_subscribe_url_view),
     path('accounts/profile/', views.profile, name='profile'),
     path(
         'accounts/profile/subdomain',

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -34,6 +34,9 @@ from emails.models import (
 )
 from emails.utils import incr_if_enabled
 
+from privaterelay.templatetags.relay_tags import premium_subscribe_url
+
+
 FXA_PROFILE_CHANGE_EVENT = (
     'https://schemas.accounts.firefox.com/event/profile-change'
 )
@@ -162,6 +165,16 @@ def profile_subdomain(request):
             'message': e.message,
             'subdomain': subdomain
         }, status=400)
+
+
+@csrf_exempt
+def premium_subscribe_url_view(request):
+    accept_lang = request.headers.get('Accept-Language', 'en-US')
+    cc = request.GET.get('cc', None)
+    lower_cc = cc.lower()
+    return JsonResponse(
+        {'url': premium_subscribe_url(accept_lang, lower_cc)}
+    )
 
 
 def version(request):

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -343,11 +343,39 @@ function setTranslatedStringLinks() {
 
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+/*
+    Use MLS country API to get the client's country code, pass that to a new
+    /premium_subscribe_url endpoint to get the subscription link for the
+    country code, and overwrite the URL that the server determined based only
+    on browser langauge.
+*/
+async function setPremiumSubscribeUrlsByCountry() {
+  const mlsUrl = "https://location.services.mozilla.com/v1/country?key=813238a9-a03c-413d-888b-98615e084a71";
+  const mlsResponse = await fetch(mlsUrl, {
+      method: "get",
+  });
+  const mlsResponseData = await mlsResponse.json();
+  const requestUrl = `/premium_subscribe_url?cc=${mlsResponseData.country_code}`;
+  const subscribeUrlResponse = await fetch(requestUrl, {
+      method: "get",
+      mode: "same-origin",
+      credentials: "same-origin",
+  });
+  const subscribeUrlData = await subscribeUrlResponse.json();
+
+  const premiumSubscribeLinks = document.querySelectorAll(".js-purchase-premium");
+
+  for (const subLink of premiumSubscribeLinks) {
+    subLink.href=subscribeUrlData.url;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", async () => {
   watchForInstalledAddon();
   addEventListeners();
   vpnBannerLogic();
   setTranslatedStringLinks();
+  await setPremiumSubscribeUrlsByCountry()
   premiumOnboardingLogic();
   privacyNoticeUpdateBannerLogic();
   dataCollectionBannerLogic();


### PR DESCRIPTION
Use MLS country API to get the client's country code, pass that to a new
/premium_subscribe_url endpoint to get the subscription link for the
country code based on IP address, and overwrite the URL that was
rendered server-side based on browser langauge.

# To test:

0. Make sure your `PREMIUM_PRICE_ID_OVERRIDE` env var is blank so it doesn't force the same price id for everyone
1. Go to a page with a "purchase premium" link
2. Note/copy the url (e.g., in the US it's https://accounts.stage.mozaws.net/subscriptions/products/prod_K29ULZL9pUR9Fr?plan=price_1JmRSRJNcmPzuWtRN9MG5cBy)
   * Check that the `plan=price_*` value matches the country in [the Relay Plan IDs spreadsheet](https://docs.google.com/spreadsheets/d/1UhfHtQP8OOqi8tptTLjzC6dRmqSKLKqOi6Q1HO8N2ig/edit#gid=0).
3. Use a VPN to change country to one of the other supported countries.
4. Reload the page with "purchase premium" link
5. Note/copy the url again (e.g., in Germany it's https://accounts.stage.mozaws.net/subscriptions/products/prod_K29ULZL9pUR9Fr?plan=price_1JmRTDJNcmPzuWtRnJavIXXX)
   * Check that the `plan=price_*` value matches the country in [the Relay Plan IDs spreadsheet](https://docs.google.com
6. Repeat with as many countries as desired