### PR TITLE
Separate logs stream to stderr and stdout mpp 1275

### DIFF
--- a/emails/management/commands/process_delayed_emails_from_sqs.py
+++ b/emails/management/commands/process_delayed_emails_from_sqs.py
@@ -16,6 +16,7 @@ from emails.utils import incr_if_enabled
 
 
 logger = logging.getLogger('events')
+info_logger = logging.getLogger('eventsinfo')
 
 
 def _verify_and_run_sns_inbound_on_message(message):
@@ -27,7 +28,7 @@ def _verify_and_run_sns_inbound_on_message(message):
     validate_sns_header(topic_arn, message_type)
     try:
         _sns_inbound_logic(topic_arn, message_type, verified_json_body)
-        logger.info(f'processed sqs message ID: {message.message_id}')
+        info_logger.info(f'processed sqs message ID: {message.message_id}')
         message.delete()
     except ClientError as e:
         incr_if_enabled('rerun_message_from_sqs_error', 1)
@@ -43,7 +44,7 @@ def _verify_and_run_sns_inbound_on_message(message):
             time.sleep(1)
             try:
                 _sns_inbound_logic(topic_arn, message_type, verified_json_body)
-                logger.info(f'processed sqs message ID: {message.message_id}')
+                info_logger.info(f'processed sqs message ID: {message.message_id}')
                 message.delete()
             except ClientError as e:
                 incr_if_enabled('rerun_message_from_sqs_error', 1)

--- a/emails/views.py
+++ b/emails/views.py
@@ -56,6 +56,7 @@ from .sns import verify_from_sns, SUPPORTED_SNS_TYPES
 
 
 logger = logging.getLogger('events')
+info_logger = logging.getLogger('eventsinfo')
 
 
 class InReplyToNotFound(Exception):
@@ -236,7 +237,7 @@ def validate_sns_header(topic_arn, message_type):
 
 def _sns_inbound_logic(topic_arn, message_type, json_body):
     if message_type == 'SubscriptionConfirmation':
-        logger.info(
+        info_logger.info(
             'SNS SubscriptionConfirmation',
             extra={'SubscribeURL': json_body['SubscribeURL']}
         )

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 import ipaddress
-import os
+import os, sys
 from datetime import datetime
 
 from decouple import config
@@ -421,6 +421,8 @@ LANGUAGE_CODE = 'en'
 LANGUAGES = settings.LANGUAGES + [
     ('zh-tw', 'Chinese'),
     ('zh-cn', 'Chinese'),
+    ('fy', 'Frisian'),
+    # ('fy-nl', 'Frisian'),
 ]
 
 TIME_ZONE = 'UTC'
@@ -484,7 +486,13 @@ LOGGING = {
         }
     },
     'handlers': {
-        'console': {
+        'console_out': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'stream': sys.stdout,
+            'formatter': 'json'
+        },
+        'console_err': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'formatter': 'json'
@@ -492,15 +500,19 @@ LOGGING = {
     },
     'loggers': {
         'request.summary': {
-            'handlers': ['console'],
+            'handlers': ['console_out'],
             'level': 'DEBUG',
         },
         'events': {
-            'handlers': ['console'],
+            'handlers': ['console_err'],
+            'level': 'ERROR',
+        },
+        'eventsinfo': {
+            'handlers': ['console_out'],
             'level': 'INFO',
         },
         'abusemetrics': {
-            'handlers': ['console'],
+            'handlers': ['console_out'],
             'level': 'INFO'
         }
     }

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -421,8 +421,6 @@ LANGUAGE_CODE = 'en'
 LANGUAGES = settings.LANGUAGES + [
     ('zh-tw', 'Chinese'),
     ('zh-cn', 'Chinese'),
-    ('fy', 'Frisian'),
-    # ('fy-nl', 'Frisian'),
 ]
 
 TIME_ZONE = 'UTC'

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -48,6 +48,7 @@ FXA_DELETE_EVENT = (
 PROFILE_EVENTS = [FXA_PROFILE_CHANGE_EVENT, FXA_SUBSCRIPTION_CHANGE_EVENT]
 
 logger = logging.getLogger('events')
+info_logger = logging.getLogger('eventsinfo')
 
 
 def home(request):
@@ -244,7 +245,7 @@ def fxa_rp_events(request):
     for event_key in event_keys:
         if (event_key in PROFILE_EVENTS):
             if settings.DEBUG:
-                logger.info('fxa_profile_update', extra={
+                info_logger.info('fxa_profile_update', extra={
                     'jwt': authentic_jwt,
                     'event_key': event_key,
                 })
@@ -321,7 +322,7 @@ def _handle_fxa_profile_change(
         return HttpResponse('202 Accepted', status=202)
 
     if authentic_jwt and event_key:
-        logger.info('fxa_rp_event', extra={
+        info_logger.info('fxa_rp_event', extra={
             'fxa_uid': authentic_jwt['sub'],
             'event_key': event_key,
             'real_address': sha256(new_email.encode('utf-8')).hexdigest(),
@@ -352,7 +353,7 @@ def _handle_fxa_delete(authentic_jwt, social_account, event_key):
     # to create hard bounce receipt rules in SES,
     # because cascade deletes like this don't necessarily call delete()
     social_account.user.delete()
-    logger.info('fxa_rp_event', extra={
+    info_logger.info('fxa_rp_event', extra={
         'fxa_uid': authentic_jwt['sub'],
         'event_key': event_key,
     })


### PR DESCRIPTION
# About this PR
Logs are all going to stderr which makes it hard for our SREs to find err messages. This PR sets all none error logs to go to stdout instead of stderr by creating a separate handler `console_out` stream logs from `request.summary`, `eventsinfo`, and `abusemetrics` to go to stdout.

# How to test
Because there is no well documented ways to mimic how Google's Log Explorer highlights the stdout from stderr, this should be tested on Stage and Prod. Instead here are some documentations to prove that this fix should solve the problem.

Before the fix we were using [logging.StreamHandler](https://docs.python.org/3/library/logging.handlers.html#logging.StreamHandler) in our settings.py which defaults to logging to `sys.stderr`. Setting the `stream` value in the settings.py to `sys.stdout` should update the StreamHandler to stream the logs to `sys.stdout` [[1](https://docs.python.org/3/library/logging.handlers.html#logging.StreamHandler.setStream)]. While GCP, may handle any log with ERROR messages stream to stderr, I separated the handlers and the loggers so that each logger is printing only to one or the other. Here are the list of places where each logger and the type of messages are used:
 . | request.summary | request.summary | request.summary | events | events | events | abusemetrics | abusemetrics | abusemetrics |
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
  | INFO | WARNING | ERROR | INFO | WARNING | ERROR | INFO | WARNING | ERROR
emails/views.py |   |   |   | 1 |   | 10 |   |   |  
models.py |   |   |   |   |   |   | 1 |   |  
utils.py |   |   |   |   |   | 5 |   |   |  
sns.py |   |   |   |   |   | 1 |   |   |  
commands/ |   |   |   | 2 |   | 4 |   |   |  
privaterelay/views.py |   |   |   | 3 |   | 1 |   |   |  
models.py |   |   |   |   |   |   |   |   |  
utils.py |   |   |   |   |   |   |   |   |  



#
This PR fixes [MPP-1275](https://mozilla-hub.atlassian.net/browse/MPP-1275).