### PR TITLE
Content refresh

### DIFF
--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -62,12 +62,12 @@
                   {% if recipient_profile.has_premium %}
                     <br />
                     <img alt="" width="24" style="display: inline-block; margin-bottom: 0px; width: 24px;"  src="{{ SITE_ORIGIN }}/static/images/email-images/tip-purple.png" />
-                    {% ftlmsg 'forwarded-email-header-cc-notice' %}
+                    {% ftlmsg 'forwarded-email-header-cc-notice-2' %}
                   {% elif not recipient_profile.has_premium and recipient_profile.fxa_locale_in_premium_country %}
                     {% bold_violet_link SITE_ORIGIN|add:'/premium?utm_source=emails&utm_medium=email&utm_campaign=alias-email&utm_content=header' 'Firefox Relay Premium' as premium_link %}
                     <br />
                     <img width="15" height="15" src="{{ SITE_ORIGIN }}/static/images/email-images/smile-purple.png" style="display: inline-block; width: 15px;" alt="" />
-                    {% ftlmsg 'forwarded-email-header-premium-banner' premium_link=premium_link as premium_header_banner %}
+                    {% ftlmsg 'forwarded-email-header-premium-banner-2' premium_link=premium_link as premium_header_banner %}
                     {{ premium_header_banner|safe }}
                   {% endif %}
                 </p>
@@ -96,7 +96,7 @@
             <tr>
               <td align="center" style="line-height: 150%; padding-left: 20px; padding-right: 20px;">
                 <p style="display: inline-block; padding-top: 0; font-size: 13px; color: #363959; font-family: sans-serif; padding-left: 20px; padding-right: 20px; margin-top: 0; margin-bottom: 0;">
-                  <a href="{{ SITE_ORIGIN }}/accounts/profile?utm_source=emails&utm_medium=email&utm_campaign=alias-email" target="_blank" rel="noopener noreferrer" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">{% ftlmsg 'forwarded-email-footer' %}</a>
+                  <a href="{{ SITE_ORIGIN }}/accounts/profile?utm_source=emails&utm_medium=email&utm_campaign=alias-email" target="_blank" rel="noopener noreferrer" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">{% ftlmsg 'forwarded-email-footer-2' %}</a>
                   {% if not recipient_profile.has_premium and recipient_profile.fxa_locale_in_premium_country %}
                     |
                     <a href="{{ SITE_ORIGIN }}/premium?utm_source=emails&utm_medium=email&utm_campaign=alias-email&utm_content=footer" target="_blank" rel="noopener noreferrer" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">{% ftlmsg 'forwarded-email-footer-premium-banner' %}</a>

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -10,6 +10,9 @@ landing-how-it-works-step-2-body-2 = As you browse, the { -brand-name-relay } ic
 
 landing-use-cases-heading = Use { -brand-name-firefox-relay } for:
 
+faq-question-acceptable-use-answer-measure-unlimited-payment-2 = Requiring payment for a user to create more than five masks
+faq-question-acceptable-use-answer-measure-rate-limit-2 = Rate-limiting the number of masks that can be generated in one day
+
 error-settings-update = There was an error updating your settings, please try again
 error-mask-create-failed = The mask could not be created. Please try again.
 # This currently appears when a mask label could not be updated,
@@ -32,6 +35,9 @@ profile-filter-category-button-label = Filter visible masks
 profile-filter-category-button-tooltip = Filter masks by subdomain and/or whether they are currently blocking incoming email
 profile-filter-category-title = Filter visible masks
 profile-filter-no-results = No masks match your selected criteria. <clear-button>Clear all filters.</clear-button>
+
+profile-promo-email-blocking-description-all-2 = { -brand-name-relay } is blocking all emails sent to this mask.
+profile-promo-email-blocking-description-none-2 = { -brand-name-relay } is not blocking any emails for this mask.
 
 # Variables:
 #   $subdomain (string) - Chosen subdomain, i.e. the part after `@` and before `.mozmail.com`

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -2,18 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-common-link-newtab-alt = (Opens in a new tab)
-
-survey-option-dismiss = Dismiss
-
-survey-csat-question = How satisfied are you with your Firefox Relay experience?
-survey-csat-answer-very-dissatisfied = Very Dissatisfied
-survey-csat-answer-dissatisfied = Dissatisfied
-survey-csat-answer-neutral = Neutral
-survey-csat-answer-satisfied = Satisfied
-survey-csat-answer-very-satisfied = Very Satisfied
-survey-csat-followup = Thank you for your feedback. We would like to learn more about how we can improve Relay for you, would you be willing to take a two-minute survey?
-
 banner-dismiss = Dismiss
 
 # Do not change '@mozmail.com'
@@ -45,9 +33,6 @@ profile-filter-category-button-tooltip = Filter aliases by domain and/or whether
 profile-filter-category-title = Filter visible aliases
 profile-filter-no-results = No aliases match your selected criteria. <clear-button>Clear all filters.</clear-button>
 
-# Filter on Relay masks that block promotional emails. "Promo" is an English slang/shortened version of "Promotion".
-profile-filter-category-option-promo-blocking-masks = Promo-blocking masks
-
 # Variables:
 #   $subdomain (string) - Chosen subdomain, i.e. the part after `@` and before `.mozmail.com`
 #   $domain (string) - Applicable domain, i.e. `.mozmail.com`
@@ -66,103 +51,10 @@ modal-domain-register-success-v2 = <subdomain>{ $subdomain }</subdomain><domain>
 #   $max (number) - Total number of steps
 multi-part-onboarding-step-counter = Step { $step } of { $max }.
 
-profile-label-generate-new-alias-menu-random = Random Alias
-# Variables
-#   $subdomain (string) - The user's custom subdomain, if any, e.g. `@eduardofeo`.
-profile-label-generate-new-alias-menu-custom = @{ $subdomain } Alias
-
-## The following two strings were already submitted in
-## https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/59:
-banner-choose-subdomain-input-placeholder-2 = Search your new domain
-onboarding-premium-domain-title-2 = Use a custom domain for sharing aliases:
-
-tips-header-title = Help & Tips
-tips-header-button-close-label = Dismiss
-tips-footer-link-faq-label = FAQ
-tips-footer-link-faq-tooltip = Frequently asked questions
-tips-footer-link-feedback-label = Feedback
-tips-footer-link-feedback-tooltip = Give feedback
-tips-footer-link-support-label = Support
-tips-footer-link-support-tooltip = Contact support
-
-## The Chrome extension strings have already been submitted:
-## https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/65
--brand-name-chrome = Chrome
--brand-name-google-chrome = Google Chrome
-banner-download-install-chrome-extension-headline = Try { -brand-name-relay } for { -brand-name-google-chrome }
-banner-download-install-chrome-extension-copy = The { -brand-name-firefox-relay } extension for { -brand-name-chrome } makes creating and using aliases even easier.
-banner-download-install-chrome-extension-cta = Get the { -brand-name-relay } extension
-multi-part-onboarding-premium-chrome-extension-get-title = Get the { -brand-name-relay } extension for { -brand-name-google-chrome }
-multi-part-onboarding-premium-chrome-extension-get-description = The { -brand-name-firefox-relay } extension for { -brand-name-chrome } makes creating and using email aliases even easier.
-multi-part-onboarding-premium-chrome-extension-button-download = Get { -brand-name-relay } Extension
-
-## The Acceptable Use FAQ entry has already been submitted:
-## https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/60
-faq-question-acceptable-use-question = What are the acceptable uses of { -brand-name-relay }?
-#   $url (url) - link to Mozilla's Acceptable Use Policy, i.e. https://www.mozilla.org/about/legal/acceptable-use/
-#   $attrs (string) - specific attributes added to external links
-faq-question-acceptable-use-answer-a-html = { -brand-name-firefox-relay } has the same <a href="{ $url }" { $attrs }>conditions of use as all { -brand-name-mozilla } products</a>. We have a zero-tolerance policy when it comes to using { -brand-name-relay } for malicious purposes like spam, resulting in the termination of a user’s account. We take measures to prevent users from violating our conditions by:
-faq-question-acceptable-use-answer-measure-account = Requiring a { -brand-name-firefox-account(capitalization: "uppercase") } with a verified email address
-faq-question-acceptable-use-answer-measure-unlimited-payment = Requiring payment for a user to create more than five aliases
-faq-question-acceptable-use-answer-measure-rate-limit = Rate-limiting the number of aliases that can be generated in one day
-#   $url (url) - link to the Terms of Service, i.e. https://www.mozilla.org/about/legal/terms/firefox-relay/
-#   $attrs (string) - specific attributes added to external links
-faq-question-acceptable-use-answer-b-html = Please review our <a href="{ $url }" { $attrs }>Terms of Service</a> for more information.
-faq-question-availability-answer-v2 = Free { -brand-name-relay } is available in most countries. { -brand-name-relay-premium } is available in the United States, Germany, United Kingdom, Canada, Singapore, Malaysia, New Zealand, Finland, France, Belgium, Austria, Spain, Italy, Sweden, Switzerland, Netherlands, and Ireland.
-
-
-faq-question-promotional-email-blocking-question = What is promotional email blocking?
-faq-question-promotional-email-blocking-answer = { -brand-name-relay-premium } subscribers can enable promotional email blocking. This feature will forward you important emails, such as receipts, password resets and confirmations, while still blocking marketing messages. There is a slight risk that an important message could still be blocked, so we recommend that you not use this feature for very important places like your bank. If an email is blocked, it cannot be recovered.
-faq-question-detect-promotional-question = How does { -brand-name-relay } detect if an email is Promotional or not?
-faq-question-detect-promotional-answer = Many emails are sent with “header” metadata to indicate that they are from list-based automated tools. { -brand-name-firefox-relay } detects this header data so it can block these emails.
-
-## Alias Promotional Email Blocking (displayed on the profile page)
-profile-promo-email-blocking-title = What emails do you want to block?
-# Block all emails sent to a speciic alias
-profile-promo-email-blocking-option-all = All
-# Block promotional emails sent to a speciic alias
-profile-promo-email-blocking-option-promotionals = Promotionals
-# Allow/forward all emails sent to a speciic alias
-profile-promo-email-blocking-option-none = None
-profile-promo-email-blocking-description-all = { -brand-name-relay } is blocking all emails sent to this alias.
-profile-promo-email-blocking-description-promotionals = { -brand-name-relay } will attempt to block promotional emails, while still forwarding emails like receipts and shipping information.
-profile-promo-email-blocking-description-none = { -brand-name-relay } is not blocking any emails for this alias.
-profile-promo-email-blocking-label-promotionals = Block promotions
-profile-promo-email-blocking-label-none = Block all
-profile-promo-email-blocking-label-forwarding = { profile-label-forwarding }
-profile-promo-email-blocking-label-not-forwarding = Not forwarding
-
-modal-custom-alias-picker-heading = Create a new custom alias
-modal-custom-alias-picker-warning = All you need to do is make up and share a unique alias that uses your custom domain — the alias will be generated automatically. Try “shop@customdomain.mozmail.com” next time you shop online, for example.
-modal-custom-alias-picker-form-heading = Or, create a custom alias manually
-modal-custom-alias-picker-form-prefix-label = Enter alias prefix
-# This is shown in placeholder of the form field in which users can pick a custom alias prefix for their own subdomain,
-# as an example of what email addresses to use (e.g. `coffee@customdomain.mozmail.com`).
-modal-custom-alias-picker-form-prefix-placeholder = e.g. "coffee"
-modal-custom-alias-picker-form-submit-label = Generate Alias
-modal-custom-alias-picker-creation-error = Your custom alias could not be created. Please try again, or send an email to the alias to create it.
-
-popover-custom-alias-explainer-heading = How to create custom aliases
-popover-custom-alias-explainer-explanation = All you need to do is make up and share a unique alias that uses your custom domain — the alias will be generated automatically. Try “shop@customdomain.mozmail.com” next time you shop online, for example.
-popover-custom-alias-explainer-generate-button-heading = Generate a custom alias manually
-popover-custom-alias-explainer-generate-button-label = Generate custom alias
-popover-custom-alias-explainer-close-button-label = Close
-# Checkbox the user can click to adjust the block level of the new alias
-popover-custom-alias-explainer-promotional-block-checkbox = Block promotional emails
-popover-custom-alias-explainer-promotional-block-tooltip = Enable Block Promotional Emails on an alias to stop marketing emails from reaching your inbox.
-
 # Label for each of the dots representing a tip in a panel in the bottom right-hand corner.
 # Variables
 #   $nr (number) - Which tip can be seen by clicking/tapping this particular dot.
 tips-switcher-label = Tip { $nr }
-
-tips-custom-alias-heading = Creating aliases using your custom domain
-tips-custom-alias-content = All you need to do is make up and share a unique alias that uses your custom domain — the alias will be generated automatically. Try “shop@customdomain.mozmail.com” next time you shop online, for example.
-
-## Tip about using custom aliases
-
-tips-promo-email-blocking-heading = Block Promotional Emails
-tips-promo-email-blocking-content = With { -brand-name-relay-premium }, you can block promotional emails from reaching your inbox while still allowing you to receive emails like receipts or shipping information.
 
 # This copy (and the term "critical email") is not final yet:
 tips-critical-emails-heading = Critical email forwarding
@@ -173,40 +65,3 @@ tips-critical-emails-content = Relay allows you to receive only critical emails 
 tips-addon-signin-heading = Sign in with your aliases
 # This copy is not final yet:
 tips-addon-signin-content = To sign in with a previously-used alias, open the context menu (right-click or control-click) where the site asks for your email. You’ll be able to select the alias and auto-fill the email field.
-
-whatsnew-trigger-label = News
-whatsnew-counter-label = { $count } new announcements.
-whatsnew-close-label = Close
-whatsnew-tab-new-label = News
-whatsnew-tab-archive-label = History
-whatsnew-footer-clear-all-label = Clear all
-whatsnew-footer-back-label = Back
-whatsnew-footer-learn-more-label = Learn more
-
-whatsnew-empty-message = Be sure to check back here—we’re always working on great new features to make { -brand-name-relay } even better.
-
-whatsnew-feature-size-limit-heading = Attachment size increase
-# A preview of the full content of `whatsnew-feature-size-limit-description`.
-# When translating, please make sure the resulting string is of roughly similar
-# length as the English version.
-whatsnew-feature-size-limit-snippet = { -brand-name-firefox-relay } can now forward emails up to 25MB, including…
-whatsnew-feature-size-limit-description = { -brand-name-firefox-relay } can now forward emails up to 25MB, including attachments.
-# A preview of the full content of `whatsnew-feature-size-limit-description-var`.
-# When translating, please make sure the resulting string is of roughly similar
-# length as the English version.
-whatsnew-feature-size-limit-snippet-var = { -brand-name-firefox-relay } can now forward emails up to { email-size-limit }, including…
-whatsnew-feature-size-limit-description-var = { -brand-name-firefox-relay } can now forward emails up to { email-size-limit }, including attachments.
-
-whatsnew-feature-sign-back-in-heading = Sign back in with your aliases
-# A preview of the full content of `whatsnew-feature-sign-back-in-description`.
-# When translating, please make sure the resulting string is of roughly similar
-# length as the English version.
-whatsnew-feature-sign-back-in-snippet = To create a new alias when you’re asked for your email, open...
-whatsnew-feature-sign-back-in-description = To sign in with a previously-used alias, open the context menu where the site asks for your email. You’ll be able to select the alias and auto-fill the email field.
-
-whatsnew-feature-forward-some-heading = Promotional email blocking
-# A preview of the full content of `whatsnew-feature-forward-some-description`.
-# When translating, please make sure the resulting string is of roughly similar
-# length as the English version.
-whatsnew-feature-forward-some-snippet = { -brand-name-relay-premium } allows you to block only promotional emails...
-whatsnew-feature-forward-some-description = { -brand-name-relay-premium } allows you to block only promotional emails sent to an alias. You’ll receive emails like receipts but not marketing emails.

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -19,7 +19,7 @@ error-alias-update-failed = The alias data could not be updated. Please try agai
 #   $alias (string) - The email alias (e.g. abcdef@mozmail.com) that the user tried to delete
 error-alias-delete-failed = The alias { $alias } could not be deleted. Please try again.
 
-profile-label-domain-tooltip-trigger = More info
+profile-label-subdomain-tooltip-trigger = More info
 # This will be read to screen readers when focusing the button to copy an alias to the clipboard.
 # Variables:
 #   $address (string) - Alias address, e.g. wz7n0vykd@mozmail.com.
@@ -44,7 +44,7 @@ modal-domain-register-confirmation-checkbox-v2 = Yes, I want to register <subdom
 # Variables:
 #   $subdomain (string) - Chosen subdomain, i.e. the part after `@` and before `.mozmail.com`
 #   $domain (string) - Applicable domain, i.e. `.mozmail.com`
-modal-domain-register-success-v2 = <subdomain>{ $subdomain }</subdomain><domain>.{ $domain }</domain> is now your email domain!
+modal-domain-register-success-3 = <subdomain>{ $subdomain }</subdomain><domain>.{ $domain }</domain> is now your email subdomain!
 
 # Variables:
 #   $step (number) - Which step the user currently is on

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -5,41 +5,41 @@
 banner-dismiss = Dismiss
 
 # Do not change '@mozmail.com'
-landing-how-it-works-step-2-body-v2 = As you browse, the { -brand-name-relay } icon will appear where sites ask for your email address.
+landing-how-it-works-step-2-body-2 = As you browse, the { -brand-name-relay } icon will appear where sites ask for your email address.
     Select it to generate a new, random address that ends in @mozmail.com.
 
 landing-use-cases-heading = Use { -brand-name-firefox-relay } for:
 
 error-settings-update = There was an error updating your settings, please try again
