### PR TITLE
CircleCI: Optimize Docker build and test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,8 @@ jobs:
               echo "Skipping exporting Docker image, not main branch or tag."
               circleci step halt
             fi
-            if [[ "${CIRCLE_TAG}" =~ ^addon-.* ]]; then
+            # https://stackoverflow.com/a/18558871/10612
+            if case $CIRCLE_TAG in addon-*) ;; *) false;; esac; then
               echo "Skipping exporting Docker image, ${CIRCLE_TAG} has addon- prefix."
               circleci step halt
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
           # and
           # https://circleci.com/docs/2.0/building-docker-images/#docker-version
           version: 20.10.11
+          docker_layer_caching: True
       - restore_cache:
           key: v1-frontend-build-{{ .Branch }}-{{ .Revision }}
       - run:
@@ -161,7 +162,8 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: True
       - restore_cache:
           key: v1-backend-build-{{.Branch}}
       - run:
@@ -233,7 +235,8 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: True
       - restore_cache:
           key: v1-backend-build-{{.Branch}}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,7 @@ jobs:
                  mv .coverage /tmp/workspace/test-results/backend-coverage/.coverage'
 
             # Copy results to local disk
+            mkdir --parents /tmp/workspace/
             docker cp workspace-test-results:/tmp/workspace/test-results /tmp/workspace
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,7 +306,6 @@ workflows:
 
       - deploy:
           requires:
-            - build_backend
             - test_backend
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
             - test-results/frontend-coverage/lcov-prefixed.info
             - test-results/frontend-coverage/coveralls.json
 
-  build_and_test_backend:
+  build_test_backend:
     docker:
       - image: docker:stable-git
         auth:
@@ -269,7 +269,7 @@ workflows:
             tags:
               only: /.*/
 
-      - build_and_test_backend:
+      - build_test_backend:
           requires:
             - build_frontend
           filters:
@@ -293,14 +293,14 @@ workflows:
       - upload_coverage:
           requires:
             - convert_frontend_coverage
-            - build_and_test_backend
+            - build_test_backend
           filters:
             tags:
               only: /.*/
 
       - deploy:
           requires:
-            - build_and_test_backend
+            - build_test_backend
           filters:
             tags:
               ignore: /addon-.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,11 +83,13 @@ jobs:
       # required since Workflows do not have the same remote docker instance.
       - run:
           name: docker save fx-private-relay
-          command: mkdir --parents /cache; docker save --output /cache/docker.tar "fx-private-relay"
-      - save_cache:
-          key: v1-backend-build-{{ .Branch }}-{{epoch}}
+          command: |
+            mkdir --parents /tmp/workspace/build_backend;
+            docker save --output /tmp/workspace/build_backend/docker.tar "fx-private-relay"
+      - persist_to_workspace:
+          root: /tmp/workspace
           paths:
-            - /cache/docker.tar
+            - build_backend/docker.tar
 
   test_frontend:
     docker:
@@ -164,11 +166,11 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: True
-      - restore_cache:
-          key: v1-backend-build-{{.Branch}}
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           name: Restore Docker image cache
-          command: docker load --input /cache/docker.tar
+          command: docker load --input /tmp/workspace/build_backend/docker.tar
 
       - run:
           name: Test Code
@@ -201,7 +203,7 @@ jobs:
                  mv .coverage /tmp/workspace/test-results/backend-coverage/.coverage'
 
             # Copy results to local disk
-            docker cp workspace-test-results:/tmp/workspace /tmp
+            docker cp workspace-test-results:/tmp/workspace/test-results /tmp/workspace
 
       - store_test_results:
           path: /tmp/workspace/test-results
@@ -237,11 +239,11 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: True
-      - restore_cache:
-          key: v1-backend-build-{{.Branch}}
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           name: Restore Docker image cache
-          command: docker load --input /cache/docker.tar
+          command: docker load --input /tmp/workspace/build_backend/docker.tar
 
       - run:
           name: Deploy to Dockerhub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,65 +32,6 @@ jobs:
           paths:
             - ./frontend/out/
 
