### PR TITLE
Add a CSAT survey

### DIFF
--- a/privaterelay/context_processors.py
+++ b/privaterelay/context_processors.py
@@ -26,31 +26,31 @@ def common(request):
     if (not request.user.is_anonymous and profile.has_premium and profile.date_subscribed):
         days_since_subscription = (datetime.now(timezone.utc) - profile.date_subscribed).days
         if (days_since_subscription >= 3 * 30):
-            csat_dismissal_cookie = f'csat-survey-premium-3month_{profile.id}_dismissed'
+            csat_dismissal_cookie = f'csat-survey-premium-90days_{profile.id}_dismissed'
             if (not request.COOKIES.get(csat_dismissal_cookie)):
-                reason_to_show_csat_survey = "premium3month"
+                reason_to_show_csat_survey = "premium90days"
         elif (days_since_subscription >= 30):
-            csat_dismissal_cookie = f'csat-survey-premium-1month_{profile.id}_dismissed'
+            csat_dismissal_cookie = f'csat-survey-premium-30days_{profile.id}_dismissed'
             if (not request.COOKIES.get(csat_dismissal_cookie)):
-                reason_to_show_csat_survey = "premium1month"
+                reason_to_show_csat_survey = "premium30days"
         elif (days_since_subscription >= 7):
-            csat_dismissal_cookie = f'csat-survey-premium-1week_{profile.id}_dismissed'
+            csat_dismissal_cookie = f'csat-survey-premium-7days_{profile.id}_dismissed'
             if (not request.COOKIES.get(csat_dismissal_cookie)):
-                reason_to_show_csat_survey = "premium1week"
+                reason_to_show_csat_survey = "premium7days"
     elif (not request.user.is_anonymous and not profile.has_premium and first_visit):
         days_since_first_visit = (datetime.now(timezone.utc) - first_visit).days
         if (days_since_first_visit >= 3 * 30):
-            csat_dismissal_cookie = f'csat-survey-free-3month_{profile.id}_dismissed'
+            csat_dismissal_cookie = f'csat-survey-free-90days_{profile.id}_dismissed'
             if (not request.COOKIES.get(csat_dismissal_cookie)):
-                reason_to_show_csat_survey = "free3month"
+                reason_to_show_csat_survey = "free90days"
         elif (days_since_first_visit >= 30):
-            csat_dismissal_cookie = f'csat-survey-free-1month_{profile.id}_dismissed'
+            csat_dismissal_cookie = f'csat-survey-free-30days_{profile.id}_dismissed'
             if (not request.COOKIES.get(csat_dismissal_cookie)):
-                reason_to_show_csat_survey = "free1month"
+                reason_to_show_csat_survey = "free30days"
         elif (days_since_first_visit >= 7):
-            csat_dismissal_cookie = f'csat-survey-free-1week_{profile.id}_dismissed'
+            csat_dismissal_cookie = f'csat-survey-free-7days_{profile.id}_dismissed'
             if (not request.COOKIES.get(csat_dismissal_cookie)):
-                reason_to_show_csat_survey = "free1week"
+                reason_to_show_csat_survey = "free7days"
 
     lang = accept_language.split(',')[0]
     lang_parts = lang.split("-") if lang and "-" in lang else [lang]

--- a/privaterelay/context_processors.py
+++ b/privaterelay/context_processors.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from functools import lru_cache
 
 from django.conf import settings
@@ -19,43 +19,14 @@ def common(request):
         get_premium_countries_info_from_request(request)
     )
 
