### PR TITLE
Add bottom padding to the profile wrapper

### DIFF
--- a/frontend/src/pages/accounts/profile.module.scss
+++ b/frontend/src/pages/accounts/profile.module.scss
@@ -78,6 +78,7 @@
   flex-direction: column;
   align-items: baseline;
   gap: $spacing-md;
+  padding-bottom: $spacing-xl;
 }
 
 .main-wrapper,

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -360,8 +360,8 @@ const Profile: NextPage = () => {
             </p>
           </section>
           {bottomBanners}
-          {bottomPremiumSection}
         </main>
+        {bottomPremiumSection}
         <Tips
           profile={profile}
           customAliases={aliasData.customAliasData.data}

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -361,7 +361,7 @@ const Profile: NextPage = () => {
           </section>
           {bottomBanners}
         </main>
-        {bottomPremiumSection}
+        <aside>{bottomPremiumSection}</aside>
         <Tips
           profile={profile}
           customAliases={aliasData.customAliasData.data}


### PR DESCRIPTION

<!-- When adding a new feature: -->

# New feature description
This adds padding to the bottom of the `profile-wrapper` component so that the bottom banners aren't touching the footer.


# Screenshot (if applicable)

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/13066134/161104309-92e04426-4bc9-4941-87c9-dae00df3f188.png">




# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
