### PR TITLE
Display use case interstitial page on Premium hompeage

### DIFF
--- a/privaterelay/templates/premium-promo.html
+++ b/privaterelay/templates/premium-promo.html
@@ -158,8 +158,8 @@
     <section>
         <div class="container mzp-l-content">
             <h2 class="use-case-headline">{% ftlmsg 'premium-promo-use-cases-headline' %}</h2>
-            <ul class="c-use-case-content has-3">
-                <li class="use-case-title use-case-shopping is-active remove-box-shadow">
+            <ul class="c-use-case-content has-3" id="use-cases">
+                <li class="use-case-title use-case-shopping is-active remove-box-shadow" data-use-case="shopping">
                     <div class="use-case-title-text">{% ftlmsg 'premium-promo-use-cases-shopping-heading' %}</div>
                     <div class="drop-down"></div>
                 </li>
@@ -169,7 +169,7 @@
                         {% ftlmsg 'premium-promo-use-cases-shopping-body' %}
                     </div>
                 </li>
-                <li class="use-case-title use-case-social-networks">
+                <li class="use-case-title use-case-social-networks" data-use-case="social-networks">
                     <div class="use-case-title-text">{% ftlmsg 'premium-promo-use-cases-social-networks-heading' %}</div>
                     <div class="drop-down"></div>
                 </li>
@@ -179,7 +179,7 @@
                         {% ftlmsg 'premium-promo-use-cases-social-networks-body' %}
                     </div>
                 </li>
-                <li class="use-case-title use-case-gaming">
+                <li class="use-case-title use-case-gaming" data-use-case="gaming">
                     <div class="use-case-title-text">{% ftlmsg 'premium-promo-use-cases-gaming-heading' %}</div>
                     <div class="drop-down"></div>
                 </li>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -765,7 +765,6 @@ function toggleClass(elem) {
    useCaseTitle.forEach( item => {
       item.classList.remove("is-active");
   });
-  useCaseSection.scrollIntoView();
   elem.target.classList.add("is-active");
   window.location.hash = "#use-cases" + "/" + elem.target.dataset.useCase;
 }
@@ -796,7 +795,7 @@ function hashChangeAccordion(){
 
 hashChangeAccordion();
 
-window.onhashchange = hashChangeAccordion;
+window.addEventListener("hashchange", hashChangeAccordion, false);
 
 useCaseTitle.forEach( item => {
     item.addEventListener("click", toggleClass, false);


### PR DESCRIPTION
This PR fixes the bug of not showing the description in the homepage accordion.




# Screenshot (if applicable)
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/13066134/157493669-f742064f-ff80-4a5e-be81-aee27b99edc1.png">
<img width="1469" alt="image" src="https://user-images.githubusercontent.com/13066134/157493712-ed2ac38e-fa8e-436a-8913-0cf2094208a0.png">


# How to test
Go to `http://127.0.0.1:8000/premium` and check that the use case section functions like an accordion.

# Checklist

- [ ] l10n dependencies have been merged, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
