### PR TITLE
Add Accordion Anchor Links

### DIFF
--- a/privaterelay/templates/newlanding/a/use-cases.html
+++ b/privaterelay/templates/newlanding/a/use-cases.html
@@ -3,7 +3,7 @@
 
 <section>
     <div class="container mzp-l-content">
-        <ul class="c-use-case-content">
+        <ul class="c-use-case-content" id="use-cases">
             <li class="use-case-title use-case-shopping is-active remove-box-shadow" data-use-case="shopping">
                 <div class="use-case-title-text">{% ftlmsg 'landing-use-cases-shopping' %}</div>
                 <div class="drop-down"></div>

--- a/privaterelay/templates/newlanding/a/use-cases.html
+++ b/privaterelay/templates/newlanding/a/use-cases.html
@@ -4,7 +4,7 @@
 <section>
     <div class="container mzp-l-content">
         <ul class="c-use-case-content">
-            <li class="use-case-title use-case-shopping is-active remove-box-shadow">
+            <li class="use-case-title use-case-shopping is-active remove-box-shadow" data-use-case="shopping">
                 <div class="use-case-title-text">{% ftlmsg 'landing-use-cases-shopping' %}</div>
                 <div class="drop-down"></div>
             </li>
@@ -14,7 +14,7 @@
                     {% ftlmsg 'landing-use-cases-shopping-body' %}
                 </div>
             </li>
-            <li class="use-case-title use-case-social-networks">
+            <li class="use-case-title use-case-social-networks" data-use-case="social-networks">
                 <div class="use-case-title-text">{% ftlmsg 'landing-use-cases-social-networks' %}</div>
                 <div class="drop-down"></div>
             </li>
@@ -24,7 +24,7 @@
                     {% ftlmsg 'landing-use-cases-social-networks-body' %}
                 </div>
             </li>
-            <li class="use-case-title use-case-offline">  
+            <li class="use-case-title use-case-offline" data-use-case="offline">  
                 <div class="use-case-title-text">{% ftlmsg 'landing-use-cases-offline' %}</div>
                 <div class="drop-down"></div>
             </li>
@@ -34,7 +34,7 @@
                     {% ftlmsg 'landing-use-cases-offline-body' %}
                 </div>
             </li>
-            <li class="use-case-title use-case-access-content">
+            <li class="use-case-title use-case-access-content" data-use-case="access-content">
                 <div class="use-case-title-text">{% ftlmsg 'landing-use-cases-access-content' %}</div>
                 <div class="drop-down"></div>
             </li>
@@ -44,7 +44,7 @@
                     {% ftlmsg 'landing-use-cases-access-content-body' %}
                 </div>
             </li>
-            <li class="use-case-title use-case-gaming">
+            <li class="use-case-title use-case-gaming" data-use-case="gaming">
                 <div class="use-case-title-text">{% ftlmsg 'landing-use-cases-gaming' %}</div>
                 <div class="drop-down"></div>
             </li>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -686,55 +686,56 @@ if ( document.getElementById("survey-dismiss") ) {
 }
 
 
-//Landing page use case accordion 
+//Landing page use case accordion
+const useCaseSection = document.getElementById("use-cases");
 const useCaseTitle = document.querySelectorAll(".use-case-title");
 
 function toggleClass(elem) {
    useCaseTitle.forEach( item => {
       item.classList.remove("is-active");
   });
+  useCaseSection.scrollIntoView();
   elem.target.classList.add("is-active");
   window.location.hash = "#use-cases" + "/" + elem.target.dataset.useCase;
 }
 
