### PR TITLE
Only show interview recruitment banner if logged in

### DIFF
--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -9,7 +9,7 @@
     {% include "includes/vpn-promo-banner.html" %}
   {% endif %}
 
-  {% if settings.RECRUITMENT_BANNER_LINK and country_code == "us" %}
+  {% if settings.RECRUITMENT_BANNER_LINK and country_code == "us" and not request.user.is_anonymous %}
     <div class="recruitment-banner">
       <a id="recruitment-banner" class="text-link" href="{{ settings.RECRUITMENT_BANNER_LINK }}" target="_blank" rel="noopener noreferrer" data-ga="send-ga-pings" data-event-category="Recruitment" data-event-label="{{ settings.RECRUITMENT_BANNER_TEXT }}">{{ settings.RECRUITMENT_BANNER_TEXT }}</a>
     </div>


### PR DESCRIPTION
# New feature description

The interview recruitment banner should only be shown to people who are logged in.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/150135226-2288d2e2-cfe9-45f7-b315-bca2219b5cd2.png)

# How to test

1. Set your browser's language to `en-US`.
2. Add the following to your `.env` before starting the server, if not present yet:

```
RECRUITMENT_BANNER_TEXT="Want to help improve Firefox Relay? We'd love to hear what you think. Research participants receive a $50  gift card."
RECRUITMENT_BANNER_LINK="https://survey.alchemer.com/s3/6678255/Firefox-Relay-Research-Study"
```

2. Visit the homepage when logged out. No banner should be visible at the top.
3. Log in. The banner should now be visible.

# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
