### PR TITLE
Add tests for `_get_attachment`, and do not use attachment filename for temporary storage

### DIFF
--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -409,48 +409,39 @@ class GetAttachmentTests(TestCase):
         message.add_attachment(data, maintype=maintype, subtype=subtype, filename=filename)
         return message
 
+    def get_name_and_stream(self, message):
+        """Get the first attachment's filename and data stream from a message."""
+        for part in message.walk():
+            if part.is_attachment():
+                return _get_attachment(part)
+        return None, None
+
     def test_short_attachment(self):
         """A short attachment is stored in memory"""
         message = self.create_message(b"A short attachment", "text/plain", "short.txt")
-        att_name, att = None, None
-        for part in message.walk():
-            if part.is_attachment():
-                att_name, att = _get_attachment(part)
-                break
-        assert att_name == 'short.txt'
-        assert isinstance(att._file, io.BytesIO)
+        name, stream = self.get_name_and_stream(message)
+        assert name == 'short.txt'
+        assert isinstance(stream._file, io.BytesIO)
 
     def test_long_attachment(self):
         """A long attachment is stored on disk"""
         message = self.create_message(self.long_data, "application/octet-stream", "long.txt")
-        att_name, att = None, None
-        for part in message.walk():
-            if part.is_attachment():
-                att_name, att = _get_attachment(part)
-                break
-        assert att_name == 'long.txt'
-        assert isinstance(att._file, io.BufferedRandom)
+        name, stream = self.get_name_and_stream(message)
+        assert name == 'long.txt'
+        assert isinstance(stream._file, io.BufferedRandom)
 
     def test_attachment_unicode_filename(self):
         """A unicode filename can be stored on disk"""
         filename = "Some Binary data 😀.bin"
         message = self.create_message(self.long_data, "application/octet-stream", filename)
-        att_name, att = None, None
-        for part in message.walk():
-            if part.is_attachment():
-                att_name, att = _get_attachment(part)
-                break
-        assert att_name == filename
-        assert isinstance(att._file, io.BufferedRandom)
+        name, stream = self.get_name_and_stream(message)
+        assert name == filename
+        assert isinstance(stream._file, io.BufferedRandom)
 
     def test_attachment_url_filename(self):
         """A URL filename can be stored on disk"""
         filename = "https://example.com/data.bin"
         message = self.create_message(self.long_data, "application/octet-stream", filename)
-        att_name, att = None, None
-        for part in message.walk():
-            if part.is_attachment():
-                att_name, att = _get_attachment(part)
-                break
-        assert att_name == filename
-        assert isinstance(att._file, io.BufferedRandom)
+        name, stream = self.get_name_and_stream(message)
+        assert name == filename
+        assert isinstance(stream._file, io.BufferedRandom)

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -443,7 +443,6 @@ class GetAttachmentTests(TestCase):
         assert att_name == filename
         assert isinstance(att._file, io.BufferedRandom)
 
-    @pytest.mark.xfail(reason="Filename with colon fails")
     def test_attachment_url_filename(self):
         """A URL filename can be stored on disk"""
         filename = "https://example.com/data.bin"

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -445,3 +445,10 @@ class GetAttachmentTests(TestCase):
         name, stream = self.get_name_and_stream(message)
         assert name == filename
         assert isinstance(stream._file, io.BufferedRandom)
+
+    def test_attachment_no_filename(self):
+        """An attachment without a filename can be stored on disk"""
+        message = self.create_message(self.long_data, "application/octet-stream", None)
+        name, stream = self.get_name_and_stream(message)
+        assert name is None
+        assert isinstance(stream._file, io.BufferedRandom)

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -391,7 +391,8 @@ class GetAddressTest(TestCase):
 class GetAttachmentTests(TestCase):
 
     def setUp(self):
-        # Define contents large enough to be stored on disk
+        # Binary string of 10 chars * 16,000 = 160,000 byte string, longer than
+        # 150k max size of SpooledTemporaryFile, so it is written to disk
         self.long_data = b'0123456789' * 16_000
 
     def create_message(self, data, mimetype, filename):

--- a/emails/views.py
+++ b/emails/views.py
@@ -764,8 +764,7 @@ def _get_attachment(part):
 
     attachment = SpooledTemporaryFile(
         max_size=150*1000,  # 150KB max from SES
-        suffix=extension,
-        prefix=os.path.splitext(fn)[0]
+        prefix="relay_attachment_"
     )
     attachment.write(payload)
     return fn, attachment


### PR DESCRIPTION
This PR fixes #1551 by using the prefix `"relay_attachment_"`, and not basing the filename prefix or suffix on user data from the attachment filename. It also adds some tests for `_get_attachment()`.

`_get_attachment()` uses [SpooledTemporaryFile](https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile), which holds an attachment in memory until it reaches 150 KiB, when it is stored in a temporary file. Previously, we used the attachment filename to make the prefix and suffix for the temporary file. However, this fails when the attachment filename has invalid characters, such as a colon (`:`). Now that we support larger files, we're starting to see some large attachments with a URL for the filename (`https://example.com/image.jpg`), and failures when writing to a tempfile with that name, such as:

```
FileNotFoundError: [Errno 2] No such file or directory: '/var/folders/_y/72__kkbs2tqd5ch4gwrgnwtr0000gn/T/https://example.com/image7piavr1v.jpg`
```

With this change, the temporary file will now have a randomly generated name, not related to the attachment name.

There is another potential bug for attachments with no filename, but I have not seen the signature in production yet, where calling `prefix=os.path.splitext(fn)[0]` results in the error:

```
TypeError: expected str, bytes or os.PathLike object, not NoneType
```
