### PR TITLE
Try other mechanism for detecting authn'd users

### DIFF
--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -11,7 +11,7 @@
     {% include "includes/vpn-promo-banner.html" %}
   {% endif %}
 
-  {% if settings.RECRUITMENT_BANNER_LINK and LANGUAGE_CODE|slice:"0:2" == "en" and country_code == "us" and not request.user.is_anonymous and not "Disabled while we figure out why this is shown to anonymous users as well." %}
+  {% if settings.RECRUITMENT_BANNER_LINK and LANGUAGE_CODE|slice:"0:2" == "en" and country_code == "us" and request.user.is_authenticated %}
     <div class="recruitment-banner">
       <a id="recruitment-banner" class="text-link" href="{{ settings.RECRUITMENT_BANNER_LINK }}" target="_blank" rel="noopener noreferrer" data-ga="send-ga-pings" data-event-category="Recruitment" data-event-label="{{ settings.RECRUITMENT_BANNER_TEXT }}">{{ settings.RECRUITMENT_BANNER_TEXT }}</a>
       <button id="recruitment-dismiss" class="dismiss-btn">


### PR DESCRIPTION
Supposedly the former mechanism still resulted in the interview
recruitment banner being shown to people who weren't logged in.
Since the Django docs recommend using is_authenticated rather than
is_anonymous [1], possibly that resolves the issue. (Unfortunately
I can't test myself since I'm not in the US.)

[1] https://docs.djangoproject.com/en/2.2/ref/contrib/auth/#django.contrib.auth.models.User.is_anonymous

@maxxcrawford I'll need you to test this once this is on stage, since you're the only one who has seen the problem so far, if that's OK :) 

But **do not merge until after the next production release**. We can only test this in stage (with proper country detection), and we wouldn't want to deploy it to production if it turns out not to work.

How to test:

1. Make sure this is deployed to stage.
2. Be in the US, and have your browser language set to English.
3. If logged in on stage, you should see the interview recruitment banner.
4. If logged out (i.e. on the homepage), you should not see it.

- [x] l10n dependencies have been merged, if any.
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
