### PR TITLE
Fix #1461 - Update UI of subdomain onboarding module

### DIFF
--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -59,8 +59,11 @@
                         {% endif %}
                         
                         <div class="c-premium-onboarding-action-completed {% if user_profile.subdomain %} is-visible {% endif %}">
-                            <img class="margin-right" src="/static/images/icon-check.svg" alt="">
-                            <samp class="js-premium-onboarding-domain-registration-preview">{{ user_profile.custom_domain }}</samp>
+                            <div class="c-premium-onboarding-subdomain-set-module">
+                                <p class="c-premium-onboarding-label">{% ftlmsg 'profile-label-domain' %}</p>
+                                <p class="c-premium-onboarding-subdomain">@{{ user_profile.subdomain }}</p>
+                                <span class="c-premium-onboarding-mozmail">.mozmail.com</span>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -61,7 +61,7 @@
                         <div class="c-premium-onboarding-action-completed {% if user_profile.subdomain %} is-visible {% endif %}">
                             <div class="c-premium-onboarding-subdomain-set-module">
                                 <p class="c-premium-onboarding-label">{% ftlmsg 'profile-label-domain' %}</p>
-                                <p class="c-premium-onboarding-subdomain">@{{ user_profile.subdomain }}</p>
+                                <span>@</span><p class="c-premium-onboarding-subdomain js-premium-onboarding-domain-registration-preview">{{ user_profile.subdomain }}</p>
                                 <span class="c-premium-onboarding-mozmail">.mozmail.com</span>
                             </div>
                         </div>

--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -61,7 +61,7 @@
                         <div class="c-premium-onboarding-action-completed {% if user_profile.subdomain %} is-visible {% endif %}">
                             <div class="c-premium-onboarding-subdomain-set-module">
                                 <p class="c-premium-onboarding-label">{% ftlmsg 'profile-label-domain' %}</p>
-                                <span>@</span><p class="c-premium-onboarding-subdomain js-premium-onboarding-domain-registration-preview">{{ user_profile.subdomain }}</p>
+                                <p class="c-premium-onboarding-subdomain js-premium-onboarding-domain-registration-preview">{{ user_profile.subdomain }}</p>
                                 <span class="c-premium-onboarding-mozmail">.mozmail.com</span>
                             </div>
                         </div>

--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -40,8 +40,8 @@
                         {% if not user_profile.subdomain %}
                             <div class="js-premium-onboarding-domain-registration-form">
                                 <p>{% ftlmsg 'multi-part-onboarding-premium-domain-cta' %}</p>
-                                <samp>***@<span>{% ftlmsg 'banner-register-subdomain-example-address' %}</span>.mozmail.com</samp>
-                                <form id="onboardingDomainRegistration" class="c-premium-onboarding-domain-registration-form" method="post" action="{% url 'profile_subdomain' %}">
+                                <samp class="c-premium-onboarding-subdomain-registration">***@<span>{% ftlmsg 'banner-register-subdomain-example-address' %}</span>.mozmail.com</samp>
+                                <form id="onboardingDomainRegistration" method="post" action="{% url 'profile_subdomain' %}">
                                     {% csrf_token %}
                                     <input
                                     class="js-subdomain-value subdomain-banner-input"
@@ -61,7 +61,7 @@
                         <div class="c-premium-onboarding-action-completed {% if user_profile.subdomain %} is-visible {% endif %}">
                             <div class="c-premium-onboarding-subdomain-set-module">
                                 <p class="c-premium-onboarding-label">{% ftlmsg 'profile-label-domain' %}</p>
-                                <p class="c-premium-onboarding-subdomain js-premium-onboarding-domain-registration-preview">{{ user_profile.subdomain }}</p>
+                                <samp class="c-premium-onboarding-subdomain">@<span class="js-premium-onboarding-domain-registration-preview">{{ user_profile.subdomain }}</span></samp>
                                 <span class="c-premium-onboarding-mozmail">.mozmail.com</span>
                             </div>
                         </div>

--- a/static/js/domain-registration.js
+++ b/static/js/domain-registration.js
@@ -187,10 +187,6 @@
                 const modalRegistrationSuccessState = document.querySelector(".js-domain-registration-success");
                 modalRegistrationForm.classList.add("is-hidden");
                 modalRegistrationSuccessState.classList.remove("is-hidden");
