### PR TITLE
Don't let .mzp-l-content overlap dismiss button

### DIFF
--- a/static/scss/partials/onboarding.scss
+++ b/static/scss/partials/onboarding.scss
@@ -78,6 +78,7 @@
 
     .mzp-l-content {
         padding: $spacing-lg $spacing-lg;
+        position: initial;
     }
 }
 
@@ -131,7 +132,6 @@
     padding: 0;
     cursor: pointer;
     display: block;
-    z-index: 5;
     transition: transform .3s ease-in;
 
     &:hover {


### PR DESCRIPTION
The z-index already did that, but then made the dismiss button
in turn overlap the header. This just removes the relative
positioning from .mzp-l-content, which it doesn't seem to need (at
least not here).

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #<issue ID>.

How to test:

- [ ] l10n dependencies have been merged, if any.
- [ ] I've added a unit test to test for potential regressions of this bug (or this is a front-end change, where we don't yet have unit test infrastructure).
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description



# Screenshot (if applicable)

Not applicable.

# How to test



# Checklist

- [ ] l10n dependencies have been merged, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