-    profile = request.user.profile_set.first()
-    first_visit = request.COOKIES.get("first_visit")
-    reason_to_show_csat_survey = None
-    csat_dismissal_cookie = ""
-    if (not request.user.is_anonymous and profile.has_premium and profile.date_subscribed):
-        days_since_subscription = (datetime.now(timezone.utc) - profile.date_subscribed).days
-        if (days_since_subscription >= 3 * 30):
-            csat_dismissal_cookie = f'csat-survey-premium-90days_{profile.id}_dismissed'
-            if (not request.COOKIES.get(csat_dismissal_cookie)):
-                reason_to_show_csat_survey = "premium90days"
-        elif (days_since_subscription >= 30):
-            csat_dismissal_cookie = f'csat-survey-premium-30days_{profile.id}_dismissed'
-            if (not request.COOKIES.get(csat_dismissal_cookie)):
-                reason_to_show_csat_survey = "premium30days"
-        elif (days_since_subscription >= 7):
-            csat_dismissal_cookie = f'csat-survey-premium-7days_{profile.id}_dismissed'
-            if (not request.COOKIES.get(csat_dismissal_cookie)):
-                reason_to_show_csat_survey = "premium7days"
-    elif (not request.user.is_anonymous and not profile.has_premium and first_visit):
-        days_since_first_visit = (datetime.now(timezone.utc) - first_visit).days
-        if (days_since_first_visit >= 3 * 30):
-            csat_dismissal_cookie = f'csat-survey-free-90days_{profile.id}_dismissed'
-            if (not request.COOKIES.get(csat_dismissal_cookie)):
-                reason_to_show_csat_survey = "free90days"
-        elif (days_since_first_visit >= 30):
-            csat_dismissal_cookie = f'csat-survey-free-30days_{profile.id}_dismissed'
-            if (not request.COOKIES.get(csat_dismissal_cookie)):
-                reason_to_show_csat_survey = "free30days"
-        elif (days_since_first_visit >= 7):
-            csat_dismissal_cookie = f'csat-survey-free-7days_{profile.id}_dismissed'
-            if (not request.COOKIES.get(csat_dismissal_cookie)):
-                reason_to_show_csat_survey = "free7days"
-
+    csat_dismissal_cookie, reason_to_show_csat_survey = _get_csat_cookie_and_reason(request)
     lang = accept_language.split(',')[0]
     lang_parts = lang.split("-") if lang and "-" in lang else [lang]
     lang = lang_parts[0].lower()