-
-                const domainPreview = document.querySelector(".js-premium-onboarding-domain-registration-preview");
-                domainPreview.textContent = domain + ".mozmail.com";
-
                 const modalContinue = document.querySelector(".js-modal-domain-registration-continue");
 
                 if (form === "onboarding") {

--- a/static/js/domain-registration.js
+++ b/static/js/domain-registration.js
@@ -174,23 +174,20 @@
                 
                 switch (e.target.parentFormHTMLElement.id) {
                     case "domainRegistration":
-                        domainRegistration.modal.showSuccessState(e.target.parentFormRequestedDomain,{ "form": "dashboard" });
+                        domainRegistration.modal.showSuccessState({ "form": "dashboard" });
                         break;
                     case "onboardingDomainRegistration":
-                        domainRegistration.modal.showSuccessState(e.target.parentFormRequestedDomain, { "form": "onboarding" });
+                        domainRegistration.modal.showSuccessState({ "form": "onboarding" });
                         break;
                 }
                 
             },
-            showSuccessState: (domain, {form})=> {
+            showSuccessState: ({form})=> {
                 const modalRegistrationForm = document.querySelector(".js-domain-registration-form");
                 const modalRegistrationSuccessState = document.querySelector(".js-domain-registration-success");
                 modalRegistrationForm.classList.add("is-hidden");
                 modalRegistrationSuccessState.classList.remove("is-hidden");
 
-                const domainPreview = document.querySelector(".js-premium-onboarding-domain-registration-preview");
-                domainPreview.textContent = domain + ".mozmail.com";
-                
                 const modalContinue = document.querySelector(".js-modal-domain-registration-continue");
 
                 if (form === "onboarding") {

--- a/static/js/domain-registration.js
+++ b/static/js/domain-registration.js
@@ -187,6 +187,10 @@
                 const modalRegistrationSuccessState = document.querySelector(".js-domain-registration-success");
                 modalRegistrationForm.classList.add("is-hidden");
                 modalRegistrationSuccessState.classList.remove("is-hidden");
+
+                const domainPreview = document.querySelector(".js-premium-onboarding-domain-registration-preview");
+                domainPreview.textContent = domain + ".mozmail.com";
+                
                 const modalContinue = document.querySelector(".js-modal-domain-registration-continue");
 
                 if (form === "onboarding") {

--- a/static/js/domain-registration.js
+++ b/static/js/domain-registration.js
@@ -174,19 +174,22 @@
                 
                 switch (e.target.parentFormHTMLElement.id) {
                     case "domainRegistration":
-                        domainRegistration.modal.showSuccessState({ "form": "dashboard" });
+                        domainRegistration.modal.showSuccessState(e.target.parentFormRequestedDomain, { "form": "dashboard" });
                         break;
                     case "onboardingDomainRegistration":
-                        domainRegistration.modal.showSuccessState({ "form": "onboarding" });
+                        domainRegistration.modal.showSuccessState(e.target.parentFormRequestedDomain, { "form": "onboarding" });
                         break;
                 }
                 
             },
-            showSuccessState: ({form})=> {
+            showSuccessState: (domain, {form})=> {
                 const modalRegistrationForm = document.querySelector(".js-domain-registration-form");
                 const modalRegistrationSuccessState = document.querySelector(".js-domain-registration-success");
                 modalRegistrationForm.classList.add("is-hidden");
                 modalRegistrationSuccessState.classList.remove("is-hidden");
+
+                const domainPreview = document.querySelector(".js-premium-onboarding-domain-registration-preview");
+                domainPreview.textContent = domain;
 
                 const modalContinue = document.querySelector(".js-modal-domain-registration-continue");
 

--- a/static/js/domain-registration.js
+++ b/static/js/domain-registration.js
@@ -189,7 +189,7 @@
                 modalRegistrationSuccessState.classList.remove("is-hidden");
 
                 const domainPreview = document.querySelector(".js-premium-onboarding-domain-registration-preview");
-                domainPreview.textContent = "@" + domain;
+                domainPreview.textContent = domain;
 
                 const modalContinue = document.querySelector(".js-modal-domain-registration-continue");
 

--- a/static/js/domain-registration.js
+++ b/static/js/domain-registration.js
@@ -189,7 +189,7 @@
                 modalRegistrationSuccessState.classList.remove("is-hidden");
 
                 const domainPreview = document.querySelector(".js-premium-onboarding-domain-registration-preview");
-                domainPreview.textContent = domain;
+                domainPreview.textContent = "@" + domain;
 
                 const modalContinue = document.querySelector(".js-modal-domain-registration-continue");
 

--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -406,29 +406,57 @@ firefox-private-relay-addon[data-addon-installed="true"] + firefox-private-relay
 }
 
 .c-premium-onboarding-action-completed {
-    padding: $spacing-md;
+    padding: $spacing-lg;
     padding-inline-end: $spacing-lg;
     background-color: $color-white;
     display: none;
     align-items: center;
     border-radius: $border-radius-md;
-    width: auto;
+    width: 100%;
 
-    samp {
-        margin-bottom: 0;
-        color: $color-informational;
-        max-width: 100%;
-        word-break: break-all;
-
-        @include text-title-3xs;
+    @media #{$mq-md} {
+        width: auto;
     }
 
     &.is-visible {
         display: inline-flex;
     }
 
-    img {
-        margin-right: $spacing-sm;
+    p {
+        margin: 0;
+    }
+
+    .c-premium-onboarding-subdomain-set-module {
+        font-family: $font-stack-firefox;
+        text-align: center;
+        font-weight: 600;
+        margin: 0 auto;
+    }
+
+    .c-premium-onboarding-label {
+        color: $color-dark-gray-05;
+    }
+
+    .c-premium-onboarding-label::before {
+        width: $layout-2xs;
+        height: $layout-2xs;
+        display: inline-block;
+        content: "";
+        background-image: url("/static/images/icon-check.svg");
+        background-repeat: no-repeat;
+        background-position: center center;
+        padding-right:$spacing-sm;
+    }
+
+    .c-premium-onboarding-subdomain {
+        @include text-body-lg;
+        font-weight: bold;
+        color: $color-purple-50;
+    }
+
+    .c-premium-onboarding-mozmail {
+        @include text-body-sm;
+        color: $color-light-gray-90;
     }
 }
 

--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -445,7 +445,7 @@ firefox-private-relay-addon[data-addon-installed="true"] + firefox-private-relay
         background-image: url("/static/images/icon-check.svg");
         background-repeat: no-repeat;
         background-position: center center;
-        padding-right:$spacing-sm;
+        padding-right: $spacing-sm;
     }
 
     .c-premium-onboarding-subdomain {

--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -48,7 +48,7 @@
     &::after {
         content: attr(data-number);
         display: block;
-        font-weight: bold;
+        font-weight: 700;
         font-size: 1rem;
         text-align: center;
         color: $color-light-gray-70;
@@ -450,7 +450,7 @@ firefox-private-relay-addon[data-addon-installed="true"] + firefox-private-relay
 
     .c-premium-onboarding-subdomain {
         @include text-body-lg;
-        font-weight: bold;
+        font-weight: 700;
         color: $color-purple-50;
     }
 

--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -282,7 +282,7 @@
 // Step 2: Register custom subdomain 
 .c-premium-onboarding-step-2 {
 
-    samp {
+    .c-premium-onboarding-subdomain-registration {
         @include text-title-2xs;
         display: block;
         color: $color-grey-30;
@@ -428,6 +428,7 @@ firefox-private-relay-addon[data-addon-installed="true"] + firefox-private-relay
 
     .c-premium-onboarding-subdomain-set-module {
         font-family: $font-stack-firefox;
+        display: grid;
         text-align: center;
         font-weight: 600;
         margin: 0 auto;
@@ -450,6 +451,8 @@ firefox-private-relay-addon[data-addon-installed="true"] + firefox-private-relay
 
     .c-premium-onboarding-subdomain {
         @include text-body-lg;
+        font-family: $font-stack-firefox;
+        word-break: break-word;
         font-weight: 700;
         color: $color-purple-50;
     }

--- a/static/scss/partials/vpn-promo.scss
+++ b/static/scss/partials/vpn-promo.scss
@@ -70,7 +70,7 @@
     cursor: pointer;
     display: inline-block;
     font-size: 1.125rem;
-    font-weight: bold;
+    font-weight: 700;
     line-height: 1.5rem;
     padding: $spacing-sm $spacing-md;
     margin-bottom: $spacing-md;


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #1461.

<!-- When adding a new feature: -->

# New feature description

This updates the design of the subdomain module on the premium onboarding flow for users who already have a pre-existing subdomain.


# Screenshot (if applicable)

Mobile view: 
<img width="412" alt="image" src="https://user-images.githubusercontent.com/13066134/151852990-36d66ce5-6dff-4a5c-b17e-be379c8eface.png">

Desktop view:
<img width="998" alt="image" src="https://user-images.githubusercontent.com/13066134/151853017-219bc54c-f98a-4a56-92eb-c8550328e896.png">


# How to test

Have an with a premium account with a subdomain set, on the inspect tool turn off the `display: none` property on `.c-multipart-premium-onboarding` and `.c-premium-onboarding-step`.

# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
