### PR TITLE
Consolidate alias update functions

### DIFF
--- a/frontend/__mocks__/hooks/api/aliases.ts
+++ b/frontend/__mocks__/hooks/api/aliases.ts
@@ -7,9 +7,8 @@ import {
   getAllAliases,
   getFullAddress,
   AliasUpdateFn,
-  RandomAliasCreateFn,
-  CustomAliasCreateFn,
   AliasDeleteFn,
+  AliasCreateFn,
 } from "../../../src/hooks/api/aliases";
 
 jest.mock("../../../src/hooks/api/aliases");
@@ -82,18 +81,9 @@ type MockData = {
   custom?: Array<Partial<CustomAliasData>>;
 };
 type Callbacks = {
-  creaters?: {
-    random?: RandomAliasCreateFn;
-    custom?: CustomAliasCreateFn;
-  };
-  updaters?: {
-    random?: AliasUpdateFn;
-    custom?: AliasUpdateFn;
-  };
-  deleters?: {
-    random?: AliasDeleteFn;
-    custom?: AliasDeleteFn;
-  };
+  creater?: AliasCreateFn;
+  updater?: AliasUpdateFn;
+  deleter?: AliasDeleteFn;
 };
 function getReturnValue(
   aliasesData?: MockData,
@@ -110,19 +100,16 @@ function getReturnValue(
     randomAliasData: {
       isValidating: false,
       mutate: jest.fn(),
-      create: callbacks?.creaters?.random || jest.fn(),
-      update: callbacks?.updaters?.random || jest.fn(),
-      delete: callbacks?.deleters?.random || jest.fn(),
       data: randomAliasData,
     },
     customAliasData: {
       isValidating: false,
       mutate: jest.fn(),
-      create: callbacks?.creaters?.custom || jest.fn(),
-      update: callbacks?.updaters?.custom || jest.fn(),
-      delete: callbacks?.deleters?.custom || jest.fn(),
       data: customAliasData,
     },
+    create: callbacks?.creater || jest.fn(),
+    update: callbacks?.updater || jest.fn(),
+    delete: callbacks?.deleter || jest.fn(),
   };
 }
 

--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -402,7 +402,7 @@ describe("The dashboard", () => {
     const updateFn: AliasUpdateFn = jest.fn();
     setMockAliasesDataOnce(
       { random: [{ enabled: true, id: 42 }], custom: [] },
-      { updaters: { random: updateFn } }
+      { updater: updateFn }
     );
     render(<Profile />);
 
@@ -411,7 +411,10 @@ describe("The dashboard", () => {
     });
     userEvent.click(aliasToggleButton);
 
-    expect(updateFn).toHaveBeenCalledWith({ enabled: false, id: 42 });
+    expect(updateFn).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 42, type: "random" }),
+      { enabled: false }
+    );
   });
 
   it("shows the Generate Alias button if the user is not at the max number of aliases", () => {


### PR DESCRIPTION
As per discussions with @groovecoder in #1554,
instead of having to determine whether a given alias is a random or
a custom alias at the call site before creating, updating, or
deleting it, this is now taken care of by the alias fetching hook.
This reduces the number of branches in our code.

# Checklist

- [x] l10n dependencies have been merged, if any.
- [ ] All acceptance criteria are met. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
