### PR TITLE
Back-end changes to allow website feature-parity through the API

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -41,8 +41,8 @@ class DomainAddressSerializer(serializers.ModelSerializer):
 class ProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = Profile
-        fields = ['id', 'server_storage', 'subdomain', 'has_premium', 'onboarding_state', 'date_subscribed']
-        read_only_fields = ['id', 'subdomain', 'has_premium', 'date_subscribed']
+        fields = ['id', 'server_storage', 'subdomain', 'has_premium', 'onboarding_state', 'date_subscribed', 'avatar']
+        read_only_fields = ['id', 'subdomain', 'has_premium', 'date_subscribed', 'avatar']
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -41,8 +41,23 @@ class DomainAddressSerializer(serializers.ModelSerializer):
 class ProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = Profile
-        fields = ['id', 'server_storage', 'subdomain', 'has_premium', 'onboarding_state', 'date_subscribed', 'avatar']
-        read_only_fields = ['id', 'has_premium', 'date_subscribed', 'avatar']
+        fields = [
+            'id',
+            'server_storage',
+            'subdomain',
+            'has_premium',
+            'onboarding_state',
+            'date_subscribed',
+            'avatar',
+            'api_token'
+        ]
+        read_only_fields = [
+            'id',
+            'has_premium',
+            'date_subscribed',
+            'avatar',
+            'api_token'
+        ]
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -40,5 +40,5 @@ class DomainAddressSerializer(serializers.ModelSerializer):
 class ProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = Profile
-        fields = ['id', 'server_storage', 'subdomain', 'onboarding_state', 'date_subscribed']
-        read_only_fields = ['id', 'subdomain', 'date_subscribed']
+        fields = ['id', 'server_storage', 'subdomain', 'has_premium', 'onboarding_state', 'date_subscribed']
+        read_only_fields = ['id', 'subdomain', 'has_premium', 'date_subscribed']

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from emails.models import Profile, DomainAddress, RelayAddress
+from django.contrib.auth.models import User
 
 
 class RelayAddressSerializer(serializers.ModelSerializer):
@@ -42,3 +43,9 @@ class ProfileSerializer(serializers.ModelSerializer):
         model = Profile
         fields = ['id', 'server_storage', 'subdomain', 'has_premium', 'onboarding_state', 'date_subscribed']
         read_only_fields = ['id', 'subdomain', 'has_premium', 'date_subscribed']
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['email']
+        read_only_fields = ['email']

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -49,6 +49,8 @@ class ProfileSerializer(serializers.ModelSerializer):
             'onboarding_state',
             'date_subscribed',
             'avatar',
+            'next_email_try',
+            'bounce_status',
             'api_token'
         ]
         read_only_fields = [
@@ -56,6 +58,8 @@ class ProfileSerializer(serializers.ModelSerializer):
             'has_premium',
             'date_subscribed',
             'avatar',
+            'next_email_try',
+            'bounce_status',
             'api_token'
         ]
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -42,7 +42,7 @@ class ProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = Profile
         fields = ['id', 'server_storage', 'subdomain', 'has_premium', 'onboarding_state', 'date_subscribed', 'avatar']
-        read_only_fields = ['id', 'subdomain', 'has_premium', 'date_subscribed', 'avatar']
+        read_only_fields = ['id', 'has_premium', 'date_subscribed', 'avatar']
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:

--- a/api/urls.py
+++ b/api/urls.py
@@ -3,7 +3,7 @@ from django.urls import include, path, register_converter
 from rest_framework import routers
 
 from .views import (
-    DomainAddressViewSet, ProfileViewSet, RelayAddressViewSet,
+    DomainAddressViewSet, ProfileViewSet, UserViewSet, RelayAddressViewSet,
     premium_countries, schema_view
 )
 
