### PR TITLE
use x_client_region header to detect country

### DIFF
--- a/privaterelay/context_processors.py
+++ b/privaterelay/context_processors.py
@@ -12,11 +12,13 @@ def common(request):
     fxa = _get_fxa(request)
     avatar = fxa.extra_data['avatar'] if fxa else None
     accept_language = request.headers.get('Accept-Language', 'en-US')
+    country_code = request.headers.get('X-Client-Region', 'us').lower()
     return {
         'avatar': avatar,
         'ftl_mode': 'server',
         'accept_language': accept_language,
-        'monthly_price': premium_plan_price(accept_language)
+        'country_code': country_code,
+        'monthly_price': premium_plan_price(accept_language, country_code)
     }
 
 @lru_cache(maxsize=None)

--- a/privaterelay/templates/includes/banners/default-banners.html
+++ b/privaterelay/templates/includes/banners/default-banners.html
@@ -42,7 +42,7 @@
                     <p class="banner-hl ff-Met">{% ftlmsg 'banner-upgrade-headline' %}</p>
                     <p class="banner-sub">{% ftlmsg 'banner-upgrade-copy' %}</p>
                     <a class="banner-link ff-Met js-purchase-premium" target="_blank" rel="noopener noreferrer"
-                        href="{% premium_subscribe_url accept_language %}" data-ga="send-ga-pings"
+                        href="{% premium_subscribe_url accept_language country_code %}" data-ga="send-ga-pings"
                         data-event-category="Purchase Button" data-event-label="profile-banner-promo"
                         data-cookie-for-server="clicked-purchase">
                         {% ftlmsg 'banner-upgrade-cta' %}

--- a/privaterelay/templates/includes/dashboard-filter.html
+++ b/privaterelay/templates/includes/dashboard-filter.html
@@ -107,7 +107,7 @@
             {% if user_profile.at_max_free_aliases and not user_profile.has_premium %}
                 {% if settings.PREMIUM_ENABLED %}
                     <a
-                        href="{% premium_subscribe_url accept_language %}"
+                        href="{% premium_subscribe_url accept_language country_code %}"
                         target="_blank"
                         rel="noopener noreferrer"
                         class="btn btn-blue--ghost js-purchase-premium"

--- a/privaterelay/templates/includes/domain-alias-dashboard.html
+++ b/privaterelay/templates/includes/domain-alias-dashboard.html
@@ -13,7 +13,7 @@
             {% ftlmsg 'banner-pack-upgrade-copy' %}
           </p>
           <a  class="mzp-c-button mzp-t-product js-purchase-premium" target="_blank" rel="noopener noreferrer"
-              href="{% premium_subscribe_url accept_language %}"
+              href="{% premium_subscribe_url accept_language country_code %}"
               data-ga="send-ga-pings"
               data-event-category="Purchase Button"
               data-event-label="profile-bottom-promo"

--- a/privaterelay/templates/newlanding/a/plans.html
+++ b/privaterelay/templates/newlanding/a/plans.html
@@ -45,7 +45,7 @@
                     </div>
                     <a
                         class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-lg js-purchase-premium"
-                        href="{% premium_subscribe_url accept_language %}"
+                        href="{% premium_subscribe_url accept_language country_code %}"
                         target="_blank" rel="noopener noreferrer"
                         data-ga="send-ga-pings"
                         data-event-category="Purchase Button"

--- a/privaterelay/urls.py
+++ b/privaterelay/urls.py
@@ -32,7 +32,6 @@ urlpatterns = [
     path('fxa-rp-events', views.fxa_rp_events),
     path('metrics-event', views.metrics_event),
 
-    path('premium_subscribe_url', views.premium_subscribe_url_view),
     path('accounts/profile/', views.profile, name='profile'),
     path(
         'accounts/profile/subdomain',

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -34,8 +34,6 @@ from emails.models import (
 )
 from emails.utils import incr_if_enabled
 
-from privaterelay.templatetags.relay_tags import premium_subscribe_url
-
 
 FXA_PROFILE_CHANGE_EVENT = (
     'https://schemas.accounts.firefox.com/event/profile-change'
@@ -165,16 +163,6 @@ def profile_subdomain(request):
             'message': e.message,
             'subdomain': subdomain
         }, status=400)
-
-
-@csrf_exempt
-def premium_subscribe_url_view(request):
-    accept_lang = request.headers.get('Accept-Language', 'en-US')
-    cc = request.GET.get('cc', None)
-    lower_cc = cc.lower()
-    return JsonResponse(
-        {'url': premium_subscribe_url(accept_lang, lower_cc)}
-    )
 
 
 def version(request):

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -343,39 +343,11 @@ function setTranslatedStringLinks() {
 
 }
 
-/*
-    Use MLS country API to get the client's country code, pass that to a new
-    /premium_subscribe_url endpoint to get the subscription link for the
-    country code, and overwrite the URL that the server determined based only
-    on browser langauge.
-*/
-async function setPremiumSubscribeUrlsByCountry() {
-  const mlsUrl = "https://location.services.mozilla.com/v1/country?key=813238a9-a03c-413d-888b-98615e084a71";
-  const mlsResponse = await fetch(mlsUrl, {
-      method: "get",
-  });
-  const mlsResponseData = await mlsResponse.json();
-  const requestUrl = `/premium_subscribe_url?cc=${mlsResponseData.country_code}`;
-  const subscribeUrlResponse = await fetch(requestUrl, {
-      method: "get",
-      mode: "same-origin",
-      credentials: "same-origin",
-  });
-  const subscribeUrlData = await subscribeUrlResponse.json();
-
-  const premiumSubscribeLinks = document.querySelectorAll(".js-purchase-premium");
-
-  for (const subLink of premiumSubscribeLinks) {
-    subLink.href=subscribeUrlData.url;
-  }
-}
-
-document.addEventListener("DOMContentLoaded", async () => {
+document.addEventListener("DOMContentLoaded", () => {
   watchForInstalledAddon();
   addEventListeners();
   vpnBannerLogic();
   setTranslatedStringLinks();
-  await setPremiumSubscribeUrlsByCountry()
   premiumOnboardingLogic();
   privacyNoticeUpdateBannerLogic();
   dataCollectionBannerLogic();


### PR DESCRIPTION
Removes the `/premium_subscribe_url` endpoint, `premium_subscribe_url_view` view, and the `setPremiumSubscribeUrlsByCountry` JS function that used them.

Instead, uses the new `x_client_region` HTTP header to pass `country_code` to the `premium_subscribe_url` template tag.