### PR TITLE
Also expose plan IDs in the premium_countries API

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -3,7 +3,8 @@ from django.urls import include, path
 from rest_framework import routers
 
 from .views import (
-    DomainAddressViewSet, ProfileViewSet, RelayAddressViewSet, schema_view
+    DomainAddressViewSet, ProfileViewSet, RelayAddressViewSet,
+    premium_countries, schema_view
 )
 
 
@@ -19,6 +20,10 @@ api_router.register(
 )
 
 urlpatterns = [
+    path('v1/premium_countries',
+         premium_countries,
+         name='premium_countries'
+    ),
     path('v1/swagger(?P<format>\.json|\.yaml)',
         schema_view.without_ui(cache_timeout=0),
         name='schema-json'

--- a/api/views.py
+++ b/api/views.py
@@ -2,9 +2,10 @@ from django.conf import settings
 
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
-from rest_framework import permissions, viewsets
+from rest_framework import decorators, permissions, response, viewsets
 
 from emails.models import DomainAddress, Profile, RelayAddress
+from privaterelay.utils import get_premium_countries_info_from_request
 
 from .permissions import IsOwner
 from .serializers import (
@@ -51,3 +52,10 @@ class ProfileViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         return Profile.objects.filter(user=self.request.user)
+
+@decorators.api_view()
+@decorators.permission_classes([permissions.AllowAny])
+def premium_countries(request):
+    return response.Response(
+        get_premium_countries_info_from_request(request)
+    )

--- a/privaterelay/context_processors.py
+++ b/privaterelay/context_processors.py
@@ -12,13 +12,17 @@ def common(request):
     fxa = _get_fxa(request)
     avatar = fxa.extra_data['avatar'] if fxa else None
     accept_language = request.headers.get('Accept-Language', 'en-US')
-    country_code = request.headers.get('X-Client-Region', 'us').lower()
+    country_code = request.headers.get('X-Client-Region', '').lower()
+    premium_available_in_country = (
+        country_code in settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING.keys()
+    )
     return {
         'avatar': avatar,
         'ftl_mode': 'server',
         'accept_language': accept_language,
         'country_code': country_code,
-        'monthly_price': premium_plan_price(accept_language, country_code)
+        'monthly_price': premium_plan_price(accept_language, country_code),
+        'premium_available_in_country': premium_available_in_country
     }
 
 @lru_cache(maxsize=None)

--- a/privaterelay/templatetags/relay_tags.py
+++ b/privaterelay/templatetags/relay_tags.py
@@ -36,11 +36,15 @@ def premium_plan_id(accept_lang, cc=None):
     if settings.PREMIUM_PRICE_ID_OVERRIDE:
         return settings.PREMIUM_PRICE_ID_OVERRIDE
     cc, lang = get_premium_country_lang(accept_lang, cc)
-    return settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING[cc][lang]["id"]
+    if cc in settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING:
+        return settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING[cc][lang]["id"]
+    return ''
 
 @register.simple_tag
 def premium_plan_price(accept_lang, cc=None):
     cc, lang = get_premium_country_lang(accept_lang, cc)
+    if cc not in settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING:
+        cc = 'us'
     return settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING[cc][lang]["price"]
 
 @register.simple_tag

--- a/privaterelay/templatetags/relay_tags.py
+++ b/privaterelay/templatetags/relay_tags.py
@@ -3,6 +3,8 @@ from django.conf import settings
 
 from emails.utils import get_email_domain_from_settings
 
+from ..utils import get_premium_country_lang
+
 register = template.Library()
 
 
@@ -28,21 +30,6 @@ def message_in_fluent(message):
     ]
     return message in ftl_messages
 
-
-def get_premium_country_lang(accept_lang, cc=None):
-    lang = accept_lang.split(',')[0]
-    lang_parts = lang.split("-") if lang and "-" in lang else [lang]
-    lang = lang_parts[0].lower()
-    if cc is None:
-        cc = lang_parts[1] if len(lang_parts) == 2 else lang_parts[0]
-        cc = cc.lower()
-
-    if cc in settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING.keys():
-        languages = settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING[cc]
-        if lang in languages.keys():
-            return cc, lang
-        return cc, list(languages.keys())[0]
-    return 'us', 'en'
 
 @register.simple_tag
 def premium_plan_id(accept_lang, cc=None):

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -1,9 +1,6 @@
 from django.test import TestCase
 
-from ..utils import (
-    get_premium_country_lang,
-    get_premium_countries_info_from_request
-)
+from ..utils import get_premium_country_lang
 
 
 class GetPremiumCountryLangTest(TestCase):

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -1,0 +1,25 @@
+from django.test import TestCase
+
+from ..utils import (
+    get_premium_country_lang,
+    get_premium_countries_info_from_request
+)
+
+
+class GetPremiumCountryLangTest(TestCase):
+    def test_get_premium_country_lang(self):
+        cc, lang = get_premium_country_lang('en-au,')
+        assert cc == 'au'
+        assert lang == 'en'
+
+        cc, lang = get_premium_country_lang('en-us,')
+        assert cc == 'us'
+        assert lang == 'en'
+
+        cc, lang = get_premium_country_lang('de-be,')
+        assert cc == 'be'
+        assert lang == 'de'
+
+        cc, lang = get_premium_country_lang('de-be,', 'at')
+        assert cc == 'at'
+        assert lang == 'de'

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -34,4 +34,4 @@ def get_premium_country_lang(accept_lang, cc=None):
         if lang in languages.keys():
             return cc, lang
         return cc, list(languages.keys())[0]
-    return 'us', 'en'
+    return cc, 'en'

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -1,0 +1,37 @@
+from django.conf import settings
+
+def get_premium_countries_info_from_request(request):
+    country_code = _get_cc_from_request(request)
+    premium_countries = settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING.keys()
+    premium_available_in_country = country_code in premium_countries
+    return({
+        'country_code': country_code,
+        'premium_countries': premium_countries,
+        'premium_available_in_country': premium_available_in_country
+    })
+
+
+def _get_cc_from_request(request):
+    if 'X-Client-Region' in request.headers:
+        return request.headers['X-Client-Region'].lower()
+    if 'Accept-Language' in request.headers:
+        return get_premium_country_lang(request.headers['Accept-Language'])
+    if settings.DEBUG:
+        return 'us'
+    return 'us'
+
+
+def get_premium_country_lang(accept_lang, cc=None):
+    lang = accept_lang.split(',')[0]
+    lang_parts = lang.split("-") if lang and "-" in lang else [lang]
+    lang = lang_parts[0].lower()
+    if cc is None:
+        cc = lang_parts[1] if len(lang_parts) == 2 else lang_parts[0]
+        cc = cc.lower()
+
+    if cc in settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING.keys():
+        languages = settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING[cc]
+        if lang in languages.keys():
+            return cc, lang
+        return cc, list(languages.keys())[0]
+    return 'us', 'en'

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -7,7 +7,8 @@ def get_premium_countries_info_from_request(request):
     return({
         'country_code': country_code,
         'premium_countries': premium_countries,
-        'premium_available_in_country': premium_available_in_country
+        'premium_available_in_country': premium_available_in_country,
+        'plan_country_lang_mapping': settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING,
     })
 
 

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -15,7 +15,7 @@ def _get_cc_from_request(request):
     if 'X-Client-Region' in request.headers:
         return request.headers['X-Client-Region'].lower()
     if 'Accept-Language' in request.headers:
-        return get_premium_country_lang(request.headers['Accept-Language'])
+        return get_premium_country_lang(request.headers['Accept-Language'])[0]
     if settings.DEBUG:
         return 'us'
     return 'us'


### PR DESCRIPTION
# New feature description

This also exposes plan IDs in he `premium_countries` API.

# How to test

Visit http://127.0.0.1:8000/api/v1/premium_countries, check that `plan_country_lang_mapping` is listed.

# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
