### PR TITLE
Link to Chrome extension on Chrome (React)

### DIFF
--- a/frontend/__mocks__/hooks/mediaQuery.ts
+++ b/frontend/__mocks__/hooks/mediaQuery.ts
@@ -1,0 +1,18 @@
+import { jest } from "@jest/globals";
+import { useMinViewportWidth } from "../../src/hooks/mediaQuery";
+
+jest.mock("../../src/hooks/mediaQuery");
+
+// We know that `jest.mock` has turned `useMinViewportWidth` into a mock function,
+// but TypeScript can't — so we tell it using a type assertion:
+const mockedUseMinViewportWidth = useMinViewportWidth as jest.MockedFunction<
+  typeof useMinViewportWidth
+>;
+
+export function setMockMinViewportWidth(matches?: boolean) {
+  mockedUseMinViewportWidth.mockReturnValue(matches ?? true);
+}
+
+export function setMockMinViewportWidthOnce(matches?: boolean) {
+  mockedUseMinViewportWidth.mockReturnValueOnce(matches ?? true);
+}

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -80,6 +80,17 @@ tips-footer-link-feedback-tooltip = Give feedback
 tips-footer-link-support-label = Support
 tips-footer-link-support-tooltip = Contact support
 
+## The Chrome extension strings have already been submitted:
+## https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/65
+-brand-name-chrome = Chrome
+-brand-name-google-chrome = Google Chrome
+banner-download-install-chrome-extension-headline = Try { -brand-name-relay } for { -brand-name-google-chrome }
+banner-download-install-chrome-extension-copy = The { -brand-name-firefox-relay } extension for { -brand-name-chrome } makes creating and using aliases even easier.
+banner-download-install-chrome-extension-cta = Get the { -brand-name-relay } extension
+multi-part-onboarding-premium-chrome-extension-get-title = Get the { -brand-name-relay } extension for { -brand-name-google-chrome }
+multi-part-onboarding-premium-chrome-extension-get-description = The { -brand-name-firefox-relay } extension for { -brand-name-chrome } makes creating and using email aliases even easier.
+multi-part-onboarding-premium-chrome-extension-button-download = Get { -brand-name-relay } Extension
+
 ## The Acceptable Use FAQ entry has already been submitted:
 ## https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/60
 faq-question-acceptable-use-question = What are the acceptable uses of { -brand-name-relay }?

--- a/frontend/src/components/dashboard/PremiumOnboarding.module.scss
+++ b/frontend/src/components/dashboard/PremiumOnboarding.module.scss
@@ -151,6 +151,17 @@
       }
     }
 
+    @media screen and #{$mq-md} {
+      // Don't show the description of replies on small screens,
+      // to focus on the add-on availability:
+      .reply-description {
+        display: none;
+      }
+      .addon-description {
+        display: block;
+      }
+    }
+
     h3 {
       @include text-body-md;
     }

--- a/frontend/src/components/dashboard/PremiumOnboarding.tsx
+++ b/frontend/src/components/dashboard/PremiumOnboarding.tsx
@@ -1,4 +1,4 @@
-import { useState, createContext, useContext } from "react";
+import { useState } from "react";
 import { useLocalization } from "@fluent/react";
 import { event as gaEvent } from "react-ga";
 import { useOverlayTriggerState } from "react-stately";
