### PR TITLE
Add a FAQ entry on acceptable use of Relay

### DIFF
--- a/privaterelay/templates/faq.html
+++ b/privaterelay/templates/faq.html
@@ -104,6 +104,18 @@
             <h2 class="faq-headline">{% ftlmsg 'faq-question-email-storage-question' %}</h2>
             <p class="faq-answer js-set-href">{% ftlmsg 'faq-question-email-storage-answer' url='https://www.mozilla.org/privacy/firefox-relay/' attrs='class="text-link" data-url="https://www.mozilla.org/privacy/firefox-relay/"' %}</p>
           </section>
+          <section class="faq" id="faq-acceptable-use">
+            <h2 class="faq-headline">{% ftlmsg 'faq-question-acceptable-use-question' %}</h2>
+            <div class="faq-answer js-set-href">
+              <p>{% ftlmsg 'faq-question-acceptable-use-answer-a-html' url='https://www.mozilla.org/about/legal/acceptable-use/' attrs='class="text-link" data-url="https://www.mozilla.org/about/legal/acceptable-use/"' %}</p>
+              <ul>
+                <li>{% ftlmsg 'faq-question-acceptable-use-answer-measure-account' %}</li>
+                <li>{% ftlmsg 'faq-question-acceptable-use-answer-measure-unlimited-payment' %}</li>
+                <li>{% ftlmsg 'faq-question-acceptable-use-answer-measure-rate-limit' %}</li>
+              </ul>
+              <p>{% ftlmsg 'faq-question-acceptable-use-answer-b-html' url='https://www.mozilla.org/about/legal/terms/firefox-relay/' attrs='class="text-link" data-url="https://www.mozilla.org/about/legal/terms/firefox-relay/"' %}</p>
+            </div>
+          </section>
         </div>
       </div>
     </main>


### PR DESCRIPTION
# New feature description

An FAQ entry referencing our Acceptable Use Policy and emphasising that we take measures to prevent abuse.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/153869400-c148c72f-741f-4e6c-8543-09943a534a12.png)

# How to test

Visit the FAQ page, verify that the entry is added.

# Checklist

- [ ] l10n dependencies have been merged, if any. Not yet: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/60
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
