### PR TITLE
add X-Detected-Client-Region to response headers

### DIFF
--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -50,6 +50,19 @@ class FxAToRequest:
         return self.get_response(request)
 
 
+class AddDetectedCountryToResponseHeaders:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if 'X-Client-Region' in request.headers:
+            response['X-Detected-Client-Region'] = (
+                request.headers['X-Client-Region']
+            )
+        return response
+
+
 def _get_metric_view_name(request):
     if request.resolver_match:
         view = request.resolver_match.func

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -207,7 +207,9 @@ MIDDLEWARE += [
     'csp.middleware.CSPMiddleware',
     'django_referrer_policy.middleware.ReferrerPolicyMiddleware',
     'dockerflow.django.middleware.DockerflowMiddleware',
+
     'privaterelay.middleware.FxAToRequest',
+    'privaterelay.middleware.AddDetectedCountryToResponseHeaders',
     'privaterelay.middleware.StoreFirstVisit',
 ]
 


### PR DESCRIPTION
# New feature description
Add a new `X-Detected-Client-Region` response header to help debug which country is detected in the `X-Client-Region` header passed from load balancer to app.

# How to test
1. Open dev tool network inspector
2. Go to a Relay page
3. Right-click the request in the network inspector, and choose 'Edit and Resend"
4. In the request headers, add a line like `X-Client-Region: ie`
5. Send the request
6. Click the new request in the network inspector
   * [ ] Check that the "Response Headers" section shows the same value in the `X-Detected-Client-Region` header


# Checklist

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).