### PR TITLE
capture bounce details into sentry

### DIFF
--- a/emails/sns.py
+++ b/emails/sns.py
@@ -29,6 +29,18 @@ Type
 {Type}
 '''
 
+NOTIFICATION_WITHOUT_SUBJECT_HASH_FORMAT = u'''Message
+{Message}
+MessageId
+{MessageId}
+Timestamp
+{Timestamp}
+TopicArn
+{TopicArn}
+Type
+{Type}
+'''
+
 SUBSCRIPTION_HASH_FORMAT = u'''Message
 {Message}
 MessageId
@@ -56,7 +68,7 @@ def verify_from_sns(json_body):
     cert = crypto.load_certificate(crypto.FILETYPE_PEM, pemfile)
     signature = base64.decodebytes(json_body['Signature'].encode('utf-8'))
 
-    hash_format = _get_hash_format(json_body['Type'])
+    hash_format = _get_hash_format(json_body)
 
     crypto.verify(
         cert,
@@ -67,9 +79,12 @@ def verify_from_sns(json_body):
     return json_body
 
 
-def _get_hash_format(message_type):
+def _get_hash_format(json_body):
+    message_type = json_body['Type']
     if message_type == "Notification":
-        return NOTIFICATION_HASH_FORMAT
+        if 'Subject' in json_body.keys():
+            return NOTIFICATION_HASH_FORMAT
+        return NOTIFICATION_WITHOUT_SUBJECT_HASH_FORMAT
 
     return SUBSCRIPTION_HASH_FORMAT
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -609,14 +609,16 @@ def _handle_bounce(message_json):
     bounce = message_json.get('bounce')
     bounced_recipients = bounce.get('bouncedRecipients')
     for recipient in bounced_recipients:
-        recipient_address = recipient.pop('emailAddress', None)
+        recipient_address = recipient.get('emailAddress', None)
+        if recipient_address is None:
+            continue
         recipient_address = parseaddr(recipient_address)[1]
         recipient_domain = recipient_address.split('@')[1]
         capture_message(
             f'bounced recipient domain: {recipient_domain}, {recipient}'
         )
         try:
-            user = User.objects.get(email=recipient.get('emailAddress'))
+            user = User.objects.get(email=recipient_address)
             profile = user.profile_set.first()
         except User.DoesNotExist:
             incr_if_enabled('email_bounce_relay_user_gone', 1)


### PR DESCRIPTION
To help us understand why some receiving MTA's are bouncing emails back at Relay, capture bounced recipient details in sentry messages. (Note: this strips the localpart of the bounced recipient so we don't leak that PII into sentry.)

This also updates the bounce-handling code to match the bounce notification I got from my local SES. It should keep the existing logic working too, in case my bounce notifications are different from what's in dev/stage/prod.

Example of the message:
```
bounced recipient domain: simulator.amazonses.com, {'action': 'failed', 'status': '5.1.1', 'diagnosticCode': 'smtp; 550 5.1.1 user unknown'}
```