### PR TITLE
Return 404 if the S3 object no longer exists

### DIFF
--- a/emails/utils.py
+++ b/emails/utils.py
@@ -330,6 +330,9 @@ def remove_message_from_s3(bucket, object_key):
         )
         return response.get('DeleteMarker')
     except ClientError as e:
-        logger.error('s3_client_error_delete_email', extra=e.response['Error'])
+        if e.response['Error'].get('Code', '') == 'NoSuchKey':
+            logger.error('s3_object_does_not_exist', extra=e.response['Error'])
+        else:
+            logger.error('s3_client_error_delete_email', extra=e.response['Error'])
         incr_if_enabled('message_not_removed_from_s3', 1)
     return False

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -331,7 +331,7 @@ def remove_message_from_s3(bucket, object_key):
         return response.get('DeleteMarker')
     except ClientError as e:
         if e.response['Error'].get('Code', '') == 'NoSuchKey':
-            logger.error('s3_object_does_not_exist', extra=e.response['Error'])
+            logger.error('s3_delete_object_does_not_exist', extra=e.response['Error'])
         else:
             logger.error('s3_client_error_delete_email', extra=e.response['Error'])
         incr_if_enabled('message_not_removed_from_s3', 1)

--- a/emails/views.py
+++ b/emails/views.py
@@ -443,6 +443,9 @@ def _sns_message(message_json):
             message_json
         )
     except ClientError as e:
+        if e.response['Error'].get('Code', '') == 'NoSuchKey':
+            logger.error('s3_object_does_not_exist', extra=e.response['Error'])
+            return HttpResponse("Email not in S3", status=404)
         logger.error('s3_client_error_get_email', extra=e.response['Error'])
         # we are returning a 503 so that SNS can retry the email processing
         return HttpResponse("Cannot fetch the message content from S3", status=503)
@@ -605,6 +608,9 @@ def _handle_reply(from_address, message_json, to_address):
             message_json
         )
     except ClientError as e:
+        if e.response['Error'].get('Code', '') == 'NoSuchKey':
+            logger.error('s3_object_does_not_exist', extra=e.response['Error'])
+            return HttpResponse("Email not in S3", status=404)
         logger.error('s3_client_error_get_email', extra=e.response['Error'])
         # we are returning a 500 so that SNS can retry the email processing
         return HttpResponse("Cannot fetch the message content from S3", status=503)


### PR DESCRIPTION
# About this PR
We are getting [S3 client error](https://sentry.prod.mozaws.net/operations/fx-private-relay-prod/issues/18255993/?query=is%3Aunresolved) with `NoSuchKey` code in the error response, likely because we have already processed the email but we are not responding to the SNS in time resulting in SNS retry. If the email is not in S3, instead of returning a 503, we should return a 404 so the SNS does not send us the retry ping.

Fixes #1590 