### PR TITLE
Delete emails from S3 if relaying should not be retried

### DIFF
--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -95,7 +95,6 @@ class SNSNotificationTest(TestCase):
 
     @patch('emails.views.ses_relay_email')
     def test_list_email_sns_notification(self, mock_ses_relay_email):
-        expected_status_code = 200
         mock_ses_relay_email.return_value = HttpResponse(
             "Successfully relayed emails", status=200
         )

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -75,7 +75,7 @@ class SNSNotificationTest(TestCase):
         self.premium_profile.save()
 
         patcher = patch('emails.views.remove_message_from_s3')
-        patcher.start()
+        self.mock_remove_message_from_s3 = self.patcher.start()
         self.addCleanup(patcher.stop)
 
 

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -292,9 +292,17 @@ def _get_bucket_and_key_from_s3_json(message_json):
         )
         return None, None
 
-    if 'S3' in message_json_receipt['action']['type']:
-        bucket = message_json_receipt['action']['bucketName']
-        object_key = message_json_receipt['action']['objectKey']
+    try:
+        if 'S3' in message_json_receipt['action']['type']:
+            bucket = message_json_receipt['action']['bucketName']
+            object_key = message_json_receipt['action']['objectKey']
+    except (KeyError, TypeError) as e:
+        logger.error(
+            'sns_inbound_message_receipt_malformed',
+            extra={
+                'receipt_action': message_json_receipt['action'],
+            }
+        )
     return bucket, object_key
 
 

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -284,12 +284,16 @@ def _get_bucket_and_key_from_s3_json(message_json):
     if 'receipt' in message_json and 'action' in message_json['receipt']:
         message_json_receipt = message_json['receipt']
     else:
-        # TODO: sns inbound notification does not have 'receipt'
-        # we need to look into this more
-        logger.error(
-            'sns_inbound_message_without_receipt',
-            extra={'message_json_keys': message_json.keys()}
-        )
+        notification_type = message_json.get('notificationType')
+        event_type = message_json.get('eventType')
+        is_bounce_notification = notification_type == 'Bounce' or event_type == 'Bounce'
+        if not is_bounce_notification:
+            # TODO: sns inbound notification does not have 'receipt'
+            # we need to look into this more
+            logger.error(
+                'sns_inbound_message_without_receipt',
+                extra={'message_json_keys': message_json.keys()}
+            )
         return None, None
 
     try:

--- a/emails/views.py
+++ b/emails/views.py
@@ -346,7 +346,7 @@ def _sns_message(message_json):
         [to_local_portion, to_domain_portion] = to_address.split('@')
     except ValueError:
         # TODO: Add metric
-        return HttpResponse('Malformed to field.', 400)
+        return HttpResponse('Malformed to field.', status=400)
 
     if to_local_portion == 'noreply':
         incr_if_enabled('email_for_noreply_address', 1)


### PR DESCRIPTION
While handling inbound notification from AWS SNS there are several reasons why an email will fail to be relayed. In such cases we should immediately dispose the emails as we will not re-attempt to relay the email to the user.

How to test:

- [ ] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

#
I added the #1602 as a follow-up for this PR to include the metric, visualization, documentation for email processing.