@@ -29,6 +29,9 @@ api_router.register(
 )
 api_router.register(
     r'profiles', ProfileViewSet, 'profiles'
+)
+api_router.register(
+    r'users', UserViewSet, 'user'
 )
 
 urlpatterns = [

--- a/api/views.py
+++ b/api/views.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.db import IntegrityError
+from django.contrib.auth.models import User
 
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
@@ -15,7 +16,7 @@ from privaterelay.utils import get_premium_countries_info_from_request
 
 from .permissions import IsOwner
 from .serializers import (
-    DomainAddressSerializer, ProfileSerializer, RelayAddressSerializer
+    DomainAddressSerializer, ProfileSerializer, RelayAddressSerializer, UserSerializer
 )
 from .exceptions import ConflictError
 
@@ -71,6 +72,13 @@ class ProfileViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         return Profile.objects.filter(user=self.request.user)
+
+class UserViewSet(viewsets.ModelViewSet):
+    serializer_class = UserSerializer
+    permission_classes = [permissions.IsAuthenticated, IsOwner]
+
+    def get_queryset(self):
+        return User.objects.filter(id=self.request.user.id)
 
 @decorators.api_view()
 @decorators.permission_classes([permissions.AllowAny])

--- a/api/views.py
+++ b/api/views.py
@@ -76,6 +76,7 @@ class ProfileViewSet(viewsets.ModelViewSet):
 class UserViewSet(viewsets.ModelViewSet):
     serializer_class = UserSerializer
     permission_classes = [permissions.IsAuthenticated, IsOwner]
+    http_method_names = ['get', 'head']
 
     def get_queryset(self):
         return User.objects.filter(id=self.request.user.id)

--- a/emails/models.py
+++ b/emails/models.py
@@ -171,6 +171,10 @@ class Profile(models.Model):
         return False
 
     @property
+    def avatar(self):
+        return self.fxa.extra_data.get('avatar')
+
+    @property
     def num_active_address(self):
         return (
             RelayAddress.objects.filter(user=self.user).count() +

--- a/emails/models.py
+++ b/emails/models.py
@@ -203,6 +203,10 @@ class Profile(models.Model):
         return BounceStatus(False, '')
 
     @property
+    def bounce_status(self):
+        return self.check_bounce_pause()
+
+    @property
     def next_email_try(self):
         bounce_pause, bounce_type = self.check_bounce_pause()
 

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -150,6 +150,7 @@ INSTALLED_APPS = [
 
     'rest_framework',
     'rest_framework.authtoken',
+    'corsheaders',
 
     'privaterelay.apps.PrivateRelayConfig',
 ]
@@ -195,6 +196,7 @@ MIDDLEWARE += [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -546,6 +548,22 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_RENDERER_CLASSES': DRF_RENDERERS,
 }
+
+CORS_ALLOWED_ORIGINS = []
+CSRF_TRUSTED_ORIGINS = []
+if DEBUG:
+    # In local development, the React UI can be served up from a different server
+    # that needs to be allowed to make requests.
+    # In production, the frontend is served by Django, is therefore on the same
+    # origin and thus has access to the same cookies.
+    CORS_ALLOW_CREDENTIALS = True
+    SESSION_COOKIE_SAMESITE = None
+    CORS_ALLOWED_ORIGINS += [
+        'http://localhost:3000',
+    ]
+    CSRF_TRUSTED_ORIGINS += [
+        'http://localhost:3000',
+    ]
 
 sentry_sdk.init(
     dsn=config('SENTRY_DSN', None),

--- a/privaterelay/urls.py
+++ b/privaterelay/urls.py
@@ -38,6 +38,11 @@ urlpatterns = [
         views.profile_subdomain,
         name='profile_subdomain'
     ),
+    path(
+        'accounts/profile/refresh',
+        views.profile_refresh,
+        name='profile_refresh'
+    ),
     path('accounts/settings/', views.settings_view, name='settings'),
     # This redirects users back to the homepage after updating settings
     path('accounts/profile/settings_update', views.settings_update_view, name='settings-update'),

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -4,6 +4,7 @@ from hashlib import sha256
 import json
 import logging
 import os
+from rest_framework.decorators import api_view
 
 from google_measurement_protocol import event, report
 import jwt
@@ -133,6 +134,7 @@ def _get_fxa(request):
     return request.user.socialaccount_set.filter(provider='fxa').first()
 
 
+@api_view()
 @require_http_methods(['POST', 'GET'])
 def profile_subdomain(request):
     if (not request.user or request.user.is_anonymous):

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -141,19 +141,13 @@ def profile_refresh(request):
         return redirect(reverse('fxa_login'))
     profile = request.user.profile_set.first()
 
-    newly_premium = False
-    had_premium = profile.has_premium
     fxa = _get_fxa(request)
     _handle_fxa_profile_change(fxa)
-    now_has_premium = profile.has_premium
-    newly_premium = not had_premium and now_has_premium
-    if newly_premium:
-        profile.date_subscribed = datetime.now(timezone.utc)
-        profile.save()
+    if ('clicked-purchase' in request.COOKIES and profile.has_premium):
         event = 'user_purchased_premium'
         incr_if_enabled(event, 1)
 
-    return JsonResponse({'newly_premium': newly_premium})
+    return JsonResponse({})
 
 
 @api_view()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cryptography==3.3.2
 Django==2.2.24
 dj-database-url==0.5.0
 django-allauth==0.39.1
+django-cors-headers==3.10.0
 django-csp==3.5
 django-debug-toolbar==2.2.1
 django-gulp==4.1.0


### PR DESCRIPTION
# New feature description

To allow the entire website to be generated based on data from the API, a couple of changes were needed. This PR includes those changes. Specifically, it:

- exposes the user avatar as read-only (I added a new property to the Profile model, since this comes from FxA).
- exposes whether the user has Premium as read-only (`has_premium`).
- exposes data used in the bounce warning as read-only (`next_email_try` and `bounce_status`).
- exposes the user's API token as read-only - this can be removed again once the add-on has its own OAuth flow.
- makes the subdomain writable (*note:* there's a bit of validation in `add_subdomain` that I think does not get called now - can/should that be added as a validator on the field directly, or should it be called from django_rest_framework somehow?).
- makes `accounts/profile/subdomain` callable as an API (so a local devserver hosting the front-end can call it).
- adds an API endpoint for `Users` and exposes the user's email through the API.
- adds an endpoint `/accounts/profile/refresh` that refetches data from FXA (i.e. called when `?fxa_refresh=1`).
- adds CORS headers when running with `DEBUG` that allows http://localhost:3000 to make API calls.

# How to test

I've pushed a rebased version of the branch `react-experiment` that builds on top of this one. It has an updated README that demonstrates how to run the front-end (essentially: `cd frontend; npm install; npm run watch` in addition to running the backend).

# Checklist

- [x] l10n dependencies have been merged, if any.
- [ ] All acceptance criteria are met. N/A
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
