### PR TITLE
Cache has_premium property to fix slow requests

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from datetime import datetime, timedelta, timezone
+from functools import lru_cache
 from hashlib import sha256
 import logging
 import random
@@ -252,6 +253,7 @@ class Profile(models.Model):
         return f'@{self.subdomain}.{settings.MOZMAIL_DOMAIN}'
 
     @property
+    @lru_cache(maxsize=None)
     def has_premium(self):
         # FIXME: as we don't have all the tiers defined we are over-defining
         # this to mark the user as a premium user as well


### PR DESCRIPTION
Issue: I was having slow page load times (~12 seconds) when loading a premium account with a high number of aliases. 

As introduced in 56755320375d5dcc799d3f8c92b3d89e43883069, the alias-card loop includes additional "checks" when displaying certain UI. 

To test: 
- Create account that is premium with 40+ aliases
- Log in
- **Expected:** Page load time should be under ~2 seconds

Try this same setup from `main`: 
- **Expected:** The page load should be extremely long. 