### PR TITLE
Fix #1459 - Update UI of second onboarding step V2

### DIFF
--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -41,10 +41,10 @@
                             <div class="js-premium-onboarding-domain-registration-form">
                                 <p>{% ftlmsg 'multi-part-onboarding-premium-domain-cta' %}</p>
                                 <samp class="c-premium-onboarding-subdomain-registration">***@<span>{% ftlmsg 'banner-register-subdomain-example-address' %}</span>.mozmail.com</samp>
-                                <form id="onboardingDomainRegistration" method="post" action="{% url 'profile_subdomain' %}">
+                                <form class="c-premium-onboarding-domain-registration-form" id="onboardingDomainRegistration" method="post" action="{% url 'profile_subdomain' %}">
                                     {% csrf_token %}
                                     <input
-                                    class="js-subdomain-value subdomain-banner-input"
+                                    class="js-subdomain-value subdomain-banner-input subdomain-search-icon"
                                     data-domain="{{ MOZMAIL_DOMAIN }}"
                                     required
                                     type="text"

--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -36,7 +36,7 @@
                     </div>
                     <div class="c-premium-onboarding-content-description">
                         <p class="c-premium-onboarding-detail">{% ftlmsg 'onboarding-premium-title-detail' %}</p>
-                        <p><strong>{% ftlmsg 'onboarding-premium-domain-title' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-get-domain-description-2' mozmail='.mozmail.com' %}
+                        <p><strong>Use a custom domain for sharing aliases:</strong> {% ftlmsg 'multi-part-onboarding-premium-get-domain-description-2' mozmail='.mozmail.com' %}
                         {% if not user_profile.subdomain %}
                             <div class="js-premium-onboarding-domain-registration-form">
                                 <p>{% ftlmsg 'multi-part-onboarding-premium-domain-cta' %}</p>
@@ -48,7 +48,7 @@
                                     data-domain="{{ MOZMAIL_DOMAIN }}"
                                     required
                                     type="text"
-                                    placeholder="{% ftlmsg 'banner-choose-subdomain-input-placeholder' %}"
+                                    placeholder="Search your new domain"
                                     name="subdomain"
                                     minlength="1"
                                     maxlength="63"

--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -36,7 +36,7 @@
                     </div>
                     <div class="c-premium-onboarding-content-description">
                         <p class="c-premium-onboarding-detail">{% ftlmsg 'onboarding-premium-title-detail' %}</p>
-                        <p><strong>Use a custom domain for sharing aliases:</strong> {% ftlmsg 'multi-part-onboarding-premium-get-domain-description-2' mozmail='.mozmail.com' %}
+                        <p><strong>{% ftlmsg 'onboarding-premium-domain-title-2' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-get-domain-description-2' mozmail='.mozmail.com' %}
                         {% if not user_profile.subdomain %}
                             <div class="js-premium-onboarding-domain-registration-form">
                                 <p>{% ftlmsg 'multi-part-onboarding-premium-domain-cta' %}</p>
@@ -48,7 +48,7 @@
                                     data-domain="{{ MOZMAIL_DOMAIN }}"
                                     required
                                     type="text"
-                                    placeholder="Search your new domain"
+                                    placeholder="{% ftlmsg 'banner-choose-subdomain-input-placeholder-2' %}"
                                     name="subdomain"
                                     minlength="1"
                                     maxlength="63"

--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -309,10 +309,25 @@
         @media #{$mq-md} {
             display: inline;
         }
-    }
 
-    .subdomain-banner-input {
-        margin-bottom: $spacing-md;
+        ::placeholder {
+            text-align: center;
+        }
+
+        input {
+            padding-left: $layout-sm;
+        }
+
+        .subdomain-banner-input {
+            margin-bottom: $spacing-md;
+        }
+
+        .subdomain-search-icon {
+            background-image: url("/static/images/icon-search.svg");
+            background-repeat: no-repeat;
+            background-position: $spacing-sm center;
+            background-size: 16px 16px;
+        }
     }
 }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #1459.

~~Currently blocked by localization PR: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/59~~

<!-- When adding a new feature: -->

# New feature description

- Centering placeholder text in input field
- Adding search icon to second step of premium onboarding
- Full width search CTA and input field on mobile
- Update 2 strings: `Use a custom domain for sharing aliases` to `Use a custom domain for sharing aliases:` and `Search domain` to `Search your new domain`


# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/13066134/153476443-d433d5b5-88d4-4b5e-b121-390cd7584540.png)



# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
