### PR TITLE
Show NPS survey for Premium subscribers

### DIFF
--- a/privaterelay/context_processors.py
+++ b/privaterelay/context_processors.py
@@ -20,10 +20,21 @@ def common(request):
     )
 
     first_visit = request.COOKIES.get("first_visit")
+    date_subscribed = not request.user.is_anonymous and request.user.profile_set.first().date_subscribed ;
     show_nps = (
-        first_visit is not None and
         not request.user.is_anonymous and
-        (datetime.now(timezone.utc) > datetime.fromisoformat(first_visit) + timedelta(days = 3))
+        (
+            # Show the NPS survey if the user created their account at least three days ago:
+            (
+                first_visit is not None and
+                datetime.now(timezone.utc) > datetime.fromisoformat(first_visit) + timedelta(days = 3)
+            ) or
+            # Show the NPS survey if the user subscribed to Premium at least three days ago:
+            (
+                date_subscribed and
+                datetime.now(timezone.utc) > (date_subscribed + timedelta(days = 3))
+            )
+        )
     )
 
     common_vars = {


### PR DESCRIPTION
# New feature description

This also shows the NPS survey if the user's date_subscribed is more than three days ago. I have no idea whether what I'm doing here to obtain the user's Profile in `context_processors.py` is terribly inefficient or not, so if there's a better way, please let me know.

# Screenshot (if applicable)

It's just the regular NPS survey at the top of the page:

![image](https://user-images.githubusercontent.com/4251/145396591-e0d2aacc-7990-4494-ab53-bb2abd7b2354.png)

# How to test

Make sure to delete any `first_visited` cookies first, to make sure you don't get the survey due to being a regular user who's had an account for three days or more.

On http://127.0.0.1:8000/admin/emails/profile/, you can modify "Date subscribed" to be a date more than three days ago. Then you should see the NPS survey.

# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