-function jumpToUseCase(){
-  const url = location.hash;
-  if (url.includes("#use-cases")) {
-    window.location.hash = "#use-cases";
-  }
-}
-
 function hashChangeAccordion(){
-  if (location.hash === "#use-cases/shopping"){
-    useCaseTitle.forEach( item => {
-      item.classList.remove("is-active");
-    });
-    document.querySelector(".use-case-shopping").classList.add("is-active");
+  const urlHash = location.hash;
+  if (urlHash.includes("#use-cases")){
+    useCaseSection.scrollIntoView();
+    
+    if (urlHash === "#use-cases/shopping"){
+      useCaseTitle.forEach( item => {
+        item.classList.remove("is-active");
+      });
+      document.querySelector(".use-case-shopping").classList.add("is-active");
+    }
+  
+    if (urlHash === "#use-cases/social-networks"){
+      useCaseTitle.forEach( item => {
+        item.classList.remove("is-active");
+      });
+      document.querySelector(".use-case-social-networks").classList.add("is-active");
+    }
+  
+    if (urlHash === "#use-cases/offline"){
+      useCaseTitle.forEach( item => {
+        item.classList.remove("is-active");
+      });
+      document.querySelector(".use-case-offline").classList.add("is-active");
+    }
+  
+    if (urlHash === "#use-cases/gaming"){
+      useCaseTitle.forEach( item => {
+        item.classList.remove("is-active");
+      });
+      document.querySelector(".use-case-gaming").classList.add("is-active");
+    }
   }
-
-  if (location.hash === "#use-cases/social-networks"){
-    useCaseTitle.forEach( item => {
-      item.classList.remove("is-active");
-    });
-    document.querySelector(".use-case-social-networks").classList.add("is-active");
-  }
-
-  if (location.hash === "#use-cases/offline"){
-    useCaseTitle.forEach( item => {
-      item.classList.remove("is-active");
-    });
-    document.querySelector(".use-case-offline").classList.add("is-active");
-  }
-
-  if (location.hash === "#use-cases/gaming"){
-    useCaseTitle.forEach( item => {
-      item.classList.remove("is-active");
-    });
-    document.querySelector(".use-case-gaming").classList.add("is-active");
-  }
+ 
 }
 
-jumpToUseCase();
+hashChangeAccordion();
 
 window.onhashchange = hashChangeAccordion;
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -695,22 +695,46 @@ function toggleClass(elem) {
   });
   elem.target.classList.add("is-active");
 
+  const findClassName = elem.target.classList;
+  const accordionClassArray = Array.from(findClassName);
+
   if(elem.target.hasAttribute("active-accordion")){
     const urlOnly = window.location.href;
     const urlStart = window.location.hash;
-    const findClassName = elem.target.classList;
-    const accordionClassArray = Array.from(findClassName);
 
     console.log(accordionClassArray[1]);
+    console.log(urlStart);
     window.location.href = urlOnly.replace(urlStart, "#" + accordionClassArray[1]);
-
-    // for (const i = 0; i < accordionClassArray.length; i++){
-    //   if (accordionClassArray[i] === 'use-case-social-networks'){
-    //     window.location.href = urlOnly.replace(urlStart, "#" + findClassName[i]);
-    //     console.log(window.location.href);
-    //   }
-    // }
   }
