### PR TITLE
fix MPP-1658: add sv and fi entries for premium

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -304,6 +304,14 @@ PREMIUM_PLAN_ID_MATRIX = {
             "id": "price_1JmRCQJNcmPzuWtRprMnmtax",
             "price": "0,99 €",
         },
+        "sv": {
+            "id": "price_1KQc1PJNcmPzuWtRsEfb6inB",
+            "price": "0,99 €",
+        },
+        "fi": {
+            "id": "price_1KQcA7JNcmPzuWtRPKNacfdn",
+            "price": "0,99 €",
+        },
     },
     "usd": {
         "en": {
@@ -352,6 +360,14 @@ PREMIUM_PLAN_COUNTRY_LANG_MAPPING = {
     # Netherlands
     "nl": {
         "nl": PREMIUM_PLAN_ID_MATRIX["euro"]["nl"],
+    },
+    # Sweden
+    "se": {
+        "sv": PREMIUM_PLAN_ID_MATRIX["euro"]["sv"],
+    },
+    # Finland
+    "fi": {
+        "fi": PREMIUM_PLAN_ID_MATRIX["euro"]["fi"],
     },
     "us": {
         "en": PREMIUM_PLAN_ID_MATRIX["usd"]["en"],
@@ -439,8 +455,9 @@ if ADMIN_ENABLED:
 
 LANGUAGE_CODE = 'en'
 
-# Mozilla l10n uses 'zh-tw' and 'zh-cn' language codes, so we need to add those
-# to LANGUAGES so Django's LocaleMiddleware can find them.
+# Mozilla l10n directories use lang-locale language codes,
+# so we need to add those to LANGUAGES so Django's LocaleMiddleware
+# can find them.
 LANGUAGES = settings.LANGUAGES + [
     ('zh-tw', 'Chinese'),
     ('zh-cn', 'Chinese'),

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -50,3 +50,9 @@ class PremiumPlanIDTest(TestCase):
 
         plan_id = premium_plan_id('en', 'at')
         assert plan_id == plans['euro']['at']['id']
+
+        plan_id = premium_plan_id('sv', 'se')
+        assert plan_id == plans['euro']['sv']['id']
+
+        plan_id = premium_plan_id('fi', 'fi')
+        assert plan_id == plans['euro']['fi']['id']


### PR DESCRIPTION
This PR fixes https://mozilla-hub.atlassian.net/browse/MPP-1658.

How to test:
The new Stripe plan IDs are only available in the production environment, so we can only end-to-end test the full purchase flow on production.

To test that we show purchase links to visitors from `sv` and `fi` country codes ...

1. Go to http://127.0.0.1:8000/
2. Open Firefox network dev-tool
3. Right-click the `GET` request to `/` and choose "Resend"
4. In the New Request Headers, add `X-Client-Region`: `se`
5. Click "Send"
6. Look at the "Response" pane of the request 
   * [ ] Scroll down and look for " 0,99 € ⁨⁩/month " and "Sign up" links
   * [ ] (Bonus) the sign up link href should have a `plan=price_` that matches the respective value for the country in this PR

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).