### PR TITLE
Add placeholder for custom aliases

### DIFF
--- a/privaterelay/templates/includes/modal-custom-alias-picker.html
+++ b/privaterelay/templates/includes/modal-custom-alias-picker.html
@@ -22,7 +22,14 @@
           <label for="customAliasPrefix" class="mzp-u-inline">
             {% ftlmsg 'modal-custom-alias-picker-form-prefix-label' subdomain='' %}
           </label>
-          <input required type="text" name="customAliasPrefix" id="customAliasPrefix" autofocus>
+          <input
+            required
+            autofocus
+            placeholder="{% ftlmsg 'modal-custom-alias-picker-form-prefix-placeholder' %}"
+            type="text"
+            name="customAliasPrefix"
+            id="customAliasPrefix"
+          >
         </div>
         <span class="t-custom-alias-suffix">@<b>{{ user_profile.subdomain }}</b>.{{ MOZMAIL_DOMAIN }}</span>
       </div>


### PR DESCRIPTION
This PR fixes #1505.

How to test: when logged in as a Premium user with a custom subdomain, generate a new custom alias via the "Generate new alias" menu. When the input field is not focused, you should see an example of the alias you could create.

- [x] l10n dependencies have been merged, if any.
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