+
+}
+
+if (location.hash === "#use-case-shopping"){
+  useCaseTitle.forEach( item => {
+    item.classList.remove("is-active");
+  });
+  document.querySelector(".use-case-shopping").classList.add("is-active");
+}
+
+if (location.hash === "#use-case-social-networks"){
+  useCaseTitle.forEach( item => {
+    item.classList.remove("is-active");
+  });
+  document.querySelector(".use-case-social-networks").classList.add("is-active");
+}
+
+if (location.hash === "#use-case-offline"){
+  useCaseTitle.forEach( item => {
+    item.classList.remove("is-active");
+  });
+  document.querySelector(".use-case-offline").classList.add("is-active");
+}
+
+if (location.hash === "#use-case-gaming"){
+  useCaseTitle.forEach( item => {
+    item.classList.remove("is-active");
+  });
+  document.querySelector(".use-case-gaming").classList.add("is-active");
 }
 
 useCaseTitle.forEach( item => {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -698,45 +698,52 @@ function toggleClass(elem) {
   const findClassName = elem.target.classList;
   const accordionClassArray = Array.from(findClassName);
 
-  if(elem.target.hasAttribute("active-accordion")){
-    const urlOnly = window.location.href;
-    const urlStart = window.location.hash;
-    window.location.href = urlOnly.replace(urlStart, "#" + accordionClassArray[1]);
+  const urlOnly = window.location.href;
+  const urlStart = window.location.hash;
+
+  if (urlStart === ""){
+    window.location.href = urlOnly.concat("#" + accordionClassArray[1]);
   }
 
+  else {
+    window.location.href = urlOnly.replace(urlStart, "#" + accordionClassArray[1]);
+  }
 }
 
-if (location.hash === "#use-case-shopping"){
-  useCaseTitle.forEach( item => {
-    item.classList.remove("is-active");
-  });
-  document.querySelector(".use-case-shopping").classList.add("is-active");
+function hashChangeAccordion(){
+  if (location.hash === "#use-case-shopping"){
+    useCaseTitle.forEach( item => {
+      item.classList.remove("is-active");
+    });
+    document.querySelector(".use-case-shopping").classList.add("is-active");
+  }
+
+  if (location.hash === "#use-case-social-networks"){
+    useCaseTitle.forEach( item => {
+      item.classList.remove("is-active");
+    });
+    document.querySelector(".use-case-social-networks").classList.add("is-active");
+  }
+
+  if (location.hash === "#use-case-offline"){
+    useCaseTitle.forEach( item => {
+      item.classList.remove("is-active");
+    });
+    document.querySelector(".use-case-offline").classList.add("is-active");
+  }
+
+  if (location.hash === "#use-case-gaming"){
+    useCaseTitle.forEach( item => {
+      item.classList.remove("is-active");
+    });
+    document.querySelector(".use-case-gaming").classList.add("is-active");
+  }
 }
 
-if (location.hash === "#use-case-social-networks"){
-  useCaseTitle.forEach( item => {
-    item.classList.remove("is-active");
-  });
-  document.querySelector(".use-case-social-networks").classList.add("is-active");
-}
-
-if (location.hash === "#use-case-offline"){
-  useCaseTitle.forEach( item => {
-    item.classList.remove("is-active");
-  });
-  document.querySelector(".use-case-offline").classList.add("is-active");
-}
-
-if (location.hash === "#use-case-gaming"){
-  useCaseTitle.forEach( item => {
-    item.classList.remove("is-active");
-  });
-  document.querySelector(".use-case-gaming").classList.add("is-active");
-}
+window.onhashchange = hashChangeAccordion;
 
 useCaseTitle.forEach( item => {
     item.addEventListener("click", toggleClass, false);
-    item.setAttribute("active-accordion", "true");
 });
 
 //Landing page accordion remove box shadow

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -694,51 +694,40 @@ function toggleClass(elem) {
       item.classList.remove("is-active");
   });
   elem.target.classList.add("is-active");
-
-  const findClassName = elem.target.classList;
-  const accordionClassArray = Array.from(findClassName);
-
-  const urlRelay = window.location.href;
-  const accordionHash = window.location.hash;
-
-  if (accordionHash === ""){
-    window.location.href = urlRelay.concat("#" + accordionClassArray[1]);
-  }
-
-  else {
-    window.location.href = urlRelay.replace(accordionHash, "#" + accordionClassArray[1]);
-  }
+  window.location.hash = elem.target.dataset.useCase;
 }
 
 function hashChangeAccordion(){
-  if (location.hash === "#use-case-shopping"){
+  if (location.hash === "#shopping"){
     useCaseTitle.forEach( item => {
       item.classList.remove("is-active");
     });
     document.querySelector(".use-case-shopping").classList.add("is-active");
   }
 
-  if (location.hash === "#use-case-social-networks"){
+  if (location.hash === "#social-networks"){
     useCaseTitle.forEach( item => {
       item.classList.remove("is-active");
     });
     document.querySelector(".use-case-social-networks").classList.add("is-active");
   }
 
-  if (location.hash === "#use-case-offline"){
+  if (location.hash === "#offline"){
     useCaseTitle.forEach( item => {
       item.classList.remove("is-active");
     });
     document.querySelector(".use-case-offline").classList.add("is-active");
   }
 
-  if (location.hash === "#use-case-gaming"){
+  if (location.hash === "#gaming"){
     useCaseTitle.forEach( item => {
       item.classList.remove("is-active");
     });
     document.querySelector(".use-case-gaming").classList.add("is-active");
   }
 }
+
+hashChangeAccordion();
 
 window.onhashchange = hashChangeAccordion;
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -694,10 +694,28 @@ function toggleClass(elem) {
       item.classList.remove("is-active");
   });
   elem.target.classList.add("is-active");
+
+  if(elem.target.hasAttribute("active-accordion")){
+    const urlOnly = window.location.href;
+    const urlStart = window.location.hash;
+    const findClassName = elem.target.classList;
+    const accordionClassArray = Array.from(findClassName);
+
+    console.log(accordionClassArray[1]);
+    window.location.href = urlOnly.replace(urlStart, "#" + accordionClassArray[1]);
+
+    // for (const i = 0; i < accordionClassArray.length; i++){
+    //   if (accordionClassArray[i] === 'use-case-social-networks'){
+    //     window.location.href = urlOnly.replace(urlStart, "#" + findClassName[i]);
+    //     console.log(window.location.href);
+    //   }
+    // }
+  }
 }
 
 useCaseTitle.forEach( item => {
     item.addEventListener("click", toggleClass, false);
+    item.setAttribute("active-accordion", "true");
 });
 
 //Landing page accordion remove box shadow

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -699,40 +699,28 @@ function toggleClass(elem) {
   window.location.hash = "#use-cases" + "/" + elem.target.dataset.useCase;
 }
 
+function resetAccordianAndSetActiveSection(useCaseName) {
+  const urlHash = location.hash;
+    if (urlHash.includes(useCaseName)){
+      useCaseTitle.forEach( item => {
+        item.classList.remove("is-active");
+      });
+      document.querySelector(".use-case-" + useCaseName).classList.add("is-active");
+    }
+}
+
 function hashChangeAccordion(){
   const urlHash = location.hash;
+
   if (urlHash.includes("#use-cases")){
     useCaseSection.scrollIntoView();
-    
-    if (urlHash === "#use-cases/shopping"){
-      useCaseTitle.forEach( item => {
-        item.classList.remove("is-active");
-      });
-      document.querySelector(".use-case-shopping").classList.add("is-active");
-    }
-  
-    if (urlHash === "#use-cases/social-networks"){
-      useCaseTitle.forEach( item => {
-        item.classList.remove("is-active");
-      });
-      document.querySelector(".use-case-social-networks").classList.add("is-active");
-    }
-  
-    if (urlHash === "#use-cases/offline"){
-      useCaseTitle.forEach( item => {
-        item.classList.remove("is-active");
-      });
-      document.querySelector(".use-case-offline").classList.add("is-active");
-    }
-  
-    if (urlHash === "#use-cases/gaming"){
-      useCaseTitle.forEach( item => {
-        item.classList.remove("is-active");
-      });
-      document.querySelector(".use-case-gaming").classList.add("is-active");
-    }
+
+    resetAccordianAndSetActiveSection("shopping");
+    resetAccordianAndSetActiveSection("social-networks");
+    resetAccordianAndSetActiveSection("offline");
+    resetAccordianAndSetActiveSection("access-content");
+    resetAccordianAndSetActiveSection("gaming");
   }
- 
 }
 
 hashChangeAccordion();

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -694,32 +694,39 @@ function toggleClass(elem) {
       item.classList.remove("is-active");
   });
   elem.target.classList.add("is-active");
-  window.location.hash = elem.target.dataset.useCase;
+  window.location.hash = "#use-cases" + "/" + elem.target.dataset.useCase;
+}
+
+function jumpToUseCase(){
+  const url = location.hash;
+  if (url.includes("#use-cases")) {
+    window.location.hash = "#use-cases";
+  }
 }
 
 function hashChangeAccordion(){
-  if (location.hash === "#shopping"){
+  if (location.hash === "#use-cases/shopping"){
     useCaseTitle.forEach( item => {
       item.classList.remove("is-active");
     });
     document.querySelector(".use-case-shopping").classList.add("is-active");
   }
 
-  if (location.hash === "#social-networks"){
+  if (location.hash === "#use-cases/social-networks"){
     useCaseTitle.forEach( item => {
       item.classList.remove("is-active");
     });
     document.querySelector(".use-case-social-networks").classList.add("is-active");
   }
 
-  if (location.hash === "#offline"){
+  if (location.hash === "#use-cases/offline"){
     useCaseTitle.forEach( item => {
       item.classList.remove("is-active");
     });
     document.querySelector(".use-case-offline").classList.add("is-active");
   }
 
-  if (location.hash === "#gaming"){
+  if (location.hash === "#use-cases/gaming"){
     useCaseTitle.forEach( item => {
       item.classList.remove("is-active");
     });
@@ -727,7 +734,7 @@ function hashChangeAccordion(){
   }
 }
 
-hashChangeAccordion();
+jumpToUseCase();
 
 window.onhashchange = hashChangeAccordion;
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -698,15 +698,15 @@ function toggleClass(elem) {
   const findClassName = elem.target.classList;
   const accordionClassArray = Array.from(findClassName);
 
-  const urlOnly = window.location.href;
-  const urlStart = window.location.hash;
+  const urlRelay = window.location.href;
+  const accordionHash = window.location.hash;
 
-  if (urlStart === ""){
-    window.location.href = urlOnly.concat("#" + accordionClassArray[1]);
+  if (accordionHash === ""){
+    window.location.href = urlRelay.concat("#" + accordionClassArray[1]);
   }
 
   else {
-    window.location.href = urlOnly.replace(urlStart, "#" + accordionClassArray[1]);
+    window.location.href = urlRelay.replace(accordionHash, "#" + accordionClassArray[1]);
   }
 }
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -701,9 +701,6 @@ function toggleClass(elem) {
   if(elem.target.hasAttribute("active-accordion")){
     const urlOnly = window.location.href;
     const urlStart = window.location.hash;
-
-    console.log(accordionClassArray[1]);
-    console.log(urlStart);
     window.location.href = urlOnly.replace(urlStart, "#" + accordionClassArray[1]);
   }
 


### PR DESCRIPTION
This PR addresses MPP-1509.

This PR generates an anchor link for each use case in the accordion. When the window hash changes, the corresponding use case element will get triggered. Note that the hash change should also anchor to the use case section.

Preview (updated Jan 24)

https://user-images.githubusercontent.com/13066134/150854901-69329aaa-e52d-4887-964c-b03690ec6584.mov



How to test:

- [ ] l10n dependencies have been merged, if any.
- [ ] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description
This PR generates an anchor link for each use case in the accordion. When the window hash changes, the corresponding use case element will get triggered.

# How to test

1) Go to the use case section, select any of them and check for a hash change. 
2) Go to `http://127.0.0.1:8000/#use-cases/shopping`, and the page should scroll to the use case section. While on the 'shopping' tab, go to `http://127.0.0.1:8000/#use-cases/gaming` and check that the active use case changes to 'gaming'.

# Checklist

- [x] l10n dependencies have been merged, if any.
- [ ] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
