### PR TITLE
Add Sweden and Finland to list of Premium Relay available countries

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -92,6 +92,8 @@ faq-question-acceptable-use-answer-measure-rate-limit = Rate-limiting the number
 #   $url (url) - link to the Terms of Service, i.e. https://www.mozilla.org/about/legal/terms/firefox-relay/
 #   $attrs (string) - specific attributes added to external links
 faq-question-acceptable-use-answer-b-html = Please review our <a href="{ $url }" { $attrs }>Terms of Service</a> for more information.
+faq-question-availability-answer-v2 = Free { -brand-name-relay } is available in most countries. { -brand-name-relay-premium } is available in the United States, Germany, United Kingdom, Canada, Singapore, Malaysia, New Zealand, Finland, France, Belgium, Austria, Spain, Italy, Sweden, Switzerland, Netherlands, and Ireland.
+
 
 modal-custom-alias-picker-heading = Create a new custom alias
 modal-custom-alias-picker-warning = All you need to do is make up and share a unique alias that uses your custom domain — the alias will be generated automatically. Try “shop@customdomain.mozmail.com” next time you shop online, for example.

--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -126,7 +126,7 @@ const Faq: NextPage = () => {
                 id="faq-availability"
                 question={l10n.getString("faq-question-availability-question")}
               >
-                <p>{l10n.getString("faq-question-availability-answer")}</p>
+                <p>{l10n.getString("faq-question-availability-answer-v2")}</p>
               </QAndA>
               <QAndA
                 id="faq-replies"

--- a/frontend/src/pages/index.page.tsx
+++ b/frontend/src/pages/index.page.tsx
@@ -194,7 +194,7 @@ const Home: NextPage = () => {
                 entries={[
                   {
                     q: l10n.getString("faq-question-availability-question"),
-                    a: l10n.getString("faq-question-availability-answer"),
+                    a: l10n.getString("faq-question-availability-answer-v2"),
                   },
                   {
                     q: l10n.getString("faq-question-what-is-question"),


### PR DESCRIPTION

<!-- When adding a new feature: -->

# New feature description

Adding Sweden and Finland to list of Premium Relay available countries.

**Pending l10n PR:** https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/68


# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/13066134/160902558-7da498dc-2caf-4299-9602-ba9bd7fbf077.png)
![image](https://user-images.githubusercontent.com/13066134/160902585-0e7f9278-4ecd-4905-9704-cbe8622e3aa6.png)


# Checklist

- [ ] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
