### PR TITLE
Sentry: ignore `request.summary`, `django.security.DisallowedHost` logs

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -18,6 +18,7 @@ from decouple import config
 import markus
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.logging import ignore_logger
 
 from django.conf import settings
 
@@ -597,6 +598,11 @@ sentry_sdk.init(
     with_locals=DEBUG,
     release=sentry_release,
 )
+# Duplicates events for unhandled exceptions, but without useful tracebacks
+ignore_logger("request.summary")
+# Security scanner attempts, no action required
+# Can be re-enabled when hostname allow list implemented at the load balancer
+ignore_logger("django.security.DisallowedHost")
 
 markus.configure(
     backends=[


### PR DESCRIPTION
`request.summary` logs at error level for uncaught exceptions, and Sentry creates an event with the text returned to the caller. However, there is already an event for the uncaught exception, which includes a traceback that is useful for debugging. [Ignore this logger](https://docs.sentry.io/platforms/python/guides/logging/#ignoring-a-logger) to avoid the duplicate and less-useful event.

`django.security.DisallowedHost` is raised when the `Host` header is not in [settings.ALLOWED_HOSTS](https://docs.djangoproject.com/en/2.2/ref/settings/#allowed-hosts), and returns a `400 Bad Request`. In deployments, these have all been security scan attempts, with a variety of hostnames or IP addresses. No further action is needed by the team, so ignore the logger and omit the events from Sentry. This does not filter other [SuspicousOperation](https://docs.djangoproject.com/en/4.0/ref/exceptions/#suspiciousoperation) logs, which may be actionable.

This PR fixes #1556.

How to test:

- It is difficult, but not impossible, to test this PR in automated tests. I believe the change is best tested by trying in a deployment, and is low-risk. If we'd like a test framework for Sentry (for example, to implement filtered [with_locals](https://docs.sentry.io/platforms/python/configuration/options/#with-locals)), that should be done in a separate PR (which could be before this one)
- Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).