### PR TITLE
Don't show NPS banner on Premium promo page

### DIFF
--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -15,7 +15,7 @@
     <div class="recruitment-banner">
       <a id="recruitment-banner" class="text-link" href="{{ settings.RECRUITMENT_BANNER_LINK }}" target="_blank" rel="noopener noreferrer" data-ga="send-ga-pings" data-event-category="Recruitment" data-event-label="{{ settings.RECRUITMENT_BANNER_TEXT }}">{{ settings.RECRUITMENT_BANNER_TEXT }}</a>
     </div>
-  {% elif show_nps %}
+  {% elif show_nps and request.path != "/premium" %}
     <div id="micro-survey-banner" class="micro-survey-banner is-hidden">
       <button id="survey-dismiss" class="dismiss-btn">
         <svg class="x-close-icon fill-current  text-gray" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>


### PR DESCRIPTION
# New feature description

This hides the NPS banner on the Premium promotional page ("the interstitial").

# Screenshot (if applicable)

Uploading Kooha-12-13-2021-10-31-24.mp4…

# How to test

Make sure you see the NPS on the homepage. (This should be visible if you signed in more than three days ago and you didn't respond to/dismiss the NPS survey yet.) Then visit `/premium` and make sure you _don't_ see the survey there.

# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
