### PR TITLE
Prevent layout shifts

### DIFF
--- a/privaterelay/templates/includes/banners/announcement-banner.html
+++ b/privaterelay/templates/includes/banners/announcement-banner.html
@@ -14,28 +14,7 @@
         </div>
     </div>
 </div>
-{% else %}
 
-{% if show_data_notification_banner %}
-{% with request.user.profile_set.first as user_profile %}
-  {% if not user_profile.server_storage %}
-    <div id="sync-labels" class="c-notification-banner c-data-notification-banner t-warning is-hidden">
-      <div class="dismiss-wrapper">
-        <button class="notification-dismiss js-data-collection-dismiss"><img src="{% static 'images/x-close.svg' %}"></button>
-      </div>
-      <div class="notification-banner-bg">
-        <div class="notification-banner-content">
-          <div class="notification-banner-copy">
-            <p class="notification-banner-header">{% ftlmsg 'banner-label-data-notification-header' %}</p>
-            <p class="notification-banner-sub">{% ftlmsg 'banner-label-data-notification-body' %}</p>
-            <a class="notification-banner-link" href="/accounts/settings" rel="noopener noreferrer">{% ftlmsg 'banner-label-data-notification-cta' %}</a>
-          </div>
-        </div>
-      </div>
-    </div>
-  {% endif %}
-{% endwith %}
-{% endif %}
 {% endif %}
 
 {% if not settings.PREMIUM_ENABLED %}

--- a/privaterelay/templates/includes/banners/default-banners.html
+++ b/privaterelay/templates/includes/banners/default-banners.html
@@ -18,7 +18,7 @@
                 </div>
             </div>
             <!-- Download Add On Banner -->
-            <div class="install-addon-banner banner-content flx flx-row">
+            <div class="install-addon-banner banner-content flx flx-row hidden">
                 <div class="banner-relay-logo banner-logo"></div>
                 <div class="banner-copy flx flx-col">
                     <p class="banner-hl ff-Met">{% ftlmsg 'banner-download-install-extension-headline' %}</p>

--- a/privaterelay/templates/includes/banners/default-banners.html
+++ b/privaterelay/templates/includes/banners/default-banners.html
@@ -3,9 +3,9 @@
 {% load ftl %}
 {% ftlconf bundle='privaterelay.ftl_bundles.main' %}
 
-<div class="dashboard-banners invisible">
+<div class="dashboard-banners">
     <div class="flx hide-750">
-        <div class="banner-gradient-bg addon">
+        <div class="banner-gradient-bg is-hidden-with-addon">
             <!-- Download Firefox Banner -->
             <div class="download-fx-banner banner-content flx flx-row hidden">
                 <div class="banner-fx-logo banner-logo"></div>
@@ -18,7 +18,7 @@
                 </div>
             </div>
             <!-- Download Add On Banner -->
-            <div class="install-addon-banner banner-content flx flx-row hidden">
+            <div class="install-addon-banner banner-content flx flx-row">
                 <div class="banner-relay-logo banner-logo"></div>
                 <div class="banner-copy flx flx-col">
                     <p class="banner-hl ff-Met">{% ftlmsg 'banner-download-install-extension-headline' %}</p>

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -107,8 +107,6 @@ def profile(request):
             'last_bounce_date': profile.last_bounce_date,
             'next_email_try': profile.next_email_try
         })
