### PR TITLE
Use country code for survey recruitment

### DIFF
--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -4,14 +4,12 @@
 {% load ftl %}
 {% ftlconf bundle='privaterelay.ftl_bundles.main' %}
 
-{% get_current_language as LANGUAGE_CODE %}
-
 <header>
   {% if settings.INCLUDE_VPN_BANNER %}
     {% include "includes/vpn-promo-banner.html" %}
   {% endif %}
 
-  {% if settings.RECRUITMENT_BANNER_LINK and LANGUAGE_CODE|slice:"0:2" == "en" %}
+  {% if settings.RECRUITMENT_BANNER_LINK and country_code == "us" %}
     <div class="recruitment-banner">
       <a id="recruitment-banner" class="text-link" href="{{ settings.RECRUITMENT_BANNER_LINK }}" target="_blank" rel="noopener noreferrer" data-ga="send-ga-pings" data-event-category="Recruitment" data-event-label="{{ settings.RECRUITMENT_BANNER_TEXT }}">{{ settings.RECRUITMENT_BANNER_TEXT }}</a>
     </div>


### PR DESCRIPTION
# New feature description

To be able to send out gift cards to survey participants, we'll
limit the calls to participate in the survey to people in the US.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/148535206-906733d8-91ff-4296-b1fb-845c87375c46.png)

# How to test

Add the following environment variables to your `.env` files:

```
RECRUITMENT_BANNER_TEXT="Want to help improve Firefox Relay? We'd love to hear what you think. Research participants receive a $50  gift card."
RECRUITMENT_BANNER_LINK="https://survey.alchemer.com/s3/6678255/Firefox-Relay-Research-Study"
```

If you're testing locally, set your browser's language to `en-US`. If you're testing on stage/production, visit the Relay website from (/using a VPN located in) the US to see the banner. Use a different country to the US, and you should not see it.

(The environment variables have yet to be set on stage and production, at the time of writing.)

# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
