### PR TITLE
Generate and upload frontend coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,13 +111,23 @@ jobs:
           working_directory: ./frontend/
       - run:
           name: Test Code
-          command: npm test -- --reporters=jest-junit
+          command: |
+            mkdir --parents /tmp/workspace/test-results/frontend-coverage
+            npm test -- \
+              --ci \
+              --coverage \
+              --coverageDirectory=/tmp/workspace/test-results/frontend-coverage \
+              --coverageReporters=text \
+              --coverageReporters=lcov \
+              --reporters=jest-junit \
+              --reporters=default
           working_directory: ./frontend/
       - store_test_results:
           path: frontend/junit.xml
-      - store_artifacts:
-          path: frontend/coverage/
-          destination: frontend_test_coverage
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - test-results/frontend-coverage
 
   test_backend:
     docker:
@@ -138,20 +148,20 @@ jobs:
           command: |
             # Create a volume owned by the app user
             docker run \
-              --volume /tmp/test-results \
-              --name test-results \
+              --volume /tmp/workspace \
+              --name workspace-test-results \
               alpine \
               /bin/sh -c \
-                "chmod 0777 /tmp/test-results && \
-                 chown 10001:10001 /tmp/test-results"
+                "chmod 0777 /tmp/workspace && \
+                 chown 10001:10001 /tmp/workspace"
             # Run coverage tests, outputting the results in XML format
             docker run \
               --entrypoint "/bin/bash" \
-              --volumes-from test-results \
+              --volumes-from workspace-test-results \
               fx-private-relay \
               -c \
-                'mkdir --parents /tmp/test-results/pytest && \
-                 mkdir --parents /tmp/test-results/coverage && \
+                'mkdir --parents /tmp/workspace/test-results/pytest && \
+                 mkdir --parents /tmp/workspace/test-results/backend-coverage && \
                  /app/.local/bin/pytest \
                    --cov=. \
                    --cov-config=.coveragerc \
@@ -159,36 +169,37 @@ jobs:
                    --cov-report=xml \
                    --cov-fail-under=60 \
                    --cov-branch \
-                   --junitxml=/tmp/test-results/pytest/results.xml ; \
-                 mv coverage.xml /tmp/test-results/coverage/results.xml ; \
-                 mv .coverage /tmp/test-results/coverage/.coverage'
+                   --junitxml=/tmp/workspace/test-results/pytest/results.xml ; \
+                 mv coverage.xml /tmp/workspace/test-results/backend-coverage/results.xml ; \
+                 mv .coverage /tmp/workspace/test-results/backend-coverage/.coverage'
 
             # Copy results to local disk
-            docker cp test-results:/tmp/test-results /tmp
+            docker cp workspace-test-results:/tmp/workspace /tmp
 
       - store_test_results:
-          path: /tmp/test-results
+          path: /tmp/workspace/test-results
 
-      - save_cache:
-          key: v1-backend-coverage-{{ .Branch }}-{{epoch}}
+      - persist_to_workspace:
+          root: /tmp/workspace
           paths:
-            - /tmp/test-results/coverage/.coverage
+            - test-results/pytest
+            - test-results/backend-coverage
 
   upload_coverage:
     docker:
       - image: cimg/python:3.7.9-node
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - restore_cache:
-          key: v1-backend-coverage-{{.Branch}}
       - run:
           name: Upload coverage
           command: |
             pip install coveralls
-            cp /tmp/test-results/coverage/.coverage .
-            coveralls
+            cp /tmp/workspace/test-results/backend-coverage/.coverage .
+            coveralls --merge=/tmp/workspace/frontend-coverage/coverage-final.json
 
   deploy:
     docker:
@@ -253,6 +264,7 @@ workflows:
       - upload_coverage:
           requires:
             - test_backend
+            - test_frontend
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
           command: |
             pip install coveralls
             cp /tmp/workspace/test-results/backend-coverage/.coverage .
-            coveralls --merge=/tmp/workspace/frontend-coverage/coverage-final.json
+            coveralls --merge=/tmp/workspace/test-results/frontend-coverage/coverage-final.json
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,7 +302,7 @@ workflows:
       - upload_coverage:
           requires:
             - convert_frontend_coverage
-            - test_frontend
+            - test_backend
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,8 +117,6 @@ jobs:
               --ci \
               --coverage \
               --coverageDirectory=/tmp/workspace/test-results/frontend-coverage \
