### PR TITLE
Add missing word in FAQ

### DIFF
--- a/privaterelay/templates/faq.html
+++ b/privaterelay/templates/faq.html
@@ -108,7 +108,7 @@
             </section>
             <section class="faq" id="faq-replies">
               <h2 class="faq-headline">{% ftlmsg 'faq-question-4-question' %}</h2>
-              <p class="faq-answer">{% ftlmsg 'faq-question-4-answer-v3' %}</p>
+              <p class="faq-answer">{% ftlmsg 'faq-question-4-answer-v4' %}</p>
             </section>
             <section class="faq" id="faq-subdomain-question">
               <h2 class="faq-headline">{% ftlmsg 'faq-question-subdomain-characters-question' %}</h2>


### PR DESCRIPTION
Depends on https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/47

How to test: see that "copied" is in the FAQ about being able to reply:

![image](https://user-images.githubusercontent.com/4251/144862916-dc153ba3-a6f8-4961-80c2-26a190124ed4.png)


- [x] l10n dependencies have been merged, if any. https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/47
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
