### PR TITLE
Ignore more files and folders

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,12 @@
 .envrc
 .git
 extension
+*.sqlite3
+env/
+__pycache__
+web-ext-artifacts/
+htmlcov
+static/downloads
+static/css
+static/scss/libs
+staticfiles

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ htmlcov
 static/downloads
 static/css
 static/scss/libs
+staticfiles


### PR DESCRIPTION
Ignore more files and folders in Git and when building the Docker image:

I copied these from `.gitignore` to `.dockerignore`. This shouldn't affect the CircleCI build, since these files shouldn't exist, but can speed up local builds.

* ``*.sqlite3``
* ``env/``
* ``__pycache__``
* ``web-ext-artifacts/``
* ``htmlcov``
* ``static/downloads``
* ``static/css``
* ``static/scss/libs``

The ``staticfiles`` folder is created when you run ``manage.py collectstatic``. @maxxcrawford and I used this when trying to figure out a gulp issue, and the folder shouldn't be checked in or passed as build context to Docker.