### PR TITLE
Refinement for the New Feature Announcement area

### DIFF
--- a/static/js/whatsnew.js
+++ b/static/js/whatsnew.js
@@ -20,14 +20,21 @@
   }, 500)
 
   trigger.addEventListener("click", (event) => {
-    const closeEventListener = () => {
+    const close = () => {
       popup.classList.remove("is-visible");
       trigger.classList.remove("is-open");
-      window.removeEventListener("click", closeEventListener);
+      window.removeEventListener("click", close);
+      window.removeEventListener("keydown", onKeyPress);
+    };
+    /** @param event {KeyboardEvent} */
+    const onKeyPress = (event) => {
+      if (event.key === "Escape") {
+        close();
+      }
     };
 
     if (trigger.classList.contains("is-open")) {
-      closeEventListener();
+      close();
       return;
     }
 
@@ -35,7 +42,8 @@
     trigger.classList.add("is-open");
 
     event.stopImmediatePropagation();
-    window.addEventListener("click", closeEventListener);
+    window.addEventListener("click", close);
+    window.addEventListener("keydown", onKeyPress);
   });
   backButton.addEventListener("click", (event) => {
     // Prevent the event listener on the window, which closes the popup,

--- a/static/js/whatsnew.js
+++ b/static/js/whatsnew.js
@@ -20,14 +20,20 @@
   }, 500)
 
   trigger.addEventListener("click", (event) => {
-    popup.classList.add("is-visible");
-    trigger.classList.add("is-open");
-
     const closeEventListener = () => {
       popup.classList.remove("is-visible");
       trigger.classList.remove("is-open");
       window.removeEventListener("click", closeEventListener);
     };
+
+    if (trigger.classList.contains("is-open")) {
+      closeEventListener();
+      return;
+    }
+
+    popup.classList.add("is-visible");
+    trigger.classList.add("is-open");
+
     event.stopImmediatePropagation();
     window.addEventListener("click", closeEventListener);
   });

--- a/static/scss/components/whatsnew.scss
+++ b/static/scss/components/whatsnew.scss
@@ -86,6 +86,10 @@ header .user-area:not(.arbitrary-class) .c-whatsnew-trigger {
             padding: $spacing-sm 0;
             border-bottom: 1px solid $color-light-gray-30;
 
+            &:last-child {
+                border-bottom-style: none;
+            }
+
             &.is-visible {
                 display: block;
             }


### PR DESCRIPTION
This PR fixes a couple of issues identified in https://github.com/mozilla/fx-private-relay/pull/1561. Specifically:

> You'll want to add an extra rule to remove this for the last item.

https://github.com/mozilla/fx-private-relay/pull/1561#discussion_r816301554

Done in c9a159c37ba179634655f969760de8bb04c0b47c.

> I can't seem to close the tab when clicking the news button again.

https://github.com/mozilla/fx-private-relay/pull/1561#pullrequestreview-895496551

Done in a967d586.

https://user-images.githubusercontent.com/4251/156178344-b7f41b85-1fee-4a09-b065-94d6f40c29ab.mp4

It also fixes #1583.

As for

> Another thing is that when I shrink the device width, the panel gets cut off at a certain breakpoint (around 762px). Are we keeping the whats new feature on mobile as well?

Since it switches to a drop-down menu on mobile, I decided to just not show it there for now, since that interaction (a drop-down in a drop-down) can get very gnarly very quickly. It's there in #1562, though that might at some point need to transition to a drop-down as well.

How to test:

- [x] l10n dependencies have been merged, if any.
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
