### PR TITLE
Allow dismissing the interview recruitment banner

### DIFF
--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -12,6 +12,9 @@
   {% if settings.RECRUITMENT_BANNER_LINK and country_code == "us" and not request.user.is_anonymous %}
     <div class="recruitment-banner">
       <a id="recruitment-banner" class="text-link" href="{{ settings.RECRUITMENT_BANNER_LINK }}" target="_blank" rel="noopener noreferrer" data-ga="send-ga-pings" data-event-category="Recruitment" data-event-label="{{ settings.RECRUITMENT_BANNER_TEXT }}">{{ settings.RECRUITMENT_BANNER_TEXT }}</a>
+      <button id="recruitment-dismiss" class="dismiss-btn">
+        <svg class="x-close-icon" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
+      </button>
     </div>
   {% elif show_nps and request.path != "/premium" %}
     <div id="micro-survey-banner" class="micro-survey-banner is-hidden">

--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -4,12 +4,14 @@
 {% load ftl %}
 {% ftlconf bundle='privaterelay.ftl_bundles.main' %}
 
+{% get_current_language as LANGUAGE_CODE %}
+
 <header>
   {% if settings.INCLUDE_VPN_BANNER %}
     {% include "includes/vpn-promo-banner.html" %}
   {% endif %}
 
-  {% if settings.RECRUITMENT_BANNER_LINK and country_code == "us" and not request.user.is_anonymous %}
+  {% if settings.RECRUITMENT_BANNER_LINK and LANGUAGE_CODE|slice:"0:2" == "en" and country_code == "us" and not request.user.is_anonymous %}
     <div class="recruitment-banner">
       <a id="recruitment-banner" class="text-link" href="{{ settings.RECRUITMENT_BANNER_LINK }}" target="_blank" rel="noopener noreferrer" data-ga="send-ga-pings" data-event-category="Recruitment" data-event-label="{{ settings.RECRUITMENT_BANNER_TEXT }}">{{ settings.RECRUITMENT_BANNER_TEXT }}</a>
       <button id="recruitment-dismiss" class="dismiss-btn">

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -202,6 +202,14 @@ function recruitmentLogic() {
     date.setTime(date.getTime() + 30*24*60*60*1000)
     document.cookie = "recruited=true; expires=" + date.toUTCString() + "; path=/";
   });
+
+  const recruitmentDismissButton = document.querySelector("#recruitment-dismiss");
+  recruitmentDismissButton.addEventListener("click", () => {
+    recruitmentBannerLink.parentElement.remove();
+    const date = new Date();
+    date.setTime(date.getTime() + 30*24*60*60*1000)
+    document.cookie = "recruited=true; expires=" + date.toUTCString() + "; path=/";
+  });
 }
 
 function addEventListeners() {

--- a/static/scss/partials/banners.scss
+++ b/static/scss/partials/banners.scss
@@ -72,7 +72,7 @@
 
 #recruitment-banner, .micro-survey-option {
     color: $color-white;
-    text-decoration: none;
+    text-decoration: underline;
     font-family: $font-metropolis;
     display: inline-block;
     padding: 0 $spacing-md;
@@ -80,7 +80,7 @@
 
 #recruitment-banner:hover, .micro-survey-option:hover {
     cursor: pointer;
-    text-decoration: underline;
+    text-decoration: none;
 }
 
 .recruitment-banner::after, .micro-survey-banner::after {

--- a/static/scss/partials/banners.scss
+++ b/static/scss/partials/banners.scss
@@ -10,6 +10,10 @@
     
     .is-premium & {
         background-color: $color-purple-90;
+
+        .x-close-icon path {
+            fill: $color-white;
+        }
     }
 }
 
@@ -117,9 +121,10 @@
     justify-content: center;
     align-items: center;
     margin-left: $spacing-2xl;
+    cursor: pointer;
   
     .x-close-icon path {
-        fill: $color-black !important; 
+        fill: $color-black;
     }
   
 }

--- a/static/scss/partials/banners.scss
+++ b/static/scss/partials/banners.scss
@@ -76,6 +76,8 @@
     font-family: $font-metropolis;
     display: inline-block;
     padding: 0 $spacing-md;
+    // Width of the dismiss button:
+    padding-right: 32px;
 }
 
 #recruitment-banner:hover, .micro-survey-option:hover {


### PR DESCRIPTION
Thanks @maxxcrawford for catching that this didn't yet meet all acceptance criteria - I though that, since the functionality had been implemented before, just exposing it would meet the acceptance criteria :)

This PR:
- Adds the ability to dismiss the interview recruitment survey.
- Only shows it if the browser language is set to English (to avoid people in the US who don't speak English)

![image](https://user-images.githubusercontent.com/4251/150504685-8a02297b-ce63-4d5a-a2ca-ade57de2a3ae.png)

(See the "X" on the right.)

How to test: Set your browser language to `en-US`. You should see the survey if you didn't click on it before (otherwise delete the `surveyed` cookie). If you click the "X", it should disappear and not return.

- [x] l10n dependencies have been merged, if any.
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`). (No, but they're consistent with the dismiss button for the NPS survey below.)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
