### PR TITLE
fix MPP-1489 add ie and at country codes to PREMIUM_PLAN_COUNTRY_LANG…

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -257,6 +257,10 @@ PREMIUM_PLAN_ID_MATRIX = {
         },
     },
     "euro": {
+        "at": {
+            "id": "price_1JmRTDJNcmPzuWtRnJavIXXX",
+            "price": "0,99 €",
+        },
         "de": {
             "id": "price_1JmRTDJNcmPzuWtRnJavIXXX",
             "price": "0,99 €",
@@ -279,6 +283,10 @@ PREMIUM_PLAN_ID_MATRIX = {
         },
         "nl": {
             "id": "price_1JmROfJNcmPzuWtR6od8OfDW",
+            "price": "0,99 €",
+        },
+        "ie": {
+            "id": "price_1JmRCQJNcmPzuWtRprMnmtax",
             "price": "0,99 €",
         },
     },

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -1,5 +1,7 @@
+from django.conf import settings
 from django.test import TestCase
 
+from ..templatetags.relay_tags import premium_plan_id
 from ..utils import get_premium_country_lang
 
 
@@ -20,3 +22,31 @@ class GetPremiumCountryLangTest(TestCase):
         cc, lang = get_premium_country_lang('de-be,', 'at')
         assert cc == 'at'
         assert lang == 'de'
+
+
+class PremiumPlanIDTest(TestCase):
+    def test_premium_plan_id_tag(self):
+        plans = settings.PREMIUM_PLAN_ID_MATRIX
+        plan_id = premium_plan_id('en-US', 'us')
+        assert plan_id == plans['usd']['en']['id']
+
+        plan_id = premium_plan_id('de', 'de')
+        assert plan_id == plans['euro']['de']['id']
+
+        plan_id = premium_plan_id('en-ca')
+        assert plan_id == plans['usd']['en']['id']
+
+        plan_id = premium_plan_id('en-gb')
+        assert plan_id == plans['usd']['en']['id']
+
+        plan_id = premium_plan_id('fr', 'fr')
+        assert plan_id == plans['euro']['fr']['id']
+
+        plan_id = premium_plan_id('it')
+        assert plan_id == plans['euro']['it']['id']
+
+        plan_id = premium_plan_id('en-ie')
+        assert plan_id == plans['euro']['ie']['id']
+
+        plan_id = premium_plan_id('en', 'at')
+        assert plan_id == plans['euro']['at']['id']


### PR DESCRIPTION
…_MAPPING

This PR fixes https://mozilla-hub.atlassian.net/browse/MPP-1489.

How to test:
1. Change your Firefox language to `en-ie`
2. Go to http://127.0.0.1:8000/premium
   * [ ] You should see the price in €
3. Change your Fireefox language to `de-at`
4. Go to http://127.0.0.1:8000/premium
   * [ ] You should see the price in €

- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).