### PR TITLE
Set asserted value in test

### DIFF
--- a/frontend/src/functions/filterAliases.test.ts
+++ b/frontend/src/functions/filterAliases.test.ts
@@ -8,7 +8,7 @@ import { filterAliases, Filters } from "./filterAliases";
 
 const getMockedAliasMatching = (
   filters: Partial<Filters>,
-  customSubdomain = "some"
+  customSubdomain = "arbitrary_subdomain"
 ): AliasData => {
   const alias = {
     address: filters.string ?? "arbitrary_string",
@@ -122,7 +122,7 @@ it("filters out aliases that do not match the given string", () => {
 it("can match on an alias's subdomain when using a string filter", () => {
   const aliases = [
     getMockedAliasMatching({ domainType: "random" }),
-    getMockedAliasMatching({ domainType: "custom" }),
+    getMockedAliasMatching({ domainType: "custom" }, "some_subdomain"),
   ];
 
   expect(filterAliases(aliases, { string: "some" })).toStrictEqual([


### PR DESCRIPTION
Rather than having a test depend on a value implicitly set in the
function, the test now explicitly passes the value it's matching on
into the mock creator. This can avoid the test accidentally passing
if the mocks are changed in the future. (For example, for this test
specifically, it's checking whether the string `some` is in a
mocked email's subdomain, but it would also succeed if that string
was in the address.)

Obviously in this one instance, it's not super important, but I
thought it could be useful to clarify what I meant by my comment in
https://github.com/mozilla/fx-private-relay/pull/1677#discussion_r840517332.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
