### PR TITLE
Build the React frontend on Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "stylelint-scss": "^3.19.0"
   },
   "engines": {
-    "node": "14.x"
+    "node": "14.x",
+    "npm": "8.x"
   },
   "homepage": "https://github.com/mozilla/fx-private-relay#readme",
   "keywords": [],
@@ -38,7 +39,8 @@
     "lint:js": "eslint .",
     "lint:css": "stylelint static/scss/",
     "lint:fix-css": "stylelint --fix static/scss/",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "heroku-postbuild": "git clone https://github.com/mozilla-l10n/fx-private-relay-l10n.git privaterelay/locales; cd frontend; NODE_ENV=\"development\" npm ci; npm run build"
   },
   "volta": {
     "node": "12.22.6",


### PR DESCRIPTION
Our dev environment is built on Heroku, which doesn't read our
CircleCI config, and therefore did not build the frontend.

For our CircleCI build, we chose not to build the frontend in the
Docker image, so that we could split out the build and test steps
without having to reinstall the dependencies. However, that does
mean that we can't simply reuse the Docker image in Heroku.

Instead, I added a `heroku-postbuild` step [1] to the package.json
at the root of the repository. That does mean that, after we've
fully migrated to the React-based frontend, we can't completely
remove the package.json at the root, though we can of course then
update the description to indicate that it's only present to tell
Heroku how to build the frontend. I also added a more recent
version of npm to the `engines` field to tell Heroku to use that,
as the way to specify that devDependencies need to be installed
(see below) differs between those versions.

Now, looking at the `heroku-postbuild` script, there are two things
that are worth calling out:

1. I'm setting NODE_ENV to "development" before running `npm ci`.
   This is to ensure that devDependencies are installed as well,
   i.e. the build tools for the frontend build.
2. I explicitly clone the l10n repository before building. This is
   because Heroku only clones submodules _after_ the build step,
   whereas we need the locales present during the build so they can
   be included in the bundle.

@groovecoder Considering that second point, doing it this way could possibly allow us to remove [this third-party buildpack](https://github.com/dmathieu/heroku-buildpack-submodules) configured [here](https://dashboard.heroku.com/apps/fx-private-relay/settings#ember224)? (Speaking of which, I think that configuration also overrides [this file](https://github.com/mozilla/fx-private-relay/blob/9801b429e9977b6afd7274b06589baf93d26097c/.buildpacks), so maybe we should remove one of the two?)

[1] https://devcenter.heroku.com/articles/nodejs-support#heroku-specific-build-steps
