### PR TITLE
Work around not-loaded Swedish and Frysian locales

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,12 @@ COPY --from=builder --chown=app /app/static ./static
 
 COPY --chown=app ./requirements.txt /app/requirements.txt
 RUN pip install -r requirements.txt
+# When the user's Accept-Language is set to `fy`, Django's LocaleMiddleware
+# doesn't load `fy-NL`. This is a workaround to force the Frysian and Swedish
+# localisations to load anyway when appropriate.
 COPY --chown=app . /app
+RUN cp -r /app/privaterelay/locales/fy-NL/ privaterelay/locales/fy/
+RUN cp -r /app/privaterelay/locales/sv-SE/ privaterelay/locales/sv/
 COPY --chown=app .env-dist /app/.env
 
 RUN mkdir -p /app/staticfiles


### PR DESCRIPTION
This PR fixes/works around Django's LocaleMiddleware not loading `fy-NL` localisations when the user's Accept-Language is set to `fy` (it _would_ do so if it was the other way around, i.e. it would load `fy` if the Accept-Language was set to `fy-NL` though).

It's more a workaround than a "proper" fix, for these reasons:

- It's probably not feasible (especially not for me) to change this behaviour upstream - it might not even be considered desirable by them/other locales, and might be confusing for their other downstreams if it were to change.
- Renaming/moving the locales in Pontoon supposedly is problematic too.
- The React front-end _does_ handle this correctly (by virtue of being able to use Fluent's `@fluent/langneg` library), so for most of the UI, it's only needed temporarily. On the other hand, we'll likely keep needing this for the email templates.

How to test:

Unfortunately I don't know how to run the Relay Docker image locally and being able to visit it from your browser. However, you can run the command locally manually, visit the site with your `Accept-Language` set to `fy`, and see the Frysian translation.

You can also verify that the command executes successfully in Docker by building the image (`docker build --tag my/relay .`), then opening a shell into that image (`sudo docker run --interactive --tty --rm --entrypoint=bash my/relay`), and verifying that the `fy-NL` directory has indeed been copied to `fy`: `ls /app/privaterelay/locales/ | grep fy`

- [x] l10n dependencies have been merged, if any.
- [ ] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
