### PR TITLE
Promo-blocking UI for free users

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -1,7 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-   
+
 landing-use-cases-shopping = Shopping
 landing-use-cases-shopping-hero-heading = Shopping with email masks
 landing-use-cases-shopping-hero-content1 = Want to buy something online and don’t know or fully trust the shop?
@@ -9,14 +9,14 @@ landing-use-cases-shopping-hero-content2 = Use an email mask whenever you shop o
 
 landing-use-cases-on-the-go = On the Go
 landing-use-cases-on-the-go-heading = On the go with { -brand-name-relay }
-landing-use-cases-on-the-go-lead = Instantly make a custom email mask anywhere and everywhere you go! 
+landing-use-cases-on-the-go-lead = Instantly make a custom email mask anywhere and everywhere you go!
 landing-use-cases-on-the-go-connect-heading = Connect on the go
-landing-use-cases-on-the-go-connect-body = Use your email mask when you want to privately sign into your favorite coffee shop or public wifi 
+landing-use-cases-on-the-go-connect-body = Use your email mask when you want to privately sign into your favorite coffee shop or public wifi
 landing-use-cases-on-the-go-receipt-heading = Get email receipts
-landing-use-cases-on-the-go-receipt-body = Share a custom email mask for in-store shopping receipts without sharing your real email 
+landing-use-cases-on-the-go-receipt-body = Share a custom email mask for in-store shopping receipts without sharing your real email
 landing-use-cases-on-the-go-phone-heading = Use on your phone
-landing-use-cases-on-the-go-phone-body = No matter where you are create a custom email mask in seconds for anything you want to do 
- 
+landing-use-cases-on-the-go-phone-body = No matter where you are create a custom email mask in seconds for anything you want to do
+
 landing-use-cases-signups = Signups
 landing-use-cases-signups-hero-heading = Worry-free signups
 landing-use-cases-signups-hero-content1 = Want to start a new subscription, RSVP to an event, or get a bargain promo code without having spam flooding your inbox?
@@ -24,6 +24,8 @@ landing-use-cases-signups-hero-content2 = Before you complete that next signup, 
 
 banner-download-install-chrome-extension-copy-2 = The { -brand-name-firefox-relay } extension for { -brand-name-chrome } makes creating and using masks even easier.
 multi-part-onboarding-premium-chrome-extension-get-description-2 = The { -brand-name-firefox-relay } extension for { -brand-name-chrome } makes creating and using email masks even easier.
