### PR TITLE
Also link to Premium with no known country code

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -150,6 +150,16 @@ class Profile(models.Model):
                     in settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING.keys()
             ):
                 return True
+            # If a language but no country is known, check if there's a country
+            # whose code is the same as the language code and has Premium available.
+            # (For example, if the locale is just the language code `fr` rather than
+            # `fr-fr`, it will still match country code `fr`.)
+            if (
+                len(accept_langs) >= 1 and
+                len(accept_langs[0][0].split('-')) == 1 and
+                accept_langs[0][0].split('-')[0]
+                    in settings.PREMIUM_PLAN_COUNTRY_LANG_MAPPING.keys()):
+                return True
         return False
 
     @property

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -730,6 +730,42 @@ class ProfileTest(TestCase):
         )
         assert self.profile.language == 'de'
 
+    def test_locale_in_premium_country_returns_True_if_premium_available(self):
+        baker.make(
+            SocialAccount,
+            user=self.profile.user,
+            provider='fxa',
+            extra_data={'locale': 'de-DE,en-xx;q=0.9,en;q=0.8'}
+        )
+        assert self.profile.fxa_locale_in_premium_country is True
+
+    def test_locale_in_premium_country_returns_False_if_premium_unavailable(self):
+        baker.make(
+            SocialAccount,
+            user=self.profile.user,
+            provider='fxa',
+            extra_data={'locale': 'en;q=0.8'}
+        )
+        assert self.profile.fxa_locale_in_premium_country is False
+
+    def test_locale_in_premium_country_returns_True_if_premium_available_in_country_with_same_language_code(self):
+        baker.make(
+            SocialAccount,
+            user=self.profile.user,
+            provider='fxa',
+            extra_data={'locale': 'de;q=0.8'}
+        )
+        assert self.profile.fxa_locale_in_premium_country is True
+
+    def test_locale_in_premium_country_returns_False_if_premium_not_available_in_country_with_same_language_code(self):
+        baker.make(
+            SocialAccount,
+            user=self.profile.user,
+            provider='fxa',
+            extra_data={'locale': 'xx;q=0.8'}
+        )
+        assert self.profile.fxa_locale_in_premium_country is False
+
     @override_settings(PREMIUM_RELEASE_DATE=datetime.fromisoformat('2021-10-27 17:00:00+00:00'))
     def test_user_joined_before_premium_release_returns_True(self):
         user = baker.make(


### PR DESCRIPTION
This PR fixes #1456.

When the user's browser's language was set to e.g. just `fr`
instead of `fr-FR` when they created their Firefox account, we used
to err on the side of not showing them the Premium promo.

With this change, we'll still show the link, as long as the
language code is equal to the country code of a country in which
Premium is available. In the rare case where Premium isn't
available after all, the user will be notified of that on /premium.

How to test:

1. Create a Firefox account with your browser's language set to just `fr`.
2. Use it to sign up for Relay.
3. Generate an email (see onboarding doc for how), and verify that the French link to get Premium is shown.

Before:

![image](https://user-images.githubusercontent.com/4251/149337729-2e6a7b16-2b52-4c9a-9dfa-431724b6db06.png)

After:

![image](https://user-images.githubusercontent.com/4251/149337768-02947422-f70c-44b0-8b75-48032f870c13.png)

- [x] l10n dependencies have been merged, if any.
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
