### PR TITLE
fix MPP-1512: send ga event for any premium user with "clicked-purchase"

### DIFF
--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -1,3 +1,5 @@
+import json
+
 from django.contrib.auth.models import User
 from django.test import TestCase
 
@@ -5,20 +7,21 @@ from allauth.socialaccount.models import SocialAccount
 from allauth.account.models import EmailAddress
 from model_bakery import baker
 
-from ..views import _update_extra_data_and_email
+from ..views import _update_all_data
 
 
 class UpdateExtraDataAndEmailTest(TestCase):
-    def test_update_extra_data_and_email(self):
+    def test_update_all_data(self):
         user = baker.make(User)
         ea = baker.make(EmailAddress, user=user)
         sa = baker.make(
-            SocialAccount, user=user, extra_data='{"test": "test"}'
+            SocialAccount, user=user, provider='fxa',
+            extra_data=json.loads('{"test": "test"}')
         )
-        new_extra_data = '{"test": "updated"}'
+        new_extra_data = json.loads('{"test": "updated"}')
         new_email = 'newemail@example.com'
 
-        response = _update_extra_data_and_email(
+        response = _update_all_data(
             sa, new_extra_data, new_email
         )
 
@@ -30,21 +33,23 @@ class UpdateExtraDataAndEmailTest(TestCase):
         assert sa.extra_data == new_extra_data
         assert ea.email == new_email
 
-    def test_update_extra_data_and_email_conflict(self):
-        extra_data='{"test": "test"}'
+    def test_update_all_data_conflict(self):
+        extra_data=json.loads('{"test": "test"}')
 
         user = baker.make(User, email='user@example.com')
         baker.make(EmailAddress, user=user, email='user@example.com')
-        baker.make(SocialAccount, user=user, extra_data=extra_data)
+        baker.make(SocialAccount, user=user, provider='fxa',
+                   extra_data=extra_data)
 
         user2 = baker.make(User, email='user2@example.com')
         ea2 = baker.make(EmailAddress, user=user2, email='user2@example.com')
-        sa2 = baker.make(SocialAccount, user=user2, extra_data=extra_data)
+        sa2 = baker.make(SocialAccount, user=user2, provider='fxa',
+                         extra_data=extra_data)
 
-        new_extra_data = '{"test": "updated"}'
+        new_extra_data = json.loads('{"test": "updated"}')
         new_email = 'user@example.com'
 
-        response = _update_extra_data_and_email(
+        response = _update_all_data(
             sa2, new_extra_data, new_email
         )
 


### PR DESCRIPTION
FXA sends the subscription state change event directly to our back-end
as soon as the user completes a purchase, and we process those events as
soon as we get them.

So, our check for "newly_premium" never evaluated to true, because the
event had already updated the profile to premium by the time the user
got back to the profile page.

So instead, always send the "user_purchased_premium" event to GA when a
user with a "clicked-purchase" cookie lands back on the profile page.

Additionally, move the code that updates date_subscribed to the
event-handling code.

This PR fixes [MPP-1512](https://mozilla-hub.atlassian.net/browse/MPP-1512).

## How to test:
0. Make sure you're not running something that blocks Google Analytics
1. Go to local relay dashboard as a free user
2. Open the developer tools "Console" tab
3. Click one of the "upgrade to relay premium"
   * [x] In the console, you should see an event sent to GA: Outbound Link, Click, Upgrade to Relay Premium
4. In the new tab that opened, open the developer tools "Console" tab
5. Go all the way thru the purchase flow in the new tab
6. Click the "Get Started" button to get back to Relay
   * [x] In the console, you should see an event sent to GA: server event, fired, user pruchased premium
7. Clear the console output to make the next step easier
8. Refresh the Relay dashboard page
   * [x] In the console, **YOU SHOULD NOT SEE AN EVENT** sent to GA: server event, fired, user pruchased premium. This makes sure we're not double-counting conversions.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).