### PR TITLE
Store attachments as a list

### DIFF
--- a/emails/utils.py
+++ b/emails/utils.py
@@ -134,7 +134,7 @@ def _add_body_to_message(msg, message_body):
 
 def _add_attachments_to_message(msg, attachments):
     # attach attachments
-    for actual_att_name, attachment in attachments.items():
+    for actual_att_name, attachment in attachments:
         # Define the attachment part and encode it using MIMEApplication.
         attachment.seek(0)
         att = MIMEApplication(attachment.read())

--- a/emails/views.py
+++ b/emails/views.py
@@ -794,7 +794,7 @@ def _get_attachment(part):
 def _get_all_contents(email_message):
     text_content = None
     html_content = None
-    attachments = {}
+    attachments = []
     if email_message.is_multipart():
         for part in email_message.walk():
             try:
@@ -802,7 +802,7 @@ def _get_all_contents(email_message):
                     att_name, att = (
                         _get_attachment(part)
                     )
-                    attachments[att_name] = att
+                    attachments.append((att_name, att))
                     continue
                 if part.get_content_type() == 'text/plain':
                     text_content = part.get_content()


### PR DESCRIPTION
Store and load attachments as a list of tuples `(name, data_stream)`, rather than a dict `{name: data_stream}`. This allows multiple attachments to have the same name (or `None` if filenames are omitted).

This PR fixes #1559

How to test:

- Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).