### PR TITLE
Remove "Let us know" link in FAQ (React)

### DIFF
--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -96,25 +96,7 @@ const Faq: NextPage = () => {
                 id="faq-rejections"
                 question={l10n.getString("faq-question-2-question")}
               >
-                <p>{l10n.getString("faq-question-missing-emails-answer-a")}</p>
-                <Localized
-                  id="faq-question-2-answer-v3-html"
-                  vars={{
-                    url: "https://addons.mozilla.org/firefox/addon/private-relay/",
-                    attrs: "",
-                  }}
-                  elems={{
-                    a: (
-                      <a
-                        href="https://addons.mozilla.org/firefox/addon/private-relay/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      />
-                    ),
-                  }}
-                >
-                  <p />
-                </Localized>
+                <p>{l10n.getString("faq-question-2-answer-v4")}</p>
               </QAndA>
               <QAndA
                 id="faq-spam"


### PR DESCRIPTION
React equivalent of #1580.

How to test: See https://deploy-preview-1581--fx-relay-demo.netlify.app/faq/

- [x] l10n dependencies have been merged, if any.
- [ ] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