-error-alias-create-failed = The alias could not be created. Please try again.
-# This currently appears when an alias label could not be updated,
-# but in the future it might also appear if other alias data could not be changed.
-error-alias-update-failed = The alias data could not be updated. Please try again.
+error-mask-create-failed = The mask could not be created. Please try again.
+# This currently appears when a mask label could not be updated,
+# but in the future it might also appear if other mask data could not be changed.
+error-mask-update-failed = The mask data could not be updated. Please try again.
 # Variables:
-#   $alias (string) - The email alias (e.g. abcdef@mozmail.com) that the user tried to delete
-error-alias-delete-failed = The alias { $alias } could not be deleted. Please try again.
+#   $mask (string) - The email mask (e.g. abcdef@mozmail.com) that the user tried to delete
+error-mask-delete-failed = The mask { $mask } could not be deleted. Please try again.
 
 profile-label-subdomain-tooltip-trigger = More info
-# This will be read to screen readers when focusing the button to copy an alias to the clipboard.
+# This will be read to screen readers when focusing the button to copy an mask to the clipboard.
 # Variables:
-#   $address (string) - Alias address, e.g. wz7n0vykd@mozmail.com.
-profile-label-click-to-copy-alt = Click to copy alias { $address }.
+#   $address (string) - Mask address, e.g. wz7n0vykd@mozmail.com.
+profile-label-click-to-copy-alt = Click to copy mask { $address }.
 
-profile-details-expand = Show alias details
-profile-details-collapse = Hide alias details
+profile-details-expand = Show mask details
+profile-details-collapse = Hide mask details
 
-profile-filter-category-button-label = Filter visible aliases
-profile-filter-category-button-tooltip = Filter aliases by domain and/or whether they are currently blocking incoming email
-profile-filter-category-title = Filter visible aliases
-profile-filter-no-results = No aliases match your selected criteria. <clear-button>Clear all filters.</clear-button>
+profile-filter-category-button-label = Filter visible masks
+profile-filter-category-button-tooltip = Filter masks by subdomain and/or whether they are currently blocking incoming email
+profile-filter-category-title = Filter visible masks
+profile-filter-no-results = No masks match your selected criteria. <clear-button>Clear all filters.</clear-button>
 
 # Variables:
 #   $subdomain (string) - Chosen subdomain, i.e. the part after `@` and before `.mozmail.com`
 #   $domain (string) - Applicable domain, i.e. `.mozmail.com`
-modal-domain-register-available-v2 = <subdomain>{ $subdomain }</subdomain><domain>.{ $domain }</domain> is available!
+modal-domain-register-available-2 = <subdomain>{ $subdomain }</subdomain><domain>.{ $domain }</domain> is available!
 # Variables:
 #   $subdomain (string) - Chosen subdomain, i.e. the part after `@` and before `.mozmail.com`
-modal-domain-register-confirmation-checkbox-v2 = Yes, I want to register <subdomain>{ $subdomain }</subdomain>
+modal-domain-register-confirmation-checkbox-2 = Yes, I want to register <subdomain>{ $subdomain }</subdomain>
 
 # Variables:
 #   $subdomain (string) - Chosen subdomain, i.e. the part after `@` and before `.mozmail.com`
@@ -59,9 +59,9 @@ tips-switcher-label = Tip { $nr }
 # This copy (and the term "critical email") is not final yet:
 tips-critical-emails-heading = Critical email forwarding
 # This copy (and the term "critical email") is not final yet:
-tips-critical-emails-content = Relay allows you to receive only critical emails sent to an alias. You’ll receive emails like receipts but not spam or marketing emails.
+tips-critical-emails-content = Relay allows you to receive only critical emails sent to an mask. You’ll receive emails like receipts but not spam or marketing emails.
 
 # This copy is not final yet:
-tips-addon-signin-heading = Sign in with your aliases
+tips-addon-signin-heading = Sign in with your masks
 # This copy is not final yet:
-tips-addon-signin-content = To sign in with a previously-used alias, open the context menu (right-click or control-click) where the site asks for your email. You’ll be able to select the alias and auto-fill the email field.
+tips-addon-signin-content = To sign in with a previously-used mask, open the context menu (right-click or control-click) where the site asks for your email. You’ll be able to select the mask and auto-fill the email field.

