### PR TITLE
Fix #1547 - Restore back to old Generate btn state after unsubscribing

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasGenerationButton.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasGenerationButton.test.tsx
@@ -1,0 +1,201 @@
+import { jest, describe, it, expect } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { mockConfigModule } from "../../../../__mocks__/configMock";
+import { getMockRandomAlias } from "../../../../__mocks__/hooks/api/aliases";
+import { getMockProfileData } from "../../../../__mocks__/hooks/api/profile";
+import {
+  getMockRuntimeDataWithoutPremium,
+  getMockRuntimeDataWithPremium,
+} from "../../../../__mocks__/hooks/api/runtimeData";
+import { mockFluentReact } from "../../../../__mocks__/modules/fluent__react";
+
+import { AliasGenerationButton } from "./AliasGenerationButton";
+
+jest.mock("@fluent/react", () => mockFluentReact);
+jest.mock("../../../config.ts", () => mockConfigModule);
+jest.mock("../../../hooks/gaViewPing.ts");
+
+describe("<AliasGenerationButton>", () => {
+  it("displays a usable button to generate an alias for a free user not at the alias limit", () => {
+    render(
+      <AliasGenerationButton
+        aliases={[getMockRandomAlias()]}
+        profile={getMockProfileData({ has_premium: false })}
+        onCreate={jest.fn()}
+        runtimeData={getMockRuntimeDataWithoutPremium()}
+      />
+    );
+
+    const button = screen.getByRole("button");
+
+    expect(button).toBeEnabled();
+    expect(button).toHaveTextContent(
+      "l10n string: [profile-label-generate-new-alias], with vars: {}"
+    );
+  });
+
+  it("displays a usable button to generate an alias for a Premium user over the free-user alias limit", () => {
+    render(
+      <AliasGenerationButton
+        aliases={[
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+        ]}
+        profile={getMockProfileData({ has_premium: true })}
+        onCreate={jest.fn()}
+        runtimeData={getMockRuntimeDataWithoutPremium()}
+      />
+    );
+
+    const button = screen.getByRole("button");
+
+    expect(button).toBeEnabled();
+    expect(button).toHaveTextContent(
+      "l10n string: [profile-label-generate-new-alias], with vars: {}"
+    );
+  });
+
+  it("displays an upgrade button when a free user has reached the alias limit, and Premium is available in their country", () => {
+    render(
+      <AliasGenerationButton
+        aliases={[
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+        ]}
+        profile={getMockProfileData({ has_premium: false })}
+        onCreate={jest.fn()}
+        runtimeData={getMockRuntimeDataWithPremium()}
+      />
+    );
+
+    const button = screen.getByRole("link");
+
+    expect(button).toHaveTextContent(
+      "l10n string: [profile-label-upgrade], with vars: {}"
+    );
+  });
+
+  it("displays a disabled button when a free user has reached the alias limit, and Premium is not available in their country", () => {
+    render(
+      <AliasGenerationButton
+        aliases={[
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+        ]}
+        profile={getMockProfileData({ has_premium: false })}
+        onCreate={jest.fn()}
+        runtimeData={getMockRuntimeDataWithoutPremium()}
+      />
+    );
+
+    const button = screen.getByRole("button");
+
+    expect(button).toBeDisabled();
+  });
+
+  it("disables the button when relevant, also if the user still has a subdomain set from a previous Premium subscription", () => {
+    render(
+      <AliasGenerationButton
+        aliases={[
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+          getMockRandomAlias(),
+        ]}
+        profile={getMockProfileData({
+          has_premium: false,
+          subdomain: "mydomain",
+        })}
+        onCreate={jest.fn()}
+        runtimeData={getMockRuntimeDataWithoutPremium()}
+      />
+    );
+
+    const button = screen.getByRole("button");
+
+    expect(button).toBeDisabled();
+  });
+
+  describe("with the `generateCustomAliasMenu` feature flag enabled", () => {
+    it("displays a usable button to generate an alias for a Premium user over the free-user alias limit, without a subdomain set", () => {
+      render(
+        <AliasGenerationButton
+          aliases={[
+            getMockRandomAlias(),
+            getMockRandomAlias(),
+            getMockRandomAlias(),
+            getMockRandomAlias(),
+            getMockRandomAlias(),
+            getMockRandomAlias(),
+          ]}
+          profile={getMockProfileData({ has_premium: true, subdomain: null })}
+          onCreate={jest.fn()}
+          runtimeData={getMockRuntimeDataWithoutPremium()}
+        />
+      );
+
+      const button = screen.getByRole("button");
+
+      expect(button).toBeEnabled();
+      expect(button).toHaveTextContent(
+        "l10n string: [profile-label-generate-new-alias], with vars: {}"
+      );
+    });
+
+    it("displays a drop-down menu to generate either a random or a custom alias for a Premium user over the free-user alias limit, with a subdomain set", () => {
+      const mockedConfig = mockConfigModule.getRuntimeConfig();
+      // getRuntimeConfig() is called frequently, so mock its return value,
+      // then restore the original mock at the end of this test:
+      mockConfigModule.getRuntimeConfig.mockReturnValue({
+        ...mockedConfig,
+        featureFlags: {
+          ...mockedConfig.featureFlags,
+          generateCustomAliasMenu: true,
+        },
+      });
+      render(
+        <AliasGenerationButton
+          aliases={[
+            getMockRandomAlias(),
+            getMockRandomAlias(),
+            getMockRandomAlias(),
+            getMockRandomAlias(),
+            getMockRandomAlias(),
+            getMockRandomAlias(),
+          ]}
+          profile={getMockProfileData({
+            has_premium: true,
+            subdomain: "mydomain",
+          })}
+          onCreate={jest.fn()}
+          runtimeData={getMockRuntimeDataWithoutPremium()}
+        />
+      );
+
+      const dropDownButton = screen.getByRole("button");
+      userEvent.click(dropDownButton);
+      const menu = screen.getByRole("menu");
+      const menuItems = screen.getAllByRole("menuitem");
+
+      expect(dropDownButton).toBeEnabled();
+      expect(dropDownButton).toHaveTextContent(
+        "l10n string: [profile-label-generate-new-alias], with vars: {}"
+      );
+      expect(menu).toBeInTheDocument();
+      expect(menuItems).toHaveLength(2);
+      mockConfigModule.getRuntimeConfig.mockReturnValue(mockedConfig);
+    });
+  });
+});