-  build_backend:
-    docker:
-      - image: docker:stable-git
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-    working_directory: /dockerflow
-    steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
-      - setup_remote_docker:
-          # Use a version of Docker that works with Node, see
-          # https://support.circleci.com/hc/en-us/articles/360050934711-Docker-build-fails-with-EPERM-operation-not-permitted-copyfile-when-using-node-14-9-0-or-later-
-          # (apparently version 17.09.0-ce is lower than 1.9.1, but 19.03.13 is not?)
-          # and
-          # https://github.com/nodejs/docker-node#supported-docker-versions
-          # and
-          # https://circleci.com/docs/2.0/building-docker-images/#docker-version
-          version: 20.10.11
-          docker_layer_caching: True
-      - restore_cache:
-          key: v1-frontend-build-{{ .Branch }}-{{ .Revision }}
-      - run:
-          name: Copy build artefacts from build_frontend into this folder
-          command: mv /home/circleci/project/frontend/out /dockerflow/frontend/
-
-      - run:
-          name: Create a version.json
-          command: |
-            # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
-            printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
-            "$CIRCLE_SHA1" \
-            "$CIRCLE_TAG" \
-            "$CIRCLE_PROJECT_USERNAME" \
-            "$CIRCLE_PROJECT_REPONAME" \
-            "$CIRCLE_BUILD_URL" > version.json
-
-      - run:
-          name: Build Docker image
-          command: |
-            docker build --tag fx-private-relay \
-            --build-arg CIRCLE_BRANCH="$CIRCLE_BRANCH" \
-            --build-arg CIRCLE_TAG="$CIRCLE_TAG" \
-            --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
-            .
-
-      # save the built docker container into CircleCI's cache. This is
-      # required since Workflows do not have the same remote docker instance.
-      - run:
-          name: docker save fx-private-relay
-          command: |
-            mkdir --parents /tmp/workspace/build_backend;
-            docker save --output /tmp/workspace/build_backend/docker.tar "fx-private-relay"
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - build_backend/docker.tar
-
   test_frontend:
     docker:
       - image: cimg/node:14.19
@@ -157,20 +98,52 @@ jobs:
             - test-results/frontend-coverage/lcov-prefixed.info
             - test-results/frontend-coverage/coveralls.json
 
-  test_backend:
+  build_and_test_backend:
     docker:
-      - image: docker:18.02.0-ce
+      - image: docker:stable-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
+    working_directory: /dockerflow
     steps:
+      - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - setup_remote_docker:
+          # Use a version of Docker that works with Node, see
+          # https://support.circleci.com/hc/en-us/articles/360050934711-Docker-build-fails-with-EPERM-operation-not-permitted-copyfile-when-using-node-14-9-0-or-later-
+          # (apparently version 17.09.0-ce is lower than 1.9.1, but 19.03.13 is not?)
+          # and
+          # https://github.com/nodejs/docker-node#supported-docker-versions
+          # and
+          # https://circleci.com/docs/2.0/building-docker-images/#docker-version
+          version: 20.10.11
           docker_layer_caching: True
-      - attach_workspace:
-          at: /tmp/workspace
+      - restore_cache:
+          key: v1-frontend-build-{{ .Branch }}-{{ .Revision }}
       - run:
-          name: Restore Docker image cache
-          command: docker load --input /tmp/workspace/build_backend/docker.tar
+          name: Copy build artefacts from build_frontend into this folder
+          command: mv /home/circleci/project/frontend/out /dockerflow/frontend/
+
+      - run:
+          name: Create a version.json
+          command: |
+            # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
+            printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
+            "$CIRCLE_SHA1" \
+            "$CIRCLE_TAG" \
+            "$CIRCLE_PROJECT_USERNAME" \
+            "$CIRCLE_PROJECT_REPONAME" \
+            "$CIRCLE_BUILD_URL" > version.json
+
+      - run:
+          name: Build Docker image
+          command: |
+            docker build --tag fx-private-relay \
+            --build-arg CIRCLE_BRANCH="$CIRCLE_BRANCH" \
+            --build-arg CIRCLE_TAG="$CIRCLE_TAG" \
+            --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
+            .
 
       - run:
           name: Test Code
@@ -214,6 +187,30 @@ jobs:
             - test-results/pytest
             - test-results/backend-coverage
 
+      - run:
+          name: Check if deploying
+          command: |
+            if [ "${CIRCLE_BRANCH}" != "main" ] && [ -z "${CIRCLE_TAG}" ]; then
+              echo "Skipping exporting Docker image, not main branch or tag."
+              circleci step halt
+            fi
+            if [[ "${CIRCLE_TAG}" =~ ^addon-.* ]]; then
+              echo "Skipping exporting Docker image, ${CIRCLE_TAG} has addon- prefix."
+              circleci step halt
+            fi
+
+      # save the built docker container into CircleCI's cache. This is
+      # required since Workflows do not have the same remote docker instance.
+      - run:
+          name: docker save fx-private-relay
+          command: |
+            mkdir --parents /tmp/workspace;
+            docker save --output /tmp/workspace/docker.tar "fx-private-relay"
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - docker.tar
+
   upload_coverage:
     docker:
       - image: cimg/python:3.7.9-node
@@ -243,7 +240,7 @@ jobs:
           at: /tmp/workspace
       - run:
           name: Restore Docker image cache
-          command: docker load --input /tmp/workspace/build_backend/docker.tar
+          command: docker load --input /tmp/workspace/docker.tar
 
       - run:
           name: Deploy to Dockerhub
@@ -270,7 +267,7 @@ workflows:
             tags:
               only: /.*/
 
-      - build_backend:
+      - build_and_test_backend:
           requires:
             - build_frontend
           filters:
@@ -280,13 +277,6 @@ workflows:
       - test_frontend:
           requires:
             - build_frontend
-          filters:
-            tags:
-              only: /.*/
-
-      - test_backend:
-          requires:
-            - build_backend
           filters:
             tags:
               only: /.*/
@@ -301,14 +291,14 @@ workflows:
       - upload_coverage:
           requires:
             - convert_frontend_coverage
