### PR TITLE
Add frontend coverage to CircleCI, coveralls.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,13 +111,51 @@ jobs:
           working_directory: ./frontend/
       - run:
           name: Test Code
-          command: npm test -- --reporters=jest-junit
+          command: |
+            mkdir --parents /tmp/workspace/test-results/frontend-coverage
+            npm test -- \
+              --ci \
+              --coverage \
+              --coverageDirectory=/tmp/workspace/test-results/frontend-coverage \
+              --reporters=jest-junit \
+              --reporters=default
           working_directory: ./frontend/
       - store_test_results:
           path: frontend/junit.xml
       - store_artifacts:
-          path: frontend/coverage/
+          path: /tmp/workspace/test-results/frontend-coverage
           destination: frontend_test_coverage
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - test-results/frontend-coverage
+
+  convert_frontend_coverage:
+    docker:
+      - image: cimg/ruby:2.7.2
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run: gem install coveralls-lcov
+      - run:
+          name: Add frontend prefix to lcov.info
+          command: |
+            sed 's|^SF:|SF:frontend/|' \
+              /tmp/workspace/test-results/frontend-coverage/lcov.info \
+              > /tmp/workspace/test-results/frontend-coverage/lcov-prefixed.info
+      - run:
+          name: Generate coveralls.json report
+          command: |
+            coveralls-lcov \
+              --verbose --dry-run \
+              /tmp/workspace/test-results/frontend-coverage/lcov-prefixed.info \
+              > /tmp/workspace/test-results/frontend-coverage/coveralls.json
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - test-results/frontend-coverage/lcov-prefixed.info
+            - test-results/frontend-coverage/coveralls.json
 
   test_backend:
     docker:
@@ -189,7 +227,7 @@ jobs:
           command: |
             pip install coveralls
             cp /tmp/workspace/test-results/backend-coverage/.coverage .
-            coveralls
+            coveralls --merge=/tmp/workspace/test-results/frontend-coverage/coveralls.json
 
   deploy:
     docker:
@@ -251,8 +289,16 @@ workflows:
             tags:
               only: /.*/
 
+      - convert_frontend_coverage:
+          requires:
+            - test_frontend
+          filters:
+            tags:
+              only: /.*/
+
       - upload_coverage:
           requires:
+            - convert_frontend_coverage
             - test_backend
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,10 +115,7 @@ jobs:
             mkdir --parents /tmp/workspace/test-results/frontend-coverage
             npm test -- \
               --ci \
-              --coverage \
-              --coverageDirectory=/tmp/workspace/test-results/frontend-coverage \
-              --reporters=jest-junit \
-              --reporters=default
+              --coverageDirectory=/tmp/workspace/test-results/frontend-coverage
           working_directory: ./frontend/
       - store_test_results:
           path: frontend/junit.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,20 +138,20 @@ jobs:
           command: |
             # Create a volume owned by the app user
             docker run \
-              --volume /tmp/test-results \
-              --name test-results \
+              --volume /tmp/workspace \
+              --name workspace-test-results \
               alpine \
               /bin/sh -c \
-                "chmod 0777 /tmp/test-results && \
-                 chown 10001:10001 /tmp/test-results"
+                "chmod 0777 /tmp/workspace && \
+                 chown 10001:10001 /tmp/workspace"
             # Run coverage tests, outputting the results in XML format
             docker run \
               --entrypoint "/bin/bash" \
-              --volumes-from test-results \
+              --volumes-from workspace-test-results \
               fx-private-relay \
               -c \
-                'mkdir --parents /tmp/test-results/pytest && \
-                 mkdir --parents /tmp/test-results/coverage && \
+                'mkdir --parents /tmp/workspace/test-results/pytest && \
+                 mkdir --parents /tmp/workspace/test-results/backend-coverage && \
                  /app/.local/bin/pytest \
                    --cov=. \
                    --cov-config=.coveragerc \
@@ -159,35 +159,36 @@ jobs:
                    --cov-report=xml \
                    --cov-fail-under=60 \
                    --cov-branch \
-                   --junitxml=/tmp/test-results/pytest/results.xml ; \
-                 mv coverage.xml /tmp/test-results/coverage/results.xml ; \
-                 mv .coverage /tmp/test-results/coverage/.coverage'
+                   --junitxml=/tmp/workspace/test-results/pytest/results.xml ; \
+                 mv coverage.xml /tmp/workspace/test-results/backend-coverage/results.xml ; \
+                 mv .coverage /tmp/workspace/test-results/backend-coverage/.coverage'
 
             # Copy results to local disk
-            docker cp test-results:/tmp/test-results /tmp
+            docker cp workspace-test-results:/tmp/workspace /tmp
 
       - store_test_results:
-          path: /tmp/test-results
+          path: /tmp/workspace/test-results
 
-      - save_cache:
-          key: v1-backend-coverage-{{ .Branch }}-{{epoch}}
+      - persist_to_workspace:
+          root: /tmp/workspace
           paths:
