### PR TITLE
Fix #1459 - Update UI of second onboarding step

### DIFF
--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -41,7 +41,7 @@
                             <div class="js-premium-onboarding-domain-registration-form">
                                 <p>{% ftlmsg 'multi-part-onboarding-premium-domain-cta' %}</p>
                                 <samp>***@<span>{% ftlmsg 'banner-register-subdomain-example-address' %}</span>.mozmail.com</samp>
-                                <form id="onboardingDomainRegistration" method="post" action="{% url 'profile_subdomain' %}">
+                                <form id="onboardingDomainRegistration" class="c-premium-onboarding-domain-registration-form" method="post" action="{% url 'profile_subdomain' %}">
                                     {% csrf_token %}
                                     <input
                                     class="js-subdomain-value subdomain-banner-input"
@@ -53,7 +53,7 @@
                                     minlength="1"
                                     maxlength="63"
                                     >
-                                    <input class="mzp-c-button mzp-t-product" type="submit" value="{% ftlmsg 'banner-register-subdomain-button-search' %}">
+                                    <input class="mzp-c-button mzp-t-product" type="submit" value="{% ftlmsg 'multi-part-onboarding-premium-get-domain' %}">
                                 </form>
                             </div>
                         {% endif %}

--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -301,6 +301,19 @@
             @include text-title-2xs;
         }
     }
+
+    .c-premium-onboarding-domain-registration-form {
+        display: flex;
+        flex-direction: column;
+
+        @media #{$mq-md} {
+            display: inline;
+        }
+    }
+
+    .subdomain-banner-input {
+        margin-bottom: $spacing-md;
+    }
 }
 
 // Step 3: Install add-on


### PR DESCRIPTION

This PR fixes #1459.

<!-- When adding a new feature: -->

# New feature description

 Updates the second step of premium onboarding:
1) changing the string of the `Search` button to `Get a custom domain`
2) Form field spans full width on mobile

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/13066134/152213510-869e8863-6e7e-4cc2-98e7-7419b04084ea.png)



# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
