### PR TITLE
Add release to Sentry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,12 @@ jobs:
 
       - run:
           name: Build Docker image
-          command: docker build -t fx-private-relay .
+          command: |
+            docker build -t fx-private-relay \
+            --build-arg CIRCLE_BRANCH="$CIRCLE_BRANCH" \
+            --build-arg CIRCLE_TAG="$CIRCLE_TAG" \
+            --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
+            .
 
       # save the built docker container into CircleCI's cache. This is
       # required since Workflows do not have the same remote docker instance.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,13 @@ RUN npm run lint:css
 
 FROM python:3.7.9
 
+ARG CIRCLE_BRANCH
+ARG CIRCLE_SHA1
+ARG CIRCLE_TAG
+ENV CIRCLE_BRANCH=${CIRCLE_BRANCH:-unknown} \
+    CIRCLE_TAG=${CIRCLE_TAG:-unknown} \
+    CIRCLE_SHA1=${CIRCLE_SHA1:-unknown}
+
 RUN apt-get update && apt-get install -y libpq-dev
 RUN pip install --upgrade pip
 

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -566,11 +566,26 @@ if DEBUG:
         'http://localhost:3000',
     ]
 
+SENTRY_RELEASE = config("SENTRY_RELEASE", "")
+CIRCLE_SHA1 = config("CIRCLE_SHA1", "")
+CIRCLE_TAG = config("CIRCLE_TAG", "")
+CIRCLE_BRANCH = config("CIRCLE_BRANCH", "")
+
+if SENTRY_RELEASE:
+    sentry_release = SENTRY_RELEASE
+elif CIRCLE_TAG and CIRCLE_TAG != "unknown":
+    sentry_release = CIRCLE_TAG
+elif CIRCLE_SHA1 and CIRCLE_SHA1 != "unknown" and CIRCLE_BRANCH and CIRCLE_BRANCH != "unknown":
+    sentry_release = f"{CIRCLE_BRANCH}:{CIRCLE_SHA1}"
+else:
+    sentry_release = None
+
 sentry_sdk.init(
     dsn=config('SENTRY_DSN', None),
     integrations=[DjangoIntegration()],
     debug=DEBUG,
-    with_locals=DEBUG
+    with_locals=DEBUG,
+    release=sentry_release,
 )
 
 markus.configure(


### PR DESCRIPTION
When building the Docker image, inject the tag, branch, and commit SHA as environment variables. Use this to create a release number, either the tag or "branch:commit".

This enables us to track releases in Sentry, and use features like "resolved in next release".