### PR TITLE
CircleCI fix: Split `docker.tar` into 100 MB parts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
           key: v2-backend-build-{{.Branch}}
       - run:
           name: Restore Docker image cache
-          command: cat /cache/docket_split/part_* | docker load
+          command: ls /cache/docker_split; cat /cache/docker_split/part_* | docker load
 
       - run:
           name: Test Code
@@ -244,7 +244,7 @@ jobs:
           key: v2-backend-build-{{.Branch}}
       - run:
           name: Restore Docker image cache
-          command: cat /cache/docket_split/part_* | docker load
+          command: ls /cache/docker_split; cat /cache/docker_split/part_* | docker load
 
       - run:
           name: Deploy to Dockerhub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
           # and
           # https://circleci.com/docs/2.0/building-docker-images/#docker-version
           version: 20.10.11
+          docker_layer_caching: True
       - restore_cache:
           key: v1-frontend-build-{{ .Branch }}-{{ .Revision }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,7 +309,6 @@ workflows:
 
       - deploy:
           requires:
-            - build_backend
             - test_backend
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,13 +81,18 @@ jobs:
 
       # save the built docker container into CircleCI's cache. This is
       # required since Workflows do not have the same remote docker instance.
+      # The container is saved as 100 MB chunks to work with CircleCI's 500MB limit
       - run:
           name: docker save fx-private-relay
-          command: mkdir --parents /cache; docker save --output /cache/docker.tar "fx-private-relay"
+          command: |
+            mkdir --parents /cache/docker_split;
+            cd /cache/docker_split;
+            docker save "fx-private-relay" | split -b 100m - part_;
+            ls
       - save_cache:
-          key: v1-backend-build-{{ .Branch }}-{{epoch}}
+          key: v2-backend-build-{{ .Branch }}-{{epoch}}
           paths:
-            - /cache/docker.tar
+            - /cache/docker_split
 
   test_frontend:
     docker:
@@ -164,10 +169,10 @@ jobs:
     steps:
       - setup_remote_docker
       - restore_cache:
-          key: v1-backend-build-{{.Branch}}
+          key: v2-backend-build-{{.Branch}}
       - run:
           name: Restore Docker image cache
-          command: docker load --input /cache/docker.tar
+          command: cat /cache/docket_split/part_* | docker load
 
       - run:
           name: Test Code
@@ -236,10 +241,10 @@ jobs:
     steps:
       - setup_remote_docker
       - restore_cache:
-          key: v1-backend-build-{{.Branch}}
+          key: v2-backend-build-{{.Branch}}
       - run:
           name: Restore Docker image cache
-          command: docker load --input /cache/docker.tar
+          command: cat /cache/docket_split/part_* | docker load
 
       - run:
           name: Deploy to Dockerhub


### PR DESCRIPTION
Attempt to get around CircleCI's 500MB cache limit by spliting `docker.tar` into 100 MB chunks.

This may still fail if CircleCI combines the files before sticking them in the cache, which is likely.