### PR TITLE
Don't re-show NPS survey after dismissing it

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -650,6 +650,9 @@ function dataCollectionBannerLogic() {
 function dismissSurvey() {
 	const survey_banner = document.getElementById("micro-survey-banner");
 	survey_banner.classList.toggle("is-hidden");
+  const date = new Date();
+  date.setTime(date.getTime() + 30*24*60*60*1000)
+  document.cookie = "surveyed=true; expires=" + date.toUTCString() + "; path=/";
 }
 
 if ( document.getElementById("survey-dismiss") ) {


### PR DESCRIPTION
The cookie-setting code is copied over from [`setSurveyedCookie` in analytics.js](https://github.com/mozilla/fx-private-relay/blob/f16cb26c3db2499f560928e739867efd1f27e0c1/static/js/analytics.js#L120-L128).

This PR fixes #1423.

How to test: Click the black cross on the NPS survey banner (it's a bit hard to see, but it's on the right-hand side). Refresh the page - the NPS survey banner should now be hidden.

(If you don't see the banner, delete the `surveyed` cookie first.)

- [x] l10n dependencies have been merged, if any.
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