-    if datetime.now(timezone.utc) < settings.PREMIUM_RELEASE_DATE:
-        context.update({'show_data_notification_banner': True})
     response = render(request, 'profile.html', context)
     if newly_premium:
         event = 'user_purchased_premium'

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -303,31 +303,16 @@ function showBannersIfNecessary() {
 
   const browserIsFirefox = /firefox|FxiOS/i.test(navigator.userAgent);
 
-  const dashboardBanners = document.querySelector(".dashboard-banners");
-  if (!dashboardBanners) {
-    return;
-  }
-
-  const showBanner = (bannerEl) => {
-    setTimeout(()=> {
-      bannerEl.classList.remove("hidden");
-      dashboardBanners.classList.remove("invisible");
-    }, 500);
-    return;
-  };
-
   if (!browserIsFirefox) {
-    const firefoxBanner = dashboardBanners.querySelector(".download-fx-banner");
+    const firefoxBanner = document.querySelector(".download-fx-banner");
+    firefoxBanner.classList.remove("hidden");
     // Used to show/hide add-on download prompts in onboarding
     document.getElementById("profile-main").classList.add("is-not-addon-compatible")
-    showBanner(firefoxBanner);
 
 
 
     return;
   }
-  const relayAddonBanner = dashboardBanners.querySelector(".install-addon-banner");
-  return showBanner(relayAddonBanner);
 }
 
 function setTranslatedStringLinks() {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -309,9 +309,11 @@ function showBannersIfNecessary() {
     // Used to show/hide add-on download prompts in onboarding
     document.getElementById("profile-main").classList.add("is-not-addon-compatible")
 
-
-
     return;
+  }
+  if (browserIsFirefox) {
+    const addonBanner = document.querySelector(".install-addon-banner");
+    addonBanner.classList.remove("hidden");
   }
 }
 

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -849,40 +849,23 @@ input:focus::placeholder {
     opacity: .5;
 }
 
-
-
-.dashboard-banners.invisible {
-    transition: all .2s ease;
-    opacity: 0;
-    padding: 0;
-    max-height: 0;
+.is-visible-with-addon {
+    // This class hides an element anything in the regular website;
+    // however, the add-on injects a stylesheet that reveals elements with this class.
+    display: none;
+    visibility: collapse;
 }
+
+.is-hidden-with-addon {
+    // This class doesn't do anything in the regular website;
+    // however, the add-on injects a stylesheet that hides elements with this class.
+}
+
 
 .dashboard-banners.drop-shadow {
     box-shadow: 0 12px 18px 2px rgba(34,0,51,.04),0 6px 22px 4px rgba(7,48,114,.12),0 6px 10px -4px rgba(14,13,26,.12);
 }
 
-.banner-content.invisible {
-    max-height: 0;
-}
-
-.dashboard-banners {
-    width: 100%;
-    opacity: 1;
-    padding: 1em 0;
-    transition: all .3s ease;
-}
-
-/* Don't show the "Install the add-on" banner if the add-on is active: */
-firefox-private-relay-addon[data-addon-installed="true"] + firefox-private-relay-addon-data + main .dashboard-banners .addon {
-    display: none;
-}
-
-
-/* Show the opt in data notification banner if add on is downloaded */
-firefox-private-relay-addon[data-addon-installed="false"] + firefox-private-relay-addon-data + main .c-data-notification-banner {
-    display: none;
-}
 
 .banner-hl {
     font-size: 1.25rem;


### PR DESCRIPTION
This PR fixes layout shifts due to revealing the "Install the add-on" banner after a delay to check if the add-on is installed. ~~**This depends on https://github.com/mozilla/fx-private-relay-add-on/pull/226 - do not merge before that is released.**~~ The required changes were included in https://github.com/mozilla/fx-private-relay-add-on/pull/249, so once a version with that has been published, this can be merged.

(I also removed the banner that pointed people to the updated privacy policy, since that wasn't shown since the Premium release anymore anyway.)

Without add-on:

https://user-images.githubusercontent.com/4251/144826048-ae682534-fad2-469e-9eb7-91d92e88e1f9.mp4

With the add-on:

https://user-images.githubusercontent.com/4251/144826072-1abe9ba5-0d2e-4b43-a268-33b460812214.mp4

Before, without the add-on:

https://user-images.githubusercontent.com/4251/144826531-d934f209-9605-45a6-b7fe-5048d8317a4b.mp4

How to test:

1. View the website without the add-on installed. Notice that the banner recommending the add-on is shown is displayed immediately and that the page does not jump around.
2. View the website with the add-on installed. Notice that the banner recommending the add-on is not shown.

- [x] l10n dependencies have been merged, if any.
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
