### PR TITLE
Fix #1383 - Truncate long aliases

### DIFF
--- a/privaterelay/templates/includes/alias-card.html
+++ b/privaterelay/templates/includes/alias-card.html
@@ -70,7 +70,7 @@
           data-ftl-copy-confirmation="{% ftlmsg 'profile-label-copy-confirmation' %}"
           data-id="{{ alias.id }}"
           data-clipboard-text="{{ alias.full_address }}"
-          class="relay-address click-copy  hide-mobile ff-Met xflx jst-cntr al-cntr">
+          class="relay-address click-copy desktop-domain ff-Met xflx jst-cntr al-cntr">
             <span class="relay-address--label">{{ alias.full_address }}</span>
             <span class="alias-copied-icon"></span>
             <span class="alias-copied-message">{% ftlmsg 'profile-label-copied' %}</span>
@@ -101,7 +101,7 @@
       data-ftl-copy-confirmation="{% ftlmsg 'profile-label-copy-confirmation' %}"
       data-id="{{ alias.id }}"
       data-clipboard-text="{{ alias.full_address }}"
-      class="relay-address click-copy ff-Met jst-cntr al-cntr">
+      class="relay-address click-copy mobile-domain ff-Met jst-cntr al-cntr">
         <span class="relay-address--label">{{ alias.full_address }}</span>
         <span class="alias-copied-icon"></span>
         <span class="alias-copied-message">{% ftlmsg 'profile-label-copied' %}</span>

--- a/privaterelay/templates/includes/alias-card.html
+++ b/privaterelay/templates/includes/alias-card.html
@@ -70,7 +70,7 @@
           data-ftl-copy-confirmation="{% ftlmsg 'profile-label-copy-confirmation' %}"
           data-id="{{ alias.id }}"
           data-clipboard-text="{{ alias.full_address }}"
-          class="relay-address click-copy desktop-domain ff-Met xflx jst-cntr al-cntr">
+          class="relay-address click-copy alias-on-desktop ff-Met xflx jst-cntr al-cntr">
             <span class="relay-address--label">{{ alias.full_address }}</span>
             <span class="alias-copied-icon"></span>
             <span class="alias-copied-message">{% ftlmsg 'profile-label-copied' %}</span>
@@ -101,7 +101,7 @@
       data-ftl-copy-confirmation="{% ftlmsg 'profile-label-copy-confirmation' %}"
       data-id="{{ alias.id }}"
       data-clipboard-text="{{ alias.full_address }}"
-      class="relay-address click-copy mobile-domain ff-Met jst-cntr al-cntr">
+      class="relay-address click-copy alias-on-mobile ff-Met jst-cntr al-cntr">
         <span class="relay-address--label">{{ alias.full_address }}</span>
         <span class="alias-copied-icon"></span>
         <span class="alias-copied-message">{% ftlmsg 'profile-label-copied' %}</span>

--- a/static/scss/pages/dashboard.scss
+++ b/static/scss/pages/dashboard.scss
@@ -281,8 +281,8 @@
 }
 
 .c-alias-copy {
-    display: block;
     padding: $spacing-sm 0 $spacing-md;
+    display: block;
 
     @media #{$mq-md} {
         display: none;

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -359,7 +359,6 @@ table {
     @media #{$mq-md} {
         max-width: $content-xs;
     }
-
     @media #{$mq-lg} {
         max-width: $content-sm;
     }

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -336,7 +336,7 @@ table {
     opacity: .75;
 }
 
-.desktop-domain {
+.alias-on-desktop {
     display: none;
 
     @media #{$mq-md} {
@@ -344,7 +344,7 @@ table {
     }
 }
 
-.mobile-domain {
+.alias-on-mobile {
     display: inline;
 
     @media #{$mq-md} {

--- a/static/scss/partials/main.scss
+++ b/static/scss/partials/main.scss
@@ -334,10 +334,40 @@ table {
 .relay-address:hover,
 .relay-address:focus {
     opacity: .75;
+}
 
-    .relay-address--label {
-        text-decoration: underline;
+.desktop-domain {
+    display: none;
+
+    @media #{$mq-md} {
+        display: inline;
     }
+}
+
+.mobile-domain {
+    display: inline;
+
+    @media #{$mq-md} {
+        display: none;
+    }
+}
+
+.relay-address--label {
+
+    max-width: calc((#{$content-xs} - #{$spacing-2xl}));
+
+    @media #{$mq-md} {
+        max-width: $content-xs;
+    }
+
+    @media #{$mq-lg} {
+        max-width: $content-sm;
+    }
+
+    display: inline-block;
+    text-decoration: underline;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .relay-address:active {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #1383.

How to test:

Use the inspect tool and make the domain as long as you want, this PR should truncate the line on mobile and desktop states.

I'm not entirely sure why there are two sets of `<span class="relay-address--label">{{ alias.full_address }}</span>` in `alias-card.html`. The way it was working was that there was one for mobile and one version for desktop. I can try to revise this file entirely so that there is only one version that we can use, and omit the media query switch.

# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
