### PR TITLE
Make `surveyed` cookie available everywhere

### DIFF
--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -120,7 +120,7 @@ function openOauth(clickEvt, entrypointElem) {
 function setSurveyedCookie() {
   const date = new Date();
   date.setTime(date.getTime() + 30*24*60*60*1000)
-  document.cookie = "surveyed=true; expires=" + date.toUTCString();
+  document.cookie = "surveyed=true; expires=" + date.toUTCString() + "; path=/";
   const microSurveyBanner = document.getElementById("micro-survey-banner");
   if (microSurveyBanner) {
     microSurveyBanner.remove();

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -200,7 +200,7 @@ function recruitmentLogic() {
   recruitmentBannerLink.addEventListener("click", () => {
     const date = new Date();
     date.setTime(date.getTime() + 30*24*60*60*1000)
-    document.cookie = "recruited=true; expires=" + date.toUTCString();
+    document.cookie = "recruited=true; expires=" + date.toUTCString() + "; path=/";
   });
 }
 


### PR DESCRIPTION
This PR fixes the issue pointed out by @maxxcrawford here: https://github.com/mozilla/fx-private-relay/pull/1386#pullrequestreview-821092010

After filling in the NPS survey, you got resurveyed on different
pages because the cookie was only valid for the path at which it
was answered.

I also made the `recruited` cookie available everywhere, although
I don't think that's actually being used anywhere at the moment
(i.e. I don't think `settings.RECRUITMENT_BANNER_LINK` is set).

How to test:

- Visit site (where you trigger the NPS banner)
- Answer/click banner
- Refresh the page
- Expected: No NPS banner
- Navigate to FAQs page
- Expected: No NPS banner

(Thanks Maxx for writing those steps up first :) )

- [x] l10n dependencies have been merged, if any.
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
