### PR TITLE
Allow posting to /profile/subdomain as an API

### DIFF
--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -150,7 +150,7 @@ def profile_refresh(request):
     return JsonResponse({})
 
 
-@api_view()
+@api_view(['POST', 'GET'])
 @require_http_methods(['POST', 'GET'])
 def profile_subdomain(request):
     if (not request.user or request.user.is_anonymous):

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -4,7 +4,7 @@ function apiRequest(path, options) {
     const cookieStringArray = cookieString
         .split(";")
         .map(individualCookieString => individualCookieString.split("="))
-        .map(([cookieKey, cookieValue]) => [cookieKey.trim(), cookieValue.trim()]);
+        .map(([cookieKey, cookieValue]) => [cookieKey?.trim(), cookieValue?.trim()]);
     // Looks like the `argsIgnorePattern` option for ESLint doesn't like array destructuring:
     // eslint-disable-next-line no-unused-vars
     const [_csrfCookieKey, csrfCookieValue] = cookieStringArray.find(([cookieKey, _cookieValue]) => cookieKey === "csrftoken");
@@ -43,7 +43,7 @@ async function postProfileSubdomain( { domain }){
     const cookieStringArray = cookieString
         .split(";")
         .map(individualCookieString => individualCookieString.split("="))
-        .map(([cookieKey, cookieValue]) => [cookieKey.trim(), cookieValue.trim()]);
+        .map(([cookieKey, cookieValue]) => [cookieKey?.trim(), cookieValue?.trim()]);
         
     // Looks like the `argsIgnorePattern` option for ESLint doesn't like array destructuring:
     // eslint-disable-next-line no-unused-vars

--- a/static/js/labels.js
+++ b/static/js/labels.js
@@ -20,7 +20,7 @@
         const cookieStringArray = cookieString
             .split(";")
             .map(individualCookieString => individualCookieString.split("="))
-            .map(([cookieKey, cookieValue]) => [cookieKey.trim(), cookieValue.trim()]);
+            .map(([cookieKey, cookieValue]) => [cookieKey?.trim(), cookieValue?.trim()]);
         // Looks like the `argsIgnorePattern` option for ESLint doesn't like array destructuring:
         // eslint-disable-next-line no-unused-vars
         const [_csrfCookieKey, csrfCookieValue] = cookieStringArray.find(([cookieKey, _cookieValue]) => cookieKey === "csrftoken");


### PR DESCRIPTION
This PR fixes #1501.

How to test: try to register a new subdomain using the banner in the dashboard. Before this fix, clicking "Register Domain" didn't do anything other than log that `POST` was not allowed. It should now work.

- [x] l10n dependencies have been merged, if any.
- [ ] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure). - I think that's not applicable here?
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