+
+popover-custom-alias-explainer-promotional-block-tooltip-trigger = More info
 
 tips-toast-button-expand-label = Learn more
 

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -28,6 +28,8 @@ multi-part-onboarding-premium-chrome-extension-get-description-2 = The { -brand-
 profile-promo-email-blocking-option-promotionals-premiumonly-marker = ({ -brand-name-premium } only)
 profile-promo-email-blocking-description-promotionals-locked-label = Available to { -brand-name-relay-premium } subscribers
 profile-promo-email-blocking-description-promotionals-locked-cta = Upgrade now
+profile-promo-email-blocking-description-promotionals-locked-waitlist-cta = Join the { -brand-name-relay-premium } wait list
+profile-promo-email-blocking-description-promotionals-locked-close = Close
 
 popover-custom-alias-explainer-promotional-block-tooltip-trigger = More info
 

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -25,6 +25,10 @@ landing-use-cases-signups-hero-content2 = Before you complete that next signup, 
 banner-download-install-chrome-extension-copy-2 = The { -brand-name-firefox-relay } extension for { -brand-name-chrome } makes creating and using masks even easier.
 multi-part-onboarding-premium-chrome-extension-get-description-2 = The { -brand-name-firefox-relay } extension for { -brand-name-chrome } makes creating and using email masks even easier.
 
+profile-promo-email-blocking-option-promotionals-premiumonly-marker = ({ -brand-name-premium } only)
+profile-promo-email-blocking-description-promotionals-locked-label = Available to { -brand-name-relay-premium } subscribers
+profile-promo-email-blocking-description-promotionals-locked-cta = Upgrade now
+
 popover-custom-alias-explainer-promotional-block-tooltip-trigger = More info
 
 tips-toast-button-expand-label = Learn more

--- a/frontend/src/apiMocks/handlers.ts
+++ b/frontend/src/apiMocks/handlers.ts
@@ -227,7 +227,7 @@ export function getHandlers(
       description: "",
       domain: 2,
       enabled: true,
-      block_list_emails: false,
+      block_list_emails: body.block_list_emails ?? false,
       id: id,
       last_modified_at: new Date(Date.now()).toISOString(),
       last_used_at: new Date(Date.now()).toISOString(),

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -85,6 +85,35 @@ export const NewTabIcon = (
   );
 };
 
+/** Lock icon that inherits the text color of its container */
+export const LockIcon = ({
+  alt,
+  ...props
+}: SVGProps<SVGSVGElement> & { alt: string }) => {
+  const width = props.width ?? 14;
+  const height = props.height ?? 16;
+
+  return (
+    <svg
+      role="img"
+      aria-label={alt}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      aria-hidden={alt === ""}
+      style={{
+        fill: "currentcolor",
+        ...props.style,
+      }}
+      {...props}
+    >
+      <title>{alt}</title>
+      <path d="M12.031 6.84h-.573V4.57a4.566 4.566 0 00-1.342-3.232 4.59 4.59 0 00-6.482 0A4.565 4.565 0 002.292 4.57V6.84h-.573c-.456 0-.893.18-1.216.502A1.712 1.712 0 000 8.554v5.732c0 .454.181.89.503 1.212.323.321.76.502 1.216.502H12.03a1.712 1.712 0 001.719-1.714V8.554c0-.455-.181-.89-.503-1.212a1.721 1.721 0 00-1.216-.502zM4.583 4.57c0-.606.242-1.187.672-1.616a2.295 2.295 0 013.24 0c.43.429.672 1.01.672 1.616V6.84H4.583V4.57z" />
+    </svg>
+  );
+};
+
 export const Cogwheel = () => (
   <svg
     width="16"

--- a/frontend/src/components/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip.tsx
@@ -23,6 +23,9 @@ export const InfoTooltip = (props: Props) => {
     <span className={styles.wrapper}>
       <button
         ref={triggerRef}
+        // Set to type="button" to prevent wrapping forms from being submitted
+        // when the info icon is clicked:
+        type="button"
         {...tooltipTrigger.triggerProps}
         className={styles.trigger}
       >

--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.module.scss
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.module.scss
@@ -93,6 +93,17 @@
       padding: $spacing-lg $spacing-sm 0;
       font-family: $font-stack-firefox;
       accent-color: $color-blue-50;
+
+      .promotionals-blocking-description {
+        a {
+          display: block;
+          color: $color-blue-50;
+
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
     }
 
     .buttons {

--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.module.scss
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.module.scss
@@ -73,13 +73,26 @@
 
         input {
           @include form-input;
+          // Override form-input's margin:
+          margin: 0;
         }
       }
 
       .suffix {
         font-family: $font-stack-firefox;
         display: block;
+        padding-top: $spacing-xs;
       }
+    }
+
+    .promotionals-blocking-control {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: $spacing-sm;
+      padding: $spacing-lg $spacing-sm 0;
+      font-family: $font-stack-firefox;
+      accent-color: $color-blue-50;
     }
 
     .buttons {

--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
 } from "react";
+import Link from "next/link";
 import { useLocalization } from "@fluent/react";
 import {
   OverlayContainer,
@@ -20,6 +21,7 @@ import styles from "./AddressPickerModal.module.scss";
 import { InfoIcon } from "../../Icons";
 import { getRuntimeConfig } from "../../../config";
 import { Button } from "../../Button";
+import { InfoTooltip } from "../../InfoTooltip";
 
 export type Props = {
   isOpen: boolean;
@@ -101,6 +103,29 @@ export const AddressPickerModal = (props: Props) => {
                   "popover-custom-alias-explainer-promotional-block-checkbox"
                 )}
               </label>
+              <InfoTooltip
+                alt={l10n.getString(
+                  "popover-custom-alias-explainer-promotional-block-tooltip-trigger"
+                )}
+              >
+                <h3>
+                  {l10n.getString(
+                    "popover-custom-alias-explainer-promotional-block-checkbox"
+                  )}
+                </h3>
+                <p className={styles["promotionals-blocking-description"]}>
+                  {l10n.getString(
+                    "popover-custom-alias-explainer-promotional-block-tooltip-2"
+                  )}
+                  <Link href="/faq#faq-promotional-email-blocking">
+                    <a>
+                      {l10n.getString(
+                        "banner-label-data-notification-body-cta"
+                      )}
+                    </a>
+                  </Link>
+                </p>
+              </InfoTooltip>
             </div>
             <div className={styles.buttons}>
               <button

--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
@@ -24,7 +24,7 @@ import { Button } from "../../Button";
 export type Props = {
   isOpen: boolean;
   onClose: () => void;
-  onPick: (address: string) => void;
+  onPick: (address: string, settings: { blockPromotionals: boolean }) => void;
   subdomain: string;
 };
 
@@ -35,6 +35,7 @@ export type Props = {
 export const AddressPickerModal = (props: Props) => {
   const { l10n } = useLocalization();
   const [address, setAddress] = useState("");
+  const [promotionalsBlocking, setPromotionalsBlocking] = useState(false);
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const cancelButton = useButton(
     { onPress: () => props.onClose() },
@@ -44,7 +45,7 @@ export const AddressPickerModal = (props: Props) => {
   const onSubmit: FormEventHandler = (event) => {
     event.preventDefault();
 
-    props.onPick(address);
+    props.onPick(address, { blockPromotionals: promotionalsBlocking });
   };
 
   return (
@@ -86,6 +87,20 @@ export const AddressPickerModal = (props: Props) => {
               <span className={styles.suffix}>
                 @<b>{props.subdomain}</b>.{getRuntimeConfig().mozmailDomain}
               </span>
+            </div>
+            <div className={styles["promotionals-blocking-control"]}>
+              <input
+                type="checkbox"
+                id="promotionalsBlocking"
+                onChange={(event) =>
+                  setPromotionalsBlocking(event.target.checked)
+                }
+              />
+              <label htmlFor="promotionalsBlocking">
+                {l10n.getString(
+                  "popover-custom-alias-explainer-promotional-block-checkbox"
+                )}
+              </label>
             </div>
             <div className={styles.buttons}>
               <button

--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -32,76 +32,9 @@ $toggleTransitionDuration: 200ms;
 
 .controls {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: 1fr;
   row-gap: $spacing-xs;
   align-items: center;
-
-  // The label field might not be present,
-  // but if it is (i.e. the copy button/email
-  // address is the third element),
-  // the copy button should be in the same column,
-  // one row below.
-  *:nth-child(3) {
-    grid-column: 2;
-  }
-}
-
-.toggle-button {
-  cursor: pointer;
-  height: 1.15rem;
-  width: 2rem;
-  position: relative;
-  overflow: hidden;
-  border: none;
-  border-radius: $border-radius-md;
-  margin-right: $spacing-sm;
-  outline: none;
-  background-color: $color-blue-50;
-
-  &:hover,
-  &:focus {
-    background-color: $color-blue-70;
-    box-shadow: $buttonFocusOutline;
-  }
-
-  &:active {
-    background-color: $color-blue-80;
-  }
-
-  // The knob:
-  &::after {
-    content: "";
-    height: 0.75rem;
-    width: 0.75rem;
-    position: absolute;
-    border-radius: 50%;
-    background-color: $color-white;
-    top: 0;
-    bottom: 0;
-    margin: auto;
-    right: 4px;
-    transition: left $toggleTransitionDuration ease,
-      right $toggleTransitionDuration ease,
-      background-color $toggleTransitionDuration ease;
-  }
-
-  .is-disabled & {
-    background-color: $color-light-gray-30;
-
-    &:hover,
-    &:focus {
-      background-color: $color-light-gray-40;
-    }
-
-    &:active {
-      background-color: $color-light-gray-50;
-    }
-
-    &::after {
-      left: 4px;
-      right: 18px;
-    }
-  }
 }
 
 .copy-controls {

--- a/frontend/src/components/dashboard/aliases/Alias.tsx
+++ b/frontend/src/components/dashboard/aliases/Alias.tsx
@@ -21,6 +21,7 @@ import { AliasDeletionButton } from "./AliasDeletionButton";
 import { getRuntimeConfig } from "../../../config";
 import { getLocale } from "../../../functions/getLocale";
 import { BlockLevel, BlockLevelSlider } from "./BlockLevelSlider";
+import { RuntimeData } from "../../../hooks/api/runtimeData";
 
 export type Props = {
   alias: AliasData;
@@ -30,6 +31,7 @@ export type Props = {
   onDelete: () => void;
   defaultOpen?: boolean;
   showLabelEditor?: boolean;
+  runtimeData?: RuntimeData;
 };
 
 /**
@@ -207,6 +209,10 @@ export const Alias = (props: Props) => {
             alias={props.alias}
             onChange={setBlockLevel}
             hasPremium={props.profile.has_premium}
+            premiumAvailableInCountry={
+              props.runtimeData?.PREMIUM_PLANS.premium_available_in_country ??
+              false
+            }
           />
         </div>
         <div className={styles.row}>

--- a/frontend/src/components/dashboard/aliases/Alias.tsx
+++ b/frontend/src/components/dashboard/aliases/Alias.tsx
@@ -38,16 +38,6 @@ export type Props = {
 export const Alias = (props: Props) => {
   const { l10n } = useLocalization();
   const [justCopied, setJustCopied] = useState(false);
-  const toggleButtonState = useToggleState({
-    defaultSelected: props.alias.enabled,
-    onChange: (isEnabled) => props.onUpdate({ enabled: isEnabled }),
-  });
-  const toggleButtonRef = useRef<HTMLButtonElement>(null);
-  const { buttonProps } = useToggleButton(
-    {},
-    toggleButtonState,
-    toggleButtonRef
-  );
 
   const expandButtonRef = useRef<HTMLButtonElement>(null);
   const expandButtonState = useToggleState({
@@ -107,42 +97,27 @@ export const Alias = (props: Props) => {
     compactDisplay: "short",
   });
 
-  // We have the <BlockLevelSlider> for Premium users, so don't show the toggle
-  // for them:
-  const toggleButton = props.profile.has_premium ? (
-    // An empty span can take the cell in the grid layout that otherwise
-    // would have been taken by the <button>:
-    <span />
-  ) : (
-    <button
-      {...buttonProps}
-      ref={toggleButtonRef}
-      className={styles["toggle-button"]}
-      aria-label={l10n.getString(
-        toggleButtonState.isSelected
-          ? "profile-label-disable-forwarding-button-2"
-          : "profile-label-enable-forwarding-button-2"
-      )}
-    ></button>
-  );
-
   const setBlockLevel = (blockLevel: BlockLevel) => {
     if (blockLevel === "none") {
-      return props.onUpdate({ enabled: true, block_list_emails: false });
+      // The back-end rejects requests trying to set this property for free users:
+      const blockPromotionals = props.profile.has_premium ? false : undefined;
+      return props.onUpdate({
+        enabled: true,
+        block_list_emails: blockPromotionals,
+      });
     }
     if (blockLevel === "promotional") {
       return props.onUpdate({ enabled: true, block_list_emails: true });
     }
     if (blockLevel === "all") {
-      return props.onUpdate({ enabled: false, block_list_emails: true });
+      // The back-end rejects requests trying to set this property for free users:
+      const blockPromotionals = props.profile.has_premium ? true : undefined;
+      return props.onUpdate({
+        enabled: false,
+        block_list_emails: blockPromotionals,
+      });
     }
   };
-
-  const blockLevelSlider = props.profile.has_premium ? (
-    <div className={styles.row}>
-      <BlockLevelSlider alias={props.alias} onChange={setBlockLevel} />
-    </div>
-  ) : null;
 
   return (
     <div
@@ -161,7 +136,6 @@ export const Alias = (props: Props) => {
     >
       <div className={styles["main-data"]}>
         <div className={styles.controls}>
-          {toggleButton}
           {labelEditor}
           <span className={styles["copy-controls"]}>
             <span className={styles["copy-button-wrapper"]}>
@@ -228,7 +202,13 @@ export const Alias = (props: Props) => {
         </div>
       </div>
       <div className={styles["secondary-data"]}>
-        {blockLevelSlider}
+        <div className={styles.row}>
+          <BlockLevelSlider
+            alias={props.alias}
+            onChange={setBlockLevel}
+            hasPremium={props.profile.has_premium}
+          />
+        </div>
         <div className={styles.row}>
           <dl>
             <div className={`${styles["forward-target"]} ${styles.metadata}`}>

--- a/frontend/src/components/dashboard/aliases/AliasGenerationButton.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasGenerationButton.tsx
@@ -43,7 +43,9 @@ export type Props = {
   profile: ProfileData;
   runtimeData?: RuntimeData;
   onCreate: (
-    options: { mask_type: "random" } | { mask_type: "custom"; address: string }
+    options:
+      | { mask_type: "random" }
+      | { mask_type: "custom"; address: string; blockPromotionals: boolean }
   ) => void;
 };
 
@@ -119,7 +121,9 @@ export const AliasGenerationButton = (props: Props) => {
 type AliasTypeMenuProps = {
   subdomain: string;
   onCreate: (
-    options: { mask_type: "random" } | { mask_type: "custom"; address: string }
+    options:
+      | { mask_type: "random" }
+      | { mask_type: "custom"; address: string; blockPromotionals: boolean }
   ) => void;
 };
 const AliasTypeMenu = (props: AliasTypeMenuProps) => {
@@ -136,8 +140,15 @@ const AliasTypeMenu = (props: AliasTypeMenuProps) => {
     }
   };
 
-  const onPick = (address: string) => {
-    props.onCreate({ mask_type: "custom", address: address });
+  const onPick = (
+    address: string,
+    settings: { blockPromotionals: boolean }
+  ) => {
+    props.onCreate({
+      mask_type: "custom",
+      address: address,
+      blockPromotionals: settings.blockPromotionals,
+    });
     modalState.close();
   };
 

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -97,6 +97,7 @@ export const AliasList = (props: Props) => {
           onDelete={() => props.onDelete(alias)}
           defaultOpen={!isExistingAlias}
           showLabelEditor={props.profile.server_storage || localLabels !== null}
+          runtimeData={props.runtimeData}
         />
       </li>
     );

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -19,7 +19,9 @@ export type Props = {
   user: UserData;
   runtimeData?: RuntimeData;
   onCreate: (
-    options: { mask_type: "random" } | { mask_type: "custom"; address: string }
+    options:
+      | { mask_type: "random" }
+      | { mask_type: "custom"; address: string; blockPromotionals: boolean }
   ) => void;
   onUpdate: (alias: AliasData, updatedFields: Partial<AliasData>) => void;
   onDelete: (alias: AliasData) => void;

--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
@@ -2,6 +2,8 @@
 @import "~@mozilla-protocol/core/protocol/css/includes/lib";
 
 $stopLabelHeight: 2rem;
+$iconHeight: 50px;
+$trackLineHeight: 4px;
 
 .group {
   // A CSS variable to enable different values depending on the screen size:
@@ -24,7 +26,7 @@ $stopLabelHeight: 2rem;
     padding: 0 $spacing-lg;
   }
   @media screen and #{$mq-lg} {
-    gap: 10%;
+    gap: $layout-2xl;
   }
 
   .control {
@@ -41,8 +43,6 @@ $stopLabelHeight: 2rem;
     }
 
     .track {
-      $iconHeight: 50px;
-      $trackLineHeight: 4px;
       // To absolutely position the track in the middle of the control, it needs
       // to be offset from the top by:
       // 1. the height of the icon on top of it ($iconHeight), plus
@@ -59,6 +59,8 @@ $stopLabelHeight: 2rem;
       // The thumb, its labels, and the track are absolutely positioned and thus
       // don't take up space by default. Hence, we need to add bottom padding
       // for them so no other content overlaps them:
+      // Note: when modifying this value, make sure to also modify it
+      // in the .isFree section down below:
       padding-bottom: calc(
         var(--thumbDiameter) + #{$trackLineHeight} + #{$stopLabelHeight}
       );
@@ -77,10 +79,12 @@ $stopLabelHeight: 2rem;
         height: var(--thumbDiameter);
         border-radius: 50%;
         background-color: $color-light-gray-20;
+        border: 4px solid transparent;
         position: absolute;
         display: flex;
         align-items: center;
         justify-content: center;
+        padding: $spacing-sm;
 
         &:hover {
           background-color: $color-purple-10;
@@ -101,6 +105,10 @@ $stopLabelHeight: 2rem;
           // and the height of the thumb:
           margin-top: calc(-1 * #{$iconHeight} - var(--thumbDiameter));
           padding-bottom: $spacing-sm;
+          // The image should not take up space within the track stop,
+          // so that the lock icon from .trackStopPromotional can be properly
+          // centered:
+          position: absolute;
         }
 
         p {
@@ -117,11 +125,24 @@ $stopLabelHeight: 2rem;
         }
 
         &.is-active {
+          background-color: $color-violet-20;
+          border-color: $color-violet-50;
+        }
+
+        &.is-selected {
           img {
             filter: grayscale(0%);
           }
+          .lock-icon {
+            color: $color-purple-50;
+          }
           p {
             color: $color-black;
+          }
+          &:not(.is-active) {
+            p {
+              color: $color-purple-50;
+            }
           }
         }
 
@@ -154,13 +175,13 @@ $stopLabelHeight: 2rem;
           width: var(--thumbDiameter);
           height: var(--thumbDiameter);
           border-radius: 50%;
-          background-color: $color-purple-20;
-          border: 4px solid $color-purple-50;
           box-shadow: $box-shadow-sm;
 
           &.is-focused {
-            background-color: $color-purple-30;
-            border-color: $color-purple-60;
+            // The alpha value makes sure the lock icon is still visible for
+            // free users when the thumb is placed on the "Promotionals" level:
+            background-color: rgba($color-purple-30, 0.5);
+            border: 4px solid $color-purple-60;
           }
           &.is-dragging {
             // This class can be used if we want to style the thumb
@@ -181,6 +202,8 @@ $stopLabelHeight: 2rem;
         }
 
         .track-stop {
+          padding: $spacing-xs;
+
           img {
             display: none;
           }
@@ -209,13 +232,30 @@ $stopLabelHeight: 2rem;
       left: calc(50% - #{$arrowEdgeLength});
     }
 
-    a {
-      display: inline-block;
-      color: $color-blue-50;
-      padding-top: $spacing-sm;
+    .value-description-content {
+      display: flex;
+      flex-direction: column;
+      gap: $spacing-xs;
 
-      &:hover {
-        text-decoration: underline;
+      a {
+        display: inline-block;
+        color: $color-blue-50;
+        font-weight: 500;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+
+      .locked-message {
+        display: flex;
+        align-items: center;
+        gap: $spacing-xs;
+        font-weight: 600;
+
+        .lock-icon {
+          color: $color-light-gray-70;
+        }
       }
     }
 
@@ -232,10 +272,35 @@ $stopLabelHeight: 2rem;
       // The content changes depending on the selected blocking mode,
       // so if the height would be based on the content, switching blocking modes
       // would cause a lot of jumping around:
-      min-height: 130px;
+      min-height: 150px;
 
       img {
         display: inline-block;
+      }
+    }
+  }
+
+  &.is-free {
+    .control .track {
+      // This is like the regular .track's bottom padding, but with
+      // $stopLabelHeight multiplied by 1.5, because there's a "(Premium only)"
+      // line in a smaller font below the "Promotionals" label for free users:
+      padding-bottom: calc(
+        var(--thumbDiameter) + #{$trackLineHeight} + #{$stopLabelHeight * 1.5}
+      );
+
+      .track-stop-promotional {
+        color: $color-light-gray-70;
+
+        p {
+          color: $color-light-gray-70;
+          text-align: center;
+
+          .premium-only-marker {
+            @include text-body-xs;
+            color: $color-purple-50;
+          }
+        }
       }
     }
   }

--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
@@ -79,7 +79,6 @@ $trackLineHeight: 4px;
         height: var(--thumbDiameter);
         border-radius: 50%;
         background-color: $color-light-gray-20;
-        border: 4px solid transparent;
         position: absolute;
         display: flex;
         align-items: center;
@@ -124,25 +123,12 @@ $trackLineHeight: 4px;
           height: $stopLabelHeight;
         }
 
-        &.is-active {
-          background-color: $color-violet-20;
-          border-color: $color-violet-50;
-        }
-
         &.is-selected {
           img {
             filter: grayscale(0%);
           }
-          .lock-icon {
-            color: $color-purple-50;
-          }
           p {
             color: $color-black;
-          }
-          &:not(.is-active) {
-            p {
-              color: $color-purple-50;
-            }
           }
         }
 
@@ -175,13 +161,15 @@ $trackLineHeight: 4px;
           width: var(--thumbDiameter);
           height: var(--thumbDiameter);
           border-radius: 50%;
+          background-color: $color-violet-20;
+          border: 4px solid $color-violet-50;
           box-shadow: $box-shadow-sm;
 
           &.is-focused {
             // The alpha value makes sure the lock icon is still visible for
             // free users when the thumb is placed on the "Promotionals" level:
             background-color: rgba($color-purple-30, 0.5);
-            border: 4px solid $color-purple-60;
+            border-color: $color-purple-60;
           }
           &.is-dragging {
             // This class can be used if we want to style the thumb
@@ -202,8 +190,6 @@ $trackLineHeight: 4px;
         }
 
         .track-stop {
-          padding: $spacing-xs;
-
           img {
             display: none;
           }
@@ -291,6 +277,13 @@ $trackLineHeight: 4px;
 
       .track-stop-promotional {
         color: $color-light-gray-70;
+        border-style: none;
+
+        &:hover {
+          // The standard background colour, because this can't be selected
+          // by a free user:
+          background-color: $color-light-gray-20;
+        }
 
         p {
           color: $color-light-gray-70;
@@ -300,6 +293,82 @@ $trackLineHeight: 4px;
             @include text-body-xs;
             color: $color-purple-50;
           }
+        }
+
+        &.is-selected {
+          p,
+          .lock-icon {
+            color: $color-purple-50;
+          }
+        }
+      }
+    }
+  }
+}
+
+.upgrade-tooltip-underlay {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .upgrade-tooltip {
+    background-color: $color-white;
+    box-shadow: $box-shadow-sm;
+    display: flex;
+    padding: $spacing-xl;
+    gap: $spacing-lg;
+    width: $content-md;
+    max-width: calc(100% - $spacing-xl);
+    border-radius: $border-radius-sm;
+
+    .close-button {
+      position: absolute;
+      top: $spacing-sm;
+      right: $spacing-sm;
+      padding: 0;
+      background-color: transparent;
+      border-style: none;
+      border-radius: $border-radius-sm;
+    }
+
+    .promotionals-blocking-icon {
+      display: none;
+
+      @media screen and #{$mq-md} {
+        display: inline-block;
+      }
+    }
+
+    .upgrade-message {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: $spacing-xs;
+
+      b {
+        display: flex;
+        align-items: center;
+        gap: $spacing-sm;
+
+        svg {
+          color: $color-light-gray-70;
+        }
+      }
+
+      a {
+        color: $color-blue-50;
+        // Add some padding to the focus outline, without affecting the CTA's
+        // position:
+        margin: -1 * $spacing-xs;
+        padding: $spacing-xs;
+
+        &:hover {
+          text-decoration: underline;
         }
       }
     }

--- a/frontend/src/components/dashboard/subdomain/SubdomainIndicator.tsx
+++ b/frontend/src/components/dashboard/subdomain/SubdomainIndicator.tsx
@@ -24,7 +24,10 @@ import { AddressPickerModal } from "../aliases/AddressPickerModal";
 
 export type Props = {
   subdomain: string | null;
-  onCreateAlias: (address: string) => void;
+  onCreateAlias: (
+    address: string,
+    settings: { blockPromotionals: boolean }
+  ) => void;
 };
 
 /**
@@ -53,7 +56,10 @@ export const SubdomainIndicator = (props: Props) => {
 
 type ExplainerTriggerProps = {
   subdomain: string;
-  onCreateAlias: (address: string) => void;
+  onCreateAlias: (
+    address: string,
+    settings: { blockPromotionals: boolean }
+  ) => void;
 };
 const ExplainerTrigger = (props: ExplainerTriggerProps) => {
   const { l10n } = useLocalization();
@@ -90,8 +96,11 @@ const ExplainerTrigger = (props: ExplainerTriggerProps) => {
     isOpen: explainerState.isOpen,
   }).overlayProps;
 
-  const onPick = (address: string) => {
-    props.onCreateAlias(address);
+  const onPick = (
+    address: string,
+    settings: { blockPromotionals: boolean }
+  ) => {
+    props.onCreateAlias(address, settings);
     addressPickerState.close();
   };
 

--- a/frontend/src/hooks/api/aliases.ts
+++ b/frontend/src/hooks/api/aliases.ts
@@ -35,7 +35,9 @@ export type CustomAliasData = CommonAliasData & {
 export type AliasData = RandomAliasData | CustomAliasData;
 
 export type AliasCreateFn = (
-  options: { mask_type: "random" } | { mask_type: "custom"; address: string }
+  options:
+    | { mask_type: "random" }
+    | { mask_type: "custom"; address: string; blockPromotionals: boolean }
 ) => Promise<Response>;
 export type AliasUpdateFn = (
   alias: Pick<CommonAliasData, "id" | "mask_type">,
@@ -69,17 +71,23 @@ export function useAliases(): {
 
   const createAlias: AliasCreateFn = async (options) => {
     if (options.mask_type === "custom") {
+      const body: Partial<CustomAliasData> = {
+        enabled: true,
+        address: options.address,
+        block_list_emails: options.blockPromotionals,
+      };
       const response = await apiFetch("/domainaddresses/", {
         method: "POST",
-        body: JSON.stringify({ enabled: true, address: options.address }),
+        body: JSON.stringify(body),
       });
       customAliases.mutate();
       return response;
     }
 
+    const body: Partial<RandomAliasData> = { enabled: true };
     const response = await apiFetch("/relayaddresses/", {
       method: "POST",
-      body: JSON.stringify({ enabled: true }),
+      body: JSON.stringify(body),
     });
     randomAliases.mutate();
     return response;

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -139,7 +139,9 @@ const Profile: NextPage = () => {
   }
 
   const createAlias = async (
-    options: { mask_type: "random" } | { mask_type: "custom"; address: string }
+    options:
+      | { mask_type: "random" }
+      | { mask_type: "custom"; address: string; blockPromotionals: boolean }
   ) => {
     try {
       const response = await aliasData.create(options);
@@ -201,8 +203,15 @@ const Profile: NextPage = () => {
         <span className={styles["profile-registered-domain-value"]}>
           <SubdomainIndicator
             subdomain={profile.subdomain}
-            onCreateAlias={(address: string) =>
-              createAlias({ mask_type: "custom", address: address })
+            onCreateAlias={(
+              address: string,
+              settings: { blockPromotionals: boolean }
+            ) =>
+              createAlias({
+                mask_type: "custom",
+                address: address,
+                blockPromotionals: settings.blockPromotionals,
+              })
             }
           />
         </span>

--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -499,10 +499,11 @@ describe("The dashboard", () => {
     );
     render(<Profile />);
 
-    const aliasToggleButton = screen.getByRole("button", {
-      name: "l10n string: [profile-label-disable-forwarding-button-2], with vars: {}",
+    const blockLevelSlider = screen.getByRole("slider", {
+      name: "l10n string: [profile-promo-email-blocking-title], with vars: {}",
     });
-    await userEvent.click(aliasToggleButton);
+    await userEvent.click(blockLevelSlider);
+    await userEvent.keyboard("[ArrowRight][ArrowRight]");
 
     expect(updateFn).toHaveBeenCalledWith(
       expect.objectContaining({ id: 42, mask_type: "random" }),


### PR DESCRIPTION
~~(Still set to draft because this feature includes a link to the waitlist, which hasn't been merged yet: https://github.com/mozilla/fx-private-relay/pull/1846.)~~

# New feature description

This implements the promo-blocking slider for free users instead of the toggle, with the promo-blocking step simply explaining the feature and its availability for Premium users. It also adds a toggle to enable promo-blocking when creating a custom alias.

After this is merged, we can also uncomment a line in this PR: https://github.com/mozilla/fx-private-relay/pull/1672/files#r833157494

# Screenshot (if applicable)

[Free slider user](https://deploy-preview-1673--fx-relay-demo.netlify.app/?mockId=empty) (create an alias first):

https://user-images.githubusercontent.com/4251/161987266-cbc9ca20-7005-4de1-99e0-18f88bba7c72.mp4

[Checkbox on alias creation](https://deploy-preview-1673--fx-relay-demo.netlify.app/?mockId=some):

https://user-images.githubusercontent.com/4251/161987210-f704acd2-30e9-40c3-b88c-18d70ab539a5.mp4

# How to test

All alias cards should show the slider. Free users should see the explanation about promo-blocking and Premium, Premium users should just be able to set it. Free users in a country without Premium should be linked to the waitlist page (which hasn't been implemented yet).

# Checklist

- [ ] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
