### PR TITLE
cache the DomainAddress.user_profile property

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -621,7 +621,7 @@ class DomainAddress(models.Model):
         # TODO: validate user is premium to set block_list_emails
         return super().save(*args, **kwargs)
 
-    @property
+    @cached_property
     def user_profile(self):
         return Profile.objects.get(user=self.user)
 

--- a/privaterelay/templates/includes/alias-card.html
+++ b/privaterelay/templates/includes/alias-card.html
@@ -1,5 +1,6 @@
 {% load ftl %}
 {% ftlconf bundle='privaterelay.ftl_bundles.main' %}
+{% load relay_tags %}
 {% load static %}
 
 {% comment %}
@@ -25,7 +26,7 @@ Premium users:
 {% else %}
   is-blocked 
 {% endif %} 
-" data-relay-address="{{ alias.full_address }}" data-relay-address-id="{{ alias.id }}">
+" data-relay-address="{{ alias|full_address:user_profile }}" data-relay-address-id="{{ alias.id }}">
 
   <div class="c-alias-main-info">
     <!-- enable/disable email forwarding -->
@@ -81,9 +82,9 @@ Premium users:
           data-ftl-click-to-copy="{% ftlmsg 'profile-label-click-to-copy' %}"
           data-ftl-copy-confirmation="{% ftlmsg 'profile-label-copy-confirmation' %}"
           data-id="{{ alias.id }}"
-          data-clipboard-text="{{ alias.full_address }}"
+          data-clipboard-text="{{ alias|full_address:user_profile }}"
           class="relay-address click-copy alias-on-desktop ff-Met xflx jst-cntr al-cntr">
-            <span class="relay-address--label">{{ alias.full_address }}</span>
+            <span class="relay-address--label">{{ alias|full_address:user_profile }}</span>
             <span class="alias-copied-icon"></span>
             <span class="alias-copied-message">{% ftlmsg 'profile-label-copied' %}</span>
         </button>
@@ -118,9 +119,9 @@ Premium users:
       data-ftl-click-to-copy="{% ftlmsg 'profile-label-click-to-copy' %}"
       data-ftl-copy-confirmation="{% ftlmsg 'profile-label-copy-confirmation' %}"
       data-id="{{ alias.id }}"
-      data-clipboard-text="{{ alias.full_address }}"
+      data-clipboard-text="{{ alias|full_address:user_profile }}"
       class="relay-address click-copy alias-on-mobile ff-Met jst-cntr al-cntr">
-        <span class="relay-address--label">{{ alias.full_address }}</span>
+        <span class="relay-address--label">{{ alias|full_address:user_profile }}</span>
         <span class="alias-copied-icon"></span>
         <span class="alias-copied-message">{% ftlmsg 'profile-label-copied' %}</span>
     </button>
@@ -217,7 +218,7 @@ Premium users:
 
       <!-- delete email address -->
       <div class="column-delete">
-        <form action="{% url 'emails-index' %}" method="POST" class="delete-email-form xflx jst-cntr al-cntr" data-type="{{ alias_type }}" data-delete-relay="{{ alias.full_address }}">
+        <form action="{% url 'emails-index' %}" method="POST" class="delete-email-form xflx jst-cntr al-cntr" data-type="{{ alias_type }}" data-delete-relay="{{ alias|full_address:user_profile }}">
           <input type="hidden" name="method_override" value="DELETE">
           <input type="hidden" name="api_token" value="{{ user_profile.api_token }}">
           <input type="hidden" name="{{ alias_type }}_address_id" value="{{ alias.id }}">

--- a/privaterelay/templatetags/relay_tags.py
+++ b/privaterelay/templatetags/relay_tags.py
@@ -1,6 +1,7 @@
 from django import template
 from django.conf import settings
 
+from emails.models import RelayAddress
 from emails.utils import get_email_domain_from_settings
 
 from ..utils import get_premium_country_lang
@@ -51,3 +52,10 @@ def premium_plan_price(accept_lang, cc=None):
 def premium_subscribe_url(accept_lang=None, cc=None):
     plan_id = premium_plan_id(accept_lang, cc)
     return f'{settings.FXA_SUBSCRIPTIONS_URL}/products/{settings.PREMIUM_PROD_ID}?plan={plan_id}'
+
+
+@register.filter
+def full_address(alias, user_profile):
+    if type(alias) == RelayAddress:
+        return '%s@%s' % (alias.address, alias.domain_value)
+    return '%s@%s.%s' % (alias.address, user_profile.subdomain, alias.domain_value)


### PR DESCRIPTION
The new `alias-card.html` template references `alias.full_address` 6 times. `Domain.full_address` calls `self.user_profile` which calls `Profile.objects.get()`. So, each domain alias in the dashboard makes 6 separate DB queries to `emails_profile` to fetch the profile.
![image](https://user-images.githubusercontent.com/71928/157741737-93f508a2-6743-4851-a145-1b7515b8588f.png)


This PR changes the `DomainAddress` model to cache its `user_profile` property, so the calls to `full_address` no longer makes so many DB queries.
![image](https://user-images.githubusercontent.com/71928/157741899-502da813-5809-4d2c-8d5b-a9cfbb6dfc27.png)


How to test:

* [ ] Make sure dashboard page still works as expected.
* [ ] Make sure replies still work as expected.