### PR TITLE
Disable the interview recruitment banner

### DIFF
--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -11,7 +11,7 @@
     {% include "includes/vpn-promo-banner.html" %}
   {% endif %}
 
-  {% if settings.RECRUITMENT_BANNER_LINK and LANGUAGE_CODE|slice:"0:2" == "en" and country_code == "us" and not request.user.is_anonymous %}
+  {% if settings.RECRUITMENT_BANNER_LINK and LANGUAGE_CODE|slice:"0:2" == "en" and country_code == "us" and not request.user.is_anonymous and not "Disabled while we figure out why this is shown to anonymous users as well." %}
     <div class="recruitment-banner">
       <a id="recruitment-banner" class="text-link" href="{{ settings.RECRUITMENT_BANNER_LINK }}" target="_blank" rel="noopener noreferrer" data-ga="send-ga-pings" data-event-category="Recruitment" data-event-label="{{ settings.RECRUITMENT_BANNER_TEXT }}">{{ settings.RECRUITMENT_BANNER_TEXT }}</a>
       <button id="recruitment-dismiss" class="dismiss-btn">


### PR DESCRIPTION
It is apparently showing up for people who are not logged in, and
I don't know why. Until we have that figured out, we're disabling
this banner.

How to test: You should no longer get the interview recruitment banner, even if you're in the US, with your browser language set to `en-US`, the `RECRUITMENT_BANNER_LINK` and `-_TEXT` environment variables set, and no `recruited` cookie set.

- [x] l10n dependencies have been merged, if any.
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
