### PR TITLE
Fix test_blocked_list_email_in_s3_deleted, avoid warning

### DIFF
--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -57,7 +57,7 @@ def make_premium_test_user():
     premium_user = baker.make(User)
     premium_user_profile = Profile.objects.get(user=premium_user)
     premium_user_profile.server_storage = True
-    premium_user_profile.date_subscribed = datetime.now()
+    premium_user_profile.date_subscribed = datetime.now(tz=timezone.utc)
     premium_user_profile.save()
     upgrade_test_user_to_premium(premium_user)
     return premium_user

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -29,7 +29,7 @@ from emails.views import (
     _sns_notification
 )
 
-from .models_tests import make_premium_test_user
+from .models_tests import make_premium_test_user, upgrade_test_user_to_premium
 
 # Load the sns json fixtures from files
 real_abs_cwd = os.path.realpath(
@@ -431,6 +431,7 @@ class SNSNotificationValidUserEmailsInS3Test(TestCase):
     def test_blocked_list_email_in_s3_deleted(
         self, mocked_message_removed, mocked_email_is_from_list
     ):
+        upgrade_test_user_to_premium(self.user)
         self.address.block_list_emails = True
         self.address.save()
         mocked_email_is_from_list.return_value = True


### PR DESCRIPTION
``SNSNotificationValidUserEmailsInS3Test.test_blocked_list_email_in_s3_deleted`` from PR #1599 tests deletion of a blocked list email. However, the test setup fails due to the checks in PR #1578. This updates the test user to premium so that the address can have the blocked list setting.

I was seeing a lot of these warnings as well:

```
emails/tests/models_tests.py::DomainAddressTest::test_make_domain_address_non_premium_user
  /Users/john/.virtualenvs/fx-private-relay/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1427: RuntimeWarning: DateTimeField Profile.date_subscribed received a naive datetime (2022-03-05 02:02:17.928299) while time zone support is active.
    RuntimeWarning)
```

These were all due to the `make_premium_test_user` function, and adding a timezone eliminates multiple warnings.

The remaining warnings are from `drf_yasg`. I filed an upstream bug in January, no movement yet.