### PR TITLE
Mark `main` as the default branch of the submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "privaterelay/locales"]
 	path = privaterelay/locales
 	url = https://github.com/mozilla-l10n/fx-private-relay-l10n.git
+	branch = main


### PR DESCRIPTION
Apparently `git submodule update --init --remote` by default assumes we're trying to get the latest `master` branch, rather than our default `main` branch:

![image](https://user-images.githubusercontent.com/4251/156549385-f7c0335b-a00f-4391-9674-0425a1b942cf.png)

I'm not sure if recent versions of Git have changed this without updating [the docs](https://git-scm.com/book/en/v2/Git-Tools-Submodules), but either way making this explicit won't harm.