### PR TITLE
Add missing alt text to the Premium promo page

### DIFF
--- a/privaterelay/templates/premium-promo.html
+++ b/privaterelay/templates/premium-promo.html
@@ -54,7 +54,7 @@
         <h2 class="perks-headline">{% ftlmsg 'premium-promo-perks-headline' %}</h2>
         <span class="perks-lead">{% ftlmsg 'premium-promo-perks-lead' %}</span>
         <div class="perk">
-        <img src="{% static 'images/premium-promo/illustration-unlimited.svg' %}" class="perk-illustration">
+        <img alt="" src="{% static 'images/premium-promo/illustration-unlimited.svg' %}" class="perk-illustration">
         <div class="perk-description">
             <h3 class="perk-headline ff-Met">{% ftlmsg 'premium-promo-perks-perk-unlimited-headline' %}</h3>
             <p class="perk-body">
@@ -84,7 +84,7 @@
         </div>
         </div>
         <div class="perk">
-        <img src="{% static 'images/premium-promo/illustration-custom-domain.svg' %}" class="perk-illustration">
+        <img alt="" src="{% static 'images/premium-promo/illustration-custom-domain.svg' %}" class="perk-illustration">
         <div class="perk-description">
             <h3 class="perk-headline ff-Met">{% ftlmsg 'premium-promo-perks-perk-custom-domain-headline' %}</h3>
             <p class="perk-body">
@@ -114,7 +114,7 @@
         </div>
         </div>
         <div class="perk">
-        <img src="{% static 'images/premium-promo/illustration-dashboard.svg' %}" class="perk-illustration">
+        <img alt="" src="{% static 'images/premium-promo/illustration-dashboard.svg' %}" class="perk-illustration">
         <div class="perk-description">
             <h3 class="perk-headline ff-Met">{% ftlmsg 'premium-promo-perks-perk-dashboard-headline' %}</h3>
             <p class="perk-body">
@@ -191,7 +191,7 @@
                     <div class="c-pricing-options">
                         <!--Non-premium option-->
                         <div class="c-option c-free">
-                            <img class="c-brand-title" src="{% static 'images/logos/logo-firefox-relay.svg' %}">
+                            <img alt="{% ftlmsg 'logo-alt' %}" class="c-brand-title" src="{% static 'images/logos/logo-firefox-relay.svg' %}">
                             <p class="c-price non-premium-price">{% ftlmsg 'premium-promo-pricing-free-price' %}</p>
                             <div class="c-features non-premium-list">
                                 <ul class="c-list">
@@ -212,7 +212,7 @@
                         <!--Premium Option-->
                         <div class="c-option c-premium">
                             <span class="c-premium-detail">{% ftlmsg 'landing-pricing-premium-price-highlight' %}</span>
-                            <img class="c-brand-title" src="{% static 'images/logos/logo-firefox-premium-relay.svg' %}">
+                            <img alt="{% ftlmsg 'logo-alt' %}" class="c-brand-title" src="{% static 'images/logos/logo-firefox-premium-relay.svg' %}">
                             <p class="c-price premium-price">
                                 <span class="c-price-number">{{ monthly_price }}</span>
                                 <span class="c-currency">{% ftlmsg 'landing-pricing-premium-price' monthly_price="" %}</span>


### PR DESCRIPTION
This PR fixes #247.

How to test: Go to `/premium` and open the accessibility inspector, and set it to check for Text Label issues. Verify that no issues are found with graphics.

Before:

![image](https://user-images.githubusercontent.com/4251/148400351-8d7ab74b-f94c-434c-9ba2-562378c9fc88.png)

After:

![image](https://user-images.githubusercontent.com/4251/148400435-b027dcc3-24f4-406c-8bd0-1f89d2428c55.png)

(Remaining issues are in Django's debug toolbar.)

- [ ] l10n dependencies have been merged, if any. Not yet: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/52
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
