### PR TITLE
Add Block promotional emails to Premium Plan on the home page

### DIFF
--- a/frontend/src/components/landing/Plans.tsx
+++ b/frontend/src/components/landing/Plans.tsx
@@ -82,6 +82,7 @@ export const Plans = (props: Props) => {
           <li>{l10n.getString("landing-pricing-premium-feature-2")}</li>
           <li>{l10n.getString("landing-pricing-premium-feature-3")}</li>
           <li>{l10n.getString("landing-pricing-premium-feature-4")}</li>
+          <li>{l10n.getString("landing-pricing-premium-feature-5")}</li>
         </ul>
         <div ref={premiumFauxButtonRef} className={styles["faux-button"]}>
           {l10n.getString("nav-profile-sign-up")}


### PR DESCRIPTION



# New feature description

Adding 'Block promotional emails' as a 5th feature on the Premium Plans section on the home page.

 **L10n dependency:** https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/67 

# Screenshot (if applicable)

<img width="317" alt="image" src="https://user-images.githubusercontent.com/13066134/160446194-574196f5-8b42-41e3-ad3d-ddf67e366cd1.png">

# How to test

On `localhost:3000` and `localhost:3000/premium`, check that the Premium Plan module contains 'Block promotional emails'

# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