-    show_csat = (reason_to_show_csat_survey is not None and (lang == 'en' or lang == 'fr' or lang == 'de'))
+    show_csat = (
+        reason_to_show_csat_survey is not None and
+        (lang == 'en' or lang == 'fr' or lang == 'de')
+    )
 
     common_vars = {
         'avatar': avatar,
@@ -77,3 +48,43 @@ def _get_fxa(request):
         return fxa
     except AttributeError:
         return None
+
+@lru_cache(maxsize=None)
+def _get_csat_cookie_and_reason(request):
+    if not request.user.is_authenticated:
+        return None, None
+    profile = request.user.profile_set.first()
+    first_visit = request.COOKIES.get("first_visit")
+
+    reason_to_show_csat_survey = None
+    csat_dismissal_cookie = ""
+    if (profile.has_premium and profile.date_subscribed):
+        days_since_subscription = (datetime.now(timezone.utc) - profile.date_subscribed).days
+        if (days_since_subscription >= 3 * 30):
+            csat_dismissal_cookie = f'csat-survey-premium-90days_{profile.id}_dismissed'
+            if (not request.COOKIES.get(csat_dismissal_cookie)):
+                reason_to_show_csat_survey = "premium90days"
+        elif (days_since_subscription >= 30):
+            csat_dismissal_cookie = f'csat-survey-premium-30days_{profile.id}_dismissed'
+            if (not request.COOKIES.get(csat_dismissal_cookie)):
+                reason_to_show_csat_survey = "premium30days"
+        elif (days_since_subscription >= 7):
+            csat_dismissal_cookie = f'csat-survey-premium-7days_{profile.id}_dismissed'
+            if (not request.COOKIES.get(csat_dismissal_cookie)):
+                reason_to_show_csat_survey = "premium7days"
+    elif (not profile.has_premium and first_visit):
+        days_since_first_visit = (datetime.now(timezone.utc) - datetime.fromisoformat(first_visit)).days
+        if (days_since_first_visit >= 3 * 30):
+            csat_dismissal_cookie = f'csat-survey-free-90days_{profile.id}_dismissed'
+            if (not request.COOKIES.get(csat_dismissal_cookie)):
+                reason_to_show_csat_survey = "free90days"
+        elif (days_since_first_visit >= 30):
+            csat_dismissal_cookie = f'csat-survey-free-30days_{profile.id}_dismissed'
+            if (not request.COOKIES.get(csat_dismissal_cookie)):
+                reason_to_show_csat_survey = "free30days"
+        elif (days_since_first_visit >= 7):
+            csat_dismissal_cookie = f'csat-survey-free-7days_{profile.id}_dismissed'
+            if (not request.COOKIES.get(csat_dismissal_cookie)):
+                reason_to_show_csat_survey = "free7days"
+
+    return csat_dismissal_cookie, reason_to_show_csat_survey

--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -18,58 +18,62 @@
         <svg class="x-close-icon" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
       </button>
     </div>
-  {% elif show_nps and request.path != "/premium" %}
-    <div id="micro-survey-banner" class="micro-survey-banner is-hidden">
-      <button id="survey-dismiss" class="dismiss-btn">
-        <svg class="x-close-icon fill-current  text-gray" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
+  {% elif show_csat %}
+    <aside
+      class="js-csat-wrapper c-csat-wrapper"
+      data-has-premium="{{ user_profile.has_premium }}"
+      data-cookie-id="{{ csat_dismissal_cookie }}"
+    >
+      <div class="js-csat-question">
+        <div class="c-csat-prompt">
+          {% ftlmsg 'survey-csat-question' %}
+        </div>
+        <div class="js-csat-answers c-csat-answers">
+          <ol>
+            <li>
+              <button data-satisfaction="Very Dissatisfied">
+                {% ftlmsg 'survey-csat-answer-very-dissatisfied' %}
+              </button>
+            </li>
+            <li>
+              <button data-satisfaction="Dissatisfied">
+                {% ftlmsg 'survey-csat-answer-dissatisfied' %}
+              </button>
+            </li>
+            <li>
+              <button data-satisfaction="Neutral">
+                {% ftlmsg 'survey-csat-answer-neutral' %}
+              </button>
+            </li>
+            <li>
+              <button data-satisfaction="Satisfied">
+                {% ftlmsg 'survey-csat-answer-satisfied' %}
+              </button>
+            </li>
+            <li>
+              <button data-satisfaction="Very Satisfied">
+                {% ftlmsg 'survey-csat-answer-very-satisfied' %}
+              </button>
+            </li>
+          </ol>
+        </div>
+      </div>
+      <div class="js-csat-followup is-hidden">
+        <div class="c-csat-prompt">
+          <a target="_blank" rel="noopen noreferrer">
+            {% ftlmsg 'survey-csat-followup' %}
+          </a>
+        </div>
+      </div>
+      <button class="js-csat-dismiss c-csat-dismiss-button" title={% ftlmsg 'survey-option-dismiss' %}>
+        <svg class="x-close-icon" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+          <title>{% ftlmsg 'survey-option-dismiss' %}</title>
+          <path
+            d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"
+          />
+        </svg>
       </button>
-      {% comment %}
-      {% now "U" as now_second %}
-      {% if now_second|last == "1" or now_second|last == "6" %}
-      {% endcomment %}
-      <span id="micro-survey-prompt" data-survey-type="nps">{% ftlmsg 'survey-question-1' %}</span>
-      <ul id="micro-survey-options"
-      data-survey-option-very-likely-translated="{% ftlmsg 'survey-option-very-likely' %}"
-      data-survey-option-not-likely-translated="{% ftlmsg 'survey-option-not-likely' %}"
-      class="micro-survey-options micro-survey-options-numeric"></ul>
-      {% comment %}
-      {% elif now_second|last == "2" or now_second|last == "7" %}
-        <span id="micro-survey-prompt" data-survey-type="usability">{% ftlmsg 'survey-question-2' %}</span>
-        <ul id="micro-survey-options"
-        data-survey-option-strongly-disagree-translated="{% ftlmsg 'survey-option-strongly-disagree' %}"
-        data-survey-option-disagree-translated="{% ftlmsg 'survey-option-disagree' %}"
-        data-survey-option-unsure-translated="{% ftlmsg 'survey-option-unsure' %}"
-        data-survey-option-agree-translated="{% ftlmsg 'survey-option-agree' %}"
-        data-survey-option-strongly-agree-translated="{% ftlmsg 'survey-option-strongly-agree' %}"
-        class="micro-survey-options micro-survey-options-likert"></ul>
-      {% elif now_second|last == "3" or now_second|last == "8" %}
-        <span id="micro-survey-prompt" data-survey-type="credibility">{% ftlmsg 'survey-question-3' %}</span>
-        <ul id="micro-survey-options"
-        data-survey-option-strongly-disagree-translated="{% ftlmsg 'survey-option-strongly-disagree' %}"
-        data-survey-option-disagree-translated="{% ftlmsg 'survey-option-disagree' %}"
-        data-survey-option-unsure-translated="{% ftlmsg 'survey-option-unsure' %}"
-        data-survey-option-agree-translated="{% ftlmsg 'survey-option-agree' %}"
-        data-survey-option-strongly-agree-translated="{% ftlmsg 'survey-option-strongly-agree' %}"
-        class="micro-survey-options micro-survey-options-likert"></ul>
-      {% elif now_second|last == "4" or now_second|last == "9" %}
-        <span id="micro-survey-prompt" data-survey-type="appearance">{% ftlmsg 'survey-question-4' %}</span>
-        <ul id="micro-survey-options"
-        data-survey-option-strongly-disagree-translated="{% ftlmsg 'survey-option-strongly-disagree' %}"
-        data-survey-option-disagree-translated="{% ftlmsg 'survey-option-disagree' %}"
-        data-survey-option-unsure-translated="{% ftlmsg 'survey-option-unsure' %}"
-        data-survey-option-agree-translated="{% ftlmsg 'survey-option-agree' %}"
-        data-survey-option-strongly-agree-translated="{% ftlmsg 'survey-option-strongly-agree' %}"
-        class="micro-survey-options micro-survey-options-likert"></ul>
-      {% else %}
-        <span id="micro-survey-prompt" data-survey-type="pmf">{% ftlmsg 'survey-question-5' %}</span>
-        <ul id="micro-survey-options" 
-        data-survey-option-i-wouldnt-care-translated="{% ftlmsg 'survey-option-i-wouldnt-care' %}"
-        data-survey-option-somewhat-disappointed-translated="{% ftlmsg 'survey-option-somewhat-disappointed' %}"
-        data-survey-option-not-likely-translated="{% ftlmsg 'survey-option-very-disappointed' %}"
-        class="micro-survey-options micro-survey-options-likert"></ul>
-      {% endif %}
-      {% endcomment %}
-    </div>
+    </aside>
   {% endif %}
 
   <div class="header-top">

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -193,16 +193,21 @@ function analyticsSurveyLogic() {
     }
   }
 