-              --coverageReporters=text \
-              --coverageReporters=lcov \
               --reporters=jest-junit \
               --reporters=default
           working_directory: ./frontend/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,7 @@ workflows:
 
       - convert_frontend_coverage:
           requires:
-            - test_backend
+            - test_frontend
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,9 @@ jobs:
           working_directory: ./frontend/
       - store_test_results:
           path: frontend/junit.xml
+      - store_artifacts:
+          path: /tmp/workspace/test-results/frontend-coverage
+          destination: frontend_test_coverage
       - persist_to_workspace:
           root: /tmp/workspace
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,7 @@ jobs:
           command: |
             pip install coveralls
             cp /tmp/workspace/test-results/backend-coverage/.coverage .
-            coveralls --merge=/tmp/workspace/test-results/frontend-coverage/coverage-final.json
+            coveralls --merge=/tmp/workspace/test-results/frontend-coverage/coveralls.json
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,32 @@ jobs:
           paths:
             - test-results/frontend-coverage
 
+  convert_frontend_coverage:
+    docker:
+      - image: cimg/ruby:2.7.2
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Convert Frontend Coverage Report
+          command: |
+            gem install coveralls-lcov
+            # Add frontend to lcov filepaths
+            sed 's|^SF:|SF:frontend/|' \
+              /tmp/workspace/test-results/frontend-coverage/lcov.info \
+              > /tmp/workspace/test-results/frontend-coverage/lcov-prefixed.info
+            # Generate coveralls.json report
+            coveralls-lcov \
+              --verbose --dry-run \
+              /tmp/workspace/test-results/frontend-coverage/lcov-prefixed.info \
+              > /tmp/workspace/test-results/frontend-coverage/coveralls.json
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - test-results/frontend-coverage/lcov-prefixed.info
+            - test-results/frontend-coverage/coveralls.json
+
   test_backend:
     docker:
       - image: docker:18.02.0-ce
@@ -265,9 +291,16 @@ workflows:
             tags:
               only: /.*/
 
-      - upload_coverage:
+      - convert_frontend_coverage:
           requires:
             - test_backend
+          filters:
+            tags:
+              only: /.*/
+
+      - upload_coverage:
+          requires:
+            - convert_frontend_coverage
             - test_frontend
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,9 +223,6 @@ jobs:
       - run: git submodule sync
       - run: git submodule update --init
       - run:
-          name: Debug workspace
-          command: find /tmp/workspace -type f
-      - run:
           name: Upload coverage
           command: |
             pip install coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,9 @@ jobs:
       - run: git submodule sync
       - run: git submodule update --init
       - run:
+          name: Debug workspace
+          command: find /tmp/workspace -type f
+      - run:
           name: Upload coverage
           command: |
             pip install coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,15 +137,16 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - checkout
+      - run: gem install coveralls-lcov
       - run:
-          name: Convert Frontend Coverage Report
+          name: Add frontend prefix to lcov.info
           command: |
-            gem install coveralls-lcov
-            # Add frontend to lcov filepaths
             sed 's|^SF:|SF:frontend/|' \
               /tmp/workspace/test-results/frontend-coverage/lcov.info \
               > /tmp/workspace/test-results/frontend-coverage/lcov-prefixed.info
-            # Generate coveralls.json report
+      - run:
+          name: Generate coveralls.json report
+          command: |
             coveralls-lcov \
               --verbose --dry-run \
               /tmp/workspace/test-results/frontend-coverage/lcov-prefixed.info \

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -30,11 +30,7 @@ const customJestConfig = {
   // collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  // collectCoverageFrom: [
-  //   "src/**/*.{js,jsx,ts,tsx}",
-  //   "!**/*.d.ts",
-  //   "!**/node_modules/**",
-  // ],
+  collectCoverageFrom: ["src/**"],
 
   // The directory where Jest should output its coverage files
   // coverageDirectory: "coverage",
@@ -54,7 +50,14 @@ const customJestConfig = {
   // ],
 
   // An object that configures minimum threshold enforcement for coverage results
-  // coverageThreshold: undefined,
+  coverageThreshold: {
+    global: {
+      branches: 40,
+      functions: 30,
+      lines: 40,
+      statements: 40,
+    },
+  },
 
   // A path to a custom dependency extractor
   // dependencyExtractor: undefined,


### PR DESCRIPTION
Generate a coverage report with jest, and output coverage and test results. Merge the test results with the backend results and upload to coveralls.io.