### PR TITLE
CircleCI: Switch to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN ./node_modules/.bin/gulp build
 RUN npm run lint:js -- --max-warnings=0
 RUN npm run lint:css
 
-FROM python:3.9.10
+FROM python:3.9.10-alpine
 
 ARG CIRCLE_BRANCH
 ARG CIRCLE_SHA1
@@ -20,11 +20,12 @@ ENV CIRCLE_BRANCH=${CIRCLE_BRANCH:-unknown} \
     CIRCLE_TAG=${CIRCLE_TAG:-unknown} \
     CIRCLE_SHA1=${CIRCLE_SHA1:-unknown}
 
-RUN apt-get update && apt-get install -y libpq-dev
+# Install libraries needed for psycopg and cryptography
+RUN apk add --update --no-cache postgresql-dev gcc musl-dev python3-dev libffi-dev openssl-dev cargo
 RUN pip install --upgrade pip
 
-RUN groupadd --gid 10001 app && \
-    useradd -g app --uid 10001 --shell /usr/sbin/nologin --create-home --home-dir /app app
+RUN addgroup -g 10001 app && \
+    adduser -D -G app -h /app -u 10001 app
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ USER app
 COPY --from=gulp-builder --chown=app /app/static ./static
 
 COPY --chown=app ./requirements.txt /app/requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 COPY --chown=app . /app
 COPY --chown=app .env-dist /app/.env
 


### PR DESCRIPTION
Another approach the CircleCI cache issue is to try to make the Docker image smaller. The `-alpine` base image is 5 MB, but requires installing a number of packages to compile `psycopg2`, `cryptography`, and `ruamel-yaml`, so the built Docker image may be larger.