### PR TITLE
don't allow DELETE requests to profiles

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -49,6 +49,7 @@ class DomainAddressViewSet(SaveToRequestUser, viewsets.ModelViewSet):
 class ProfileViewSet(viewsets.ModelViewSet):
     serializer_class = ProfileSerializer
     permission_classes = [permissions.IsAuthenticated, IsOwner]
+    http_method_names = ['get', 'post', 'head', 'put', 'patch']
 
     def get_queryset(self):
         return Profile.objects.filter(user=self.request.user)


### PR DESCRIPTION
This PR fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1742217.

How to test:
1. Visit http://127.0.0.1:8000/api/v1/docs/
2. Make sure the "DELETE" endpoint is gone from the profiles section
3. View source of http://127.0.0.1:8000/accounts/profile/
4. Get the value from `data-profile-id`
5. In network dev tool, right click the /accounts/profile/ request and choose "Edit and Resend"
6. Change the method to "DELETE" and the url to "http://127.0.0.1:8000/api/v1/profiles/${data-profile-id}/"
7. Send the request
   * [ ] The server should respond with `403 Forbidden`

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).