### PR TITLE
Also support the dev server running at 0.0.0.0

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -591,9 +591,11 @@ if DEBUG:
     SESSION_COOKIE_SAMESITE = None
     CORS_ALLOWED_ORIGINS += [
         'http://localhost:3000',
+        'http://0.0.0.0:3000',
     ]
     CSRF_TRUSTED_ORIGINS += [
         'http://localhost:3000',
+        'http://0.0.0.0:3000',
     ]
 
 SENTRY_RELEASE = config("SENTRY_RELEASE", "")


### PR DESCRIPTION
It gets started at both `localhost:3000` and `0.0.0.0:3000`. I always
ran it at localhost, and thus didn't notice that requests from
`0.0.0.0:3000` got rejected.