+  function getExpirationDateForCookie(daysFromNow) {
+    const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
+    const date = new Date();
+    date.setTime(date.getTime() + daysFromNow * oneDayInMilliseconds);
+    return date.toUTCString();
+  }
+
   const setCsatCookie = () => {
     const dismissCookieId = csatWrapperEl?.dataset.cookieId ?? "";
-    const expiresIn = dismissCookieId.indexOf("90days") !== -1
+    const expiresOn = dismissCookieId.indexOf("90days") !== -1
       // Repeat the last (90days) survey every 3 months
-      ? 90*24*60*60*1000
+      ? getExpirationDateForCookie(90)
       // Don't show the other surveys again:
-      : 1000*24*60*60*1000;
-    const date = new Date();
-    date.setTime(date.getTime() + expiresIn)
-    document.cookie = `${dismissCookieId}=${Date.now()}; expires=` + date.toUTCString() + "; path=/";
+      : getExpirationDateForCookie(1000);
+    document.cookie = `${dismissCookieId}=${Date.now()}; expires=${expiresOn}; path=/`;
   };
   csatAnswerEls.forEach(answerElement => {
     answerElement.addEventListener("click", (event) => {

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -155,6 +155,22 @@ function analyticsSurveyLogic() {
       "Very Satisfied": "https://survey.alchemer.com/s3/6665054/a957749b3de6",
     },
   };
+
+  function getNumericValueOfSatisfaction(satisfaction) {
+    switch (satisfaction) {
+      case "Very Dissatisfied":
+        return 1;
+      case "Dissatisfied":
+        return 2;
+      case "Neutral":
+        return 3;
+      case "Satisfied":
+        return 4;
+      case "Very Satisfied":
+        return 5;
+    }
+  }
+
   const setCsatCookie = () => {
     const dismissCookieId = csatWrapperEl?.dataset.cookieId ?? "";
     const expiresIn = dismissCookieId.indexOf("90days") !== -1
@@ -168,7 +184,14 @@ function analyticsSurveyLogic() {
   };
   csatAnswerEls.forEach(answerElement => {
     answerElement.addEventListener("click", (event) => {
-      ga("send", "event", "CSAT Survey", "submitted", event.target.dataset.satisfaction);
+      ga(
+        "send",
+        "event",
+        "CSAT Survey",
+        "submitted",
+        event.target.dataset.satisfaction,
+        getNumericValueOfSatisfaction(event.target.dataset.satisfaction),
+      );
       csatFollowupLinkEl.href = surveyLinks[csatWrapperEl.dataset.hasPremium === "True" ? "premium" : "free"][event.target.dataset.satisfaction];
       csatQuestionEl.classList.add("is-hidden");
       csatFollowupEl.classList.remove("is-hidden");

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -170,6 +170,28 @@ function analyticsSurveyLogic() {
         return 5;
     }
   }
+  function getCategoryOfSatisfaction(satisfaction) {
+    switch (satisfaction) {
+      case "Very Dissatisfied":
+      case "Dissatisfied":
+        return "Dissatisfied";
+      case "Neutral":
+        return "Neutral";
+      case "Satisfied":
+      case "Very Satisfied":
+        return "Satisfied";
+    }
+  }
+  function getNumericValueOfCategoryOfSatisfaction(satisfactionCategory) {
+    switch (satisfactionCategory) {
+      case "Dissatisfied":
+        return -1;
+      case "Neutral":
+        return 0;
+      case "Satisfied":
+        return 1;
+    }
+  }
 
   const setCsatCookie = () => {
     const dismissCookieId = csatWrapperEl?.dataset.cookieId ?? "";
@@ -191,6 +213,24 @@ function analyticsSurveyLogic() {
         "submitted",
         event.target.dataset.satisfaction,
         getNumericValueOfSatisfaction(event.target.dataset.satisfaction),
+        {
+          // Custom dimension 3 in Google Analytics is "CSAT Category",
+          // i.e. "Dissatisfied", "Neutral" or "Satisfied"
+          dimension3: getCategoryOfSatisfaction(event.target.dataset.satisfaction),
+          // Custom dimension 4 in Google Analytics is "CSAT Survey Rating",
+          // i.e. "Very Dissatisfied", "Dissatisfied", "Neutral", "Satisfied" or "Very Satisfied"
+          dimension4: event.target.dataset.satisfaction,
+          // Metric 10 in Google Analytics is "CSAT Survey Count",
+          // i.e. it tracks how many people have completed the CSAT survey:
+          metric10: 1,
+          // Metric 11 in Google Analytics is "CSAT Survey Rating",
+          // i.e. it tracks which answer survey takers gave ("Very Dissatisfied",
+          // "Dissatisfied", "Neutral", "Satisfied" or "Very Satisfied")
+          metric11: getNumericValueOfSatisfaction(event.target.dataset.satisfaction),
+          // Metric 12 in Google Analytics is "CSAT Satisfaction Value",
+          // i.e. it tracks where users are Satisfied, Neutral or Dissatisfied:
+          metric12: getNumericValueOfCategoryOfSatisfaction(getCategoryOfSatisfaction(event.target.dataset.satisfaction)),
+        }
       );
       csatFollowupLinkEl.href = surveyLinks[csatWrapperEl.dataset.hasPremium === "True" ? "premium" : "free"][event.target.dataset.satisfaction];
       csatQuestionEl.classList.add("is-hidden");

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -157,8 +157,8 @@ function analyticsSurveyLogic() {
   };
   const setCsatCookie = () => {
     const dismissCookieId = csatWrapperEl?.dataset.cookieId ?? "";
-    const expiresIn = dismissCookieId.indexOf("3month") !== -1
-      // Repeat the last (3-month) survey every 3 months
+    const expiresIn = dismissCookieId.indexOf("90days") !== -1
+      // Repeat the last (90days) survey every 3 months
       ? 30*24*60*60*1000
       // Don't show the other surveys again:
       : 1000*24*60*60*1000;

--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -197,7 +197,7 @@ function analyticsSurveyLogic() {
     const dismissCookieId = csatWrapperEl?.dataset.cookieId ?? "";
     const expiresIn = dismissCookieId.indexOf("90days") !== -1
       // Repeat the last (90days) survey every 3 months
-      ? 30*24*60*60*1000
+      ? 90*24*60*60*1000
       // Don't show the other surveys again:
       : 1000*24*60*60*1000;
     const date = new Date();

--- a/static/scss/partials/header.scss
+++ b/static/scss/partials/header.scss
@@ -433,3 +433,94 @@ header {
         margin-right: $spacing-sm;
     }
 }
+
+.c-csat-wrapper {
+    display: none;
+    padding: $spacing-md 0;
+    background-color: $color-purple-90;
+    color: $color-white;
+    position: relative;
+    text-align: center;
+
+    & > div {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: space-around;
+        gap: $spacing-sm;
+        width: 100%;
+    }
+
+    @media screen and #{$mq-md} {
+        display: flex;
+    }
+
+    .is-hidden {
+        display: none;
+    }
+
+    .c-csat-dismiss-button {
+        position: absolute;
+        top: 50%;
+        right: $spacing-md;
+        background-color: transparent;
+        border-style: none;
+        color: $color-white;
+        width: 30px;
+        height: 30px;
+        transform: translateY(-50%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: $border-radius-sm;
+        cursor: pointer;
+        fill: $color-white;
+
+        &:hover {
+            background-color: $color-blue-50;
+        }
+    }
+
+    .c-csat-prompt {
+
+        a, a:visited {
+            text-decoration: underline;
+            color: $color-white;
+
+            &:hover {
+                text-decoration: none;
+            }
+        }
+    }
+
+    .c-csat-answers {
+        display: flex;
+        align-items: center;
+        justify-content: space-around;
+        gap: $spacing-md;
+
+        ol {
+            display: flex;
+            gap: $spacing-md;
+            list-style-type: none;
+        }
+
+        button {
+            border-radius: $border-radius-sm;
+            background-color: $color-violet-40;
+            color: $color-white;
+            transition: background-color .1s ease-out;
+            border-style: none;
+            padding: $spacing-sm;
+            height: 2.5rem;
+            text-align: center;
+            cursor: pointer;
+            // Override the font-size set on all buttons in main.scss
+            font-size: initial;
+
+            &:hover {
+                background-color: $color-blue-50;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# New feature description

Adds a CSAT survey for people with their browser language set to English, French or German, displaying after they've created an account/upgraded to Premium 1 week ago, 1 month ago, 3 months ago, and every three months after that.

# Screenshot (if applicable)

https://user-images.githubusercontent.com/4251/151172798-c40cb992-704a-4101-be61-c8d25ac4c81b.mp4

# How to test

- Set your browser language to English, French or German.
- Make sure Google Analytics is turned on, i.e. no adblockers, no DoNotTrack.
- Sign in with a free account, and make sure the `first_visit` cookie is set to a value more than seven days ago.
- You should see the survey at the top.
- Sign in with a Premium account, make sure the `date_subscribed` value in their profile is set to a value more than seven days ago.
- The survey should no longer show up if you answered it (after a refresh), or clicked the `X`.
- If setting `first_visit`/`date_subscribed` to a value more than 1 or 3 months ago, the survey should appear again until the next dismissal.

# Checklist

- [ ] l10n dependencies have been merged, if any. - Not yet, PR is https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/57
- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
