### PR TITLE
add full_address to address API responses

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -9,12 +9,12 @@ class RelayAddressSerializer(serializers.ModelSerializer):
         fields = [
             'enabled', 'description', 'generated_for',
             # read-only
-            'id', 'address', 'domain',
+            'id', 'address', 'domain', 'full_address',
             'created_at', 'last_modified_at','last_used_at',
             'num_forwarded', 'num_blocked', 'num_spam'
         ]
         read_only_fields = [
-            'id', 'address', 'domain',
+            'id', 'address', 'domain', 'full_address',
             'created_at', 'last_modified_at','last_used_at',
             'num_forwarded', 'num_blocked', 'num_spam'
         ]
@@ -26,12 +26,12 @@ class DomainAddressSerializer(serializers.ModelSerializer):
         fields = [
             'enabled', 'description',
             # read-only
-            'id', 'address', 'domain',
+            'id', 'address', 'domain', 'full_address',
             'created_at', 'last_modified_at','last_used_at',
             'num_forwarded', 'num_blocked', 'num_spam'
         ]
         read_only_fields = [
-            'id', 'address', 'domain',
+            'id', 'address', 'domain', 'full_address',
             'created_at', 'last_modified_at','last_used_at',
             'num_forwarded', 'num_blocked', 'num_spam'
         ]


### PR DESCRIPTION
# New feature description
This adds a new field to the `/api/v1/relayaddresses/` and `/api/v1/domainaddresses/` endpoints:
* `full_address`: shows the full address


# Screenshot (if applicable)
![image](https://user-images.githubusercontent.com/71928/146085806-53de624a-5254-4d0d-ba45-b394149ac41d.png)


# How to test
* Go to http://127.0.0.1:8000/api/v1/relayaddresses/
   * [ ] Check that `full_address` values are accurate
* Go to http://127.0.0.1:8000/api/v1/domainaddresses/
   * [ ] Check that `full_address` values are accurate


# Checklist
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