--- a/privaterelay/templates/includes/dashboard-filter.html
+++ b/privaterelay/templates/includes/dashboard-filter.html
@@ -124,82 +124,98 @@
         <!-- Button -->
         <form action="{% url 'emails-index' %}" class="dash-create" method="POST">
             <input type="hidden" name="api_token" value="{{ user_profile.api_token }}">
-            {% if user_profile.at_max_free_aliases and not user_profile.has_premium %}
-                {% if premium_available_in_country %}
-                    <a
-                        href="{% premium_subscribe_url accept_language country_code %}"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="btn btn-blue--ghost js-purchase-premium"
-                        data-ga="send-ga-pings"
-                        data-event-category="Purchase Button"
-                        data-event-label="profile-create-alias-upgrade-promo"
-                        data-cookie-for-server="clicked-purchase"
-                    >
-                        <span class="generate-new-alias-text">
-                            {% ftlmsg 'profile-label-upgrade' %}
-                        </span>
-                    </a>
+            <!-- Non-premium -->
+            {% if not user_profile.has_premium %}
+                {% if user_profile.at_max_free_aliases %}
+                    {% if premium_available_in_country %}
+                        <a
+                            href="{% premium_subscribe_url accept_language country_code %}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="btn btn-blue--ghost js-purchase-premium"
+                            data-ga="send-ga-pings"
+                            data-event-category="Purchase Button"
+                            data-event-label="profile-create-alias-upgrade-promo"
+                            data-cookie-for-server="clicked-purchase"
+                        >
+                            <span class="generate-new-alias-text">
+                                {% ftlmsg 'profile-label-upgrade' %}
+                            </span>
+                        </a>
+                    {% else %}
+                        <button 
+                            disabled
+                            type="submit"
+                            class="blue-btn-states dash-create-new-relay"
+                            title="{% ftlmsg 'profile-label-generate-new-alias' %}"
+                        >
+                            <span class="generate-new-relay-icon"></span>
+                            <span class="generate-new-alias-text">
+                                {% ftlmsg 'profile-label-generate-new-alias' %}
+                            </span>
+                        </button>
+                    {% endif %}
                 {% else %}
-                    <button 
-                        disabled
-                        type="submit"
-                        class="blue-btn-states dash-create-new-relay"
-                        title="{% ftlmsg 'profile-label-generate-new-alias' %}"
-                    >
-                        <span class="generate-new-relay-icon"></span>
-                        <span class="generate-new-alias-text">
-                            {% ftlmsg 'profile-label-generate-new-alias' %}
-                        </span>
-                    </button>
-                {% endif %}
-            {% elif not user_profile.subdomain %}
-                <button
+                    <button
                     class="blue-btn-states dash-create-new-relay"
                     title="{% ftlmsg 'profile-label-generate-new-alias' %}"
                     type="submit"
