### PR TITLE
Fix #1582 - Add logic to show news items to browsers that support said feature. 

### DIFF
--- a/static/js/whatsnew.js
+++ b/static/js/whatsnew.js
@@ -6,6 +6,7 @@
   const footer = document.querySelector(".js-whatsnew-footer");
   const backButton = footer.querySelector("button");
   const profileId = popup.dataset.profileId;
+  const browserIsFirefox = /firefox|FxiOS/i.test(navigator.userAgent);
 
   enableEntry("size-limit");
   if (popup.dataset.hasPremium === "True") {
@@ -14,7 +15,8 @@
   // Wait until the add-on has initialised:
   setTimeout(() => {
     const isAddonPresent = document.querySelector("firefox-private-relay-addon")?.dataset.addonInstalled === "true";
-    if (isAddonPresent) {
+    // Only show sign-back in news item if the user is in Firefox AND has the add-on installed
+    if (isAddonPresent && browserIsFirefox) {
       enableEntry("sign-back-in")
     }
   }, 500)


### PR DESCRIPTION
Add logic to not show news items to browsers that do no support that feature

This PR fixes #1582

## How to test:

Run this branch in Firefox, with the add-on installed (on the same dev/level) on PREMIUM account: 
- Log into site, navigate to Relay dashboard
- **Expected:** There should be three news items

Run this branch in Chrome, with the add-on installed (on the same dev/level) on PREMIUM account: 
- Log into site, navigate to Relay dashboard
- **Expected:** There should be two news items

## Checklist

- [x] l10n dependencies have been merged, if any.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
