### PR TITLE
🔴 DNM 🔴 DO NOT MERGE - Update attachment size limit copy from 150KB to 25MB

### DIFF
--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -50,7 +50,7 @@
                       {% ftlmsg 'nav-faq' as faq_text %}
                       {% url 'faq' as faq_url %}
                       {% bold_violet_link faq_url faq_text as faq_link %}
-                      {% ftlmsg 'forwarded-email-header-attachment' faq_link=faq_link size='150' unit='KB' as forwarded_email_wrap_attachment %}
+                      {% ftlmsg 'forwarded-email-header-attachment' faq_link=faq_link size='25' unit='MB' as forwarded_email_wrap_attachment %}
                       {{ forwarded_email_wrap_attachment|safe }}
                   {% else %}
                     {% if survey_text and survey_link %}

--- a/privaterelay/templates/faq.html
+++ b/privaterelay/templates/faq.html
@@ -24,7 +24,7 @@
               <ul>
                 <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-spam' %}</li>
                 <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-blocked' %}</li>
-                <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-size' size='150' unit='KB' %}</li>
+                <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-size' size='25' unit='MB' %}</li>
                 <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-not-accepted' %}</li>
                 <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-turned-off' %}</li>
                 <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-delay' %}</li>
@@ -87,7 +87,7 @@
           <section class="faq" id="faq-attachments">
             <h2 class="faq-headline">{% ftlmsg 'faq-question-attachments-question' %}</h2>
             <p class="faq-answer">
-              {% ftlmsg 'faq-question-attachments-answer-v2' size='150' unit='KB' %}
+              {% ftlmsg 'faq-question-attachments-answer-v2' size='25' unit='MB' %}
             </p>
           </section>
           <section class="faq" id="faq-unsubscribe-domain">

--- a/privaterelay/templates/includes/alias-stats.html
+++ b/privaterelay/templates/includes/alias-stats.html
@@ -14,7 +14,7 @@
   <span class="forwarding-description stat-description">
     {% ftlmsg 'profile-forwarded-copy' %}
     <p>
-      <strong>{% ftlmsg 'profile-forwarded-note' %}</strong> {% ftlmsg 'profile-forwarded-note-copy' size='150' unit='KB' %}
+      <strong>{% ftlmsg 'profile-forwarded-note' %}</strong> {% ftlmsg 'profile-forwarded-note-copy' size='25' unit='MB' %}
     </p>
   </span>
 </div>

--- a/privaterelay/templates/profile.html
+++ b/privaterelay/templates/profile.html
@@ -134,7 +134,7 @@
       {% endfor %}
 
       <div> <!-- informtaion footer -->
-        {% ftlmsg 'profile-supports-email-forwarding' size='150' unit='KB' %}
+        {% ftlmsg 'profile-supports-email-forwarding' size='25' unit='MB' %}
       </div> <!-- end informtaion footer -->
       
     </div><!-- end dashboard-container -->


### PR DESCRIPTION
<!-- When adding a new feature: -->

**Under FAQ: “I’m not getting messages from my aliases.”:**

Changed “The email forwarded has an attachment larger than ⁨⁨150⁩ ⁨KB⁩⁩” to “The email forwarded has an attachment larger than ⁨⁨25 MB.”

Under FAQ: Will ⁨Firefox Relay⁩ forward emails with attachments?**
- Changed “We now support attachment forwarding. However, there is a ⁨⁨150⁩ ⁨KB⁩⁩ limit for email forwarding using ⁨Relay⁩. Any emails larger than ⁨⁨150⁩ ⁨KB⁩⁩ will not be forwarded.” to “We now support attachment forwarding. However, there is a ⁨⁨25 MB⁩⁩ limit for email forwarding using ⁨Relay⁩. Any emails larger than ⁨⁨25 MB⁩⁩ will not be forwarded.”

**Under relay dashboard:**

Changed “⁨Firefox Relay⁩ supports email forwarding (including attachments) of email up to ⁨⁨150⁩ ⁨KB⁩⁩ in size” to “⁨Firefox Relay⁩ supports email forwarding (including attachments) of email up to ⁨⁨25 MB⁩⁩ in size”


# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/13066134/154341882-554025fa-594c-4d27-bb84-d1694b6ff016.png)
![image](https://user-images.githubusercontent.com/13066134/154341993-2eb65200-43c7-46cc-b921-317ec41ea983.png)
![image](https://user-images.githubusercontent.com/13066134/154342104-e9fcf4f2-afe7-4e29-ac1f-5f9c0d4ffa44.png)


# How to test
Check FAQ and Dashboard section, and make sure there are no mentions of a 150KB limit, but 25MB instead.


# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