-            - test_backend
+            - build_and_test_backend
           filters:
             tags:
               only: /.*/
 
       - deploy:
           requires:
-            - test_backend
+            - build_and_test_backend
           filters:
             tags:
               ignore: /addon-.*/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,8 @@
-**/.DS_store
-.coverage
+# .gitignore
 .env
 .envrc
-.git
-extension
 *.sqlite3
+node_modules
 env/
 __pycache__
 web-ext-artifacts/
@@ -13,3 +11,38 @@ static/downloads
 static/css
 static/scss/libs
 staticfiles
+coverage/
+junit.xml
+
+# frontend/.gitignore
+frontend/public/mockServiceWorker.js
+frontend/node_modules
+frontend/.pnp
+frontend/.pnp.js
+frontend/coverage
+frontend/.next/
+# Needed by Docker
+# frontend/out/
+frontend/build
+frontend/.DS_Store
+frontend/*.pem
+frontend/npm-debug.log*
+frontend/yarn-debug.log*
+frontend/yarn-error.log*
+frontend/.env.local
+frontend/.env.development.local
+frontend/.env.test.local
+frontend/.env.production.local
+frontend/.vercel
+
+# frontend/.husky/_/.gitignore
+frontend/.husky
+
+# Other
+**/.DS_store
+**/__pycache__
+.buildpacks
+.coverage
+.git
+.pytest_cache
+extension

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,6 @@ ENV CIRCLE_BRANCH=${CIRCLE_BRANCH:-unknown} \
     CIRCLE_TAG=${CIRCLE_TAG:-unknown} \
     CIRCLE_SHA1=${CIRCLE_SHA1:-unknown}
 
-RUN set -eux; \
-        apt-get update; \
-        apt-get install -y --no-install-recommends libpq-dev; \
-        rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache --upgrade pip
 
 RUN groupadd --gid 10001 app && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,11 @@ ENV CIRCLE_BRANCH=${CIRCLE_BRANCH:-unknown} \
     CIRCLE_TAG=${CIRCLE_TAG:-unknown} \
     CIRCLE_SHA1=${CIRCLE_SHA1:-unknown}
 
-RUN apt-get update && apt-get install -y libpq-dev
-RUN pip install --upgrade pip
+RUN set -eux; \
+        apt-get update; \
+        apt-get install -y --no-install-recommends libpq-dev; \
+        rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache --upgrade pip
 
 RUN groupadd --gid 10001 app && \
     useradd -g app --uid 10001 --shell /usr/sbin/nologin --create-home --home-dir /app app
@@ -34,7 +37,7 @@ USER app
 COPY --from=gulp-builder --chown=app /app/static ./static
 
 COPY --chown=app ./requirements.txt /app/requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install --no-cache -r requirements.txt
 COPY --chown=app . /app
 COPY --chown=app .env-dist /app/.env
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN pip install --no-cache -r requirements.txt
 COPY --chown=app . /app
 COPY --chown=app .env-dist /app/.env
 
-RUN mkdir -p /app/staticfiles
-RUN python manage.py collectstatic --no-input -v 2
+RUN mkdir -p /app/staticfiles && \
+    python manage.py collectstatic --no-input -v 2
 
 ENTRYPOINT ["/app/.local/bin/gunicorn"]
 


### PR DESCRIPTION
This fixes #1686 by making several changes to the CircleCI job:

* Combines `build_backend` and `test_backend` jobs into `build_test_backend`, avoiding a `docker save` and `docker load`.
* Only run `docker save` if we're on the `main` branch or a (non-addons) tag. This speeds up PR runs.
* Store the tar output of `docker save` in the per-build [workspace](https://circleci.com/docs/2.0/workspaces/), avoiding the 500MB cache limit
* Enable [docker_layer_caching](https://circleci.com/docs/2.0/docker-layer-caching/) to (hopefully) speed up builds
* Reduce the size of the docker image 
  * Sync `.dockerignore` with `.gitignore`, except for `frontend/out`, which has the files from the `build_frontend` step.
  * Drop `apt-get install libpq-dev`, since this library package is in the base `python:3.9.10` image. 
  * Don't cache pip packages
  * Combine two ``RUN`` layers
  
This results in a 10% decrease in the image size (501 MiB to 449 MiB). The base Python image is 332 MB compressed, so our "layers" reduce from 169 MB to 117 MB.

The build time has also decreased. Durations vary based on what is going on in CircleCI, and "deploy" builds are slower than PR builds.

A pre-change PR build, [Build 4479](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/4479/workflows/60a61066-b094-442e-a59e-5bdd7360ef1d), took 538 seconds (8 min 38s), while the last build of this PR, [4524](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/4524/workflows/bd180264-9102-407f-b2ef-c17ed11defa5), took 280 seconds (4m 40s), not quite half as long.

We'll need to wait for merge to see what a deploy build takes. A pre-change deploy build, [Build 4480](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/4480/workflows/d3fda1f9-687b-438f-b2f6-4dc3d9ce7735), took 649 seconds (10 min 49s).