--- a/frontend/src/components/dashboard/Onboarding.tsx
+++ b/frontend/src/components/dashboard/Onboarding.tsx
@@ -22,16 +22,16 @@ export const Onboarding = (props: Props) => {
 
   return (
     <section className={styles.wrapper}>
-      <h2>{l10n.getString("onboarding-headline")}</h2>
+      <h2>{l10n.getString("onboarding-headline-2")}</h2>
       <ol className={styles.steps}>
         <li className={styles.step}>
-          <p>{l10n.getString("onboarding-alias-tip-1")}</p>
+          <p>{l10n.getString("onboarding-alias-tip-1-2")}</p>
           <div className={styles.footer}>
             <Button
               onClick={() => props.onCreate()}
-              title={l10n.getString("profile-label-generate-new-alias")}
+              title={l10n.getString("profile-label-generate-new-alias-2")}
             >
-              {l10n.getString("profile-label-generate-new-alias")}
+              {l10n.getString("profile-label-generate-new-alias-2")}
             </Button>
           </div>
         </li>
@@ -42,7 +42,7 @@ export const Onboarding = (props: Props) => {
           </div>
         </li>
         <li className={styles.step}>
-          <p>{l10n.getString("onboarding-alias-tip-3")}</p>
+          <p>{l10n.getString("onboarding-alias-tip-3-2")}</p>
           <div className={styles.footer}>
             <img src={RightClickImage.src} alt="" />
           </div>

--- a/frontend/src/components/dashboard/PremiumOnboarding.tsx
+++ b/frontend/src/components/dashboard/PremiumOnboarding.tsx
@@ -115,7 +115,7 @@ export const PremiumOnboarding = (props: Props) => {
           onClick={skipDomain}
           className={styles["skip-link"]}
         >
-          {l10n.getString("multi-part-onboarding-premium-domain-button-skip")}
+          {l10n.getString("multi-part-onboarding-premium-domain-button-skip-2")}
         </button>
       );
     } else {
@@ -265,14 +265,14 @@ const StepOne = () => {
           <br />
           <strong>
             {l10n.getString(
-              "multi-part-onboarding-premium-generate-unlimited-title"
+              "multi-part-onboarding-premium-generate-unlimited-title-2"
             )}
           </strong>
           <br />
           {l10n.getString(
             isLargeScreen
-              ? "onboarding-premium-control-description"
-              : "multi-part-onboarding-premium-welcome-description"
+              ? "onboarding-premium-control-description-2"
+              : "multi-part-onboarding-premium-welcome-description-2"
           )}
         </p>
       </div>
@@ -292,7 +292,7 @@ const StepTwo = (props: Step2Props) => {
       <p className={styles["action-complete"]}>
         <span className={styles.label}>
           <img src={checkIcon.src} alt="" width={18} />
-          {l10n.getString("profile-label-domain")}
+          {l10n.getString("profile-label-subdomain")}
         </span>
         <samp>@{props.profile.subdomain}</samp>
         <span className={styles.domain}>
@@ -309,7 +309,7 @@ const StepTwo = (props: Step2Props) => {
   return (
     <div className={`${styles.step} ${styles["step-custom-domain"]}`}>
       <div>
-        <h2>{l10n.getString("multi-part-onboarding-premium-get-domain")}</h2>
+        <h2>{l10n.getString("multi-part-onboarding-premium-get-subdomain")}</h2>
       </div>
       <div className={styles.description}>
         <img src={WomanEmail.src} alt="" width={400} />
@@ -320,11 +320,11 @@ const StepTwo = (props: Step2Props) => {
             </span>
             <br />
             <strong>
-              {l10n.getString("onboarding-premium-domain-title-2")}
+              {l10n.getString("onboarding-premium-domain-title-3")}
             </strong>
             <br />
             {l10n.getString(
-              "multi-part-onboarding-premium-get-domain-description-2",
+              "multi-part-onboarding-premium-get-domain-description-3",
               {
                 mozmail: ".mozmail.com",
               }
@@ -375,7 +375,7 @@ const Step2SubdomainPicker = (props: Step2SubdomainPickerProps) => {
   return (
     <>
       <p className={styles["subdomain-picker-heading"]}>
-        {l10n.getString("multi-part-onboarding-premium-domain-cta")}
+        {l10n.getString("multi-part-onboarding-premium-domain-cta-2")}
       </p>
       <samp className={styles["domain-example"]}>
         ***@
@@ -408,9 +408,11 @@ const StepThree = () => {
               {l10n.getString("onboarding-premium-title-detail")}
             </span>
             <br />
-            <strong>{l10n.getString("onboarding-premium-reply-title")}</strong>
+            <strong>
+              {l10n.getString("onboarding-premium-reply-title-2")}
+            </strong>
             <br />
-            {l10n.getString("onboarding-premium-reply-description")}
+            {l10n.getString("onboarding-premium-reply-description-2")}
           </p>
           <AddonDescription />
           <div
@@ -455,7 +457,7 @@ const getAddonDescriptionProps = () => {
     return {
       headerMessageId: "multi-part-onboarding-premium-extension-get-title",
       paragraphMessageId:
-        "multi-part-onboarding-premium-extension-get-description",
+        "multi-part-onboarding-premium-extension-get-description-2",
       linkHref:
         "https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon",
       linkMessageId: "multi-part-onboarding-premium-extension-button-download",

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -137,7 +137,7 @@ const NoFirefoxBanner = () => {
         content: l10n.getString("banner-download-firefox-cta"),
       }}
     >
-      <p>{l10n.getString("banner-download-firefox-copy")}</p>
+      <p>{l10n.getString("banner-download-firefox-copy-2")}</p>
     </Banner>
   );
 };
@@ -159,7 +159,7 @@ const NoAddonBanner = () => {
       }}
       hiddenWithAddon={true}
     >
-      <p>{l10n.getString("banner-download-install-extension-copy")}</p>
+      <p>{l10n.getString("banner-download-install-extension-copy-2")}</p>
     </Banner>
   );
 };
@@ -210,7 +210,7 @@ const NoPremiumBanner = (props: NoPremiumBannerProps) => {
         },
       }}
     >
-      <p>{l10n.getString("banner-upgrade-copy")}</p>
+      <p>{l10n.getString("banner-upgrade-copy-2")}</p>
     </Banner>
   );
 };

--- a/frontend/src/components/dashboard/SubdomainPicker.tsx
+++ b/frontend/src/components/dashboard/SubdomainPicker.tsx
@@ -63,7 +63,9 @@ export const SubdomainPicker = (props: Props) => {
         <span aria-hidden={true} className={styles["action-step"]}>
           {l10n.getString("banner-label-action")}
         </span>
-        <h2>{l10n.getString("banner-register-subdomain-headline-aliases")}</h2>
+        <h2>
+          {l10n.getString("banner-register-subdomain-headline-aliases-2")}
+        </h2>
         <samp className={styles.example} aria-hidden={true}>
           ***@
           <span className={styles["subdomain-part"]}>
@@ -74,7 +76,7 @@ export const SubdomainPicker = (props: Props) => {
           .{getRuntimeConfig().mozmailDomain}
         </samp>
         <p className={styles.lead}>
-          {l10n.getString("banner-register-subdomain-copy", {
+          {l10n.getString("banner-register-subdomain-copy-2", {
             mozmail: getRuntimeConfig().mozmailDomain,
           })}
         </p>

--- a/frontend/src/components/dashboard/Tips.tsx
+++ b/frontend/src/components/dashboard/Tips.tsx
@@ -131,8 +131,8 @@ const CustomAliasTip = (props: CustomAliasTipProps) => {
       <samp>
         @{props.subdomain}.{getRuntimeConfig().mozmailDomain}
       </samp>
-      <h3>{l10n.getString("tips-custom-alias-heading")}</h3>
-      <p>{l10n.getString("tips-custom-alias-content")}</p>
+      <h3>{l10n.getString("tips-custom-alias-heading-2")}</h3>
+      <p>{l10n.getString("tips-custom-alias-content-2")}</p>
     </div>
   );
 };

--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
@@ -51,7 +51,7 @@ export const AddressPickerModal = (props: Props) => {
     <>
       <OverlayContainer>
         <PickerDialog
-          title={l10n.getString("modal-custom-alias-picker-heading")}
+          title={l10n.getString("modal-custom-alias-picker-heading-2")}
           onClose={() => props.onClose()}
           isOpen={props.isOpen}
           isDismissable={true}
@@ -60,17 +60,17 @@ export const AddressPickerModal = (props: Props) => {
             <span className={styles["warning-icon"]}>
               <InfoIcon alt="" />
             </span>
-            <p>{l10n.getString("modal-custom-alias-picker-warning")}</p>
+            <p>{l10n.getString("modal-custom-alias-picker-warning-2")}</p>
           </div>
           <form onSubmit={onSubmit}>
             <div className={styles["form-wrapper"]}>
               <p className={styles["form-heading"]}>
-                {l10n.getString("modal-custom-alias-picker-form-heading")}
+                {l10n.getString("modal-custom-alias-picker-form-heading-2")}
               </p>
               <div className={styles.prefix}>
                 <label htmlFor="address">
                   {l10n.getString(
-                    "modal-custom-alias-picker-form-prefix-label"
+                    "modal-custom-alias-picker-form-prefix-label-2"
                   )}
                 </label>
                 <input
@@ -96,7 +96,9 @@ export const AddressPickerModal = (props: Props) => {
                 {l10n.getString("profile-label-cancel")}
               </button>
               <Button type="submit" disabled={address.length === 0}>
-                {l10n.getString("modal-custom-alias-picker-form-submit-label")}
+                {l10n.getString(
+                  "modal-custom-alias-picker-form-submit-label-2"
+                )}
               </Button>
             </div>
           </form>

--- a/frontend/src/components/dashboard/aliases/Alias.tsx
+++ b/frontend/src/components/dashboard/aliases/Alias.tsx
@@ -120,8 +120,8 @@ export const Alias = (props: Props) => {
       className={styles["toggle-button"]}
       aria-label={l10n.getString(
         toggleButtonState.isSelected
-          ? "profile-label-disable-forwarding-button"
-          : "profile-label-enable-forwarding-button"
+          ? "profile-label-disable-forwarding-button-2"
+          : "profile-label-enable-forwarding-button-2"
       )}
     ></button>
   );
@@ -272,7 +272,7 @@ const ForwardedTooltip = (props: TooltipProps) => {
           {...mergeProps(tooltipTrigger.tooltipProps, tooltipProps)}
           className={styles.tooltip}
         >
-          <span>{l10n.getString("profile-forwarded-copy")}</span>
+          <span>{l10n.getString("profile-forwarded-copy-2")}</span>
           <br />
           <strong>{l10n.getString("profile-forwarded-note")}</strong>&nbsp;
           <span>
@@ -308,7 +308,7 @@ const BlockedTooltip = (props: TooltipProps) => {
           {...mergeProps(tooltipTrigger.tooltipProps, tooltipProps)}
           className={styles.tooltip}
         >
-          {l10n.getString("profile-blocked-copy")}
+          {l10n.getString("profile-blocked-copy-2")}
         </span>
       )}
     </span>

--- a/frontend/src/components/dashboard/aliases/AliasDeletionButton.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButton.tsx
@@ -62,7 +62,7 @@ export const AliasDeletionButton = (props: Props) => {
   const dialog = modalState.isOpen ? (
     <OverlayContainer>
       <ConfirmationDialog
-        title={l10n.getString("modal-delete-headline")}
+        title={l10n.getString("modal-delete-headline-2")}
         onClose={() => modalState.close()}
         isOpen={modalState.isOpen}
         isDismissable={true}
@@ -71,7 +71,7 @@ export const AliasDeletionButton = (props: Props) => {
           {getFullAddress(props.alias)}
         </samp>
         <Localized
-          id="modal-delete-warning-recovery-html"
+          id="modal-delete-warning-recovery-2-html"
           vars={{ email: getFullAddress(props.alias) }}
           elems={{
             strong: <strong />,
@@ -82,8 +82,8 @@ export const AliasDeletionButton = (props: Props) => {
         <p className={styles["usage-warning"]}>
           {l10n.getString(
             isRandomAlias(props.alias)
-              ? "modal-delete-warning-upgrade"
-              : "modal-delete-domain-address-warning-upgrade"
+              ? "modal-delete-warning-upgrade-2"
+              : "modal-delete-domain-address-warning-upgrade-2"
           )}
         </p>
         <form onSubmit={onConfirm} className={styles.confirm}>
@@ -95,7 +95,7 @@ export const AliasDeletionButton = (props: Props) => {
               onChange={(e) => setConfirmCheckbox(e.target.checked)}
               required={true}
             />
-            {l10n.getString("modal-delete-confirmation")}
+            {l10n.getString("modal-delete-confirmation-2")}
           </label>
           <div className={styles.buttons}>
             <button

--- a/frontend/src/components/dashboard/aliases/AliasGenerationButton.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasGenerationButton.test.tsx
@@ -31,7 +31,7 @@ describe("<AliasGenerationButton>", () => {
 
     expect(button).toBeEnabled();
     expect(button).toHaveTextContent(
-      "l10n string: [profile-label-generate-new-alias], with vars: {}"
+      "l10n string: [profile-label-generate-new-alias-2], with vars: {}"
     );
   });
 
@@ -56,7 +56,7 @@ describe("<AliasGenerationButton>", () => {
 
     expect(button).toBeEnabled();
     expect(button).toHaveTextContent(
-      "l10n string: [profile-label-generate-new-alias], with vars: {}"
+      "l10n string: [profile-label-generate-new-alias-2], with vars: {}"
     );
   });
 
@@ -79,7 +79,7 @@ describe("<AliasGenerationButton>", () => {
     const button = screen.getByRole("link");
 
     expect(button).toHaveTextContent(
-      "l10n string: [profile-label-upgrade], with vars: {}"
+      "l10n string: [profile-label-upgrade-2], with vars: {}"
     );
   });
 
@@ -150,7 +150,7 @@ describe("<AliasGenerationButton>", () => {
 
       expect(button).toBeEnabled();
       expect(button).toHaveTextContent(
-        "l10n string: [profile-label-generate-new-alias], with vars: {}"
+        "l10n string: [profile-label-generate-new-alias-2], with vars: {}"
       );
     });
 
@@ -191,7 +191,7 @@ describe("<AliasGenerationButton>", () => {
 
       expect(dropDownButton).toBeEnabled();
       expect(dropDownButton).toHaveTextContent(
-        "l10n string: [profile-label-generate-new-alias], with vars: {}"
+        "l10n string: [profile-label-generate-new-alias-2], with vars: {}"
       );
       expect(menu).toBeInTheDocument();
       expect(menuItems).toHaveLength(2);

--- a/frontend/src/components/dashboard/aliases/AliasGenerationButton.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasGenerationButton.tsx
@@ -70,7 +70,7 @@ export const AliasGenerationButton = (props: Props) => {
       return (
         <Button disabled>
           <img src={plusIcon.src} alt="" width={16} height={16} />
-          {l10n.getString("profile-label-generate-new-alias")}
+          {l10n.getString("profile-label-generate-new-alias-2")}
         </Button>
       );
     }
@@ -87,7 +87,7 @@ export const AliasGenerationButton = (props: Props) => {
           trackPurchaseStart({ label: "profile-create-alias-upgrade-promo" })
         }
       >
-        {l10n.getString("profile-label-upgrade")}
+        {l10n.getString("profile-label-upgrade-2")}
       </LinkButton>
     );
   }
@@ -108,10 +108,10 @@ export const AliasGenerationButton = (props: Props) => {
   return (
     <Button
       onClick={() => props.onCreate({ type: "random" })}
-      title={l10n.getString("profile-label-generate-new-alias")}
+      title={l10n.getString("profile-label-generate-new-alias-2")}
     >
       <img src={plusIcon.src} alt="" width={16} height={16} />
-      {l10n.getString("profile-label-generate-new-alias")}
+      {l10n.getString("profile-label-generate-new-alias-2")}
     </Button>
   );
 };
@@ -154,10 +154,10 @@ const AliasTypeMenu = (props: AliasTypeMenuProps) => {
     <>
       <AliasTypeMenuButton onAction={onAction}>
         <Item key="random">
-          {l10n.getString("profile-label-generate-new-alias-menu-random")}
+          {l10n.getString("profile-label-generate-new-alias-menu-random-2")}
         </Item>
         <Item key="custom">
-          {l10n.getString("profile-label-generate-new-alias-menu-custom", {
+          {l10n.getString("profile-label-generate-new-alias-menu-custom-2", {
             subdomain: props.subdomain,
           })}
         </Item>
@@ -189,13 +189,13 @@ const AliasTypeMenuButton = (props: AliasTypeMenuButtonProps) => {
   return (
     <div className={styles["button-wrapper"]}>
       <Button ref={triggerRef} {...triggerButtonProps}>
-        {l10n.getString("profile-label-generate-new-alias")}
+        {l10n.getString("profile-label-generate-new-alias-2")}
         <img src={arrowHeadIcon.src} alt="" width={16} height={16} />
       </Button>
       {triggerState.isOpen && (
         <AliasTypeMenuPopup
           {...props}
-          aria-label={l10n.getString("profile-label-generate-new-alias")}
+          aria-label={l10n.getString("profile-label-generate-new-alias-2")}
           domProps={menuProps}
           autoFocus={triggerState.focusStrategy}
           onClose={() => triggerState.close()}

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -134,7 +134,7 @@ export const AliasList = (props: Props) => {
         <div className={styles["string-filter"]}>
           <VisuallyHidden>
             <label htmlFor="stringFilter">
-              {l10n.getString("profile-filter-search-placeholder")}
+              {l10n.getString("profile-filter-search-placeholder-2")}
             </label>
           </VisuallyHidden>
           <input
@@ -143,7 +143,7 @@ export const AliasList = (props: Props) => {
             type="search"
             name="stringFilter"
             id="stringFilter"
-            placeholder={l10n.getString("profile-filter-search-placeholder")}
+            placeholder={l10n.getString("profile-filter-search-placeholder-2")}
           />
           <span className={styles["match-count"]}>
             {aliases.length}/{props.aliases.length}

--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.tsx
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.tsx
@@ -169,7 +169,7 @@ const BlockLevelDescription = (props: { level: BlockLevel }) => {
 
   if (props.level === "none") {
     return (
-      <>{l10n.getString("profile-promo-email-blocking-description-none")}</>
+      <>{l10n.getString("profile-promo-email-blocking-description-none-2")}</>
     );
   }
 
@@ -187,7 +187,9 @@ const BlockLevelDescription = (props: { level: BlockLevel }) => {
     );
   }
 
-  return <>{l10n.getString("profile-promo-email-blocking-description-all")}</>;
+  return (
+    <>{l10n.getString("profile-promo-email-blocking-description-all-2")}</>
+  );
 };
 const BlockLevelIllustration = (props: { level: BlockLevel }) => {
   if (props.level === "none") {

--- a/frontend/src/components/dashboard/aliases/CategoryFilter.tsx
+++ b/frontend/src/components/dashboard/aliases/CategoryFilter.tsx
@@ -159,9 +159,7 @@ const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
                 name="customAliases"
                 id="customAliases"
               />
-              {l10n.getString(
-                "profile-filter-category-option-domain-based-aliases-v2"
-              )}
+              {l10n.getString("profile-filter-category-option-custom-masks")}
             </label>
             <label>
               <input
@@ -173,9 +171,7 @@ const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
                 name="randomAliases"
                 id="randomAliases"
               />
-              {l10n.getString(
-                "profile-filter-category-option-relay-aliases-v2"
-              )}
+              {l10n.getString("profile-filter-category-option-random-masks")}
             </label>
             <label>
               <input
@@ -187,9 +183,7 @@ const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
                 name="forwardingAliases"
                 id="forwardingAliases"
               />
-              {l10n.getString(
-                "profile-filter-category-option-active-aliases-v2"
-              )}
+              {l10n.getString("profile-filter-category-option-active-masks")}
             </label>
             <label>
               <input
@@ -215,9 +209,7 @@ const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
                 name="blockingAliases"
                 id="blockingAliases"
               />
-              {l10n.getString(
-                "profile-filter-category-option-disabled-aliases-v2"
-              )}
+              {l10n.getString("profile-filter-category-option-disabled-masks")}
             </label>
             <div className={styles.buttons}>
               <button type="reset">

--- a/frontend/src/components/dashboard/aliases/LabelEditor.tsx
+++ b/frontend/src/components/dashboard/aliases/LabelEditor.tsx
@@ -54,7 +54,7 @@ export const LabelEditor = (props: Props) => {
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
         onBlur={onBlur}
-        aria-label={l10n.getString("profile-label-edit")}
+        aria-label={l10n.getString("profile-label-edit-2")}
         ref={inputRef}
         className={styles["label-input"]}
         placeholder={l10n.getString("profile-label-placeholder")}

--- a/frontend/src/components/dashboard/subdomain/ConfirmationForm.tsx
+++ b/frontend/src/components/dashboard/subdomain/ConfirmationForm.tsx
@@ -46,7 +46,7 @@ export const SubdomainConfirmationForm = (props: Props) => {
             required={true}
           />
           <Localized
-            id="modal-domain-register-confirmation-checkbox-v2"
+            id="modal-domain-register-confirmation-checkbox-2"
             vars={{
               subdomain: props.subdomain,
             }}

--- a/frontend/src/components/dashboard/subdomain/ConfirmationForm.tsx
+++ b/frontend/src/components/dashboard/subdomain/ConfirmationForm.tsx
@@ -33,7 +33,7 @@ export const SubdomainConfirmationForm = (props: Props) => {
   return (
     <>
       <p className={styles["permanence-warning"]}>
-        {l10n.getString("modal-domain-register-warning-reminder")}
+        {l10n.getString("modal-domain-register-warning-reminder-2")}
       </p>
       <form onSubmit={onSubmit} className={styles.confirm}>
         <label>
@@ -66,7 +66,7 @@ export const SubdomainConfirmationForm = (props: Props) => {
             {l10n.getString("profile-label-cancel")}
           </button>
           <Button type="submit" disabled={!confirmCheckbox}>
-            {l10n.getString("modal-domain-register-button")}
+            {l10n.getString("modal-domain-register-button-2")}
           </Button>
         </div>
       </form>

--- a/frontend/src/components/dashboard/subdomain/ConfirmationModal.tsx
+++ b/frontend/src/components/dashboard/subdomain/ConfirmationModal.tsx
@@ -46,7 +46,7 @@ const ConfirmModal = (props: Props) => {
     <PickerDialog
       title={
         <Localized
-          id="modal-domain-register-available-v2"
+          id="modal-domain-register-available-2"
           vars={{
             subdomain: props.subdomain,
             domain: getRuntimeConfig().mozmailDomain,

--- a/frontend/src/components/dashboard/subdomain/ConfirmationModal.tsx
+++ b/frontend/src/components/dashboard/subdomain/ConfirmationModal.tsx
@@ -81,7 +81,7 @@ const SuccessModal = (props: Props) => {
       <PickerDialog
         title={
           <Localized
-            id="modal-domain-register-success-v2"
+            id="modal-domain-register-success-3"
             vars={{
               subdomain: props.subdomain,
               domain: getRuntimeConfig().mozmailDomain,
@@ -101,7 +101,7 @@ const SuccessModal = (props: Props) => {
       >
         <div className={styles["picked-confirmation-body"]}>
           <img src={partyIllustration.src} alt="" />
-          <p>{l10n.getString("modal-domain-register-success-copy")}</p>
+          <p>{l10n.getString("modal-domain-register-success-copy-2")}</p>
           <Button onClick={() => props.onClose()}>
             {l10n.getString("profile-label-continue")}
           </Button>

--- a/frontend/src/components/dashboard/subdomain/SearchForm.tsx
+++ b/frontend/src/components/dashboard/subdomain/SearchForm.tsx
@@ -23,7 +23,7 @@ export const SubdomainSearchForm = (props: Props) => {
     const isAvailable = await getAvailability(subdomainInput);
     if (!isAvailable) {
       toast(
-        l10n.getString("error-subdomain-not-available", {
+        l10n.getString("error-subdomain-not-available-2", {
           unavailable_subdomain: subdomainInput,
         }),
         { type: "error" }
@@ -43,7 +43,7 @@ export const SubdomainSearchForm = (props: Props) => {
     <form onSubmit={onSubmit}>
       <VisuallyHidden>
         <label htmlFor="subdomain">
-          {l10n.getString("banner-choose-subdomain-input-placeholder-2")}
+          {l10n.getString("banner-choose-subdomain-input-placeholder-3")}
         </label>
       </VisuallyHidden>
       <input
@@ -51,7 +51,7 @@ export const SubdomainSearchForm = (props: Props) => {
         value={subdomainInput}
         onInput={onInput}
         placeholder={l10n.getString(
-          "banner-choose-subdomain-input-placeholder-2"
+          "banner-choose-subdomain-input-placeholder-3"
         )}
         name="subdomain"
         id="subdomain"

--- a/frontend/src/components/dashboard/subdomain/SubdomainIndicator.tsx
+++ b/frontend/src/components/dashboard/subdomain/SubdomainIndicator.tsx
@@ -114,11 +114,11 @@ const ExplainerTrigger = (props: ExplainerTriggerProps) => {
             ref={overlayRef}
           >
             <p className={styles.explanation}>
-              {l10n.getString("popover-custom-alias-explainer-explanation")}
+              {l10n.getString("popover-custom-alias-explainer-explanation-2")}
             </p>
             <p className={styles["button-heading"]}>
               {l10n.getString(
-                "popover-custom-alias-explainer-generate-button-heading"
+                "popover-custom-alias-explainer-generate-button-heading-2"
               )}
             </p>
             <button
@@ -127,7 +127,7 @@ const ExplainerTrigger = (props: ExplainerTriggerProps) => {
               className={styles["generate-button"]}
             >
               {l10n.getString(
-                "popover-custom-alias-explainer-generate-button-label"
+                "popover-custom-alias-explainer-generate-button-label-2"
               )}
             </button>
             <button
@@ -187,7 +187,7 @@ const Explainer = forwardRef<HTMLDivElement, ExplainerProps>(
           className={styles["explainer-wrapper"]}
         >
           <h3 {...titleProps}>
-            {l10n.getString("popover-custom-alias-explainer-heading")}
+            {l10n.getString("popover-custom-alias-explainer-heading-2")}
           </h3>
           {props.children}
         </div>

--- a/frontend/src/components/landing/Plans.tsx
+++ b/frontend/src/components/landing/Plans.tsx
@@ -52,7 +52,7 @@ export const Plans = (props: Props) => {
           {l10n.getString("landing-pricing-free-price")}
         </b>
         <ul className={styles.features}>
-          <li>{l10n.getString("landing-pricing-free-feature-1")}</li>
+          <li>{l10n.getString("landing-pricing-free-feature-1-2")}</li>
           <li>{l10n.getString("landing-pricing-free-feature-2")}</li>
         </ul>
         <div ref={freeFauxButtonRef} className={styles["faux-button"]}>
@@ -78,9 +78,9 @@ export const Plans = (props: Props) => {
           })}
         </b>
         <ul className={styles.features}>
-          <li>{l10n.getString("landing-pricing-premium-feature-1")}</li>
+          <li>{l10n.getString("landing-pricing-premium-feature-1-2")}</li>
           <li>{l10n.getString("landing-pricing-premium-feature-2")}</li>
-          <li>{l10n.getString("landing-pricing-premium-feature-3")}</li>
+          <li>{l10n.getString("landing-pricing-premium-feature-3-2")}</li>
           <li>{l10n.getString("landing-pricing-premium-feature-4")}</li>
           <li>{l10n.getString("landing-pricing-premium-feature-5")}</li>
         </ul>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -91,7 +91,10 @@ export const Layout = (props: Props) => {
       <Head>
         <link rel="icon" type="image/svg+xml" href={favicon.src}></link>
         <title>{l10n.getString("meta-title")}</title>
-        <meta name="description" content={l10n.getString("meta-description")} />
+        <meta
+          name="description"
+          content={l10n.getString("meta-description-2")}
+        />
         <meta
           property="og:url"
           content={getRuntimeConfig().frontendOrigin + router.asPath}
@@ -100,7 +103,7 @@ export const Layout = (props: Props) => {
         <meta property="og:title" content={l10n.getString("meta-title")} />
         <meta
           property="og:description"
-          content={l10n.getString("meta-description")}
+          content={l10n.getString("meta-description-2")}
         />
         <meta property="og:image" content={socialMediaImage.src} />
         <meta name="twitter:card" content="summary_large_image" />
@@ -108,7 +111,7 @@ export const Layout = (props: Props) => {
         <meta name="twitter:title" content={l10n.getString("meta-title")} />
         <meta
           name="twitter:description"
-          content={l10n.getString("meta-description")}
+          content={l10n.getString("meta-description-2")}
         />
         <meta name="twitter:image" content={socialMediaImage.src} />
       </Head>

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -123,7 +123,7 @@ const Profile: NextPage = () => {
         );
       }
     } catch (error) {
-      toast(l10n.getString("error-alias-create-failed"), { type: "error" });
+      toast(l10n.getString("error-mask-create-failed"), { type: "error" });
     }
   };
 
@@ -140,7 +140,7 @@ const Profile: NextPage = () => {
       }
     } catch (error) {
       toast(
-        l10n.getString("error-alias-update-failed", {
+        l10n.getString("error-mask-update-failed", {
           alias: getFullAddress(alias),
         }),
         { type: "error" }
@@ -158,7 +158,7 @@ const Profile: NextPage = () => {
       }
     } catch (error: unknown) {
       toast(
-        l10n.getString("error-alias-delete-failed", {
+        l10n.getString("error-mask-delete-failed", {
           alias: getFullAddress(alias),
         }),
         { type: "error" }

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -83,7 +83,7 @@ const Profile: NextPage = () => {
     const response = await profileData.setSubdomain(customSubdomain);
     if (!response.ok) {
       toast(
-        l10n.getString("error-subdomain-not-available", {
+        l10n.getString("error-subdomain-not-available-2", {
           unavailable_subdomain: customSubdomain,
         }),
         { type: "error" }
@@ -183,7 +183,7 @@ const Profile: NextPage = () => {
   const subdomainMessage =
     typeof profile.subdomain === "string" ? (
       <>
-        {l10n.getString("profile-label-domain")}&nbsp;
+        {l10n.getString("profile-label-subdomain")}&nbsp;
         <SubdomainIndicator
           subdomain={profile.subdomain}
           onCreateAlias={(address: string) =>
@@ -194,12 +194,12 @@ const Profile: NextPage = () => {
     ) : (
       <>
         <a className={styles["open-button"]} href="#mpp-choose-subdomain">
-          {l10n.getString("profile-label-create-domain")}
+          {l10n.getString("profile-label-create-subdomain")}
         </a>
         <InfoTooltip
-          alt={l10n.getString("profile-label-domain-tooltip-trigger")}
+          alt={l10n.getString("profile-label-subdomain-tooltip-trigger")}
         >
-          {l10n.getString("profile-label-domain-tooltip")}
+          {l10n.getString("profile-label-subdomain-tooltip")}
         </InfoTooltip>
       </>
     );
@@ -233,7 +233,7 @@ const Profile: NextPage = () => {
         <dl className={styles["account-stats"]}>
           <div className={styles.stat}>
             <dt className={styles.label}>
-              {l10n.getString("profile-stat-label-aliases-used")}
+              {l10n.getString("profile-stat-label-aliases-used-2")}
             </dt>
             <dd className={styles.value}>
               {numberFormatter.format(allAliases.length)}
@@ -275,12 +275,12 @@ const Profile: NextPage = () => {
         <div className={styles["bottom-banner-wrapper"]}>
           <div className={styles["bottom-banner-content"]}>
             <Localized
-              id="banner-pack-upgrade-headline-html"
+              id="banner-pack-upgrade-headline-2-html"
               elems={{ strong: <strong /> }}
             >
               <h3 />
             </Localized>
-            <p>{l10n.getString("banner-pack-upgrade-copy")}</p>
+            <p>{l10n.getString("banner-pack-upgrade-copy-2")}</p>
             <LinkButton
               href={getPremiumSubscribeLink(runtimeData.data)}
               ref={bottomBannerSubscriptionLinkRef}

--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -90,7 +90,7 @@ describe("The dashboard", () => {
     });
     render(<Profile />);
 
-    const countOf2 = screen.getByText(/profile-stat-label-aliases-used/);
+    const countOf2 = screen.getByText(/profile-stat-label-aliases-used-2/);
 
     // Unfortunately we can't select by role=definition to directly query for
     // the parent item, so we'll have to make do with this crutch. See:
@@ -144,7 +144,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const domainSearchField = screen.getByLabelText(
-      "l10n string: [banner-choose-subdomain-input-placeholder-2], with vars: {}"
+      "l10n string: [banner-choose-subdomain-input-placeholder-3], with vars: {}"
     );
 
     expect(domainSearchField).toBeInTheDocument();
@@ -155,7 +155,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const domainSearchField = screen.queryByLabelText(
-      "l10n string: [banner-choose-subdomain-input-placeholder-2], with vars: {}"
+      "l10n string: [banner-choose-subdomain-input-placeholder-3], with vars: {}"
     );
 
     expect(domainSearchField).not.toBeInTheDocument();
@@ -169,7 +169,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const domainSearchField = screen.queryByLabelText(
-      "l10n string: [banner-choose-subdomain-input-placeholder-2], with vars: {}"
+      "l10n string: [banner-choose-subdomain-input-placeholder-3], with vars: {}"
     );
 
     expect(domainSearchField).not.toBeInTheDocument();
@@ -363,7 +363,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const searchFilter = screen.getByLabelText(
-      "l10n string: [profile-filter-search-placeholder], with vars: {}"
+      "l10n string: [profile-filter-search-placeholder-2], with vars: {}"
     );
 
     expect(searchFilter).toBeInTheDocument();
@@ -375,7 +375,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const searchFilter = screen.getByLabelText(
-      "l10n string: [profile-filter-search-placeholder], with vars: {}"
+      "l10n string: [profile-filter-search-placeholder-2], with vars: {}"
     );
 
     expect(searchFilter).toBeInTheDocument();
@@ -400,7 +400,7 @@ describe("The dashboard", () => {
 
     // The alias filter servers as a proxy here for the aliases being shown:
     const searchFilter = screen.queryByLabelText(
-      "l10n string: [profile-filter-search-placeholder], with vars: {}"
+      "l10n string: [profile-filter-search-placeholder-2], with vars: {}"
     );
 
     expect(searchFilter).not.toBeInTheDocument();
@@ -428,7 +428,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const subdomainSearchField = screen.getByLabelText(
-      "l10n string: [banner-choose-subdomain-input-placeholder-2], with vars: {}"
+      "l10n string: [banner-choose-subdomain-input-placeholder-3], with vars: {}"
     );
 
     expect(subdomainSearchField).toBeInTheDocument();
@@ -444,7 +444,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const subdomainSearchField = screen.queryByLabelText(
-      "l10n string: [banner-choose-subdomain-input-placeholder-2], with vars: {}"
+      "l10n string: [banner-choose-subdomain-input-placeholder-3], with vars: {}"
     );
 
     expect(subdomainSearchField).not.toBeInTheDocument();
@@ -475,7 +475,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const aliasToggleButton = screen.getByRole("button", {
-      name: "l10n string: [profile-label-disable-forwarding-button], with vars: {}",
+      name: "l10n string: [profile-label-disable-forwarding-button-2], with vars: {}",
     });
     userEvent.click(aliasToggleButton);
 
@@ -498,7 +498,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const generateAliasButton = screen.getByRole("button", {
-      name: "l10n string: [profile-label-generate-new-alias], with vars: {}",
+      name: "l10n string: [profile-label-generate-new-alias-2], with vars: {}",
     });
 
     expect(generateAliasButton).toBeInTheDocument();
@@ -520,7 +520,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const generateAliasButton = screen.getByRole("button", {
-      name: "l10n string: [profile-label-generate-new-alias], with vars: {}",
+      name: "l10n string: [profile-label-generate-new-alias-2], with vars: {}",
     });
 
     expect(generateAliasButton).toBeInTheDocument();
@@ -542,7 +542,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const upgradeButton = screen.getByRole("link", {
-      name: "l10n string: [profile-label-upgrade], with vars: {}",
+      name: "l10n string: [profile-label-upgrade-2], with vars: {}",
     });
 
     expect(upgradeButton).toBeInTheDocument();
@@ -563,7 +563,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const generateAliasButton = screen.getByRole("button", {
-      name: "l10n string: [profile-label-generate-new-alias], with vars: {}",
+      name: "l10n string: [profile-label-generate-new-alias-2], with vars: {}",
     });
 
     expect(generateAliasButton).toBeInTheDocument();
@@ -592,7 +592,7 @@ describe("The dashboard", () => {
       render(<Profile />);
 
       const generateAliasButton = screen.getByRole("button", {
-        name: "l10n string: [profile-label-generate-new-alias], with vars: {}",
+        name: "l10n string: [profile-label-generate-new-alias-2], with vars: {}",
       });
 
       expect(generateAliasButton).toBeInTheDocument();
@@ -623,17 +623,17 @@ describe("The dashboard", () => {
       render(<Profile />);
 
       const generateAliasDropdown = screen.getByRole("button", {
-        name: "l10n string: [profile-label-generate-new-alias], with vars: {}",
+        name: "l10n string: [profile-label-generate-new-alias-2], with vars: {}",
       });
       userEvent.click(generateAliasDropdown);
       const generateAliasMenu = screen.getByRole("menu", {
-        name: "l10n string: [profile-label-generate-new-alias], with vars: {}",
+        name: "l10n string: [profile-label-generate-new-alias-2], with vars: {}",
       });
       const generateRandomAliasMenuItem = screen.getByRole("menuitem", {
-        name: "l10n string: [profile-label-generate-new-alias-menu-random], with vars: {}",
+        name: "l10n string: [profile-label-generate-new-alias-menu-random-2], with vars: {}",
       });
       const generateCustomAliasMenuItem = screen.getByRole("menuitem", {
-        name: `l10n string: [profile-label-generate-new-alias-menu-custom], with vars: ${JSON.stringify(
+        name: `l10n string: [profile-label-generate-new-alias-menu-custom-2], with vars: ${JSON.stringify(
           { subdomain: "some_subdomain" }
         )}`,
       });

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -48,8 +48,10 @@ const Settings: NextPage = () => {
 
   const currentSettingWarning = profile.server_storage ? null : (
     <div className={styles["banner-wrapper"]}>
-      <Banner title={l10n.getString("settings-warning-collection-off-heading")}>
-        {l10n.getString("settings-warning-collection-off-description")}
+      <Banner
+        title={l10n.getString("settings-warning-collection-off-heading-2")}
+      >
+        {l10n.getString("settings-warning-collection-off-description-2")}
       </Banner>
     </div>
   );
@@ -59,7 +61,7 @@ const Settings: NextPage = () => {
     labelCollectionDisabledWarningToggles > 1 && !labelCollectionEnabled ? (
       <aside role="alert" className={styles["field-warning"]}>
         <img src={infoTriangleIcon.src} alt="" width={20} />
-        <p>{l10n.getString("setting-label-collection-off-warning")}</p>
+        <p>{l10n.getString("setting-label-collection-off-warning-2")}</p>
       </aside>
     ) : null;
 
@@ -136,7 +138,9 @@ const Settings: NextPage = () => {
                         }
                       />
                       <label htmlFor="label-collection">
-                        {l10n.getString("setting-label-collection-description")}
+                        {l10n.getString(
+                          "setting-label-collection-description-2"
+                        )}
                       </label>
                     </div>
                     {labelCollectionWarning}

--- a/frontend/src/pages/accounts/settings.test.tsx
+++ b/frontend/src/pages/accounts/settings.test.tsx
@@ -42,7 +42,7 @@ describe("The settings screen", () => {
     render(<Settings />);
 
     const bannerHeading = screen.getByRole("heading", {
-      name: "l10n string: [settings-warning-collection-off-heading], with vars: {}",
+      name: "l10n string: [settings-warning-collection-off-heading-2], with vars: {}",
     });
 
     expect(bannerHeading).toBeInTheDocument();
@@ -53,7 +53,7 @@ describe("The settings screen", () => {
     render(<Settings />);
 
     const bannerHeading = screen.queryByRole("heading", {
-      name: "l10n string: [settings-warning-collection-off-heading], with vars: {}",
+      name: "l10n string: [settings-warning-collection-off-heading-2], with vars: {}",
     });
 
     expect(bannerHeading).not.toBeInTheDocument();
@@ -65,7 +65,7 @@ describe("The settings screen", () => {
 
     userEvent.click(
       screen.getByLabelText(
-        "l10n string: [setting-label-collection-description], with vars: {}"
+        "l10n string: [setting-label-collection-description-2], with vars: {}"
       )
     );
 

--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -19,17 +19,19 @@ const Faq: NextPage = () => {
             <div className={styles.faqs}>
               <QAndA
                 id="faq-what-is"
-                question={l10n.getString("faq-question-what-is-question")}
+                question={l10n.getString("faq-question-what-is-question-2")}
               >
-                <p>{l10n.getString("faq-question-what-is-answer")}</p>
+                <p>{l10n.getString("faq-question-what-is-answer-2")}</p>
               </QAndA>
               <QAndA
                 id="faq-missing-emails"
                 question={l10n.getString(
-                  "faq-question-missing-emails-question"
+                  "faq-question-missing-emails-question-2"
                 )}
               >
-                <p>{l10n.getString("faq-question-missing-emails-answer-a")}</p>
+                <p>
+                  {l10n.getString("faq-question-missing-emails-answer-a-2")}
+                </p>
                 <ul>
                   <li>
                     {l10n.getString(
@@ -38,7 +40,7 @@ const Faq: NextPage = () => {
                   </li>
                   <li>
                     {l10n.getString(
-                      "faq-question-missing-emails-answer-reason-blocked"
+                      "faq-question-missing-emails-answer-reason-blocked-2"
                     )}
                   </li>
                   <li>
@@ -52,12 +54,12 @@ const Faq: NextPage = () => {
                   </li>
                   <li>
                     {l10n.getString(
-                      "faq-question-missing-emails-answer-reason-not-accepted"
+                      "faq-question-missing-emails-answer-reason-not-accepted-2"
                     )}
                   </li>
                   <li>
                     {l10n.getString(
-                      "faq-question-missing-emails-answer-reason-turned-off"
+                      "faq-question-missing-emails-answer-reason-turned-off-2"
                     )}
                   </li>
                   <li>
@@ -87,14 +89,14 @@ const Faq: NextPage = () => {
               </QAndA>
               <QAndA
                 id="faq-use-cases"
-                question={l10n.getString("faq-question-use-cases-question")}
+                question={l10n.getString("faq-question-use-cases-question-2")}
               >
-                <p>{l10n.getString("faq-question-use-cases-answer-part1")}</p>
-                <p>{l10n.getString("faq-question-use-cases-answer-part2")}</p>
+                <p>{l10n.getString("faq-question-use-cases-answer-part1-2")}</p>
+                <p>{l10n.getString("faq-question-use-cases-answer-part2-2")}</p>
               </QAndA>
               <QAndA
                 id="faq-rejections"
-                question={l10n.getString("faq-question-2-question")}
+                question={l10n.getString("faq-question-2-question-2")}
               >
                 <p>{l10n.getString("faq-question-2-answer-v4")}</p>
               </QAndA>
@@ -102,9 +104,9 @@ const Faq: NextPage = () => {
                 id="faq-spam"
                 question={l10n.getString("faq-question-1-question")}
               >
-                <p>{l10n.getString("faq-question-1-answer-a")}</p>
+                <p>{l10n.getString("faq-question-1-answer-a-2")}</p>
                 <Localized
-                  id="faq-question-1-answer-b-html"
+                  id="faq-question-1-answer-b-2-html"
                   vars={{
                     url: "https://addons.mozilla.org/firefox/addon/private-relay/",
                     attrs: "",
@@ -130,7 +132,7 @@ const Faq: NextPage = () => {
               </QAndA>
               <QAndA
                 id="faq-replies"
-                question={l10n.getString("faq-question-4-question")}
+                question={l10n.getString("faq-question-4-question-2")}
               >
                 <p>{l10n.getString("faq-question-4-answer-v4")}</p>
               </QAndA>
@@ -152,19 +154,19 @@ const Faq: NextPage = () => {
                   "faq-question-browser-support-question"
                 )}
               >
-                <p>{l10n.getString("faq-question-browser-support-answer")}</p>
+                <p>{l10n.getString("faq-question-browser-support-answer-2")}</p>
               </QAndA>
               <QAndA
                 id="faq-longevity"
                 question={l10n.getString("faq-question-longevity-question")}
               >
-                <p>{l10n.getString("faq-question-longevity-answer")}</p>
+                <p>{l10n.getString("faq-question-longevity-answer-2")}</p>
               </QAndA>
               <QAndA
                 id="faq-mozmail"
-                question={l10n.getString("faq-question-mozmail-question")}
+                question={l10n.getString("faq-question-mozmail-question-2")}
               >
-                <p>{l10n.getString("faq-question-mozmail-answer")}</p>
+                <p>{l10n.getString("faq-question-mozmail-answer-2")}</p>
               </QAndA>
               <QAndA
                 id="faq-attachments"
@@ -180,11 +182,11 @@ const Faq: NextPage = () => {
               <QAndA
                 id="faq-unsubscribe-domain"
                 question={l10n.getString(
-                  "faq-question-unsubscribe-domain-question"
+                  "faq-question-unsubscribe-domain-question-2"
                 )}
               >
                 <p>
-                  {l10n.getString("faq-question-unsubscribe-domain-answer")}
+                  {l10n.getString("faq-question-unsubscribe-domain-answer-2")}
                 </p>
               </QAndA>
               <QAndA
@@ -192,7 +194,7 @@ const Faq: NextPage = () => {
                 question={l10n.getString("faq-question-8-question")}
               >
                 <Localized
-                  id="faq-question-8-answer-html"
+                  id="faq-question-8-answer-2-html"
                   vars={{
                     url: "https://www.mozilla.org/privacy/firefox-relay/",
                     attrs: "",

--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -267,12 +267,12 @@ const Faq: NextPage = () => {
                   </li>
                   <li>
                     {l10n.getString(
-                      "faq-question-acceptable-use-answer-measure-unlimited-payment"
+                      "faq-question-acceptable-use-answer-measure-unlimited-payment-2"
                     )}
                   </li>
                   <li>
                     {l10n.getString(
-                      "faq-question-acceptable-use-answer-measure-rate-limit"
+                      "faq-question-acceptable-use-answer-measure-rate-limit-2"
                     )}
                   </li>
                 </ul>

--- a/frontend/src/pages/index.page.tsx
+++ b/frontend/src/pages/index.page.tsx
@@ -117,7 +117,7 @@ const Home: NextPage = () => {
               <li className={styles.step}>
                 <img src={HowItWorks2.src} alt="" />
                 <h3>{l10n.getString("how-it-works-step-2-headline-2")}</h3>
-                <p>{l10n.getString("landing-how-it-works-step-2-body-v2")}</p>
+                <p>{l10n.getString("landing-how-it-works-step-2-body-2")}</p>
               </li>
               <li className={styles.step}>
                 <img src={HowItWorks3.src} alt="" />

--- a/frontend/src/pages/index.page.tsx
+++ b/frontend/src/pages/index.page.tsx
@@ -55,11 +55,11 @@ const Home: NextPage = () => {
         </div>
         <div className={styles.callout}>
           <h2>
-            {l10n.getString("landing-pricing-headline", {
+            {l10n.getString("landing-pricing-headline-2", {
               monthly_price: getPlan(runtimeData.data).price,
             })}
           </h2>
-          <p>{l10n.getString("landing-pricing-body")}</p>
+          <p>{l10n.getString("landing-pricing-body-2")}</p>
         </div>
       </div>
     </section>
@@ -70,8 +70,8 @@ const Home: NextPage = () => {
       <main>
         <section id="hero" className={styles.hero}>
           <div className={styles.lead}>
-            <h2>{l10n.getString("landing-hero-headline")}</h2>
-            <p>{l10n.getString("landing-hero-body")}</p>
+            <h2>{l10n.getString("landing-hero-headline-2")}</h2>
+            <p>{l10n.getString("landing-hero-body-2")}</p>
             <LinkButton
               ref={heroCtaRef}
               onClick={() => signup()}
@@ -100,7 +100,7 @@ const Home: NextPage = () => {
               {l10n.getString("landing-how-it-works-headline")}
             </h2>
             <p className={styles.lead}>
-              {l10n.getString("landing-how-it-works-body")}
+              {l10n.getString("landing-how-it-works-body-2")}
             </p>
             <ol className={styles.steps}>
               <li className={styles.step}>
@@ -111,18 +111,18 @@ const Home: NextPage = () => {
                     {l10n.getString("landing-how-it-works-step-1-body-cta")}
                   </a>
                   &nbsp;
-                  {l10n.getString("landing-how-it-works-step-1-body")}
+                  {l10n.getString("landing-how-it-works-step-1-body-2")}
                 </p>
               </li>
               <li className={styles.step}>
                 <img src={HowItWorks2.src} alt="" />
-                <h3>{l10n.getString("how-it-works-step-2-headline")}</h3>
+                <h3>{l10n.getString("how-it-works-step-2-headline-2")}</h3>
                 <p>{l10n.getString("landing-how-it-works-step-2-body-v2")}</p>
               </li>
               <li className={styles.step}>
                 <img src={HowItWorks3.src} alt="" />
-                <h3>{l10n.getString("how-it-works-step-3-headline")}</h3>
-                <p>{l10n.getString("landing-how-it-works-step-3-body")}</p>
+                <h3>{l10n.getString("how-it-works-step-3-headline-2")}</h3>
+                <p>{l10n.getString("landing-how-it-works-step-3-body-2")}</p>
               </li>
             </ol>
           </div>
@@ -135,7 +135,7 @@ const Home: NextPage = () => {
                 {
                   color: "yellow",
                   heading: l10n.getString("landing-use-cases-shopping"),
-                  content: l10n.getString("landing-use-cases-shopping-body"),
+                  content: l10n.getString("landing-use-cases-shopping-body-2"),
                   illustration: ShoppingIllustration,
                   id: "use-cases/shopping",
                 },
@@ -143,7 +143,7 @@ const Home: NextPage = () => {
                   color: "orange",
                   heading: l10n.getString("landing-use-cases-social-networks"),
                   content: l10n.getString(
-                    "landing-use-cases-social-networks-body"
+                    "landing-use-cases-social-networks-body-2"
                   ),
                   illustration: SocialNetworksIllustration,
                   id: "use-cases/social-networks",
@@ -151,7 +151,7 @@ const Home: NextPage = () => {
                 {
                   color: "teal",
                   heading: l10n.getString("landing-use-cases-offline"),
-                  content: l10n.getString("landing-use-cases-offline-body"),
+                  content: l10n.getString("landing-use-cases-offline-body-2"),
                   illustration: OfflineIllustration,
                   id: "use-cases/offline",
                 },
@@ -159,7 +159,7 @@ const Home: NextPage = () => {
                   color: "red",
                   heading: l10n.getString("landing-use-cases-access-content"),
                   content: l10n.getString(
-                    "landing-use-cases-access-content-body"
+                    "landing-use-cases-access-content-body-2"
                   ),
                   illustration: AccessContentIllustration,
                   id: "use-cases/access-content",
@@ -167,7 +167,7 @@ const Home: NextPage = () => {
                 {
                   color: "pink",
                   heading: l10n.getString("landing-use-cases-gaming"),
-                  content: l10n.getString("landing-use-cases-gaming-body"),
+                  content: l10n.getString("landing-use-cases-gaming-body-2"),
                   illustration: GamingIllustration,
                   id: "use-cases/gaming",
                 },
@@ -198,21 +198,21 @@ const Home: NextPage = () => {
                     a: l10n.getString("faq-question-availability-answer-v2"),
                   },
                   {
-                    q: l10n.getString("faq-question-what-is-question"),
-                    a: l10n.getString("faq-question-what-is-answer"),
+                    q: l10n.getString("faq-question-what-is-question-2"),
+                    a: l10n.getString("faq-question-what-is-answer-2"),
                   },
                   {
-                    q: l10n.getString("faq-question-use-cases-question"),
+                    q: l10n.getString("faq-question-use-cases-question-2"),
                     a: (
                       <>
                         <p>
                           {l10n.getString(
-                            "faq-question-use-cases-answer-part1"
+                            "faq-question-use-cases-answer-part1-2"
                           )}
                         </p>
                         <p>
                           {l10n.getString(
-                            "faq-question-use-cases-answer-part2"
+                            "faq-question-use-cases-answer-part2-2"
                           )}
                         </p>
                       </>
@@ -220,7 +220,7 @@ const Home: NextPage = () => {
                   },
                   {
                     q: l10n.getString("faq-question-browser-support-question"),
-                    a: l10n.getString("faq-question-browser-support-answer"),
+                    a: l10n.getString("faq-question-browser-support-answer-2"),
                   },
                 ]}
               />

--- a/frontend/src/pages/premium.page.tsx
+++ b/frontend/src/pages/premium.page.tsx
@@ -60,11 +60,11 @@ const PremiumPromo: NextPage = () => {
         </div>
         <div className={styles.callout}>
           <h2>
-            {l10n.getString("landing-pricing-headline", {
+            {l10n.getString("landing-pricing-headline-2", {
               monthly_price: getPlan(runtimeData.data).price,
             })}
           </h2>
-          <p>{l10n.getString("landing-pricing-body")}</p>
+          <p>{l10n.getString("landing-pricing-body-2")}</p>
         </div>
       </div>
     </section>
@@ -110,7 +110,7 @@ const PremiumPromo: NextPage = () => {
           <div className={styles.lead}>
             <h2>{l10n.getString("premium-promo-hero-headline")}</h2>
             <Localized
-              id="premium-promo-hero-body-html"
+              id="premium-promo-hero-body-2-html"
               vars={{
                 monthly_price: isPremiumAvailableInCountry(runtimeData.data)
                   ? getPlan(runtimeData.data).price
@@ -141,18 +141,18 @@ const PremiumPromo: NextPage = () => {
               {l10n.getString("premium-promo-perks-headline")}
             </h2>
             <p className={styles.lead}>
-              {l10n.getString("premium-promo-perks-lead")}
+              {l10n.getString("premium-promo-perks-lead-2")}
             </p>
             <div className={styles.perk}>
               <img src={PerkIllustrationUnlimited.src} alt="" />
               <div className={styles.description}>
                 <h3>
                   {l10n.getString(
-                    "premium-promo-perks-perk-unlimited-headline"
+                    "premium-promo-perks-perk-unlimited-headline-2"
                   )}
                 </h3>
                 <p>
-                  {l10n.getString("premium-promo-perks-perk-unlimited-body")}
+                  {l10n.getString("premium-promo-perks-perk-unlimited-body-2")}
                 </p>
                 {getPerkCta("premium-promo-perk-unlimited-cta")}
               </div>
@@ -162,12 +162,12 @@ const PremiumPromo: NextPage = () => {
               <div className={styles.description}>
                 <h3>
                   {l10n.getString(
-                    "premium-promo-perks-perk-custom-domain-headline"
+                    "premium-promo-perks-perk-custom-domain-headline-2"
                   )}
                 </h3>
                 <p>
                   {l10n.getString(
-                    "premium-promo-perks-perk-custom-domain-body"
+                    "premium-promo-perks-perk-custom-domain-body-2"
                   )}
                 </p>
                 {getPerkCta("premium-promo-perk-custom-domain-cta")}
@@ -178,11 +178,11 @@ const PremiumPromo: NextPage = () => {
               <div className={styles.description}>
                 <h3>
                   {l10n.getString(
-                    "premium-promo-perks-perk-dashboard-headline"
+                    "premium-promo-perks-perk-dashboard-headline-2"
                   )}
                 </h3>
                 <p>
-                  {l10n.getString("premium-promo-perks-perk-dashboard-body")}
+                  {l10n.getString("premium-promo-perks-perk-dashboard-body-2")}
                 </p>
                 {getPerkCta("premium-promo-perk-dashboard-cta")}
               </div>
@@ -192,10 +192,10 @@ const PremiumPromo: NextPage = () => {
         <section id="use-cases" className={styles["use-cases-wrapper"]}>
           <div className={styles["use-cases"]}>
             <h2 className={styles.headline}>
-              {l10n.getString("premium-promo-use-cases-headline")}
+              {l10n.getString("premium-promo-use-cases-headline-2")}
             </h2>
             <Carousel
-              title={l10n.getString("premium-promo-use-cases-headline")}
+              title={l10n.getString("premium-promo-use-cases-headline-2")}
               tabs={[
                 {
                   color: "yellow",
@@ -203,7 +203,7 @@ const PremiumPromo: NextPage = () => {
                     "premium-promo-use-cases-shopping-heading"
                   ),
                   content: l10n.getString(
-                    "premium-promo-use-cases-shopping-body"
+                    "premium-promo-use-cases-shopping-body-2"
                   ),
                   illustration: ShoppingIllustration,
                   id: "use-cases/shopping",
@@ -214,7 +214,7 @@ const PremiumPromo: NextPage = () => {
                     "premium-promo-use-cases-social-networks-heading"
                   ),
                   content: l10n.getString(
-                    "premium-promo-use-cases-social-networks-body"
+                    "premium-promo-use-cases-social-networks-body-2"
                   ),
                   illustration: SocialNetworksIllustration,
                   id: "use-cases/social-networks",
@@ -225,7 +225,7 @@ const PremiumPromo: NextPage = () => {
                     "premium-promo-use-cases-gaming-heading"
                   ),
                   content: l10n.getString(
-                    "premium-promo-use-cases-gaming-body"
+                    "premium-promo-use-cases-gaming-body-2"
                   ),
                   illustration: GamingIllustration,
                   id: "use-cases/gaming",

--- a/privaterelay/templates/base.html
+++ b/privaterelay/templates/base.html
@@ -15,7 +15,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="description" content="{% ftlmsg 'meta-description' %}" />
+    <meta name="description" content="{% ftlmsg 'meta-description-2' %}" />
     <title>{% ftlmsg 'meta-title' %}</title>
     <link rel="stylesheet" href="{% static 'css/app.css' %}">
     <link rel="icon" type="image/svg+xml" href="{% static 'images/logos/relay-logo-dark.svg' %}">
@@ -26,14 +26,14 @@
     <meta property="og:url" content="{{request.scheme}}://{{request.META.HTTP_HOST}}{{ request.path }}" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="{% ftlmsg 'meta-title' %}" />
-    <meta property="og:description" content="{% ftlmsg 'meta-description' %}" />
+    <meta property="og:description" content="{% ftlmsg 'meta-description-2' %}" />
     <meta property="og:image" content="{{request.scheme}}://{{request.META.HTTP_HOST}}{% static 'images/share-relay.jpg' %}" />
     
     <!-- Twitter Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@firefox">
     <meta name="twitter:title" content="{% ftlmsg 'meta-title' %}">
-    <meta name="twitter:description" content="{% ftlmsg 'meta-description' %}">
+    <meta name="twitter:description" content="{% ftlmsg 'meta-description-2' %}">
     <meta name="twitter:image" content="{{request.scheme}}://{{request.META.HTTP_HOST}}{% static 'images/share-relay.jpg' %}">
   </head>
   <body class="{% if user_has_premium %}is-premium{% endif %} {% if request.resolver_match.url_name == "faq" %}is-dark{% endif %}" data-fxa-settings-url="{{ settings.FXA_SETTINGS_URL }}" data-site-origin="{{ settings.SITE_ORIGIN }}" data-google-analytics-id="{{ settings.GOOGLE_ANALYTICS_ID }}" data-debug="{{ settings.DEBUG }}">

--- a/privaterelay/templates/faq.html
+++ b/privaterelay/templates/faq.html
@@ -14,33 +14,33 @@
           <section class="faq" id="faq-what-is">
             <h2 class="faq-headline">{% ftlmsg 'faq-question-what-is-question' %}</h2>
             <p class="faq-answer">
-              {% ftlmsg 'faq-question-what-is-answer' %}
+              {% ftlmsg 'faq-question-what-is-answer-2' %}
             </p>
           </section>
           <section class="faq" id="faq-missing-emails">
-            <h2 class="faq-headline">{% ftlmsg 'faq-question-missing-emails-question' %}</h2>
+            <h2 class="faq-headline">{% ftlmsg 'faq-question-missing-emails-question-2' %}</h2>
             <div class="faq-answer js-set-href">
-              <p>{% ftlmsg 'faq-question-missing-emails-answer-a' %}</p>
+              <p>{% ftlmsg 'faq-question-missing-emails-answer-a-2' %}</p>
               <ul>
                 <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-spam' %}</li>
-                <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-blocked' %}</li>
+                <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-blocked-2' %}</li>
                 <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-size' size='10' unit='MB' %}</li>
-                <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-not-accepted' %}</li>
-                <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-turned-off' %}</li>
+                <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-not-accepted-2' %}</li>
+                <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-turned-off-2' %}</li>
                 <li>{% ftlmsg 'faq-question-missing-emails-answer-reason-delay' %}</li>
               </ul>
               <p>{% ftlmsg 'faq-question-missing-emails-answer-support-site-html' url='https://support.mozilla.org/products/relay/' attrs='class="text-link" data-url="https://support.mozilla.org/products/relay/"' %}</p>
             </div>
           </section>
           <section class="faq" id="faq-use-cases">
-            <h2 class="faq-headline">{% ftlmsg 'faq-question-use-cases-question' %}</h2>
+            <h2 class="faq-headline">{% ftlmsg 'faq-question-use-cases-question-2' %}</h2>
             <div class="faq-answer">
-              <p>{% ftlmsg 'faq-question-use-cases-answer-part1' %}</p>
-              <p>{% ftlmsg 'faq-question-use-cases-answer-part2' %}</p>
+              <p>{% ftlmsg 'faq-question-use-cases-answer-part1-2' %}</p>
+              <p>{% ftlmsg 'faq-question-use-cases-answer-part2-2' %}</p>
             </div>
           </section>
           <section class="faq" id="faq-rejections">
-            <h2 class="faq-headline">{% ftlmsg 'faq-question-2-question' %}</h2>
+            <h2 class="faq-headline">{% ftlmsg 'faq-question-2-question-2' %}</h2>
             <p class="faq-answer">
               {% ftlmsg 'faq-question-2-answer-v4' %}
             </p>
@@ -48,8 +48,8 @@
           <section class="faq" id="faq-spam">
             <h2 class="faq-headline">{% ftlmsg 'faq-question-1-question' %}</h2>
             <div class="faq-answer js-set-href">
-              <p>{% ftlmsg 'faq-question-1-answer-a' %}</p>
-              <p>{% ftlmsg 'faq-question-1-answer-b-html' url='https://addons.mozilla.org/firefox/addon/private-relay/' attrs='class="text-link" data-url="https://addons.mozilla.org/firefox/addon/private-relay/"' %}</p>
+              <p>{% ftlmsg 'faq-question-1-answer-a-2' %}</p>
+              <p>{% ftlmsg 'faq-question-1-answer-b-2-html' url='https://addons.mozilla.org/firefox/addon/private-relay/' attrs='class="text-link" data-url="https://addons.mozilla.org/firefox/addon/private-relay/"' %}</p>
             </div>
           </section>
           <section class="faq" id="faq-availability">
@@ -59,7 +59,7 @@
             </p>
           </section>
           <section class="faq" id="faq-replies">
-            <h2 class="faq-headline">{% ftlmsg 'faq-question-4-question' %}</h2>
+            <h2 class="faq-headline">{% ftlmsg 'faq-question-4-question-2' %}</h2>
             <p class="faq-answer">{% ftlmsg 'faq-question-4-answer-v4' %}</p>
           </section>
           <section class="faq" id="faq-subdomain-question">
@@ -69,19 +69,19 @@
           <section class="faq" id="faq-browser-support">
             <h2 class="faq-headline">{% ftlmsg 'faq-question-browser-support-question' %}</h2>
             <p class="faq-answer">
-              {% ftlmsg 'faq-question-browser-support-answer' %}
+              {% ftlmsg 'faq-question-browser-support-answer-2' %}
             </p>
           </section>
           <section class="faq" id="faq-longevity">
             <h2 class="faq-headline">{% ftlmsg 'faq-question-longevity-question' %}</h2>
             <p class="faq-answer">
-              {% ftlmsg 'faq-question-longevity-answer' %}
+              {% ftlmsg 'faq-question-longevity-answer-2' %}
             </p>
           </section>
           <section class="faq" id="faq-mozmail">
-            <h2 class="faq-headline">{% ftlmsg 'faq-question-mozmail-question' %}</h2>
+            <h2 class="faq-headline">{% ftlmsg 'faq-question-mozmail-question-2' %}</h2>
             <p class="faq-answer">
-              {% ftlmsg 'faq-question-mozmail-answer' %}
+              {% ftlmsg 'faq-question-mozmail-answer-2' %}
             </p>
           </section>
           <section class="faq" id="faq-attachments">
@@ -91,14 +91,14 @@
             </p>
           </section>
           <section class="faq" id="faq-unsubscribe-domain">
-            <h2 class="faq-headline">{% ftlmsg 'faq-question-unsubscribe-domain-question' %}</h2>
+            <h2 class="faq-headline">{% ftlmsg 'faq-question-unsubscribe-domain-question-2' %}</h2>
             <p class="faq-answer">
-              {% ftlmsg 'faq-question-unsubscribe-domain-answer' %}
+              {% ftlmsg 'faq-question-unsubscribe-domain-answer-2' %}
             </p>
           </section>
           <section class="faq" id="faq-data-collection">
             <h2 class="faq-headline">{% ftlmsg 'faq-question-8-question' %}</h2>
-            <p class="faq-answer js-set-href">{% ftlmsg 'faq-question-8-answer-html' url='https://www.mozilla.org/privacy/firefox-relay/' attrs='class="text-link" data-url="https://www.mozilla.org/privacy/firefox-relay/"' %}</p>
+            <p class="faq-answer js-set-href">{% ftlmsg 'faq-question-8-answer-2-html' url='https://www.mozilla.org/privacy/firefox-relay/' attrs='class="text-link" data-url="https://www.mozilla.org/privacy/firefox-relay/"' %}</p>
           </section>
           <section class="faq" id="faq-email-storage">
             <h2 class="faq-headline">{% ftlmsg 'faq-question-email-storage-question' %}</h2>

--- a/privaterelay/templates/includes/alias-card.html
+++ b/privaterelay/templates/includes/alias-card.html
@@ -42,7 +42,7 @@ Premium users:
       </span>
 
       <div class="c-alias-email-fowarding-button {% if not alias.enabled %}t-disabled{% endif %}">
-        <input {% if alias.enabled %}checked{% endif %}  name="aliasForwardingToggle{{ alias.id }}" id="aliasForwardingToggle{{ alias.id }}" value="true" type="checkbox" data-default-forwarding-title="{% ftlmsg 'profile-label-enable-forwarding-button' %}" data-default-blocking-title="{% ftlmsg 'profile-label-disable-forwarding-button' %}">
+        <input {% if alias.enabled %}checked{% endif %}  name="aliasForwardingToggle{{ alias.id }}" id="aliasForwardingToggle{{ alias.id }}" value="true" type="checkbox" data-default-forwarding-title="{% ftlmsg 'profile-label-enable-forwarding-button-2' %}" data-default-blocking-title="{% ftlmsg 'profile-label-disable-forwarding-button-2' %}">
         <label for="aliasForwardingToggle{{ alias.id }}">
           <div class="forwarding-toggle js-forwarding-toggle"></div>
         </label>
@@ -66,7 +66,7 @@ Premium users:
               type="text"
               maxlength="50"
               value="{{ alias.description }}"
-              aria-label="{% ftlmsg 'profile-label-edit' %}"
+              aria-label="{% ftlmsg 'profile-label-edit-2' %}"
               placeholder="{% ftlmsg 'profile-label-placeholder' %}"
               class="relay-email-address-label js-relay-email-address-label ff-Met"
               {# Require at least one non-whitespace character:  #}
@@ -79,7 +79,7 @@ Premium users:
 
         <button title="{% ftlmsg 'profile-label-click-to-copy' %}"
           data-ftl-click-to-copy="{% ftlmsg 'profile-label-click-to-copy' %}"
-          data-ftl-copy-confirmation="{% ftlmsg 'profile-label-copy-confirmation' %}"
+          data-ftl-copy-confirmation="{% ftlmsg 'profile-label-copy-confirmation-2' %}"
           data-id="{{ alias.id }}"
           data-clipboard-text="{{ alias.full_address }}"
           class="relay-address click-copy alias-on-desktop ff-Met xflx jst-cntr al-cntr">
@@ -116,7 +116,7 @@ Premium users:
   <div class="c-alias-copy">
     <button title="{% ftlmsg 'profile-label-click-to-copy' %}"
       data-ftl-click-to-copy="{% ftlmsg 'profile-label-click-to-copy' %}"
-      data-ftl-copy-confirmation="{% ftlmsg 'profile-label-copy-confirmation' %}"
+      data-ftl-copy-confirmation="{% ftlmsg 'profile-label-copy-confirmation-2' %}"
       data-id="{{ alias.id }}"
       data-clipboard-text="{{ alias.full_address }}"
       class="relay-address click-copy alias-on-mobile ff-Met jst-cntr al-cntr">
@@ -221,7 +221,7 @@ Premium users:
           <input type="hidden" name="method_override" value="DELETE">
           <input type="hidden" name="api_token" value="{{ user_profile.api_token }}">
           <input type="hidden" name="{{ alias_type }}_address_id" value="{{ alias.id }}">
-          <button type="submit" name="delete" value="" class="dashboard-delete-button delete-relay-email-button" aria-label="{% ftlmsg 'profile-label-delete-alias' %}">
+          <button type="submit" name="delete" value="" class="dashboard-delete-button delete-relay-email-button" aria-label="{% ftlmsg 'profile-label-delete-alias-2' %}">
             <span class="remove-label relay-email-label">{% ftlmsg 'profile-label-delete' %}</span>
           </button>
         </form>

--- a/privaterelay/templates/includes/alias-stats.html
+++ b/privaterelay/templates/includes/alias-stats.html
@@ -5,14 +5,14 @@
 <div class="column-blocked relay-stat">
   <span class="email-value relay-stat-value num-blocked">{{ alias.num_blocked }}</span>
   <span class="relay-email-label card-small-text">{% ftlmsg 'profile-label-blocked' %}</span>
-  <span class="blocked-description stat-description">{% ftlmsg 'profile-blocked-copy' %}</span>
+  <span class="blocked-description stat-description">{% ftlmsg 'profile-blocked-copy-2' %}</span>
 </div>
 <!-- forwarded emails -->
 <div class="column-forwarded relay-stat">
   <span class="email-value relay-stat-value num-forwarded">{{ alias.num_forwarded }}</span>
   <span class="relay-email-label card-small-text">{% ftlmsg 'profile-label-forwarded' %}</span>
   <span class="forwarding-description stat-description">
-    {% ftlmsg 'profile-forwarded-copy' %}
+    {% ftlmsg 'profile-forwarded-copy-2' %}
     <p>
       <strong>{% ftlmsg 'profile-forwarded-note' %}</strong> {% ftlmsg 'profile-forwarded-note-copy' size='10' unit='MB' %}
     </p>

--- a/privaterelay/templates/includes/banners/default-banners.html
+++ b/privaterelay/templates/includes/banners/default-banners.html
@@ -11,7 +11,7 @@
                 <div class="banner-fx-logo banner-logo"></div>
                 <div class="banner-copy flx flx-col">
                     <p class="banner-hl ff-Met">{% ftlmsg 'banner-download-firefox-headline' %}</p>
-                    <p class="banner-sub">{% ftlmsg 'banner-download-firefox-copy' %}</p>
+                    <p class="banner-sub">{% ftlmsg 'banner-download-firefox-copy-2' %}</p>
                     <a class="banner-link ff-Met"
                         href="https://www.mozilla.org/firefox/new/?utm_source=fx-relay&utm_medium=banner&utm_campaign=download-fx"
                         target="_blank" rel="noopener noreferrer">{% ftlmsg 'banner-download-firefox-cta' %}</a>
@@ -22,7 +22,7 @@
                 <div class="banner-relay-logo banner-logo"></div>
                 <div class="banner-copy flx flx-col">
                     <p class="banner-hl ff-Met">{% ftlmsg 'banner-download-install-extension-headline' %}</p>
-                    <p class="banner-sub">{% ftlmsg 'banner-download-install-extension-copy' %}</p>
+                    <p class="banner-sub">{% ftlmsg 'banner-download-install-extension-copy-2' %}</p>
                     <a class="banner-link ff-Met"
                         href="https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay&utm_medium=banner&utm_campaign=install-addon"
                         target="_blank" rel="noopener noreferrer">{% ftlmsg 'banner-download-install-extension-cta' %}</a>
@@ -50,7 +50,7 @@
                 <div class="banner-mpp-logo banner-logo"></div>
                 <div class="banner-copy flx flx-col">
                     <p class="banner-hl ff-Met">{% ftlmsg 'banner-upgrade-headline' %}</p>
-                    <p class="banner-sub">{% ftlmsg 'banner-upgrade-copy' %}</p>
+                    <p class="banner-sub">{% ftlmsg 'banner-upgrade-copy-2' %}</p>
                     <a class="banner-link ff-Met js-purchase-premium" target="_blank" rel="noopener noreferrer"
                         href="{% premium_subscribe_url accept_language country_code %}" data-ga="send-ga-pings"
                         data-event-category="Purchase Button" data-event-label="profile-banner-promo"

--- a/privaterelay/templates/includes/banners/subdomain-banner.html
+++ b/privaterelay/templates/includes/banners/subdomain-banner.html
@@ -12,9 +12,9 @@
 <div class="c-notification-banner subdomain-banner" id="mpp-choose-subdomain">
     <div class="subdomain-banner-copy">
       <div class="c-notification-banner-label">{% ftlmsg 'banner-label-action' %}</div>
-      <h2>{% ftlmsg 'banner-register-subdomain-headline-aliases' %}</h2>
+      <h2>{% ftlmsg 'banner-register-subdomain-headline-aliases-2' %}</h2>
       <samp>***@<span>{% ftlmsg 'banner-register-subdomain-example-address' %}</span>.mozmail.com</samp>
-      <p>{% ftlmsg 'banner-register-subdomain-copy' mozmail='mozmail.com' %}</p>
+      <p>{% ftlmsg 'banner-register-subdomain-copy-2' mozmail='mozmail.com' %}</p>
       <a href="/faq">{% ftlmsg 'banner-label-data-notification-body-cta' %}</a>
     </div>
     <div class="subdomain-banner-form">
@@ -25,7 +25,7 @@
             data-domain="{{ MOZMAIL_DOMAIN }}"
             required
             type="text"
-            placeholder="{% ftlmsg 'banner-choose-subdomain-input-placeholder' %}"
+            placeholder="{% ftlmsg 'banner-choose-subdomain-input-placeholder-3' %}"
             name="subdomain"
             minlength="1"
             maxlength="63"

--- a/privaterelay/templates/includes/dashboard-filter.html
+++ b/privaterelay/templates/includes/dashboard-filter.html
@@ -11,7 +11,7 @@
     <div class="c-filter-search">
         <div class="c-filter-icon c-filter-icon-search js-filter-mobile-search-toggle"></div>
         <form class="js-filter-search-form c-filter-search-form" action="">
-            <input class="c-filter-search-input js-filter-search-input " type="search" name="search" id="search" placeholder="{% ftlmsg 'profile-filter-search-placeholder' %}" >
+            <input class="c-filter-search-input js-filter-search-input " type="search" name="search" id="search" placeholder="{% ftlmsg 'profile-filter-search-placeholder-2' %}" >
             <div class="c-filter-search-controls">
                 <div class="c-filter-case-count">
                     <span class="js-filter-case-visible"></span>
@@ -43,7 +43,7 @@
                                     id="domain-aliases"
                                     value=""
                                 >
-                                <label class="mzp-c-choice-label" for="domain-aliases">{% ftlmsg 'profile-filter-category-option-domain-based-aliases-v2' %}</label>
+                                <label class="mzp-c-choice-label" for="domain-aliases">{% ftlmsg 'profile-filter-category-option-custom-masks' %}</label>
                             </div>
                         </div>
                     </li>
@@ -58,7 +58,7 @@
                                     id="relay-aliases"
                                     value=""
                                 >
-                                <label class="mzp-c-choice-label" for="relay-aliases">{% ftlmsg 'profile-filter-category-option-relay-aliases-v2' %}</label>
+                                <label class="mzp-c-choice-label" for="relay-aliases">{% ftlmsg 'profile-filter-category-option-random-masks' %}</label>
                             </div>
                         </div>
                     </li>
@@ -73,7 +73,7 @@
                                     id="active-aliases"
                                     value=""
                                 >
-                                <label class="mzp-c-choice-label" for="active-aliases">{% ftlmsg 'profile-filter-category-option-active-aliases-v2' %}</label>
+                                <label class="mzp-c-choice-label" for="active-aliases">{% ftlmsg 'profile-filter-category-option-active-masks' %}</label>
                             </div>
                         </div>
                     </li>
@@ -104,7 +104,7 @@
                                     id="disabled-aliases"
                                     value=""
                                 >
-                                <label class="mzp-c-choice-label" for="disabled-aliases">{% ftlmsg 'profile-filter-category-option-disabled-aliases-v2' %}</label>
+                                <label class="mzp-c-choice-label" for="disabled-aliases">{% ftlmsg 'profile-filter-category-option-disabled-masks' %}</label>
                             </div>
                         </div>
                     </li>
@@ -139,7 +139,7 @@
                             data-cookie-for-server="clicked-purchase"
                         >
                             <span class="generate-new-alias-text">
-                                {% ftlmsg 'profile-label-upgrade' %}
+                                {% ftlmsg 'profile-label-upgrade-2' %}
                             </span>
                         </a>
                     {% else %}
@@ -147,23 +147,23 @@
                             disabled
                             type="submit"
                             class="blue-btn-states dash-create-new-relay"
-                            title="{% ftlmsg 'profile-label-generate-new-alias' %}"
+                            title="{% ftlmsg 'profile-label-generate-new-alias-2' %}"
                         >
                             <span class="generate-new-relay-icon"></span>
                             <span class="generate-new-alias-text">
-                                {% ftlmsg 'profile-label-generate-new-alias' %}
+                                {% ftlmsg 'profile-label-generate-new-alias-2' %}
                             </span>
                         </button>
                     {% endif %}
                 {% else %}
                     <button
                     class="blue-btn-states dash-create-new-relay"
-                    title="{% ftlmsg 'profile-label-generate-new-alias' %}"
+                    title="{% ftlmsg 'profile-label-generate-new-alias-2' %}"
                     type="submit"
                     data-event-label="Create New Relay Alias">
                         <span class="generate-new-relay-icon"></span>
                             <span class="generate-new-alias-text">
-                                {% ftlmsg 'profile-label-generate-new-alias' %}
+                                {% ftlmsg 'profile-label-generate-new-alias-2' %}
                             </span>
                     </button>
                 {% endif %}
@@ -172,45 +172,45 @@
                 {% if not user_profile.subdomain %}
                     <button
                     class="blue-btn-states dash-create-new-relay"
-                    title="{% ftlmsg 'profile-label-generate-new-alias' %}"
+                    title="{% ftlmsg 'profile-label-generate-new-alias-2' %}"
                     type="submit"
                     data-event-label="Create New Relay Alias">
                         <span class="generate-new-relay-icon"></span>
                             <span class="generate-new-alias-text">
-                                {% ftlmsg 'profile-label-generate-new-alias' %}
+                                {% ftlmsg 'profile-label-generate-new-alias-2' %}
                             </span>
                     </button>
                 {% else %}
                     <div class="dash-create-new-alias-menu-wrapper">
                         <button
                             class="js-dash-create-new-alias-menu-trigger blue-btn-states dash-create-new-alias-menu-trigger"
-                            title="{% ftlmsg 'profile-label-generate-new-alias' %}"
+                            title="{% ftlmsg 'profile-label-generate-new-alias-2' %}"
                         >
                             <span class="generate-new-alias-text">
-                                {% ftlmsg 'profile-label-generate-new-alias' %}
+                                {% ftlmsg 'profile-label-generate-new-alias-2' %}
                             </span>
                             <span class="generate-new-alias-menu-trigger-icon"></span>
                         </button>
                         <div class="js-dash-create-new-alias-menu-popup generate-new-alias-menu-popup is-hidden">
                             <button
-                                title="{% ftlmsg 'profile-label-generate-new-alias-menu-random' %}"
+                                title="{% ftlmsg 'profile-label-generate-new-alias-menu-random-2' %}"
                                 type="submit"
                                 data-event-label="Create New Relay Alias"
                             >
                                 <span class="generate-new-relay-icon"></span>
                                 <span class="generate-new-alias-text">
-                                    {% ftlmsg 'profile-label-generate-new-alias-menu-random' %}
+                                    {% ftlmsg 'profile-label-generate-new-alias-menu-random-2' %}
                                 </span>
                             </button>
                             <button
                                 class="js-dash-create-new-domain-alias-dialog-trigger"
-                                title="{% ftlmsg 'profile-label-generate-new-alias-menu-custom' subdomain=user_profile.subdomain %}"
+                                title="{% ftlmsg 'profile-label-generate-new-alias-menu-custom-2' subdomain=user_profile.subdomain %}"
                                 type="submit"
                                 data-event-label="Create New Domain Alias"
                             >
                                 <span class="generate-new-relay-icon"></span>
                                 <span class="generate-new-alias-text">
-                                    {% ftlmsg 'profile-label-generate-new-alias-menu-custom' subdomain=user_profile.subdomain %}
+                                    {% ftlmsg 'profile-label-generate-new-alias-menu-custom-2' subdomain=user_profile.subdomain %}
                                 </span>
                             </button>
                         </div>

--- a/privaterelay/templates/includes/dashboard_onboarding.html
+++ b/privaterelay/templates/includes/dashboard_onboarding.html
@@ -3,26 +3,26 @@
 {% ftlconf bundle='privaterelay.ftl_bundles.main' %}
 
 <section class="c-onboarding">
-  <h2>{% ftlmsg 'onboarding-headline' %}</h2>
+  <h2>{% ftlmsg 'onboarding-headline-2' %}</h2>
   <ol class="c-onboarding-steps mzp-l-columns mzp-t-columns-three">
     <li class="c-onboarding-step">
       <div class="c-onboarding-step-number" data-number="1"></div>
       <p class="c-onboarding-step-copy">
-        {% ftlmsg 'onboarding-alias-tip-1' %}
+        {% ftlmsg 'onboarding-alias-tip-1-2' %}
       </p>
       <div class="c-onboarding-step-action">
         <form action="{% url 'emails-index' %}" class="dash-create" method="POST">
             <input type="hidden" name="api_token" value="{{ user_profile.api_token }}">
               <button
                   class="mzp-c-button mzp-t-product has-icon"
-                  title="{% ftlmsg 'profile-label-generate-new-alias' %}"
+                  title="{% ftlmsg 'profile-label-generate-new-alias-2' %}"
                   type="submit"
-                  value="{% ftlmsg 'profile-label-generate-new-alias' %}"
+                  value="{% ftlmsg 'profile-label-generate-new-alias-2' %}"
                   data-event-label="Create New Relay Alias"
               >
                 <span class="generate-new-relay-icon"></span>
                 <span class="generate-new-alias-text">
-                {% ftlmsg 'profile-label-generate-new-alias' %}</span>
+                {% ftlmsg 'profile-label-generate-new-alias-2' %}</span>
               </button>
           </form>
       </div>
@@ -39,7 +39,7 @@
     <li class="c-onboarding-step">
       <div class="c-onboarding-step-number" data-number="3"></div>
       <p class="c-onboarding-step-copy">
-        {% ftlmsg 'onboarding-alias-tip-3' %}
+        {% ftlmsg 'onboarding-alias-tip-3-2' %}
       </p>
       <div class="c-onboarding-step-graphic">
         <img class="" src="{% static 'images/dashboard-onboarding/onboarding-step-3.svg' %}" aria-hidden="true" alt="">

--- a/privaterelay/templates/includes/domain-alias-dashboard.html
+++ b/privaterelay/templates/includes/domain-alias-dashboard.html
@@ -7,10 +7,10 @@
       <div class="c-footer-banner-container">
         <div class="c-footer-banner-content">
           <h3>
-            {% ftlmsg 'banner-pack-upgrade-headline-html' %}
+            {% ftlmsg 'banner-pack-upgrade-headline-2-html' %}
           </h3>
           <p>
-            {% ftlmsg 'banner-pack-upgrade-copy' %}
+            {% ftlmsg 'banner-pack-upgrade-copy-2' %}
           </p>
           <a  class="mzp-c-button mzp-t-product js-purchase-premium" target="_blank" rel="noopener noreferrer"
               href="{% premium_subscribe_url accept_language country_code %}"

--- a/privaterelay/templates/includes/messages-frontend.html
+++ b/privaterelay/templates/includes/messages-frontend.html
@@ -2,9 +2,9 @@
 {% load relay_tags %}
 <div class="js-notification-html messages is-hidden">
 	<fluent 
-		data-error-subdomain-not-available="{% ftlmsg 'error-subdomain-not-available' unavailable_subdomain='REPLACE'  %}"
-		data-success-subdomain-registered="{% ftlmsg 'success-subdomain-registered' unavailable_subdomain='REPLACE'  %}"
-		data-error-alias-creation="{% ftlmsg 'modal-custom-alias-picker-creation-error' %}"
+		data-error-subdomain-not-available="{% ftlmsg 'error-subdomain-not-available-2' unavailable_subdomain='REPLACE'  %}"
+		data-success-subdomain-registered="{% ftlmsg 'success-subdomain-registered-2' unavailable_subdomain='REPLACE'  %}"
+		data-error-alias-creation="{% ftlmsg 'modal-custom-alias-picker-creation-error-2' %}"
 	>
 
 	</fluent>

--- a/privaterelay/templates/includes/modal-custom-alias-picker.html
+++ b/privaterelay/templates/includes/modal-custom-alias-picker.html
@@ -7,20 +7,20 @@
     
     <div class="c-modal-header t-custom-alias-picker-hero">
       <div class="c-modal-header-content">
-        <h3>{% ftlmsg 'modal-custom-alias-picker-heading' %}</h3>
+        <h3>{% ftlmsg 'modal-custom-alias-picker-heading-2' %}</h3>
       </div>
     </div>
 
     <div class="c-modal-body t-custom-alias-picker-body">
       <div class="c-superfluous-warning">
         <img src="{% static 'images/icon-info-pink.svg' %}" alt="">
-        <p>{% ftlmsg 'modal-custom-alias-picker-warning' %}</p>
+        <p>{% ftlmsg 'modal-custom-alias-picker-warning-2' %}</p>
       </div>
       <div class="t-custom-alias-picker-form">
-        <p>{% ftlmsg 'modal-custom-alias-picker-form-heading' %}</p>
+        <p>{% ftlmsg 'modal-custom-alias-picker-form-heading-2' %}</p>
         <div class="t-custom-alias-picker-form-prefix">
           <label for="customAliasPrefix" class="mzp-u-inline">
-            {% ftlmsg 'modal-custom-alias-picker-form-prefix-label' subdomain='' %}
+            {% ftlmsg 'modal-custom-alias-picker-form-prefix-label-2' subdomain='' %}
           </label>
           <input
             required
@@ -37,7 +37,7 @@
 
     <div class="c-modal-footer">
       <button type="submit" disabled class="mzp-c-button mzp-t-product js-modal-custom-alias-picker-submit">
-        {% ftlmsg 'modal-custom-alias-picker-form-submit-label' %}
+        {% ftlmsg 'modal-custom-alias-picker-form-submit-label-2' %}
       </button>
       <button type="button" class="mzp-c-button mzp-t-neutral js-modal-custom-alias-picker-cancel">
         {% ftlmsg 'profile-label-cancel' %}

--- a/privaterelay/templates/includes/modal-delete.html
+++ b/privaterelay/templates/includes/modal-delete.html
@@ -5,17 +5,17 @@
 <div class="modal c-modal-wrapper js-modal-delete-alias">
   <div class="c-modal t-modal-delete">
     <div class="c-modal-header t-delete-hero">
-      {% ftlmsg 'modal-delete-headline' %}
+      {% ftlmsg 'modal-delete-headline-2' %}
     </div>
     <div class="c-modal-body">
       <span class="alias-to-delete js-alias-to-delete demi"></span>
-      <p class="modal-message">{% ftlmsg 'modal-delete-warning-recovery-html' email='' %}</p> 
-      <p class="warning-text  modal-message js-relay-address-warning">{% ftlmsg 'modal-delete-warning-upgrade' %}</p>
-      <p class="warning-text  modal-message is-hidden js-domain-address-warning">{% ftlmsg 'modal-delete-domain-address-warning-upgrade' %}</p>
+      <p class="modal-message">{% ftlmsg 'modal-delete-warning-recovery-2-html' email='' %}</p>
+      <p class="warning-text  modal-message js-relay-address-warning">{% ftlmsg 'modal-delete-warning-upgrade-2' %}</p>
+      <p class="warning-text  modal-message is-hidden js-domain-address-warning">{% ftlmsg 'modal-delete-domain-address-warning-upgrade-2' %}</p>
       <div class="t-domain-delete-form">
         <label for="deleteAliasCheckbox" class="mzp-u-inline">
           <input required type="checkbox" name="checkboxes" id="deleteAliasCheckbox" class="js-modal-delete-alias-checkbox">
-          {% ftlmsg 'modal-delete-confirmation' %}
+          {% ftlmsg 'modal-delete-confirmation-2' %}
         </label>
       </div>
     </div>

--- a/privaterelay/templates/includes/modal-domain-registration-confirmation.html
+++ b/privaterelay/templates/includes/modal-domain-registration-confirmation.html
@@ -14,7 +14,7 @@
     </div>
 
     <div class="c-modal-body t-domain-registration-body">
-      <p>{% ftlmsg 'modal-domain-register-warning-reminder' %}</p>
+      <p>{% ftlmsg 'modal-domain-register-warning-reminder-2' %}</p>
       <div class="t-domain-registration-form">
         <label for="domainRegistrationCheckbox" class="mzp-u-inline">
           <input required type="checkbox" name="domainRegistrationCheckbox" id="domainRegistrationCheckbox" class="js-modal-domain-registration-confirmation-checkbox">
@@ -25,7 +25,7 @@
 
     <div class="c-modal-footer">
       <button type="submit" disabled class="mzp-c-button mzp-t-product js-modal-domain-registration-submit">
-        {% ftlmsg 'modal-domain-register-button' %}
+        {% ftlmsg 'modal-domain-register-button-2' %}
       </button>
       <button type="button" class="mzp-c-button mzp-t-neutral js-modal-domain-registration-cancel">
         {% ftlmsg 'profile-label-cancel' %}
@@ -39,13 +39,13 @@
       <div class="c-modal-header-content">
         <span class="c-modal-header-headline"><img src="{% static 'images/icon-check-green.svg' %}" aria-hidden="true" alt="check mark">{% ftlmsg 'modal-domain-register-success-title' %}</span>
         <h3><strong class="js-modal-domain-registration-confirmation-domain-preview"></strong></h3>
-        <span class="c-modal-header-headline"><span class="js-modal-domain-registration-confirmation-domain-ending"> </span>{% ftlmsg 'modal-domain-register-success' subdomain='' %}</span>
+        <span class="c-modal-header-headline"><span class="js-modal-domain-registration-confirmation-domain-ending"> </span>{% ftlmsg 'modal-domain-register-success-2' subdomain='' %}</span>
       </div>
     </div>
 
     <div class="c-modal-body t-domain-registration-body">
       <img src="{% static 'images/dashboard-onboarding/success-party.svg' %}" aria-hidden="true" alt="party streamers">
-      <p>{% ftlmsg 'modal-domain-register-success-copy' %}</p>
+      <p>{% ftlmsg 'modal-domain-register-success-copy-2' %}</p>
     </div>
 
     <div class="c-modal-footer">

--- a/privaterelay/templates/includes/premium-onboarding.html
+++ b/privaterelay/templates/includes/premium-onboarding.html
@@ -18,7 +18,7 @@
                     </div>
                     <div class="c-premium-onboarding-content-description">
                         <p class="c-premium-onboarding-detail">{% ftlmsg 'onboarding-premium-title-detail' %}</p>
-                        <p><strong>{% ftlmsg 'multi-part-onboarding-premium-generate-unlimited-title' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-welcome-description' %}</p>
+                        <p><strong>{% ftlmsg 'multi-part-onboarding-premium-generate-unlimited-title-2' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-welcome-description-2' %}</p>
                     </div>
                 </div>
             </div>
@@ -27,7 +27,7 @@
         <li class="c-premium-onboarding-step c-premium-onboarding-step-2 {% if user_profile.onboarding_state == 1 %} is-visible {% endif %}">
             <div class="mzp-l-content mzp-t-content-xl mzp-t-content-nospace">
                 <div class="c-premium-onboarding-headlines">
-                    <h1>{% ftlmsg 'multi-part-onboarding-premium-get-domain' %}</h1>
+                    <h1>{% ftlmsg 'multi-part-onboarding-premium-get-subdomain' %}</h1>
                 </div>
 
                 <div class="c-premium-onboarding-content">
@@ -36,10 +36,10 @@
                     </div>
                     <div class="c-premium-onboarding-content-description">
                         <p class="c-premium-onboarding-detail">{% ftlmsg 'onboarding-premium-title-detail' %}</p>
-                        <p><strong>{% ftlmsg 'onboarding-premium-domain-title-2' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-get-domain-description-2' mozmail='.mozmail.com' %}
+                        <p><strong>{% ftlmsg 'onboarding-premium-domain-title-3' %}</strong> {% ftlmsg 'multi-part-onboarding-premium-get-domain-description-3' mozmail='.mozmail.com' %}
                         {% if not user_profile.subdomain %}
                             <div class="js-premium-onboarding-domain-registration-form">
-                                <p>{% ftlmsg 'multi-part-onboarding-premium-domain-cta' %}</p>
+                                <p>{% ftlmsg 'multi-part-onboarding-premium-domain-cta-2' %}</p>
                                 <samp class="c-premium-onboarding-subdomain-registration">***@<span>{% ftlmsg 'banner-register-subdomain-example-address' %}</span>.mozmail.com</samp>
                                 <form class="c-premium-onboarding-domain-registration-form" id="onboardingDomainRegistration" method="post" action="{% url 'profile_subdomain' %}">
                                     {% csrf_token %}
@@ -48,19 +48,19 @@
                                     data-domain="{{ MOZMAIL_DOMAIN }}"
                                     required
                                     type="text"
-                                    placeholder="{% ftlmsg 'banner-choose-subdomain-input-placeholder-2' %}"
+                                    placeholder="{% ftlmsg 'banner-choose-subdomain-input-placeholder-3' %}"
                                     name="subdomain"
                                     minlength="1"
                                     maxlength="63"
                                     >
-                                    <input class="mzp-c-button mzp-t-product" type="submit" value="{% ftlmsg 'multi-part-onboarding-premium-get-domain' %}">
+                                    <input class="mzp-c-button mzp-t-product" type="submit" value="{% ftlmsg 'multi-part-onboarding-premium-get-subdomain' %}">
                                 </form>
                             </div>
                         {% endif %}
                         
                         <div class="c-premium-onboarding-action-completed {% if user_profile.subdomain %} is-visible {% endif %}">
                             <div class="c-premium-onboarding-subdomain-set-module">
-                                <p class="c-premium-onboarding-label">{% ftlmsg 'profile-label-domain' %}</p>
+                                <p class="c-premium-onboarding-label">{% ftlmsg 'profile-label-subdomain' %}</p>
                                 <samp class="c-premium-onboarding-subdomain">@<span class="js-premium-onboarding-domain-registration-preview">{{ user_profile.subdomain }}</span></samp>
                                 <span class="c-premium-onboarding-mozmail">.mozmail.com</span>
                             </div>
@@ -90,15 +90,15 @@
                         <div class="c-premium-onboarding-install-addon">
                             <strong>
                                 <!-- Mobile title -->
-                                <span class="c-premium-onboarding-replies-copy">{% ftlmsg 'onboarding-premium-reply-title' %}</span>
+                                <span class="c-premium-onboarding-replies-copy">{% ftlmsg 'onboarding-premium-reply-title-2' %}</span>
                                 <!-- Desktop title -->
                                 <span class="c-premium-onboarding-extension-copy t-firefox-extension">{% ftlmsg 'multi-part-onboarding-premium-extension-get-title' %}</span>
                                 <span class="c-premium-onboarding-extension-copy t-chrome-extension">{% ftlmsg 'multi-part-onboarding-premium-chrome-extension-get-title' %}</span>
                             </strong> 
                                 <!-- Mobile copy -->
-                                <span class="c-premium-onboarding-replies-copy">{% ftlmsg 'onboarding-premium-reply-description' %}</span>
+                                <span class="c-premium-onboarding-replies-copy">{% ftlmsg 'onboarding-premium-reply-description-2' %}</span>
                                 <!-- Desktop copy -->
-                                <span class="c-premium-onboarding-extension-copy t-firefox-extension">{% ftlmsg 'multi-part-onboarding-premium-extension-get-description' %}</span>
+                                <span class="c-premium-onboarding-extension-copy t-firefox-extension">{% ftlmsg 'multi-part-onboarding-premium-extension-get-description-2' %}</span>
                                 <span class="c-premium-onboarding-extension-copy t-chrome-extension">{% ftlmsg 'multi-part-onboarding-premium-chrome-extension-get-description' %}</span>
                             </p>
                             <a target="_blank" href="https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon" class=" mzp-c-button mzp-t-product">{% ftlmsg 'multi-part-onboarding-premium-extension-button-download' %}</a>
@@ -135,7 +135,7 @@
                             data-event-label="onboarding-step-2-skip"    
                             data-event-value="2"
                             data-event-nonInteraction="false"
-                         >{% ftlmsg 'multi-part-onboarding-premium-domain-button-skip' %}</button>
+                         >{% ftlmsg 'multi-part-onboarding-premium-domain-button-skip-2' %}</button>
                     {% endif %}
                     <button class="mzp-c-button mzp-t-product js-premium-onboarding-next-step {% if not user_profile.subdomain %} is-hidden {% endif %}"
                         data-ga="send-ga-pings"

--- a/privaterelay/templates/newlanding/a/faq.html
+++ b/privaterelay/templates/newlanding/a/faq.html
@@ -21,23 +21,23 @@
             </dd>
             <dt class="c-faq-question">
                 <button id="faq-what-is-question" aria-expanded="false" aria-controls="faq-what-is-answer">
-                    {% ftlmsg 'faq-question-what-is-question' %}
+                    {% ftlmsg 'faq-question-what-is-question-2' %}
                     <span aria-hidden="true" class="c-faq-plus-icon"></span>
                 </button>
             </dt>
             <dd id="faq-what-is-answer" hidden aria-labelledby="faq-what-is-question" class="c-faq-answer">
-                {% ftlmsg 'faq-question-what-is-answer' %}
+                {% ftlmsg 'faq-question-what-is-answer-2' %}
             </dd>
 
             <dt class="c-faq-question">
                 <button id="faq-use-cases-question" aria-expanded="false" aria-controls="faq-use-cases-answer">
-                    {% ftlmsg 'faq-question-use-cases-question' %}
+                    {% ftlmsg 'faq-question-use-cases-question-2' %}
                     <span aria-hidden="true" class="c-faq-plus-icon"></span>
                 </button>
             </dt>
             <dd id="faq-use-cases-answer" hidden aria-labelledby="faq-use-cases-question" class="c-faq-answer">
-                <p>{% ftlmsg 'faq-question-use-cases-answer-part1' %}</p>
-                <p>{% ftlmsg 'faq-question-use-cases-answer-part2' %}</p>
+                <p>{% ftlmsg 'faq-question-use-cases-answer-part1-2' %}</p>
+                <p>{% ftlmsg 'faq-question-use-cases-answer-part2-2' %}</p>
             </dd>
 
             <dt class="c-faq-question">
@@ -47,7 +47,7 @@
                 </button>
             </dt>
             <dd id="faq-browser-support-answer" hidden aria-labelledby="faq-browser-support-question" class="c-faq-answer">
-                {% ftlmsg 'faq-question-browser-support-answer' %}
+                {% ftlmsg 'faq-question-browser-support-answer-2' %}
             </dd>
         </dl>
     </div>

--- a/privaterelay/templates/newlanding/a/hero.html
+++ b/privaterelay/templates/newlanding/a/hero.html
@@ -3,8 +3,8 @@
 
 <section class="c-landing-hero t-landing-a mzp-l-content">
     <div class="c-landing-hero--lead">
-        <h1 class="c-landing-hero--title mzp-c-section-heading">{% ftlmsg 'landing-hero-headline' %}</h1>
-        <p>{% ftlmsg 'landing-hero-body' %}</p>
+        <h1 class="c-landing-hero--title mzp-c-section-heading">{% ftlmsg 'landing-hero-headline-2' %}</h1>
+        <p>{% ftlmsg 'landing-hero-body-2' %}</p>
         <div>{% include "includes/landing_ctas.html" with page_position="landing-hero" %}</div>
         <img class="c-landing-hero-brands" src="{% static 'images/newlanding/a/hero-brands.svg' %}">
     </div>

--- a/privaterelay/templates/newlanding/a/how-it-works.html
+++ b/privaterelay/templates/newlanding/a/how-it-works.html
@@ -5,7 +5,7 @@
     <div class="mzp-l-content">
     <div class="how-it-works-content-new">
     <h2 class="how-it-works-header">{% ftlmsg 'landing-how-it-works-headline' %}</h2>
-    <span class="how-it-works-subheader">{% ftlmsg 'landing-how-it-works-body' %}</span>
+    <span class="how-it-works-subheader">{% ftlmsg 'landing-how-it-works-body-2' %}</span>
     <div class="how-it-works-steps mzp-l-columns mzp-t-columns-three">
         <section class="step step-1">
         <img src="{% static 'images/how-it-works/how-it-works-1.svg' %}" class="step-illustration step-1">
@@ -13,14 +13,14 @@
             <h3 class="step-headline ff-Met">{% ftlmsg 'how-it-works-step-1-headline' %}</h3>
             <p class="step-body">
             <a href="https://addons.mozilla.org/firefox/addon/private-relay/">{% ftlmsg 'landing-how-it-works-step-1-body-cta' %}</a>
-            {% ftlmsg 'landing-how-it-works-step-1-body' %}
+            {% ftlmsg 'landing-how-it-works-step-1-body-2' %}
             </p>
         </div>
         </section>
         <section class="step step-2">
         <img src="{% static 'images/how-it-works/how-it-works-2.svg' %}" class="step-illustration step-2">
         <div class="step-text step-2">
-            <h3 class="step-headline ff-Met">{% ftlmsg 'how-it-works-step-2-headline' %}</h3>
+            <h3 class="step-headline ff-Met">{% ftlmsg 'how-it-works-step-2-headline-2' %}</h3>
             <p class="step-body">
             {% ftlmsg 'landing-how-it-works-step-2-body' %}
             </p>
@@ -29,9 +29,9 @@
         <section class="step step-3">
         <img src="{% static 'images/how-it-works/how-it-works-3.svg' %}" class="step-illustration step-3">
         <div class="step-text step-3">
-            <h3 class="step-headline ff-Met">{% ftlmsg 'how-it-works-step-3-headline' %}</h3>
+            <h3 class="step-headline ff-Met">{% ftlmsg 'how-it-works-step-3-headline-2' %}</h3>
             <p class="step-body">
-            {% ftlmsg 'landing-how-it-works-step-3-body' %}
+            {% ftlmsg 'landing-how-it-works-step-3-body-2' %}
             </p>
         </div>
         </section>

--- a/privaterelay/templates/newlanding/a/plans.html
+++ b/privaterelay/templates/newlanding/a/plans.html
@@ -13,7 +13,7 @@
                     <p class="c-price non-premium-price">{% ftlmsg 'landing-pricing-free-price' %}</p>
                     <div class="c-features non-premium-list">
                         <ul class="c-list">
-                            <li>{% ftlmsg 'landing-pricing-free-feature-1' %}</li>
+                            <li>{% ftlmsg 'landing-pricing-free-feature-1-2' %}</li>
                             <li>{% ftlmsg 'landing-pricing-free-feature-2' %}</li>
                         </ul>
                     </div>
@@ -37,9 +37,9 @@
                     </p>
                     <div class="c-features premium-list">
                         <ul class="c-list">
-                            <li>{% ftlmsg 'landing-pricing-premium-feature-1' %}</li>
+                            <li>{% ftlmsg 'landing-pricing-premium-feature-1-2' %}</li>
                             <li>{% ftlmsg 'landing-pricing-premium-feature-2' %}</li>
-                            <li>{% ftlmsg 'landing-pricing-premium-feature-3' %}</li>
+                            <li>{% ftlmsg 'landing-pricing-premium-feature-3-2' %}</li>
                             <li>{% ftlmsg 'landing-pricing-premium-feature-4' %}</li>
                         </ul>
                     </div>
@@ -59,8 +59,8 @@
     
             <div class="c-pricing-text">
                 <div class="c-text">
-                    <h2 class="c-main-header">{% ftlmsg 'landing-pricing-headline' monthly_price=monthly_price %}</h2>
-                    <p class="c-pricing-body">{% ftlmsg 'landing-pricing-body' %}</p>
+                    <h2 class="c-main-header">{% ftlmsg 'landing-pricing-headline-2' monthly_price=monthly_price %}</h2>
+                    <p class="c-pricing-body">{% ftlmsg 'landing-pricing-body-2' %}</p>
                 </div>
             </div>
         </div>

--- a/privaterelay/templates/newlanding/a/use-cases.html
+++ b/privaterelay/templates/newlanding/a/use-cases.html
@@ -11,7 +11,7 @@
             <li class="use-case-desc">
                 <div class="desc-headline">{% ftlmsg 'landing-use-cases-shopping' %}</div>
                 <div class="desc-body">
-                    {% ftlmsg 'landing-use-cases-shopping-body' %}
+                    {% ftlmsg 'landing-use-cases-shopping-body-2' %}
                 </div>
             </li>
             <li class="use-case-title use-case-social-networks" data-use-case="social-networks">
@@ -21,7 +21,7 @@
             <li class="use-case-desc">
                 <div class="desc-headline">{% ftlmsg 'landing-use-cases-social-networks' %}</div>
                 <div class="desc-body">
-                    {% ftlmsg 'landing-use-cases-social-networks-body' %}
+                    {% ftlmsg 'landing-use-cases-social-networks-body-2' %}
                 </div>
             </li>
             <li class="use-case-title use-case-offline" data-use-case="offline">  
@@ -31,7 +31,7 @@
             <li class="use-case-desc">
                 <div class="desc-headline">{% ftlmsg 'landing-use-cases-offline' %}</div>
                 <div class="desc-body">
-                    {% ftlmsg 'landing-use-cases-offline-body' %}
+                    {% ftlmsg 'landing-use-cases-offline-body-2' %}
                 </div>
             </li>
             <li class="use-case-title use-case-access-content" data-use-case="access-content">
@@ -41,7 +41,7 @@
             <li class="use-case-desc">
                 <div class="desc-headline">{% ftlmsg 'landing-use-cases-access-content' %}</div>
                 <div class="desc-body">
-                    {% ftlmsg 'landing-use-cases-access-content-body' %}
+                    {% ftlmsg 'landing-use-cases-access-content-body-2' %}
                 </div>
             </li>
             <li class="use-case-title use-case-gaming" data-use-case="gaming">
@@ -51,7 +51,7 @@
             <li class="use-case-desc">
                 <div class="desc-headline">{% ftlmsg 'landing-use-cases-gaming' %}</div>
                 <div class="desc-body">
-                    {% ftlmsg 'landing-use-cases-gaming-body' %}
+                    {% ftlmsg 'landing-use-cases-gaming-body-2' %}
                 </div>
             </li>
         </ul>

--- a/privaterelay/templates/premium-promo.html
+++ b/privaterelay/templates/premium-promo.html
@@ -13,7 +13,7 @@
     <section class="c-landing-hero t-landing-a mzp-l-content">
         <div class="c-landing-hero--lead">
             <h1 class="c-landing-hero--title mzp-c-section-heading">{% ftlmsg 'premium-promo-hero-headline' %}</h1>
-            <p>{% ftlmsg 'premium-promo-hero-body-html' monthly_price=monthly_price %}</p>
+            <p>{% ftlmsg 'premium-promo-hero-body-2-html' monthly_price=monthly_price %}</p>
             <div class="premium-promo-hero-cta">
                 {% if premium_available_in_country %}
                     <a
@@ -61,13 +61,13 @@
         <div class="mzp-l-content">
         <div class="perks-content">
         <h2 class="perks-headline">{% ftlmsg 'premium-promo-perks-headline' %}</h2>
-        <span class="perks-lead">{% ftlmsg 'premium-promo-perks-lead' %}</span>
+        <span class="perks-lead">{% ftlmsg 'premium-promo-perks-lead-2' %}</span>
         <div class="perk">
         <img alt="" src="{% static 'images/premium-promo/illustration-unlimited.svg' %}" class="perk-illustration">
         <div class="perk-description">
-            <h3 class="perk-headline ff-Met">{% ftlmsg 'premium-promo-perks-perk-unlimited-headline' %}</h3>
+            <h3 class="perk-headline ff-Met">{% ftlmsg 'premium-promo-perks-perk-unlimited-headline-2' %}</h3>
             <p class="perk-body">
-                {% ftlmsg 'premium-promo-perks-perk-unlimited-body' %}
+                {% ftlmsg 'premium-promo-perks-perk-unlimited-body-2' %}
             </p>
             {% if premium_available_in_country %}
                 <a
@@ -95,9 +95,9 @@
         <div class="perk">
         <img alt="" src="{% static 'images/premium-promo/illustration-custom-domain.svg' %}" class="perk-illustration">
         <div class="perk-description">
-            <h3 class="perk-headline ff-Met">{% ftlmsg 'premium-promo-perks-perk-custom-domain-headline' %}</h3>
+            <h3 class="perk-headline ff-Met">{% ftlmsg 'premium-promo-perks-perk-custom-domain-headline-2' %}</h3>
             <p class="perk-body">
-            {% ftlmsg 'premium-promo-perks-perk-custom-domain-body' %}
+            {% ftlmsg 'premium-promo-perks-perk-custom-domain-body-2' %}
             </p>
             {% if premium_available_in_country %}
                 <a
@@ -125,9 +125,9 @@
         <div class="perk">
         <img alt="" src="{% static 'images/premium-promo/illustration-dashboard.svg' %}" class="perk-illustration">
         <div class="perk-description">
-            <h3 class="perk-headline ff-Met">{% ftlmsg 'premium-promo-perks-perk-dashboard-headline' %}</h3>
+            <h3 class="perk-headline ff-Met">{% ftlmsg 'premium-promo-perks-perk-dashboard-headline-2' %}</h3>
             <p class="perk-body">
-            {% ftlmsg 'premium-promo-perks-perk-dashboard-body' %}
+            {% ftlmsg 'premium-promo-perks-perk-dashboard-body-2' %}
             </p>
             {% if premium_available_in_country %}
                 <a
@@ -157,7 +157,7 @@
 
     <section>
         <div class="container mzp-l-content">
-            <h2 class="use-case-headline">{% ftlmsg 'premium-promo-use-cases-headline' %}</h2>
+            <h2 class="use-case-headline">{% ftlmsg 'premium-promo-use-cases-headline-2' %}</h2>
             <ul class="c-use-case-content has-3" id="use-cases">
                 <li class="use-case-title use-case-shopping is-active remove-box-shadow" data-use-case="shopping">
                     <div class="use-case-title-text">{% ftlmsg 'premium-promo-use-cases-shopping-heading' %}</div>
@@ -166,7 +166,7 @@
                 <li class="use-case-desc">
                     <div class="desc-headline">{% ftlmsg 'premium-promo-use-cases-shopping-heading' %}</div>
                     <div class="desc-body">
-                        {% ftlmsg 'premium-promo-use-cases-shopping-body' %}
+                        {% ftlmsg 'premium-promo-use-cases-shopping-body-2' %}
                     </div>
                 </li>
                 <li class="use-case-title use-case-social-networks" data-use-case="social-networks">
@@ -176,7 +176,7 @@
                 <li class="use-case-desc">
                     <div class="desc-headline">{% ftlmsg 'premium-promo-use-cases-social-networks-heading' %}</div>
                     <div class="desc-body">
-                        {% ftlmsg 'premium-promo-use-cases-social-networks-body' %}
+                        {% ftlmsg 'premium-promo-use-cases-social-networks-body-2' %}
                     </div>
                 </li>
                 <li class="use-case-title use-case-gaming" data-use-case="gaming">
@@ -186,7 +186,7 @@
                 <li class="use-case-desc">
                     <div class="desc-headline">{% ftlmsg 'premium-promo-use-cases-gaming-heading' %}</div>
                     <div class="desc-body">
-                        {% ftlmsg 'premium-promo-use-cases-gaming-body' %}
+                        {% ftlmsg 'premium-promo-use-cases-gaming-body-2' %}
                     </div>
                 </li>
             </ul>
@@ -204,7 +204,7 @@
                             <p class="c-price non-premium-price">{% ftlmsg 'premium-promo-pricing-free-price' %}</p>
                             <div class="c-features non-premium-list">
                                 <ul class="c-list">
-                                    <li>{% ftlmsg 'landing-pricing-free-feature-1' %}</li>
+                                    <li>{% ftlmsg 'landing-pricing-free-feature-1-2' %}</li>
                                     <li>{% ftlmsg 'landing-pricing-free-feature-2' %}</li>
                                 </ul>
                             </div>
@@ -228,9 +228,9 @@
                             </p>
                             <div class="c-features premium-list">
                                 <ul class="c-list">
-                                    <li>{% ftlmsg 'landing-pricing-premium-feature-1' %}</li>
+                                    <li>{% ftlmsg 'landing-pricing-premium-feature-1-2' %}</li>
                                     <li>{% ftlmsg 'landing-pricing-premium-feature-2' %}</li>
-                                    <li>{% ftlmsg 'landing-pricing-premium-feature-3' %}</li>
+                                    <li>{% ftlmsg 'landing-pricing-premium-feature-3-2' %}</li>
                                     <li>{% ftlmsg 'landing-pricing-premium-feature-4' %}</li>
                                 </ul>
                             </div>
@@ -250,8 +250,8 @@
 
                     <div class="c-pricing-text">
                         <div class="c-text">
-                            <h2 class="c-main-header">{% ftlmsg 'landing-pricing-headline' monthly_price=monthly_price %}</h2>
-                            <p class="c-pricing-body">{% ftlmsg 'landing-pricing-body' %}</p>
+                            <h2 class="c-main-header">{% ftlmsg 'landing-pricing-headline-2' monthly_price=monthly_price %}</h2>
+                            <p class="c-pricing-body">{% ftlmsg 'landing-pricing-body-2' %}</p>
                         </div>
                     </div>
                 </div>

--- a/privaterelay/templates/profile.html
+++ b/privaterelay/templates/profile.html
@@ -61,26 +61,26 @@
         {% if not user_profile.subdomain %}
           <div class="mpp-dashbaord-header-action">
             <a href="#mpp-choose-subdomain" class="mpp-action-link">
-              <img src="/static/images/icon-check.svg" alt=""> {% ftlmsg 'profile-label-create-domain' %}
+              <img src="/static/images/icon-check.svg" alt=""> {% ftlmsg 'profile-label-create-subdomain' %}
             </a>
             <div class="mpp-action-tooltip">
               <img src="/static/images/icon-info.svg" alt="">
               <div class="mpp-action-tooltip-hover">
                 <div class="mpp-action-tooltip-hover-wrapper">
-                  {% ftlmsg 'profile-label-domain-tooltip' %}
+                  {% ftlmsg 'profile-label-subdomain-tooltip' %}
                 </div>
               </div>
             </div>
           </div>
         {% else %}
           <div class="mpp-dashbaord-header-action">
-              <img src="/static/images/icon-check.svg" alt=""> {% ftlmsg 'profile-label-domain' %} 
+              <img src="/static/images/icon-check.svg" alt=""> {% ftlmsg 'profile-label-subdomain' %}
               <samp>{{ user_profile.custom_domain }}</samp>
           </div>
         {% endif %}
       </div>
       <ul class="mpp-dashbaord-header-stats">
-        <li><span class="label">{% ftlmsg 'profile-stat-label-aliases-used' %}</span> <span>{{user_profile.num_active_address}}</span> </li>
+        <li><span class="label">{% ftlmsg 'profile-stat-label-aliases-used-2' %}</span> <span>{{user_profile.num_active_address}}</span> </li>
         <li><span class="label">{% ftlmsg 'profile-stat-label-blocked' %}</span> <span>{{user_profile.emails_blocked}}</span> </li>
         <li><span class="label">{% ftlmsg 'profile-stat-label-forwarded' %}</span> <span>{{user_profile.emails_forwarded}}</span> </li>
       </ul>

--- a/privaterelay/templates/settings.html
+++ b/privaterelay/templates/settings.html
@@ -71,10 +71,10 @@
         <div class="notification-banner-content">
           <div class="notification-banner-copy">
             <h2 class="notification-banner-header">
-              {% ftlmsg 'settings-warning-collection-off-heading' %}
+              {% ftlmsg 'settings-warning-collection-off-heading-2' %}
             </h2>
             <p class="notification-banner-sub">
-              {% ftlmsg 'settings-warning-collection-off-description' %}
+              {% ftlmsg 'settings-warning-collection-off-description-2' %}
             </p>
           </div>
         </div>
@@ -98,12 +98,12 @@
                 class="mzp-c-choice-label"
                 for="label-collection"
               >
-                {% ftlmsg 'setting-label-collection-description' %}
+                {% ftlmsg 'setting-label-collection-description-2' %}
               </label>
             </div>
             <aside role="alert" class="js-label-collection-off-warning mzp-c-notification-bar hidden c-settings-form--inline-warning">
               <p>
-                  {% ftlmsg 'setting-label-collection-off-warning' %}
+                  {% ftlmsg 'setting-label-collection-off-warning-2' %}
               </p>
             </aside>
           </div>

--- a/privaterelay/templatetags/relay_tags.py
+++ b/privaterelay/templatetags/relay_tags.py
@@ -21,9 +21,9 @@ def user_email_domain(user_profile):
 @register.simple_tag
 def message_in_fluent(message):
     ftl_messages = [
-        'success-subdomain-registered',
+        'success-subdomain-registered-2',
         'success-settings-update',
-        'error-subdomain-not-available',
+        'error-subdomain-not-available-2',
         'error-premium-cannot-change-subdomain',
         'error-premium-set-subdomain',
         'error-premium-check-subdomain'


### PR DESCRIPTION
# New feature description

~~Do not merge this until after April 19th, so that localisers have time to deal with the unfortunate massive workload we're generating here :(~~

This applies three primary changes across the entire website:
- An "alias" is now called a "mask"
- A "real email" is now called a "true email"
- We're using "subdomain" consistently now, rather than "domain"

For that, it uses the strings from https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/66.

Fixes #1814.

# How to test

Check out https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/66, then verify that there's no mention of "alias", "real email" and "domain" anywhere anymore.

# Checklist

- [x] l10n dependencies have been merged, if any. Not yet: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/66
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
