### PR TITLE
remove linebreak from ftlmsg tag

### DIFF
--- a/privaterelay/templates/includes/banners/announcement-banner.html
+++ b/privaterelay/templates/includes/banners/announcement-banner.html
@@ -9,8 +9,7 @@
         <div class="bounced-email-banner banner-content flx flx-row">
             <div class="banner-copy flx flx-col">
                 <p class="banner-hl ff-Met">{% ftlmsg 'banner-bounced-headline' %}</p>
-                <p class="banner-sub">{% ftlmsg 'banner-bounced-copy' username=request.user.email
-                    bounce_type=last_bounce_type date=next_email_try|date:"SHORT_DATETIME_FORMAT" %}</p>
+                <p class="banner-sub">{% ftlmsg 'banner-bounced-copy' username=request.user.email bounce_type=last_bounce_type date=next_email_try|date:"SHORT_DATETIME_FORMAT" %}</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes https://github.com/mozilla/fx-private-relay/issues/1392.

How to test:

1. Go to a profile in the admin page (http://127.0.0.1:8000/admin/emails/profile/)
2. Set either its "last soft bounce" or "last hard bounce" values to today + now
3. Go to http://127.0.0.1:8000/accounts/profile/
   * Expected: You should see a real error message in the box, not the `ftlmsg` code.

- ~[ ] l10n dependencies have been merged, if any.~
- ~[ ] I've added a unit test to test for potential regressions of this bug~ (or this is a front-end change, where we don't yet have unit test infrastructure).
- ~[ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
