### PR TITLE
Show NPS banner after three days

### DIFF
--- a/privaterelay/context_processors.py
+++ b/privaterelay/context_processors.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 
 from django.conf import settings
@@ -13,12 +14,21 @@ def common(request):
     avatar = fxa.extra_data['avatar'] if fxa else None
     accept_language = request.headers.get('Accept-Language', 'en-US')
     country_code = request.headers.get('X-Client-Region', 'us').lower()
+
+    first_visit = request.COOKIES.get("first_visit")
+    show_nps = (
+        first_visit is not None and
+        not request.user.is_anonymous and
+        (datetime.now(timezone.utc) > datetime.fromisoformat(first_visit) + timedelta(days = 3))
+    )
+
     return {
         'avatar': avatar,
         'ftl_mode': 'server',
         'accept_language': accept_language,
         'country_code': country_code,
-        'monthly_price': premium_plan_price(accept_language, country_code)
+        'monthly_price': premium_plan_price(accept_language, country_code),
+        'show_nps': show_nps,
     }
 
 @lru_cache(maxsize=None)

--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -75,3 +75,14 @@ class ResponseMetrics:
         ])
 
         return response
+
+class StoreFirstVisit:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        first_visit = request.COOKIES.get("first_visit")
+        if (first_visit is None and not request.user.is_anonymous):
+            response.set_cookie("first_visit", datetime.now(timezone.utc))
+        return response

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -208,6 +208,7 @@ MIDDLEWARE += [
     'django_referrer_policy.middleware.ReferrerPolicyMiddleware',
     'dockerflow.django.middleware.DockerflowMiddleware',
     'privaterelay.middleware.FxAToRequest',
+    'privaterelay.middleware.StoreFirstVisit',
 ]
 
 ROOT_URLCONF = 'privaterelay.urls'

--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -15,7 +15,7 @@
     <div class="recruitment-banner">
       <a id="recruitment-banner" class="text-link" href="{{ settings.RECRUITMENT_BANNER_LINK }}" target="_blank" rel="noopener noreferrer" data-ga="send-ga-pings" data-event-category="Recruitment" data-event-label="{{ settings.RECRUITMENT_BANNER_TEXT }}">{{ settings.RECRUITMENT_BANNER_TEXT }}</a>
     </div>
-  {% elif not request.user.is_anonymous %}
+  {% elif show_nps %}
     <div id="micro-survey-banner" class="micro-survey-banner is-hidden">
       <button id="survey-dismiss" class="dismiss-btn">
         <svg class="x-close-icon fill-current  text-gray" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
@@ -24,11 +24,11 @@
       {% now "U" as now_second %}
       {% if now_second|last == "1" or now_second|last == "6" %}
       {% endcomment %}
-        <span id="micro-survey-prompt" data-survey-type="nps">{% ftlmsg 'survey-question-1' %}</span>
-        <ul id="micro-survey-options"
-        data-survey-option-very-likely-translated="{% ftlmsg 'survey-option-very-likely' %}"
-        data-survey-option-not-likely-translated="{% ftlmsg 'survey-option-not-likely' %}"
-        class="micro-survey-options micro-survey-options-numeric"></ul>
+      <span id="micro-survey-prompt" data-survey-type="nps">{% ftlmsg 'survey-question-1' %}</span>
+      <ul id="micro-survey-options"
+      data-survey-option-very-likely-translated="{% ftlmsg 'survey-option-very-likely' %}"
+      data-survey-option-not-likely-translated="{% ftlmsg 'survey-option-not-likely' %}"
+      class="micro-survey-options micro-survey-options-numeric"></ul>
       {% comment %}
       {% elif now_second|last == "2" or now_second|last == "7" %}
         <span id="micro-survey-prompt" data-survey-type="usability">{% ftlmsg 'survey-question-2' %}</span>

--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -16,18 +16,20 @@
       <a id="recruitment-banner" class="text-link" href="{{ settings.RECRUITMENT_BANNER_LINK }}" target="_blank" rel="noopener noreferrer" data-ga="send-ga-pings" data-event-category="Recruitment" data-event-label="{{ settings.RECRUITMENT_BANNER_TEXT }}">{{ settings.RECRUITMENT_BANNER_TEXT }}</a>
     </div>
   {% elif not request.user.is_anonymous %}
-      {% comment %}
     <div id="micro-survey-banner" class="micro-survey-banner">
       <button id="survey-dismiss" class="dismiss-btn">
         <svg class="x-close-icon fill-current  text-gray" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
       </button>
+      {% comment %}
       {% now "U" as now_second %}
       {% if now_second|last == "1" or now_second|last == "6" %}
+      {% endcomment %}
         <span id="micro-survey-prompt" data-survey-type="nps">{% ftlmsg 'survey-question-1' %}</span>
         <ul id="micro-survey-options"
         data-survey-option-very-likely-translated="{% ftlmsg 'survey-option-very-likely' %}"
         data-survey-option-not-likely-translated="{% ftlmsg 'survey-option-not-likely' %}"
         class="micro-survey-options micro-survey-options-numeric"></ul>
+      {% comment %}
       {% elif now_second|last == "2" or now_second|last == "7" %}
         <span id="micro-survey-prompt" data-survey-type="usability">{% ftlmsg 'survey-question-2' %}</span>
         <ul id="micro-survey-options"
@@ -63,8 +65,8 @@
         data-survey-option-not-likely-translated="{% ftlmsg 'survey-option-very-disappointed' %}"
         class="micro-survey-options micro-survey-options-likert"></ul>
       {% endif %}
-    </div>
       {% endcomment %}
+    </div>
   {% endif %}
 
   <div class="header-top">

--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -16,7 +16,7 @@
       <a id="recruitment-banner" class="text-link" href="{{ settings.RECRUITMENT_BANNER_LINK }}" target="_blank" rel="noopener noreferrer" data-ga="send-ga-pings" data-event-category="Recruitment" data-event-label="{{ settings.RECRUITMENT_BANNER_TEXT }}">{{ settings.RECRUITMENT_BANNER_TEXT }}</a>
     </div>
   {% elif not request.user.is_anonymous %}
-    <div id="micro-survey-banner" class="micro-survey-banner">
+    <div id="micro-survey-banner" class="micro-survey-banner is-hidden">
       <button id="survey-dismiss" class="dismiss-btn">
         <svg class="x-close-icon fill-current  text-gray" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
       </button>

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -150,7 +150,7 @@ function analyticsSurveyLogic() {
   }
 
   // Unhide the micro survey
-  microSurveyBanner.classList.remove("hidden");
+  microSurveyBanner.classList.remove("is-hidden");
 
   const surveyPrompt = document.getElementById("micro-survey-prompt");
   const surveyType = surveyPrompt.dataset.surveyType;


### PR DESCRIPTION
# New feature description

This sets a cookie when the user visits the website while logged
in, containing a timestamp. Then if the timestamp in that cookie is
more than three days ago, the NPS banner is shown.

0e1bc43897518fbf06070b92e852028a4ee31454 also fixes #1096 - only half of the NPS survey banner was shown if `analytics.js` was blocked (e.g. by uBlock Origin).

# Checklist

- [x] l10n dependencies have been merged, if any.
- [ ] All acceptance criteria are met. - Ideally for Premium users it would be shown three days after buying their subscription, but I don't know how to obtain that info. If I can find that out, that will come in a later PR.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`). (No new UI added.)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
