### PR TITLE
Hide CSAT by default

### DIFF
--- a/static/js/analytics.js
+++ b/static/js/analytics.js
@@ -130,9 +130,9 @@ function setSurveyedCookie() {
 function analyticsSurveyLogic() {
   const csatWrapperEl = document.querySelector(".js-csat-wrapper");
   if (!isGoogleAnalyticsAvailable()) {
-    csatWrapperEl.remove();
     return;
   }
+  csatWrapperEl?.classList.add("is-visible");
 
   const csatQuestionEl = document.querySelector(".js-csat-question");
   const csatFollowupEl = document.querySelector(".js-csat-followup");

--- a/static/scss/partials/header.scss
+++ b/static/scss/partials/header.scss
@@ -435,12 +435,19 @@ header {
 }
 
 .c-csat-wrapper {
-    display: none;
     padding: $spacing-md 0;
     background-color: $color-purple-90;
     color: $color-white;
     position: relative;
     text-align: center;
+    display: none;
+
+    @media screen and #{$mq-md} {
+
+        &.is-visible {
+            display: flex;
+        }
+    }
 
     & > div {
         display: flex;
@@ -449,10 +456,6 @@ header {
         justify-content: space-around;
         gap: $spacing-sm;
         width: 100%;
-    }
-
-    @media screen and #{$mq-md} {
-        display: flex;
     }
 
     .is-hidden {


### PR DESCRIPTION
This PR fixes #1564.

Only display the CSAT if the script to handle its interactions was
properly loaded (i.e. not blocked by an adblocker).

How to test: Make sure your browser language is set to `en-US`, is in the US, you don't have `RECRUITMENT_BANNER_*` env vars set, and you're logged in to an account that has had Premium for at least seven days. (Alternatively, add `or True` to line 21 of `header.html`.) You should see the CSAT banner.

Now install/enable an adblocker. You should no longer see the banner. (Whereas before, it would be visible but just not work.)

- [x] l10n dependencies have been merged, if any.
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
