### PR TITLE
Fix swagger API schema endpoint

### DIFF
--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 
 import pytest
 
-@pytest.mark.xfail(reason="urlpattern needs migration to django.urls.path")
 @pytest.mark.parametrize("format", ("yaml", "json"))
 def test_swagger_format(client, format):
     path = f"/api/v1/swagger.{format}"

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+
+import pytest
+
+@pytest.mark.xfail(reason="urlpattern needs migration to django.urls.path")
+@pytest.mark.parametrize("format", ("yaml", "json"))
+def test_swagger_format(client, format):
+    path = f"/api/v1/swagger.{format}"
+    response = client.get(path)
+    assert response.status_code == 200
+    expected_content_type = {
+        "yaml": "application/yaml; charset=utf-8",
+        "json": "application/json; charset=utf-8",
+    }[format]
+    assert response["Content-Type"].startswith(f"application/{format}")
+
+
+@pytest.mark.parametrize("subpath", ("swagger", "swagger.", "swagger.txt"))
+def test_swagger_unknown_format(client, subpath):
+    path = f"/api/v1/{subpath}"
+    response = client.get(path)
+    assert response.status_code == 404

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -2,15 +2,12 @@ from django.test import TestCase
 
 import pytest
 
+
 @pytest.mark.parametrize("format", ("yaml", "json"))
 def test_swagger_format(client, format):
     path = f"/api/v1/swagger.{format}"
     response = client.get(path)
     assert response.status_code == 200
-    expected_content_type = {
-        "yaml": "application/yaml; charset=utf-8",
-        "json": "application/json; charset=utf-8",
-    }[format]
     assert response["Content-Type"].startswith(f"application/{format}")
 
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, path
+from django.urls import include, path, register_converter
 
 from rest_framework import routers
 
@@ -6,6 +6,18 @@ from .views import (
     DomainAddressViewSet, ProfileViewSet, RelayAddressViewSet,
     premium_countries, schema_view
 )
+
+
+class SwaggerFormatConverter:
+    regex = r'\.(json|yaml)'
+
+    def to_python(self, value):
+        return value
+
+    def to_url(self, value):
+        return value
+
+register_converter(SwaggerFormatConverter, "swagger_format")
 
 
 api_router = routers.DefaultRouter()
@@ -24,7 +36,7 @@ urlpatterns = [
          premium_countries,
          name='premium_countries'
     ),
-    path('v1/swagger(?P<format>\.json|\.yaml)',
+    path('v1/swagger<swagger_format:format>',
         schema_view.without_ui(cache_timeout=0),
         name='schema-json'
     ),


### PR DESCRIPTION
Use a [custom path converter](https://docs.djangoproject.com/en/4.0/topics/http/urls/#registering-custom-path-converters) for the Swagger API schema endpoint. This continues passing `.json` and `.yaml` as `format`, which is [required by the view](https://github.com/axnsan12/drf-yasg/blob/d9700dbf8cc80d725a7db485c2d4446c19c29840/src/drf_yasg/views.py#L87) returned by [get_schema_view](https://github.com/axnsan12/drf-yasg/blob/master/src/drf_yasg/views.py#L50).

This PR fixes #1201. Tests are included, that break before the change and pass after the change.

An alternate way to test is with ``curl``, against a local dev instance or a deployed instance:

```sh
curl -I http://localhost:8000/api/v1/swagger.json
curl -I https://relay.firefox.com/api/v1/swagger.json
```

The tests capture additional warnings from ``drf_yasg`` and the upstream ``ruamel.yaml`` library:

```
api/tests/views_tests.py::test_swagger_format[yaml]
  /Users/john/.virtualenvs/fx-private-relay/lib/python3.7/site-packages/drf_yasg/codecs.py:202: PendingDeprecationWarning: 
  dump will be removed, use
  
    yaml=YAML(typ='unsafe', pure=True)
    yaml.dump(...)
  
  instead
    return yaml.dump(data, Dumper=SaneYamlDumper, default_flow_style=False, encoding='utf-8' if binary else None)

api/tests/views_tests.py::test_swagger_format[yaml]
  /Users/john/.virtualenvs/fx-private-relay/lib/python3.7/site-packages/ruamel/yaml/main.py:1380: PendingDeprecationWarning: 
  dump_all will be removed, use
  
    yaml=YAML(typ='unsafe', pure=True)
    yaml.dump_all(...)
  
  instead
    block_seq_indent=block_seq_indent,
```

These will probably require upstream changes.