### PR TITLE
Also show CSAT survey to longtime Premium users

### DIFF
--- a/privaterelay/context_processors.py
+++ b/privaterelay/context_processors.py
@@ -58,8 +58,18 @@ def _get_csat_cookie_and_reason(request):
 
     reason_to_show_csat_survey = None
     csat_dismissal_cookie = ""
-    if (profile.has_premium and profile.date_subscribed):
-        days_since_subscription = (datetime.now(timezone.utc) - profile.date_subscribed).days
+    if (profile.has_premium):
+        # There are two reasons why someone might not have a subscription date set:
+        # - They subscribed before we started tracking that.
+        # - They have Premium because they have a Mozilla email address.
+        # In the latter case, their first visit date is effectively their
+        # subscription date. In the former case, they will have had Premium for
+        # a while, so they can be shown the survey too. Their first visit will
+        # have been a while ago, so we'll just use that as a proxy for the
+        # subscription date:
+        days_since_subscription = (datetime.now(timezone.utc) - datetime.fromisoformat(first_visit)).days
+        if (profile.date_subscribed):
+            days_since_subscription = (datetime.now(timezone.utc) - profile.date_subscribed).days
         if (days_since_subscription >= 3 * 30):
             csat_dismissal_cookie = f'csat-survey-premium-90days_{profile.id}_dismissed'
             if (not request.COOKIES.get(csat_dismissal_cookie)):


### PR DESCRIPTION
This PR fixes the CSAT survey not shown to users who've had Premium for so long that we didn't yet keep track of when they subscribed, and we're not tracking that for people who get it because of their email either. For them, this makes us just use the first visit date as a proxy.

How to test: Sign in with a Premium user who's `date_subscribed` is unset (on stage: whose account is from before Dec 9th, 2021), and make sure there's a `first_visit` a while in the past. Then, with your browser set to English and being in the US, you should see the CSAT survey.

- [x] l10n dependencies have been merged, if any.
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
