### PR TITLE
Add custom dimension to add-on telemtry events

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -20,6 +20,8 @@ This is the Analytics plan for Firefox Relay. It documents our use of Google Ana
 
 >Which devices are most commonly used to access the Firefox Relay website?
 
+>Which browser is running the Firefox Relay the add-on?  
+
 **User Behavior:**
 
 >Do users delete aliases?
@@ -69,7 +71,6 @@ We collect data for the following extension events:
 - When the Relay icon is clicked by an unauthenticated user
 
 - When the Relay icon is clicked by a user who has already reached the maximum number of allowed aliases
-
 
 ### Post-install page events:
 

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -225,6 +225,7 @@ def metrics_event(request):
         request_data.get('action', None),
         request_data.get('label', None),
         request_data.get('value', None),
+        dimension5 = request_data.get('dimension5', None),
     )
     try:
         report(

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -220,12 +220,14 @@ def metrics_event(request):
         return JsonResponse({'msg': 'Could not decode JSON'}, status=415)
     if 'ga_uuid' not in request_data:
         return JsonResponse({'msg': 'No GA uuid found'}, status=404)
+    # "dimension5" is a Google Analytics-specific variable to track a custom dimension.
+    # This dimension is used to determine which browser vendor the add-on is using: Firefox or Chrome
     event_data = event(
         request_data.get('category', None),
         request_data.get('action', None),
         request_data.get('label', None),
         request_data.get('value', None),
-        dimension5 = request_data.get('dimension5', None),
+        dimension5=request_data.get('dimension5', None),
     )
     try:
         report(


### PR DESCRIPTION
## Summary 

This PR passes additional data field(s) from the add-on telemetry events (using the `metrics_event` route) to GA. 

See https://github.com/mozilla/fx-private-relay-add-on/pull/301

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
