### PR TITLE
check request.path is on profile to show recruitment

### DIFF
--- a/privaterelay/templates/includes/header.html
+++ b/privaterelay/templates/includes/header.html
@@ -11,7 +11,7 @@
     {% include "includes/vpn-promo-banner.html" %}
   {% endif %}
 
-  {% if settings.RECRUITMENT_BANNER_LINK and LANGUAGE_CODE|slice:"0:2" == "en" and country_code == "us" and request.user.is_authenticated %}
+  {% if settings.RECRUITMENT_BANNER_LINK and LANGUAGE_CODE|slice:"0:2" == "en" and country_code == "us" and '/accounts/profile' in request.path %}
     <div class="recruitment-banner">
       <a id="recruitment-banner" class="text-link" href="{{ settings.RECRUITMENT_BANNER_LINK }}" target="_blank" rel="noopener noreferrer" data-ga="send-ga-pings" data-event-category="Recruitment" data-event-label="{{ settings.RECRUITMENT_BANNER_TEXT }}">{{ settings.RECRUITMENT_BANNER_TEXT }}</a>
       <button id="recruitment-dismiss" class="dismiss-btn">


### PR DESCRIPTION
How to test:
1. Make sure you DO have values for `RECRUITMENT_BANNER_TEXT` and `RECRUITMENT_BANNER_LINK` env vars
2. Make sure you do NOT have a `recruited` cookie for 127.0.0.1:8000
3. Go to http://127.0.0.1:8000
   * [ ] Verify you do NOT see the recruitment banner
4. Go to http://127.0.0.1:8000/accounts/profile/
   * Note: you will need to sign in
   * [ ] Verify you DO see the recruitment banner


- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).