### PR TITLE
use django-restql to enable graphql-like ?fields={} queries

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,9 +1,11 @@
 from rest_framework import serializers
 
+from django_restql.mixins import DynamicFieldsMixin
+
 from emails.models import Profile, DomainAddress, RelayAddress
 
 
-class RelayAddressSerializer(serializers.ModelSerializer):
+class RelayAddressSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model = RelayAddress
         fields = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,11 @@ dj-database-url==0.5.0
 django-allauth==0.39.1
 django-csp==3.5
 django-debug-toolbar==2.2.1
+django-ftl==0.12.1
 django-gulp==4.1.0
 django-redis==4.12.1
-django-ftl==0.12.1
 django-referrer-policy==1.0
+django-restql==0.15.1
 djangorestframework==3.12.4
 dockerflow==2021.7.0
 drf-yasg==1.20.0


### PR DESCRIPTION
# New feature description

Add GraphQL-like queries to our API with [django-restql](https://yezyilomo.github.io/django-restql/).

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/71928/144625718-9f3a5ed3-2e92-4647-9a4e-7f828f10620b.png)

# How to test

http://127.0.0.1:8000/api/v1/relayaddresses/?format=json&query=%7Bgenerated_for%7D

# Checklist

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
