### PR TITLE
fix #1405: improvements to _handle_fxa_profile_change

### DIFF
--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -1,0 +1,58 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from allauth.socialaccount.models import SocialAccount
+from allauth.account.models import EmailAddress
+from model_bakery import baker
+
+from ..views import _update_extra_data_and_email
+
+
+class UpdateExtraDataAndEmailTest(TestCase):
+    def test_update_extra_data_and_email(self):
+        user = baker.make(User)
+        ea = baker.make(EmailAddress, user=user)
+        sa = baker.make(
+            SocialAccount, user=user, extra_data='{"test": "test"}'
+        )
+        new_extra_data = '{"test": "updated"}'
+        new_email = 'newemail@example.com'
+
+        response = _update_extra_data_and_email(
+            sa, new_extra_data, new_email
+        )
+
+        assert response.status_code == 202
+
+        sa.refresh_from_db()
+        ea.refresh_from_db()
+
+        assert sa.extra_data == new_extra_data
+        assert ea.email == new_email
+
+    def test_update_extra_data_and_email_conflict(self):
+        extra_data='{"test": "test"}'
+
+        user = baker.make(User, email='user@example.com')
+        baker.make(EmailAddress, user=user, email='user@example.com')
+        baker.make(SocialAccount, user=user, extra_data=extra_data)
+
+        user2 = baker.make(User, email='user2@example.com')
+        ea2 = baker.make(EmailAddress, user=user2, email='user2@example.com')
+        sa2 = baker.make(SocialAccount, user=user2, extra_data=extra_data)
+
+        new_extra_data = '{"test": "updated"}'
+        new_email = 'user@example.com'
+
+        response = _update_extra_data_and_email(
+            sa2, new_extra_data, new_email
+        )
+
+        assert response.status_code == 409
+
+        sa2.refresh_from_db()
+        ea2.refresh_from_db()
+
+        # values should be un-changed because of the dupe error
+        assert sa2.extra_data == extra_data
+        assert ea2.email == 'user2@example.com'

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -14,7 +14,7 @@ import sentry_sdk
 from django.apps import apps
 from django.conf import settings
 from django.contrib import messages
-from django.db import connections
+from django.db import IntegrityError, connections, transaction
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render, redirect
 from django.urls import reverse
@@ -319,13 +319,24 @@ def _handle_fxa_profile_change(
             'real_address': sha256(new_email.encode('utf-8')).hexdigest(),
         })
 
-    social_account.extra_data = extra_data
-    social_account.save()
-    social_account.user.email = new_email
-    social_account.user.save()
-    email_address_record = social_account.user.emailaddress_set.first()
-    email_address_record.email = new_email
-    email_address_record.save()
+    return _update_extra_data_and_email(
+        social_account, extra_data, new_email
+    )
+
+def _update_extra_data_and_email(social_account, extra_data, new_email):
+    try:
+        with transaction.atomic():
+            social_account.extra_data = extra_data
+            social_account.save()
+            social_account.user.email = new_email
+            social_account.user.save()
+            email_address_record = social_account.user.emailaddress_set.first()
+            email_address_record.email = new_email
+            email_address_record.save()
+            return HttpResponse('202 Accepted', status=202)
+    except IntegrityError as e:
+        sentry_sdk.capture_exception(e)
+        return HttpResponse('Conflict', status=409)
 
 
 def _handle_fxa_delete(authentic_jwt, social_account, event_key):


### PR DESCRIPTION
use `transaction.atomic` and catch `IntegrityError`

This PR fixes #1405.

- [x] I've added a unit test to test for potential regressions of this bug

# How to test
After this is merged to `main` dev server, we want to do FXA profile updates to make sure the rest of the webhook logic is still working fine.