### PR TITLE
use profile_set.prefetch_related during sns-inbound

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -377,7 +377,7 @@ def _sns_message(message_json):
         # RelayAddress or DomainAddress types makes the Rustacean in me throw
         # up a bit.
         address = _get_address(to_address, to_local_portion, to_domain_portion)
-        user_profile = address.user.profile_set.first()
+        user_profile = address.user.profile_set.prefetch_related('user__socialaccount_set').first()
     except (ObjectDoesNotExist, CannotMakeAddressException, DeletedAddress.MultipleObjectsReturned):
         if to_local_portion == 'replies':
             response = _handle_reply(from_address, message_json, to_address)


### PR DESCRIPTION
The `wrapped_email.html` template references `Profile.has_premium` 3 times. In https://github.com/mozilla/fx-private-relay/pull/1608, we updated the dashboard view to add `prefetch_related` so that the `socialaccount_set` (i.e., the `fxa` property which is used in `has_premium`) only triggers a single DB query.

In this case, it saves us 3 DB queries ...

## OLD:
![image](https://user-images.githubusercontent.com/71928/157754024-bcead29f-792a-46a3-a0e7-613dbde2ec59.png)

## New Hotness:
![image](https://user-images.githubusercontent.com/71928/157754099-aade0991-7f02-4390-859f-743b6c486bd7.png)


How to test:
(Probably on dev server)
- [ ] Check that emails flow thru the server as expected.