### PR TITLE
Remove redundant last_used_at

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -587,7 +587,6 @@ class DomainAddress(models.Model):
     domain = models.PositiveSmallIntegerField(choices=DOMAIN_CHOICES, default=2)
     created_at = models.DateTimeField(auto_now_add=True, db_index=True)
     first_emailed_at = models.DateTimeField(null=True, db_index=True)
-    last_used_at = models.DateTimeField(auto_now_add=True, db_index=True)
     last_modified_at = models.DateTimeField(auto_now=True, db_index=True)
     last_used_at = models.DateTimeField(blank=True, null=True)
     num_forwarded = models.PositiveIntegerField(default=0)


### PR DESCRIPTION
This removes a property on the DomainAddress model that was listed twice (`last_used_at`).

How to test: There should be no regressions.

- [x] l10n dependencies have been merged, if any.
- [ ] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure). N/A
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
