### PR TITLE
Only expand newly-created aliases

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -32,6 +32,9 @@ export const AliasList = (props: Props) => {
   const [stringFilterInput, setStringFilterInput] = useState("");
   const [categoryFilters, setCategoryFilters] = useState<SelectedFilters>({});
   const [localLabels, storeLocalLabel] = useLocalLabels();
+  // Whenever a new alias is created, this value tracks the aliases that existed
+  // before that. That allows us to expand newly-created aliases by default.
+  const [existingAliases, setExistingAliases] = useState(props.aliases);
 
   if (props.aliases.length === 0) {
     return null;
@@ -44,7 +47,7 @@ export const AliasList = (props: Props) => {
     })
   );
 
-  const aliasCards = aliases.map((alias, index) => {
+  const aliasCards = aliases.map((alias) => {
     const aliasWithLocalLabel = { ...alias };
     if (
       alias.description.length === 0 &&
@@ -81,7 +84,7 @@ export const AliasList = (props: Props) => {
           profile={props.profile}
           onUpdate={onUpdate}
           onDelete={() => props.onDelete(alias)}
-          defaultOpen={index === 0}
+          defaultOpen={!existingAliases.includes(alias)}
           showLabelEditor={props.profile.server_storage || localLabels !== null}
         />
       </li>
@@ -139,6 +142,12 @@ export const AliasList = (props: Props) => {
       </Localized>
     ) : null;
 
+  const onCreate: typeof props.onCreate = (options) => {
+    setExistingAliases(props.aliases);
+
+    return props.onCreate(options);
+  };
+
   return (
     <section>
       <div className={styles.controls}>
@@ -148,7 +157,7 @@ export const AliasList = (props: Props) => {
             aliases={props.aliases}
             profile={props.profile}
             runtimeData={props.runtimeData}
-            onCreate={props.onCreate}
+            onCreate={onCreate}
           />
         </div>
       </div>


### PR DESCRIPTION
We used to always expand the top-most alias, but this changes that
to only expand aliases that have just been created, to align with
https://github.com/mozilla/fx-private-relay/pull/1524.

# Code walkthrough

This is in the `<AliasList>` component, which essentially is only in charge of displaying the list of aliases - actual fetching and saving of alias data is handled by the Profile page that includes this component through callbacks like `onCreate` and `onUpdate`. This means that when the `onCreate` callback is called, the Profile page will send a request to the API, get the updated list of aliases, and will then re-render `<AliasList>`, simply passing it a new list of aliases.

In other words: `<AliasList>` just gets a list of aliases, and can't see which of those are "new". To solve this, I modified `<AliasList>` to keep track of the aliases it has already seen (in the `existingAliases` state variable). It updates this variable whenever someone clicks the `<GenerateAliasButton>` (by calling `setExistingAliases`), but _before_ it passes that signal on to the Profile page through the `onCreate` handler.

Then when it gets re-rendered, `existingAliases` contains the list of aliases that were known when the user clicked the `<GenerateAliasButton>`, and `props.aliases` contains the updated list of aliases passed to it by the Profile. It can then choose to expand alias cards that are in the latter but not in the former (`defaultOpen={!existingAliases.includes(alias)}`).

Explaining code can get quite length, but I hope it's still useful :sweat_smile: 

# Screenshot (if applicable)

https://user-images.githubusercontent.com/4251/154667344-7b1648a4-6ddb-41dc-abe3-465a1bc68659.mp4

# How to test

Open the dashboard, verify that no aliases are expanded by default. Then create a new alias, and verify that it is expanded.

# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
