### PR TITLE
Remove "Let us know" link in FAQ

### DIFF
--- a/privaterelay/templates/faq.html
+++ b/privaterelay/templates/faq.html
@@ -41,8 +41,8 @@
           </section>
           <section class="faq" id="faq-rejections">
             <h2 class="faq-headline">{% ftlmsg 'faq-question-2-question' %}</h2>
-            <p class="faq-answer js-set-href">
-              {% ftlmsg 'faq-question-2-answer-v3-html' url='https://addons.mozilla.org/firefox/addon/private-relay/' attrs='class="text-link" data-url="https://addons.mozilla.org/firefox/addon/private-relay/"' %}
+            <p class="faq-answer">
+              {% ftlmsg 'faq-question-2-answer-v4' %}
             </p>
           </section>
           <section class="faq" id="faq-spam">


### PR DESCRIPTION
The link led to the Addon page because we don't really have a good
way for free users to report issues, but that page wasn't a clear
destination at all. No link is better than a misleading one, so
removing it :)

This PR fixes #1565

How to test: visit the FAQ page, and verify that it says this:

![image](https://user-images.githubusercontent.com/4251/156181529-cbc7f1ed-c707-4271-aaee-4f394b066829.png)

instead of this:

![image](https://user-images.githubusercontent.com/4251/156181434-f55badb5-1fa5-4097-a297-df39ffe46ba2.png)


- [x] l10n dependencies have been merged, if any. Yep: https://github.com/mozilla-l10n/fx-private-relay-l10n/commit/d793b6416a6870771fe6f6da779c07185a364708
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
