### PR TITLE
Promo Page: Revise SCSS to match Figma layout closer

### DIFF
--- a/static/scss/partials/landing/a.scss
+++ b/static/scss/partials/landing/a.scss
@@ -506,13 +506,14 @@
             @include text-title-2xs;
             font-weight: 700;
             min-width: $content-xs;
-            padding-top: $spacing-md;
-            padding-right: $spacing-xl;
-            display: inline;
+            display: flex;
+            align-items: center;
+            justify-content: center;
         }
 
         .desc-body {
             display: flex;
+            align-items: center;
             min-height: $layout-xl;
         }
 

--- a/static/scss/partials/premium-promo.scss
+++ b/static/scss/partials/premium-promo.scss
@@ -43,9 +43,15 @@
         flex-direction: row;
         padding: $spacing-2xl;
 
-        &:nth-child(odd) {
+        &:nth-child(even) {
             flex-direction: row-reverse;
         }
+    }
+}
+
+.perk-description {
+    @media screen and #{$mq-md} {
+        width: 50%;
     }
 }
 
@@ -55,6 +61,9 @@
 
 .perk-illustration {
     max-width: 90%;
+    @media screen and #{$mq-md} {
+        max-width: 50%;
+    }
 }
 
 .use-case-headline {

--- a/static/scss/partials/premium-promo.scss
+++ b/static/scss/partials/premium-promo.scss
@@ -61,6 +61,7 @@
 
 .perk-illustration {
     max-width: 90%;
+    
     @media screen and #{$mq-md} {
         max-width: 50%;
     }


### PR DESCRIPTION
This PR applies fixes from the review on #1409. These changes are all visual/low-risk. 

It addresses the: 
- Initial content order (image/content flow) for the perks section on desktop and max-width the inner items (50%)
- Vertical content centering on the use-case section (for this page AND the homepage) 

How to test: 
1. Open browser to http://127.0.0.1:8000/premium

- [x] l10n dependencies have been merged, if any.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

## Screenshots: 

Revised order/widths for perks section: 
![image](https://user-images.githubusercontent.com/2692333/145304606-4bffdfad-0292-49b5-9716-96bcb88722f1.png)


Revised use-case section: 
![image](https://user-images.githubusercontent.com/2692333/145303163-616452cd-7a08-433f-b33d-583fc1d79573.png)
