### PR TITLE
Don't inline lightbulb image

### DIFF
--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -59,7 +59,7 @@
                   {% endif %}
                   {% if recipient_profile.has_premium %}
                     <br />
-                    <img alt="" width="24" style="display: inline-block; margin-bottom: 0px; width: 24px;"  src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAA7DAAAOwwHHb6hkAAAA GXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAX1JREFUSIntlLEvQ2EUxX/3a+uN JcZuXRm6EIn4AyTWSqh0a5sOIozCPyFEWhual7B2EQtRQ1kk5tpsTS0MbT3X4BHE1+cZMPRMN985 95x77/BBH38NCRJsTKvjDJNDWQBGARSuRagMtSnPHkrnxwHbWU0YjyqQskiuniLMFHfl1uZhek3+ Zi40RJmLeiSiHgkV5oEbIGU8qgdpHbD5RG2Ef5YUQgOPibwrzXe0W5rTYwx1IHXnkAc2Q23g3xyF 9cJHcwAKrjQVVgFUydhs7AEwAhB75NQmcGIcAYivDRvwANCNMGgTdNsk/PL+JwEnAEbI2gRqXjjx taECjLAFoMrK9ryOf+b9t2VAPV60oQJy+3KmsAPEjOCW0hp/5UppjRvBBWJAuViR89ABAJ0Wi8Al kFSHtdd3v04KXLRbLPXyCPwqyhkdU7iwjDdR2JN6r/6eGwDkK3KJUPtitFqQ+a8g8EQA5YzWFCY/ ddYK+zIV1Bt4IgAV9Du6Pv4nngE8HXRqmKzo6wAAAABJRU5ErkJggg==" />
+                    <img alt="" width="24" style="display: inline-block; margin-bottom: 0px; width: 24px;"  src="{{ SITE_ORIGIN }}/static/images/email-images/tip-purple.png" />
                     {% ftlmsg 'forwarded-email-header-cc-notice' %}
                   {% elif not recipient_profile.has_premium and recipient_profile.fxa_locale_in_premium_country %}
                     {% bold_violet_link SITE_ORIGIN|add:'/premium?utm_source=emails&utm_medium=email&utm_campaign=alias-email&utm_content=header' 'Firefox Relay Premium' as premium_link %}


### PR DESCRIPTION
Apparently Gmail strips data URIs, so the lightbulb image isn't visible there without this change: https://stackoverflow.com/a/8580387

How to test: I think this is a straightforward enough change that we can just deploy this to stage, send an email to an alias for a Premium account there, and verify that the image shows up in Gmail. Otherwise, render the email locally and verify that you can see the image and that its `src` points to your local server.

- [x] l10n dependencies have been merged, if any.
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