@@ -18,60 +18,13 @@ import { useMinViewportWidth } from "../../hooks/mediaQuery";
 import {
   supportsChromeExtension,
   supportsFirefoxExtension,
+  supportsAnExtension,
 } from "../../functions/userAgent";
 
 export type Props = {
   profile: ProfileData;
   onNextStep: (step: number) => void;
   onPickSubdomain: (subdomain: string) => void;
-};
-
-interface IBrowserContext {
-  extensionsSupported: boolean;
-}
-const BrowserContext = createContext<IBrowserContext>({
-  extensionsSupported: supportsFirefoxExtension() || supportsChromeExtension(),
-});
-interface AddonDescriptionProps {
-  extSupported: boolean;
-  headerMessageId: string;
-  paragraphMessageId: string;
-  linkHref: string;
-  linkMessageId: string;
-}
-
-const _getAddonDescriptionProps = (): AddonDescriptionProps => {
-  if (supportsFirefoxExtension()) {
-    return {
-      extSupported: true,
-      headerMessageId: "multi-part-onboarding-premium-extension-get-title",
-      paragraphMessageId:
-        "multi-part-onboarding-premium-extension-get-description",
-      linkHref:
-        "https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon",
-      linkMessageId: "multi-part-onboarding-premium-extension-button-download",
-    };
-  }
-  if (supportsChromeExtension()) {
-    return {
-      extSupported: true,
-      headerMessageId:
-        "multi-part-onboarding-premium-chrome-extension-get-title",
-      paragraphMessageId:
-        "multi-part-onboarding-premium-chrome-extension-get-description",
-      linkHref:
-        "https://chrome.google.com/webstore/detail/firefox-relay/lknpoadjjkjcmjhbjpcljdednccbldeb?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon",
-      linkMessageId:
-        "multi-part-onboarding-premium-chrome-extension-button-download",
-    };
-  }
-  return {
-    extSupported: false,
-    headerMessageId: "",
-    paragraphMessageId: "",
-    linkHref: "",
-    linkMessageId: "",
-  };
 };
 
 /**
@@ -432,34 +385,13 @@ const Step2SubdomainPicker = (props: Step2SubdomainPickerProps) => {
   );
 };
 
-const _getStepThreeTitle = (
-  isLargeScreen: boolean,
-  chrome: boolean,
-  firefox: boolean
-): string => {
-  const { l10n } = useLocalization();
-  if (isLargeScreen && firefox) {
-    return l10n.getString("multi-part-onboarding-premium-extension-get-title");
-  }
-  if (isLargeScreen && chrome) {
-    return l10n.getString(
-      "multi-part-onboarding-premium-chrome-extension-get-title"
-    );
-  }
-  return l10n.getString("multi-part-onboarding-reply-headline");
-};
-
 const StepThree = () => {
   const { l10n } = useLocalization();
-  const isLargeScreen = useMinViewportWidth("md");
-  const firefox = supportsFirefoxExtension();
-  const chrome = supportsChromeExtension();
-  const title = _getStepThreeTitle(isLargeScreen, chrome, firefox);
 
   return (
     <div className={`${styles.step} ${styles["step-addon"]}`}>
       <div>
-        <h2>{title}</h2>
+        <StepThreeTitle />
       </div>
       <div className={styles.description}>
         <img src={ManLaptopEmail.src} alt="" width={500} />
@@ -488,30 +420,77 @@ const StepThree = () => {
   );
 };
 
+const StepThreeTitle = () => {
+  const { l10n } = useLocalization();
+  const isLargeScreen = useMinViewportWidth("md");
+  if (!isLargeScreen) {
+    return <h2>{l10n.getString("multi-part-onboarding-reply-headline")}</h2>;
+  }
+  return (
+    <h2>
+      {l10n.getString(
+        supportsFirefoxExtension()
+          ? "multi-part-onboarding-premium-extension-get-title"
+          : "multi-part-onboarding-premium-chrome-extension-get-title"
+      )}
+    </h2>
+  );
+};
+
+interface AddonDescriptionProps {
+  headerMessageId: string;
+  paragraphMessageId: string;
+  linkHref: string;
+  linkMessageId: string;
+}
+const getAddonDescriptionProps = () => {
+  if (supportsFirefoxExtension()) {
+    return {
+      headerMessageId: "multi-part-onboarding-premium-extension-get-title",
+      paragraphMessageId:
+        "multi-part-onboarding-premium-extension-get-description",
+      linkHref:
+        "https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon",
+      linkMessageId: "multi-part-onboarding-premium-extension-button-download",
+    };
+  }
+  if (supportsChromeExtension()) {
+    return {
+      headerMessageId:
+        "multi-part-onboarding-premium-chrome-extension-get-title",
+      paragraphMessageId:
+        "multi-part-onboarding-premium-chrome-extension-get-description",
+      linkHref:
+        "https://chrome.google.com/webstore/detail/firefox-relay/lknpoadjjkjcmjhbjpcljdednccbldeb?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon",
+      linkMessageId:
+        "multi-part-onboarding-premium-chrome-extension-button-download",
+    };
+  }
+  return {
+    headerMessageId: "",
+    paragraphMessageId: "",
+    linkHref: "",
+    linkMessageId: "",
+  };
+};
+
 const AddonDescription = () => {
   const isLargeScreen = useMinViewportWidth("md");
-  const {
-    extSupported,
-    headerMessageId,
-    paragraphMessageId,
-    linkHref,
-    linkMessageId,
-  }: AddonDescriptionProps = _getAddonDescriptionProps();
+  const { headerMessageId, paragraphMessageId, linkHref, linkMessageId } =
+    getAddonDescriptionProps();
   if (!isLargeScreen) {
     return null;
   }
-  if (extSupported) {
+  if (supportsAnExtension()) {
     return (
-      <BrowserContext.Provider value={{ extensionsSupported: extSupported }}>
-        <div className={`${styles["addon-description"]} is-hidden-with-addon`}>
-          <AddonDescriptionHeader headerMessageId={headerMessageId} />
-          <AddonDescriptionParagraph paragraphMessageId={paragraphMessageId} />
-          <AddonDescriptionLinkButton
-            linkHref={linkHref}
-            linkMessageId={linkMessageId}
-          />
-        </div>
-      </BrowserContext.Provider>
+      <div className={`${styles["addon-description"]} is-hidden-with-addon`}>
+        <AddonDescriptionHeader headerMessageId={headerMessageId} />
+        <AddonDescriptionParagraph paragraphMessageId={paragraphMessageId} />
+        <AddonDescriptionLinkButton
+          linkHref={linkHref}
+          linkMessageId={linkMessageId}
+        />
+      </div>
     );
   }
   return null;
@@ -521,8 +500,7 @@ const AddonDescriptionHeader = ({
   headerMessageId,
 }: Pick<AddonDescriptionProps, "headerMessageId">) => {
   const { l10n } = useLocalization();
-  const { extensionsSupported } = useContext(BrowserContext);
-  if (!extensionsSupported) {
+  if (!supportsAnExtension()) {
     return null;
   }
   return <h3>{l10n.getString(headerMessageId)}</h3>;
@@ -532,8 +510,7 @@ const AddonDescriptionParagraph = ({
   paragraphMessageId,
 }: Pick<AddonDescriptionProps, "paragraphMessageId">) => {
   const { l10n } = useLocalization();
-  const { extensionsSupported } = useContext(BrowserContext);
-  if (!extensionsSupported) {
+  if (!supportsAnExtension()) {
     return null;
   }
   return <p>{l10n.getString(paragraphMessageId)}</p>;
@@ -544,8 +521,7 @@ const AddonDescriptionLinkButton = ({
   linkMessageId,
 }: Pick<AddonDescriptionProps, "linkHref" | "linkMessageId">) => {
   const { l10n } = useLocalization();
-  const { extensionsSupported } = useContext(BrowserContext);
-  if (!extensionsSupported) {
+  if (!supportsAnExtension()) {
     return null;
   }
   return (

--- a/frontend/src/components/dashboard/PremiumOnboarding.tsx
+++ b/frontend/src/components/dashboard/PremiumOnboarding.tsx
@@ -15,6 +15,10 @@ import { SubdomainConfirmationModal } from "./subdomain/ConfirmationModal";
 import { VisuallyHidden } from "react-aria";
 import { getRuntimeConfig } from "../../config";
 import { useMinViewportWidth } from "../../hooks/mediaQuery";
+import {
+  supportsChromeExtension,
+  supportsFirefoxExtension,
+} from "../../functions/userAgent";
 
 export type Props = {
   profile: ProfileData;
@@ -384,21 +388,69 @@ const StepThree = () => {
   const { l10n } = useLocalization();
   const isLargeScreen = useMinViewportWidth("md");
 
+  let addonDescription = null;
+  let title = l10n.getString("multi-part-onboarding-reply-headline");
+  if (isLargeScreen && supportsFirefoxExtension()) {
+    title = l10n.getString("multi-part-onboarding-premium-extension-get-title");
+    addonDescription = (
+      <div className={`${styles["addon-description"]} is-hidden-with-addon`}>
+        <h3>
+          {l10n.getString("multi-part-onboarding-premium-extension-get-title")}
+        </h3>
+        <p>
+          {l10n.getString(
+            "multi-part-onboarding-premium-extension-get-description"
+          )}
+        </p>
+        <LinkButton
+          href="https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon"
+          target="_blank"
+          className={styles["get-addon-button"]}
+        >
+          {l10n.getString(
+            "multi-part-onboarding-premium-extension-button-download"
+          )}
+        </LinkButton>
+      </div>
+    );
+  } else if (isLargeScreen && supportsChromeExtension()) {
+    title = l10n.getString(
+      "multi-part-onboarding-premium-chrome-extension-get-title"
+    );
+    addonDescription = (
+      <div className={`${styles["addon-description"]} is-hidden-with-addon`}>
+        <h3>
+          {l10n.getString(
+            "multi-part-onboarding-premium-chrome-extension-get-title"
+          )}
+        </h3>
+        <p>
+          {l10n.getString(
+            "multi-part-onboarding-premium-chrome-extension-get-description"
+          )}
+        </p>
+        <LinkButton
+          href="https://chrome.google.com/webstore/detail/firefox-relay/lknpoadjjkjcmjhbjpcljdednccbldeb?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon"
+          target="_blank"
+          className={styles["get-addon-button"]}
+        >
+          {l10n.getString(
+            "multi-part-onboarding-premium-chrome-extension-button-download"
+          )}
+        </LinkButton>
+      </div>
+    );
+  }
+
   return (
     <div className={`${styles.step} ${styles["step-addon"]}`}>
       <div>
-        <h2>
-          {l10n.getString(
-            isLargeScreen
-              ? "multi-part-onboarding-premium-extension-get-title"
-              : "multi-part-onboarding-reply-headline"
-          )}
-        </h2>
+        <h2>{title}</h2>
       </div>
       <div className={styles.description}>
         <img src={ManLaptopEmail.src} alt="" width={500} />
         <div>
-          <p>
+          <p className={styles["reply-description"]}>
             <span className={styles["description-caption"]}>
               {l10n.getString("onboarding-premium-title-detail")}
             </span>
@@ -407,29 +459,7 @@ const StepThree = () => {
             <br />
             {l10n.getString("onboarding-premium-reply-description")}
           </p>
-          <div
-            className={`${styles["addon-description"]} is-hidden-with-addon`}
-          >
-            <h3>
-              {l10n.getString(
-                "multi-part-onboarding-premium-extension-get-title"
-              )}
-            </h3>
-            <p>
-              {l10n.getString(
-                "multi-part-onboarding-premium-extension-get-description"
-              )}
-            </p>
-            <LinkButton
-              href="https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon"
-              target="_blank"
-              className={styles["get-addon-button"]}
-            >
-              {l10n.getString(
-                "multi-part-onboarding-premium-extension-button-download"
-              )}
-            </LinkButton>
-          </div>
+          {addonDescription}
           <div
             className={`${styles["addon-description"]} is-visible-with-addon`}
           >

--- a/frontend/src/components/dashboard/PremiumOnboarding.tsx
+++ b/frontend/src/components/dashboard/PremiumOnboarding.tsx
@@ -384,15 +384,77 @@ const Step2SubdomainPicker = (props: Step2SubdomainPickerProps) => {
   );
 };
 
+const _getStepThreeTitle = (
+  isLargeScreen: boolean,
+  chrome: boolean,
+  firefox: boolean
+): string => {
+  const { l10n } = useLocalization();
+  if (isLargeScreen && firefox) {
+    return l10n.getString("multi-part-onboarding-premium-extension-get-title");
+  }
+  if (isLargeScreen && chrome) {
+    return l10n.getString(
+      "multi-part-onboarding-premium-chrome-extension-get-title"
+    );
+  }
+  return l10n.getString("multi-part-onboarding-reply-headline");
+};
+
 const StepThree = () => {
   const { l10n } = useLocalization();
   const isLargeScreen = useMinViewportWidth("md");
+  const firefox = supportsFirefoxExtension();
+  const chrome = supportsChromeExtension();
+  const title = _getStepThreeTitle(isLargeScreen, chrome, firefox);
 
-  let addonDescription = null;
-  let title = l10n.getString("multi-part-onboarding-reply-headline");
-  if (isLargeScreen && supportsFirefoxExtension()) {
-    title = l10n.getString("multi-part-onboarding-premium-extension-get-title");
-    addonDescription = (
+  return (
+    <div className={`${styles.step} ${styles["step-addon"]}`}>
+      <div>
+        <h2>{title}</h2>
+      </div>
+      <div className={styles.description}>
+        <img src={ManLaptopEmail.src} alt="" width={500} />
+        <div>
+          <p className={styles["reply-description"]}>
+            <span className={styles["description-caption"]}>
+              {l10n.getString("onboarding-premium-title-detail")}
+            </span>
+            <br />
+            <strong>{l10n.getString("onboarding-premium-reply-title")}</strong>
+            <br />
+            {l10n.getString("onboarding-premium-reply-description")}
+          </p>
+          <AddonDescription
+            supportsFirefoxExtension={firefox}
+            supportsChromeExtension={chrome}
+          />
+          <div
+            className={`${styles["addon-description"]} is-visible-with-addon`}
+          >
+            <div className={styles["action-complete"]}>
+              <img src={checkIcon.src} alt="" width={18} />
+              {l10n.getString("multi-part-onboarding-premium-extension-added")}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+type AddonDescriptionProps = {
+  supportsFirefoxExtension: boolean;
+  supportsChromeExtension: boolean;
+};
+const AddonDescription = (props: AddonDescriptionProps) => {
+  const { l10n } = useLocalization();
+  const isLargeScreen = useMinViewportWidth("md");
+  if (!isLargeScreen) {
+    return null;
+  }
+  if (props.supportsFirefoxExtension) {
+    return (
       <div className={`${styles["addon-description"]} is-hidden-with-addon`}>
         <h3>
           {l10n.getString("multi-part-onboarding-premium-extension-get-title")}
@@ -413,11 +475,9 @@ const StepThree = () => {
         </LinkButton>
       </div>
     );
-  } else if (isLargeScreen && supportsChromeExtension()) {
-    title = l10n.getString(
-      "multi-part-onboarding-premium-chrome-extension-get-title"
-    );
-    addonDescription = (
+  }
+  if (props.supportsChromeExtension) {
+    return (
       <div className={`${styles["addon-description"]} is-hidden-with-addon`}>
         <h3>
           {l10n.getString(
@@ -441,35 +501,5 @@ const StepThree = () => {
       </div>
     );
   }
-
-  return (
-    <div className={`${styles.step} ${styles["step-addon"]}`}>
-      <div>
-        <h2>{title}</h2>
-      </div>
-      <div className={styles.description}>
-        <img src={ManLaptopEmail.src} alt="" width={500} />
-        <div>
-          <p className={styles["reply-description"]}>
-            <span className={styles["description-caption"]}>
-              {l10n.getString("onboarding-premium-title-detail")}
-            </span>
-            <br />
-            <strong>{l10n.getString("onboarding-premium-reply-title")}</strong>
-            <br />
-            {l10n.getString("onboarding-premium-reply-description")}
-          </p>
-          {addonDescription}
-          <div
-            className={`${styles["addon-description"]} is-visible-with-addon`}
-          >
-            <div className={styles["action-complete"]}>
-              <img src={checkIcon.src} alt="" width={18} />
-              {l10n.getString("multi-part-onboarding-premium-extension-added")}
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+  return null;
 };

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -9,7 +9,11 @@ import {
   isPremiumAvailableInCountry,
   RuntimeDataWithPremiumAvailable,
 } from "../../functions/getPlan";
-import { isUsingFirefox } from "../../functions/userAgent";
+import {
+  isUsingFirefox,
+  supportsChromeExtension,
+  supportsFirefoxExtension,
+} from "../../functions/userAgent";
 import { ProfileData } from "../../hooks/api/profile";
 import { UserData } from "../../hooks/api/user";
 import { RuntimeData } from "../../hooks/api/runtimeData";
@@ -59,15 +63,24 @@ export const ProfileBanners = (props: Props) => {
     />
   );
 
-  if (!isUsingFirefox()) {
+  // Don't show the "Get Firefox" banner if we have an extension available,
+  // to avoid banner overload:
+  if (!isUsingFirefox() && !supportsChromeExtension()) {
     banners.push(<NoFirefoxBanner key="firefox-banner" />);
   }
 
-  if (isUsingFirefox()) {
+  if (supportsFirefoxExtension()) {
     // This pushes a banner promoting the add-on - detecting the add-on
     // and determining whether to show it based on that is a bit slow,
     // so we'll just let the add-on hide it:
     banners.push(<NoAddonBanner key="addon-banner" />);
+  }
+
+  if (supportsChromeExtension()) {
+    // This pushes a banner promoting the add-on - detecting the add-on
+    // and determining whether to show it based on that is a bit slow,
+    // so we'll just let the add-on hide it:
+    banners.push(<NoChromeExtensionBanner key="chrome-extension-banner" />);
   }
 
   if (
@@ -145,6 +158,30 @@ const NoAddonBanner = () => {
       hiddenWithAddon={true}
     >
       <p>{l10n.getString("banner-download-install-extension-copy")}</p>
+    </Banner>
+  );
+};
+
+const NoChromeExtensionBanner = () => {
+  const { l10n } = useLocalization();
+
+  return (
+    <Banner
+      type="promo"
+      title={l10n.getString(
+        "banner-download-install-chrome-extension-headline"
+      )}
+      illustration={
+        <img src={AddonIllustration.src} alt="" width={60} height={60} />
+      }
+      cta={{
+        target:
+          "https://chrome.google.com/webstore/detail/firefox-relay/lknpoadjjkjcmjhbjpcljdednccbldeb?utm_source=fx-relay&utm_medium=banner&utm_campaign=install-addon",
+        content: l10n.getString("banner-download-install-chrome-extension-cta"),
+      }}
+      hiddenWithAddon={true}
+    >
+      <p>{l10n.getString("banner-download-install-chrome-extension-copy")}</p>
     </Banner>
   );
 };

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -21,6 +21,7 @@ import { Banner } from "../Banner";
 import { trackPurchaseStart } from "../../functions/trackPurchase";
 import { renderDate } from "../../functions/renderDate";
 import { SubdomainPicker } from "./SubdomainPicker";
+import { useMinViewportWidth } from "../../hooks/mediaQuery";
 
 export type Props = {
   profile: ProfileData;
@@ -43,6 +44,7 @@ export type Props = {
  */
 export const ProfileBanners = (props: Props) => {
   const banners: ReactNode[] = [];
+  const isLargeScreen = useMinViewportWidth("md");
 
   const bounceStatus = props.profile.bounce_status;
   if (bounceStatus[0]) {
@@ -65,18 +67,18 @@ export const ProfileBanners = (props: Props) => {
 
   // Don't show the "Get Firefox" banner if we have an extension available,
   // to avoid banner overload:
-  if (!isUsingFirefox() && !supportsChromeExtension()) {
+  if (!isUsingFirefox() && (!supportsChromeExtension() || !isLargeScreen)) {
     banners.push(<NoFirefoxBanner key="firefox-banner" />);
   }
 
-  if (supportsFirefoxExtension()) {
+  if (supportsFirefoxExtension() && isLargeScreen) {
     // This pushes a banner promoting the add-on - detecting the add-on
     // and determining whether to show it based on that is a bit slow,
     // so we'll just let the add-on hide it:
     banners.push(<NoAddonBanner key="addon-banner" />);
   }
 
-  if (supportsChromeExtension()) {
+  if (supportsChromeExtension() && isLargeScreen) {
     // This pushes a banner promoting the add-on - detecting the add-on
     // and determining whether to show it based on that is a bit slow,
     // so we'll just let the add-on hide it:

--- a/frontend/src/functions/userAgent.ts
+++ b/frontend/src/functions/userAgent.ts
@@ -18,6 +18,10 @@ export function supportsChromeExtension() {
   );
 }
 
+export function supportsAnExtension() {
+  return supportsFirefoxExtension() || supportsChromeExtension();
+}
+
 export function hasDoNotTrackEnabled() {
   return typeof navigator !== "undefined" && navigator.doNotTrack === "1";
 }

--- a/frontend/src/functions/userAgent.ts
+++ b/frontend/src/functions/userAgent.ts
@@ -5,6 +5,19 @@ export function isUsingFirefox() {
   );
 }
 
+export function supportsFirefoxExtension() {
+  return (
+    typeof navigator !== "undefined" && /firefox/i.test(navigator.userAgent)
+  );
+}
+
+export function supportsChromeExtension() {
+  return (
+    typeof navigator !== "undefined" &&
+    /chrome|chromium/i.test(navigator.userAgent)
+  );
+}
+
 export function hasDoNotTrackEnabled() {
   return typeof navigator !== "undefined" && navigator.doNotTrack === "1";
 }

--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -170,7 +170,26 @@ describe("The dashboard", () => {
     expect(domainSearchField).not.toBeInTheDocument();
   });
 
-  it("shows a banner to download Firefox if using a different browser", () => {
+  it("shows a banner to download Firefox if using a different browser that does not support Chrome extensions", () => {
+    // navigator.userAgent is read-only, so we use `Object.defineProperty`
+    // as a workaround to be able to replace it with mock data anyway:
+    const previousUserAgent = navigator.userAgent;
+    Object.defineProperty(navigator, "userAgent", {
+      value:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1",
+      configurable: true,
+    });
+    render(<Profile />);
+    Object.defineProperty(navigator, "userAgent", { value: previousUserAgent });
+
+    const firefoxBanner = screen.getByRole("link", {
+      name: "l10n string: [banner-download-firefox-cta], with vars: {}",
+    });
+
+    expect(firefoxBanner).toBeInTheDocument();
+  });
+
+  it("shows a banner to download the Chrome extension if using a different browser that supports Chrome extensions", () => {
     // navigator.userAgent is read-only, so we use `Object.defineProperty`
     // as a workaround to be able to replace it with mock data anyway:
     const previousUserAgent = navigator.userAgent;
@@ -182,11 +201,11 @@ describe("The dashboard", () => {
     render(<Profile />);
     Object.defineProperty(navigator, "userAgent", { value: previousUserAgent });
 
-    const firefoxBanner = screen.getByRole("link", {
-      name: "l10n string: [banner-download-firefox-cta], with vars: {}",
+    const chromeExtensionBanner = screen.getByRole("link", {
+      name: "l10n string: [banner-download-install-chrome-extension-cta], with vars: {}",
     });
 
-    expect(firefoxBanner).toBeInTheDocument();
+    expect(chromeExtensionBanner).toBeInTheDocument();
   });
 
   it("does not show a banner to download Firefox if the user is already using it", () => {


### PR DESCRIPTION
# New feature description

This is the React equivalent of https://github.com/mozilla/fx-private-relay/pull/1615.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/157248855-bd76c245-9ac9-49ff-8d69-841620ec580c.png)

![image](https://user-images.githubusercontent.com/4251/157249554-36594f41-9fcb-4e16-bf85-b8b55cb60d9e.png)

# How to test

Same as #1615. See https://deploy-preview-1616--fx-relay-demo.netlify.app/?mockId=some and https://deploy-preview-1616--fx-relay-demo.netlify.app/?mockId=onboarding in Chrome.

# Checklist

- [x] l10n dependencies have been merged, if any. - No: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/65
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
