### PR TITLE
Fix #1605 - Overlapping issue with Alias Filter Menu/Promo Blocking UI on mobile breakpoins

### DIFF
--- a/static/scss/components/filter-bar.scss
+++ b/static/scss/components/filter-bar.scss
@@ -215,7 +215,8 @@
     top: calc(100% + #{$spacing-md});
     background-color: $color-white;
     box-shadow: $box-shadow-sm;
-    z-index: 1;
+    // #fx-private-relay/issues/1605: Z-index is 2 to appear over the Promo Blocking UI form
+    z-index: 2;
     padding: 0;
     border-radius: $border-radius-md;
     


### PR DESCRIPTION
This PR fixes an issue where the Promo Blocking UI was appearing over the filter menu on mobile. 

Issue #1605 / [MPP-1741](https://mozilla-hub.atlassian.net/browse/MPP-1741)

## Testing Steps 

- Set browser to mobile/narrow width
- Log into dashboard with premium account
- Open first alias so that Promo Blocking UI is visible
- Open filter menu
- **Expected:** The filter menu appears OVER the Promo Blocking UI.

## Screenshot

![image](https://user-images.githubusercontent.com/2692333/157524708-03eff92f-11cc-4fbd-8f8d-048e5a6cc02e.png)


- [x] l10n dependencies have been merged, if any.
- [x] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
