### PR TITLE
Fix deployment job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           paths:
             - ./frontend/out/
 
-  build:
+  build_backend:
     docker:
       - image: docker:stable-git
         auth:
@@ -84,7 +84,7 @@ jobs:
           name: docker save fx-private-relay
           command: mkdir --parents /cache; docker save --output /cache/docker.tar "fx-private-relay"
       - save_cache:
-          key: v1-{{ .Branch }}-{{epoch}}
+          key: v1-backend-build-{{ .Branch }}-{{epoch}}
           paths:
             - /cache/docker.tar
 
@@ -128,7 +128,7 @@ jobs:
     steps:
       - setup_remote_docker
       - restore_cache:
-          key: v1-{{.Branch}}
+          key: v1-backend-build-{{.Branch}}
       - run:
           name: Restore Docker image cache
           command: docker load --input /cache/docker.tar
@@ -170,7 +170,7 @@ jobs:
           path: /tmp/test-results
 
       - save_cache:
-          key: v1-coverage-{{ .Branch }}-{{epoch}}
+          key: v1-backend-coverage-{{ .Branch }}-{{epoch}}
           paths:
             - /tmp/test-results/coverage/.coverage
 
@@ -182,7 +182,7 @@ jobs:
       - run: git submodule sync
       - run: git submodule update --init
       - restore_cache:
-          key: v1-coverage-{{.Branch}}
+          key: v1-backend-coverage-{{.Branch}}
       - run:
           name: Upload coverage
           command: |
@@ -199,7 +199,7 @@ jobs:
     steps:
       - setup_remote_docker
       - restore_cache:
-          key: v1-{{.Branch}}
+          key: v1-backend-build-{{.Branch}}
       - run:
           name: Restore Docker image cache
           command: docker load --input /cache/docker.tar
@@ -229,7 +229,7 @@ workflows:
             tags:
               only: /.*/
 
-      - build:
+      - build_backend:
           requires:
             - build_frontend
           filters:
@@ -245,7 +245,7 @@ workflows:
 
       - test_backend:
           requires:
-            - build
+            - build_backend
           filters:
             tags:
               only: /.*/
@@ -259,7 +259,7 @@ workflows:
 
       - deploy:
           requires:
-            - build
+            - build_backend
             - test_backend
           filters:
             tags:


### PR DESCRIPTION
I tried to do a stage deploy, but [it failed](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/4357/workflows/2888c5f7-3335-4882-9f2b-a1de4e8714ec/jobs/8578):

```
Found a cache from build 8576 at v1-
Size: 84 KiB
Cached paths:
  * /tmp/test-results/coverage/.coverage

Downloading cache archive...
Validating cache...
```

```
open /cache/docker.tar: no such file or directory

Exited with code exit status 1
```

Since cache keys [are prefix-matched](https://circleci.com/docs/2.0/caching/#restoring-cache), using something like
`v1-coverage-` as a prefix for the test coverage job, and just
`v1-` for the backend build, was causing the wrong cache to be
restored in the deploy step. I think this PR should fix the deploy,
while also making naming in the CI config more consistent.

How to test: I'm afraid we can only test this by tagging a new release, in addition to confirming that [the regular PR job](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/4363/workflows/ac5b7f16-5373-4369-adef-26a8f0bd7b7d) doesn't break :/

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [ ] I've added or updated relevant docs in the docs/ directory. N/A
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