-                    data-event-label="Create New Relay Alias"
-                >
-                    <span class="generate-new-relay-icon"></span>
-                    <span class="generate-new-alias-text">
-                        {% ftlmsg 'profile-label-generate-new-alias' %}
-                    </span>
-                </button>
-            {% else %}
-                <div class="dash-create-new-alias-menu-wrapper">
-                    <button
-                        class="js-dash-create-new-alias-menu-trigger blue-btn-states dash-create-new-alias-menu-trigger"
-                        title="{% ftlmsg 'profile-label-generate-new-alias' %}"
-                    >
-                        <span class="generate-new-alias-text">
-                            {% ftlmsg 'profile-label-generate-new-alias' %}
-                        </span>
-                        <span class="generate-new-alias-menu-trigger-icon"></span>
+                    data-event-label="Create New Relay Alias">
+                        <span class="generate-new-relay-icon"></span>
+                            <span class="generate-new-alias-text">
+                                {% ftlmsg 'profile-label-generate-new-alias' %}
+                            </span>
                     </button>
-                    <div class="js-dash-create-new-alias-menu-popup generate-new-alias-menu-popup is-hidden">
-                        <button
-                            title="{% ftlmsg 'profile-label-generate-new-alias-menu-random' %}"
-                            type="submit"
-                            data-event-label="Create New Relay Alias"
-                        >
-                            <span class="generate-new-relay-icon"></span>
+                {% endif %}
+            <!-- Premium -->
+            {% else %}
+                {% if not user_profile.subdomain %}
+                    <button
+                    class="blue-btn-states dash-create-new-relay"
+                    title="{% ftlmsg 'profile-label-generate-new-alias' %}"
+                    type="submit"
+                    data-event-label="Create New Relay Alias">
+                        <span class="generate-new-relay-icon"></span>
                             <span class="generate-new-alias-text">
-                                {% ftlmsg 'profile-label-generate-new-alias-menu-random' %}
+                                {% ftlmsg 'profile-label-generate-new-alias' %}
                             </span>
-                        </button>
+                    </button>
+                {% else %}
+                    <div class="dash-create-new-alias-menu-wrapper">
                         <button
-                            class="js-dash-create-new-domain-alias-dialog-trigger"
-                            title="{% ftlmsg 'profile-label-generate-new-alias-menu-custom' subdomain=user_profile.subdomain %}"
-                            type="submit"
-                            data-event-label="Create New Domain Alias"
+                            class="js-dash-create-new-alias-menu-trigger blue-btn-states dash-create-new-alias-menu-trigger"
+                            title="{% ftlmsg 'profile-label-generate-new-alias' %}"
                         >
-                            <span class="generate-new-relay-icon"></span>
                             <span class="generate-new-alias-text">
-                                {% ftlmsg 'profile-label-generate-new-alias-menu-custom' subdomain=user_profile.subdomain %}
+                                {% ftlmsg 'profile-label-generate-new-alias' %}
                             </span>
+                            <span class="generate-new-alias-menu-trigger-icon"></span>
                         </button>
+                        <div class="js-dash-create-new-alias-menu-popup generate-new-alias-menu-popup is-hidden">
+                            <button
+                                title="{% ftlmsg 'profile-label-generate-new-alias-menu-random' %}"
+                                type="submit"
+                                data-event-label="Create New Relay Alias"
+                            >
+                                <span class="generate-new-relay-icon"></span>
+                                <span class="generate-new-alias-text">
+                                    {% ftlmsg 'profile-label-generate-new-alias-menu-random' %}
+                                </span>
+                            </button>
+                            <button
+                                class="js-dash-create-new-domain-alias-dialog-trigger"
+                                title="{% ftlmsg 'profile-label-generate-new-alias-menu-custom' subdomain=user_profile.subdomain %}"
+                                type="submit"
+                                data-event-label="Create New Domain Alias"
+                            >
+                                <span class="generate-new-relay-icon"></span>
+                                <span class="generate-new-alias-text">
+                                    {% ftlmsg 'profile-label-generate-new-alias-menu-custom' subdomain=user_profile.subdomain %}
+                                </span>
+                            </button>
+                        </div>
                     </div>
-                </div>
+                {% endif %}
             {% endif %}
         </form>
     </div>


### PR DESCRIPTION
This PR fixes #1547 

# New feature description
This reworks the logic of showing the Generate CTA's various states by segregating the UI of premium and non-premium versions more strictly. How it was built before enabled a user who's unsubscribed to still see the premium version of the Generate CTA because they had a subdomain previously set. 

# How to test
- Be signed in into a Firefox Relay account with an active subscription;
- Have at least one alias created;
- Have a subdomain name set;
- Have the subscription canceled and expired
- Check that the downgraded account has the original Generate CTA UI (without a dropdown/ability to generate with a subdomain)

# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