-            - /tmp/test-results/coverage/.coverage
+            - test-results/pytest
+            - test-results/backend-coverage
 
   upload_coverage:
     docker:
       - image: cimg/python:3.7.9-node
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - restore_cache:
-          key: v1-backend-coverage-{{.Branch}}
       - run:
           name: Upload coverage
           command: |
             pip install coveralls
-            cp /tmp/test-results/coverage/.coverage .
+            cp /tmp/workspace/test-results/backend-coverage/.coverage .
             coveralls
 
   deploy:

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -30,7 +30,7 @@ const customJestConfig = {
   // collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ["src/**"],
+  collectCoverageFrom: ["src/**", "!src/apiMocks/**"],
 
   // The directory where Jest should output its coverage files
   // coverageDirectory: "coverage",
@@ -52,10 +52,10 @@ const customJestConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 40,
+      branches: 50,
       functions: 30,
-      lines: 40,
-      statements: 40,
+      lines: 50,
+      statements: 50,
     },
   },
 

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -30,11 +30,7 @@ const customJestConfig = {
   // collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  // collectCoverageFrom: [
-  //   "src/**/*.{js,jsx,ts,tsx}",
-  //   "!**/*.d.ts",
-  //   "!**/node_modules/**",
-  // ],
+  collectCoverageFrom: ["src/**"],
 
   // The directory where Jest should output its coverage files
   // coverageDirectory: "coverage",

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -27,7 +27,7 @@ const customJestConfig = {
   clearMocks: true,
 
   // Indicates whether the coverage information should be collected while executing the test
-  // collectCoverage: true,
+  collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   collectCoverageFrom: ["src/**", "!src/apiMocks/**"],
@@ -132,7 +132,7 @@ const customJestConfig = {
   // projects: undefined,
 
   // Use this configuration option to add custom reporters to Jest
-  // reporters: undefined,
+  reporters: ["jest-junit", "default"],
 
   // Automatically reset mock state between every test
   // resetMocks: false,

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -50,7 +50,14 @@ const customJestConfig = {
   // ],
 
   // An object that configures minimum threshold enforcement for coverage results
-  // coverageThreshold: undefined,
+  coverageThreshold: {
+    global: {
+      branches: 40,
+      functions: 30,
+      lines: 40,
+      statements: 40,
+    },
+  },
 
   // A path to a custom dependency extractor
   // dependencyExtractor: undefined,


### PR DESCRIPTION
This PR runs frontend code coverage with some minimum levels, and merges it with the backend code coverage when sending to coveralls.io. This results in a drop in total code coverage, which coveralls.io will complain about.

I switched from the [Caching](https://circleci.com/docs/2.0/caching/) feature to the [Workspace](https://circleci.com/docs/2.0/workspaces/) feature for test results. The workspace is for files needed by later jobs in the same test run, while the cache is better suited for files needed in later test runs. I'm using `/tmp/workspace` as the base folder for workspace files, and placing test files in `/tmp/workspace/test-results`. This will allow us to put other stuff in the workspace in the future. The `docker.tar` file looks promising, and maybe the built frontend files.

I expanded the frontend test command:
* Use [--ci](https://jestjs.io/docs/cli#--ci) mode, failing on previous snapshots
* Use [--coverage](https://jestjs.io/docs/cli#--coverageboolean), to generate coverage reports. This was probably in an earlier version of the Big One, but was dropped at some point.
* Use ``--coverageDirectory`` to write coverage files directly to ``/tmp/workspace/test-results/frontend-coverage``. This is undocumented as a CLI option, but [is documented](https://jestjs.io/docs/configuration#coveragedirectory-string) as a config option.
* Use the ``--reporters=default``, so test results are shown in CI output

The [coveralls-python documentation](https://coveralls-python.readthedocs.io/en/latest/usage/multilang.html) (thanks @Vinnl!) suggests using the Ruby tool [coveralls-lcov](https://github.com/okkez/coveralls-lcov) to convert the JS tests to the coveralls JSON format. I added another job ``convert_frontend_coverage`` that runs the Ruby image and this tool. The ``lcov`` file paths are relative to the ``frontend`` folder, and I used ``sed`` to add that to the file paths so that all paths will be relative to the repository. The output is added to the workspace, so that coveralls-python can gather the Python test results and merge in the frontend results before uploading to coveralls.io.

Finally, I added some lower bounds for frontend coverage, based on the current coverage levels:
* Statements: 40% (currently 47.92%)
* Branches: 40% (currently 49.16%)
* Functions: 30% (currently 33.33%)
* Lines: 40% (currently 47.98%)

This is set in ``frontend/jest.config.js`` with [coverageThreshold](https://jestjs.io/docs/configuration#coveragethreshold-object), which has a ton of options for per-file coverage threshholds. I also put [collectCoverageFrom](https://jestjs.io/docs/configuration#collectcoveragefrom-array) in this file, as suggested by [Configuring code coverage in Jest, the right way](https://www.valentinog.com/blog/jest-coverage/), which was really helpful.

As with any build changes, none of this worked the first 10 times. The messier version is in https://github.com/mozilla/fx-private-relay/pull/1678.