### PR TITLE
Add `.` in between subdomain and domain

### DIFF
--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -36,7 +36,7 @@
                     </div>
                     <div class="c-premium-onboarding-content-description">
                         <p class="c-premium-onboarding-detail">{% ftlmsg 'onboarding-premium-title-detail' %}</p>
-                        <p><strong>{% ftlmsg 'onboarding-premium-domain-title' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-get-domain-description-2' mozmail='mozmail.com' %}
+                        <p><strong>{% ftlmsg 'onboarding-premium-domain-title' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-get-domain-description-2' mozmail='.mozmail.com' %}
                         {% if not user_profile.subdomain %}
                             <div class="js-premium-onboarding-domain-registration-form">
                                 <p>{% ftlmsg 'multi-part-onboarding-premium-domain-cta' %}</p>


### PR DESCRIPTION
This fix doesn't _feel_ like the best approach, but the "best" approach involves adding a new string with a `.` added, and having all translators do the same. This approach bothers far fewer people and works too, so...

How to test: Set "onboarding state" to 1 for a Premium user's profile at http://127.0.0.1:8000/admin/, then view the second onboarding page on the dashboard. 

![image](https://user-images.githubusercontent.com/4251/150958579-184bbc99-d2ba-42f9-beec-efe8b6166e0b.png)

Before:

![image](https://user-images.githubusercontent.com/4251/150958684-a2f3ebea-3b7c-4648-b1db-47e7aeecc2ff.png)

After:

![image](https://user-images.githubusercontent.com/4251/150958825-1ead48e6-af47-4ac0-9d64-d68f79e61d4d.png)

- [x] l10n dependencies have been merged, if any.
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
