### PR TITLE
Add-on information for onboarding premium users on mobile

### DIFF
--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -36,7 +36,7 @@
                     </div>
                     <div class="c-premium-onboarding-content-description">
                         <p class="c-premium-onboarding-detail">{% ftlmsg 'onboarding-premium-title-detail' %}</p>
-                        <p><strong>{% ftlmsg 'onboarding-premium-domain-title' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-get-domain-description' mozmail='mozmail.com' %}
+                        <p><strong>{% ftlmsg 'onboarding-premium-domain-title' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-get-domain-description-2' mozmail='mozmail.com' %}
                         {% if not user_profile.subdomain %}
                             <div class="js-premium-onboarding-domain-registration-form">
                                 <p>{% ftlmsg 'multi-part-onboarding-premium-domain-cta' %}</p>
@@ -71,7 +71,10 @@
         <li class="c-premium-onboarding-step c-premium-onboarding-step-3 {% if user_profile.onboarding_state == 2 %} is-visible {% endif %}">
             <div class="mzp-l-content mzp-t-content-lg mzp-t-content-nospace">
                 <div class="c-premium-onboarding-headlines">
-                    <h1>{% ftlmsg 'multi-part-onboarding-reply-headline' %}</h1>
+                    <!-- Mobile title -->
+                    <h1 class="c-premium-onboarding-replies-copy">{% ftlmsg 'multi-part-onboarding-reply-headline' %}</h1>
+                    <!-- Desktop title -->
+                    <h1 class="c-premium-onboarding-extension-copy">{% ftlmsg 'multi-part-onboarding-premium-extension-get-title' %}</h1>
                 </div>
 
                 <div class="c-premium-onboarding-content">

--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -14,11 +14,11 @@
 
                 <div class="c-premium-onboarding-content">
                     <div class="c-premium-onboarding-content-image">
-                        <img src="{% static 'images/dashboard-onboarding/woman-couch.svg' %}" alt="Woman sitting on a couch">
+                        <img src="{% static 'images/dashboard-onboarding/woman-couch.svg' %}" alt="">
                     </div>
                     <div class="c-premium-onboarding-content-description">
                         <p class="c-premium-onboarding-detail">{% ftlmsg 'onboarding-premium-title-detail' %}</p>
-                        <p><strong>{% ftlmsg 'multi-part-onboarding-premium-welcome-title' %}</strong> {% ftlmsg 'onboarding-premium-control-description' %}</p>
+                        <p><strong>{% ftlmsg 'multi-part-onboarding-premium-welcome-title' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-welcome-description' %}</p>
                     </div>
                 </div>
             </div>
@@ -32,11 +32,11 @@
 
                 <div class="c-premium-onboarding-content">
                     <div class="c-premium-onboarding-content-image">
-                        <img src="{% static 'images/dashboard-onboarding/woman-email.svg' %}" alt="Man sitting with laptop computer">
+                        <img src="{% static 'images/dashboard-onboarding/woman-email.svg' %}" alt="">
                     </div>
                     <div class="c-premium-onboarding-content-description">
                         <p class="c-premium-onboarding-detail">{% ftlmsg 'onboarding-premium-title-detail' %}</p>
-                        <p><strong>{% ftlmsg 'onboarding-premium-domain-title' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-domain-description' %}
+                        <p><strong>{% ftlmsg 'onboarding-premium-domain-title' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-get-domain-description' mozmail='mozmail.com' %}
                         {% if not user_profile.subdomain %}
                             <div class="js-premium-onboarding-domain-registration-form">
                                 <p>{% ftlmsg 'multi-part-onboarding-premium-domain-cta' %}</p>
@@ -76,7 +76,7 @@
 
                 <div class="c-premium-onboarding-content">
                     <div class="c-premium-onboarding-content-image">
-                        <img src="{% static 'images/dashboard-onboarding/man-laptop-email-alt.svg' %}" alt="Woman next to large envelope">
+                        <img src="{% static 'images/dashboard-onboarding/man-laptop-email-alt.svg' %}" alt="">
                     </div>
                     <div class="c-premium-onboarding-content-description">
                         <p class="c-premium-onboarding-detail">{% ftlmsg 'onboarding-premium-title-detail' %}</p>
@@ -105,7 +105,7 @@
                     data-event-label="onboarding-step-1-continue"
                     data-event-value="1"
                     data-event-nonInteraction="false"
-                    >{% ftlmsg 'multi-part-onboarding-premium-welcome-button-start' %}</button>
+                    >{% ftlmsg 'profile-label-continue' %}</button>
                 </div>
                 <!-- Step 2 -->
                 <div class="c-premium-onboarding-actions c-premium-onboarding-action-step-2 {% if user_profile.onboarding_state == 1 %} is-visible {% endif %}">

--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -17,7 +17,7 @@
                         <img src="{% static 'images/dashboard-onboarding/woman-couch.svg' %}" alt="Woman sitting on a couch">
                     </div>
                     <div class="c-premium-onboarding-content-description">
-                        <p class="c-premium-onboarding-detail">With Firefox Relay Premium you can:</p>
+                        <p class="c-premium-onboarding-detail">{% ftlmsg 'onboarding-premium-title-detail' %}</p>
                         <p><strong>{% ftlmsg 'multi-part-onboarding-premium-welcome-title' %}</strong> {% ftlmsg 'onboarding-premium-control-description' %}</p>
                     </div>
                 </div>
@@ -27,7 +27,7 @@
         <li class="c-premium-onboarding-step c-premium-onboarding-step-2 {% if user_profile.onboarding_state == 1 %} is-visible {% endif %}">
             <div class="mzp-l-content mzp-t-content-xl mzp-t-content-nospace">
                 <div class="c-premium-onboarding-headlines">
-                    <h1>Get a custom domain</h1>
+                    <h1>{% ftlmsg 'multi-part-onboarding-premium-get-domain' %}</h1>
                 </div>
 
                 <div class="c-premium-onboarding-content">
@@ -35,9 +35,8 @@
                         <img src="{% static 'images/dashboard-onboarding/woman-email.svg' %}" alt="Man sitting with laptop computer">
                     </div>
                     <div class="c-premium-onboarding-content-description">
-                        <p class="c-premium-onboarding-detail">With Firefox Relay Premium you can:</p>
-                        <p><strong>Use a custom domain for sharing aliases:</strong> 
-                            With a custom domain, you can create aliases without having to generate them beforehand. Need one to sign up for a newsletter? Just say “read@customdomain.mozmail.com”                        </p>
+                        <p class="c-premium-onboarding-detail">{% ftlmsg 'onboarding-premium-title-detail' %}</p>
+                        <p><strong>{% ftlmsg 'onboarding-premium-domain-title' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-domain-description' %}
                         {% if not user_profile.subdomain %}
                             <div class="js-premium-onboarding-domain-registration-form">
                                 <p>{% ftlmsg 'multi-part-onboarding-premium-domain-cta' %}</p>
@@ -72,7 +71,7 @@
         <li class="c-premium-onboarding-step c-premium-onboarding-step-3 {% if user_profile.onboarding_state == 2 %} is-visible {% endif %}">
             <div class="mzp-l-content mzp-t-content-lg mzp-t-content-nospace">
                 <div class="c-premium-onboarding-headlines">
-                    <h1>Reply to your emails</h1>
+                    <h1>{% ftlmsg 'multi-part-onboarding-reply-headline' %}</h1>
                 </div>
 
                 <div class="c-premium-onboarding-content">
@@ -80,10 +79,9 @@
                         <img src="{% static 'images/dashboard-onboarding/man-laptop-email-alt.svg' %}" alt="Woman next to large envelope">
                     </div>
                     <div class="c-premium-onboarding-content-description">
-                        <p class="c-premium-onboarding-detail">With Firefox Relay Premium you can:</p>
+                        <p class="c-premium-onboarding-detail">{% ftlmsg 'onboarding-premium-title-detail' %}</p>
                         <div class="c-premium-onboarding-install-addon">
-                            <p><strong>Reply without revealing your real address:</strong>                    
-                                Need to reply to emails forwarded from one of your aliases? Just reply as normal. Your alias will still protect your email address.
+                            <p><strong>{% ftlmsg 'onboarding-premium-reply-title' %}</strong> {% ftlmsg 'onboarding-premium-reply-description' %}                
                             </p>
                             <a target="_blank" href="https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon" class=" mzp-c-button mzp-t-product">{% ftlmsg 'multi-part-onboarding-premium-extension-button-download' %}</a>
                         </div>

--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -81,7 +81,16 @@
                     <div class="c-premium-onboarding-content-description">
                         <p class="c-premium-onboarding-detail">{% ftlmsg 'onboarding-premium-title-detail' %}</p>
                         <div class="c-premium-onboarding-install-addon">
-                            <p><strong>{% ftlmsg 'onboarding-premium-reply-title' %}</strong> {% ftlmsg 'onboarding-premium-reply-description' %}                
+                            <strong>
+                                <!-- Mobile title -->
+                                <span class="c-premium-onboarding-replies-copy">{% ftlmsg 'onboarding-premium-reply-title' %}</span>
+                                <!-- Desktop title -->
+                                <span class="c-premium-onboarding-extension-copy">{% ftlmsg 'multi-part-onboarding-premium-extension-get-title' %}</span>
+                            </strong> 
+                                <!-- Mobile copy -->
+                                <span class="c-premium-onboarding-replies-copy">{% ftlmsg 'onboarding-premium-reply-description' %}</span>
+                                <!-- Desktop copy -->
+                                <span class="c-premium-onboarding-extension-copy">{% ftlmsg 'multi-part-onboarding-premium-extension-get-description' %}</span>             
                             </p>
                             <a target="_blank" href="https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon" class=" mzp-c-button mzp-t-product">{% ftlmsg 'multi-part-onboarding-premium-extension-button-download' %}</a>
                         </div>

--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -34,7 +34,8 @@
                         <img src="{% static 'images/dashboard-onboarding/woman-email.svg' %}" alt="Man sitting with laptop computer">
                     </div>
                     <div class="c-premium-onboarding-content-description">
-                        <p><strong>{% ftlmsg 'multi-part-onboarding-premium-domain-title' %}</strong> {% ftlmsg 'banner-register-subdomain-copy' mozmail='mozmail.com' %}</p>
+                        <p><strong>Use a custom domain for sharing aliases:</strong> 
+                        With a custom domain, you can create aliases without having to generate them beforehand. Need one to sign up for a newsletter? Just say “read@customdomain.mozmail.com”                        </p>
                         {% if not user_profile.subdomain %}
                             <div class="js-premium-onboarding-domain-registration-form">
                                 <p>{% ftlmsg 'multi-part-onboarding-premium-domain-cta' %}</p>
@@ -69,7 +70,7 @@
         <li class="c-premium-onboarding-step c-premium-onboarding-step-3 {% if user_profile.onboarding_state == 2 %} is-visible {% endif %}">
             <div class="mzp-l-content mzp-t-content-lg mzp-t-content-nospace">
                 <div class="c-premium-onboarding-headlines">
-                    <h1>Use the desktop extension</h1>
+                    <h1>Reply to your emails</h1>
                 </div>
 
                 <div class="c-premium-onboarding-content">
@@ -78,8 +79,8 @@
                     </div>
                     <div class="c-premium-onboarding-content-description">
                         <div class="c-premium-onboarding-install-addon">
-                            <p><strong>{% ftlmsg 'multi-part-onboarding-premium-extension-get-title' %}</strong> 
-                            The Relay extension for Firefox makes using email aliases even easier. When enabled, the extension will allow you to manage and access your aliases directly from the sites where you’ve used them.
+                            <p><strong>Reply without revealing your real address:</strong>                    
+                            Need to reply to emails forwarded from one of your aliases? Just reply as normal. Your alias will still protect your email address.
                             </p>
                             <a target="_blank" href="https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon" class=" mzp-c-button mzp-t-product">{% ftlmsg 'multi-part-onboarding-premium-extension-button-download' %}</a>
                         </div>

--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -17,6 +17,7 @@
                         <img src="{% static 'images/dashboard-onboarding/woman-couch.svg' %}" alt="Woman sitting on a couch">
                     </div>
                     <div class="c-premium-onboarding-content-description">
+                        <p class="c-premium-onboarding-detail">With Firefox Relay Premium you can:</p>
                         <p><strong>{% ftlmsg 'multi-part-onboarding-premium-welcome-title' %}</strong> {% ftlmsg 'onboarding-premium-control-description' %}</p>
                     </div>
                 </div>
@@ -34,8 +35,9 @@
                         <img src="{% static 'images/dashboard-onboarding/woman-email.svg' %}" alt="Man sitting with laptop computer">
                     </div>
                     <div class="c-premium-onboarding-content-description">
+                        <p class="c-premium-onboarding-detail">With Firefox Relay Premium you can:</p>
                         <p><strong>Use a custom domain for sharing aliases:</strong> 
-                        With a custom domain, you can create aliases without having to generate them beforehand. Need one to sign up for a newsletter? Just say “read@customdomain.mozmail.com”                        </p>
+                            With a custom domain, you can create aliases without having to generate them beforehand. Need one to sign up for a newsletter? Just say “read@customdomain.mozmail.com”                        </p>
                         {% if not user_profile.subdomain %}
                             <div class="js-premium-onboarding-domain-registration-form">
                                 <p>{% ftlmsg 'multi-part-onboarding-premium-domain-cta' %}</p>
@@ -78,9 +80,10 @@
                         <img src="{% static 'images/dashboard-onboarding/man-laptop-email-alt.svg' %}" alt="Woman next to large envelope">
                     </div>
                     <div class="c-premium-onboarding-content-description">
+                        <p class="c-premium-onboarding-detail">With Firefox Relay Premium you can:</p>
                         <div class="c-premium-onboarding-install-addon">
                             <p><strong>Reply without revealing your real address:</strong>                    
-                            Need to reply to emails forwarded from one of your aliases? Just reply as normal. Your alias will still protect your email address.
+                                Need to reply to emails forwarded from one of your aliases? Just reply as normal. Your alias will still protect your email address.
                             </p>
                             <a target="_blank" href="https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon" class=" mzp-c-button mzp-t-product">{% ftlmsg 'multi-part-onboarding-premium-extension-button-download' %}</a>
                         </div>

--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -26,13 +26,12 @@
         <li class="c-premium-onboarding-step c-premium-onboarding-step-2 {% if user_profile.onboarding_state == 1 %} is-visible {% endif %}">
             <div class="mzp-l-content mzp-t-content-xl mzp-t-content-nospace">
                 <div class="c-premium-onboarding-headlines">
-                    <h1>{% ftlmsg 'multi-part-onboarding-premium-domain-headline' %}</h1>
-                    <h2>{% ftlmsg 'multi-part-onboarding-premium-welcome-subheadline' %}</h2>
+                    <h1>Get a custom domain</h1>
                 </div>
 
                 <div class="c-premium-onboarding-content">
                     <div class="c-premium-onboarding-content-image">
-                        <img src="{% static 'images/dashboard-onboarding/man-laptop-email-alt.svg' %}" alt="Man sitting with laptop computer">
+                        <img src="{% static 'images/dashboard-onboarding/woman-email.svg' %}" alt="Man sitting with laptop computer">
                     </div>
                     <div class="c-premium-onboarding-content-description">
                         <p><strong>{% ftlmsg 'multi-part-onboarding-premium-domain-title' %}</strong> {% ftlmsg 'banner-register-subdomain-copy' mozmail='mozmail.com' %}</p>
@@ -70,18 +69,18 @@
         <li class="c-premium-onboarding-step c-premium-onboarding-step-3 {% if user_profile.onboarding_state == 2 %} is-visible {% endif %}">
             <div class="mzp-l-content mzp-t-content-lg mzp-t-content-nospace">
                 <div class="c-premium-onboarding-headlines">
-                    <h1>{% ftlmsg 'multi-part-onboarding-premium-extension-headline' %}</h1>
-                    <h2>{% ftlmsg 'multi-part-onboarding-premium-welcome-subheadline' %}</h2>
+                    <h1>Use the desktop extension</h1>
                 </div>
 
                 <div class="c-premium-onboarding-content">
                     <div class="c-premium-onboarding-content-image">
-                        <img src="{% static 'images/dashboard-onboarding/woman-email.svg' %}" alt="Woman next to large envelope">
+                        <img src="{% static 'images/dashboard-onboarding/man-laptop-email-alt.svg' %}" alt="Woman next to large envelope">
                     </div>
                     <div class="c-premium-onboarding-content-description">
-                        <p><strong>{% ftlmsg 'multi-part-onboarding-premium-extension-reply-title' %}</strong> {% ftlmsg 'onboarding-premium-reply-description'%}</p>
                         <div class="c-premium-onboarding-install-addon">
-                            <p><strong>{% ftlmsg 'multi-part-onboarding-premium-extension-get-title' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-extension-get-description' %}</p>
+                            <p><strong>{% ftlmsg 'multi-part-onboarding-premium-extension-get-title' %}</strong> 
+                            The Relay extension for Firefox makes using email aliases even easier. When enabled, the extension will allow you to manage and access your aliases directly from the sites where you’ve used them.
+                            </p>
                             <a target="_blank" href="https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon" class=" mzp-c-button mzp-t-product">{% ftlmsg 'multi-part-onboarding-premium-extension-button-download' %}</a>
                         </div>
                         <div class="c-premium-onboarding-action-completed">

--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -307,7 +307,7 @@
 
 .c-premium-onboarding-step-3 {
 
-    .c-premium-onboarding-install-addon {
+    .c-premium-onboarding-install-addon, .c-premium-onboarding-headlines {
 
         a, .c-premium-onboarding-extension-copy {
             display: none;

--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -307,14 +307,29 @@
 
 .c-premium-onboarding-step-3 {
 
-    .c-premium-onboarding-install-addon a {
-        display: none;
+    .c-premium-onboarding-install-addon {
+
+        a, .c-premium-onboarding-extension-copy {
+            display: none;
+        }
 
         @media #{$mq-md} {
+
+            .c-premium-onboarding-replies-copy {
+                display: none;
+            }
+
+            a, .c-premium-onboarding-extension-copy {
             display: inline-block;
+            }
+
+            // .c-premium-onboarding-replies-description {
+            //     display: none;
+            // }
         }
         // TODO: Add query that user is on desktop Firefox to prompt install of add-on
     }
+
 }
 
 .c-premium-onboarding-action-step-3 {

--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -324,7 +324,6 @@
             }
         }
     }
-
 }
 
 .c-premium-onboarding-action-step-3 {

--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -97,6 +97,7 @@
     h2 {
         color: $color-black;
         font-weight: normal;
+        
         @include text-body-md;
         @include font-base;
     }

--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -320,14 +320,9 @@
             }
 
             a, .c-premium-onboarding-extension-copy {
-            display: inline-block;
+                display: inline-block;
             }
-
-            // .c-premium-onboarding-replies-description {
-            //     display: none;
-            // }
         }
-        // TODO: Add query that user is on desktop Firefox to prompt install of add-on
     }
 
 }

--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -85,7 +85,6 @@
 .c-premium-onboarding-headlines {
     text-align: center;
     margin-bottom: $spacing-xl;
-    line-height: 150% !important;
 
     h1 {
         color: $color-purple-50;

--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -12,6 +12,7 @@
         @include text-title-2xs;
         color: $color-black;
         margin-bottom: $spacing-lg;
+        line-height: 150%;
     }
 }
 
@@ -84,6 +85,7 @@
 .c-premium-onboarding-headlines {
     text-align: center;
     margin-bottom: $spacing-xl;
+    line-height: 150% !important;
 
     h1 {
         color: $color-purple-50;
@@ -94,8 +96,9 @@
 
     h2 {
         color: $color-black;
-
-        @include text-title-xs;
+        font-weight: normal;
+        @include text-body-md;
+        @include font-base;
     }
 }
 
@@ -177,6 +180,18 @@
             color: $color-purple-50;
         }
     }
+
+    p {
+        line-height: 150%;
+    }
+}
+
+.c-premium-onboarding-detail {
+    color: $color-purple-30;
+    font-weight: 500;
+    margin: 0;
+    
+    @include text-body-sm;
 }
 
 // Multi-part Premium Onboarding
@@ -200,6 +215,7 @@
     margin-left: auto;
     margin-right: auto;
     position: relative;
+    line-height: 150%;
 
     @media #{$mq-md} {
         // 150px is an approx. size of the header and footer combined
@@ -243,10 +259,6 @@
 
             @include text-title-sm;
             margin-bottom: $spacing-md;
-        }
-
-        h2 {
-            @include text-title-3xs;
         }
 
         .c-premium-onboarding-content-description {


### PR DESCRIPTION
This adds information about the add-on for premium users onboarding on mobile. This PR also updated the strings in the onboarding flow, and some corrected some UI inconsistencies as per the Figma spec. For the third step, the copy switches from a reply/extension value prop depending on if a user is on mobile or desktop.




# Screenshot (if applicable)
<img width="560" alt="image" src="https://user-images.githubusercontent.com/13066134/147238904-2982642c-165b-4803-9c2e-03443d3ab8ca.png">



# How to test

Make the `premium-onboarding` class visible by unselecting the `display: none;` property, add `is-visible` utility class to  `c-premium-onboarding-step-3`. Alternatively, make a new account, upgrade to premium and walk through onboarding steps.

# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
