### PR TITLE
use SuspiciousOperation exception to cause 400 errors

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -10,6 +10,7 @@ import uuid
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.exceptions import SuspiciousOperation
 from django.db import models
 from django.dispatch import receiver
 from django.utils.translation.trans_real import (
@@ -394,7 +395,9 @@ class RegisteredSubdomain(models.Model):
         return self.subdomain_hash
 
 
-class CannotMakeSubdomainException(Exception):
+# extend from SuspiciousOperation to trigger 400 status code error
+# TODO: in Django 3.2+ change this to BadRequest
+class CannotMakeSubdomainException(SuspiciousOperation):
     """Exception raised by Profile due to error on subdomain creation.
 
     Attributes:
@@ -405,7 +408,9 @@ class CannotMakeSubdomainException(Exception):
         self.message = message
 
 
-class CannotMakeAddressException(Exception):
+# extend from SuspiciousOperation to trigger 400 status code error
+# TODO: in Django 3.2+ change this to BadRequest
+class CannotMakeAddressException(SuspiciousOperation):
     """Exception raised by RelayAddress or DomainAddress due to error on alias creation.
 
     Attributes:


### PR DESCRIPTION
This PR fixes https://sentry.prod.mozaws.net/operations/fx-private-relay-prod/issues/15055581/?query=is%3Aunresolved.

## How to test:
1. Sign in with a local Relay account
2. (In another container/PBM window) Go to http://127.0.0.1:8000/admin/emails/profile/
3. Click the profile of the Relay account
4. Set its "Last account flagged" values to Today/Now
5. Go to http://127.0.0.1:8000/api/v1/docs/
6. At the POST /relayaddresses/ section, click "Try it out", and then "Execute"

### Expected Result:
Should get `Error: Bad Request` with status code of 400

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).