### PR TITLE
Fix #1724: check cert url

### DIFF
--- a/emails/sns.py
+++ b/emails/sns.py
@@ -10,6 +10,7 @@ from OpenSSL import crypto
 
 from django.conf import settings
 from django.core.cache import caches
+from django.core.exceptions import SuspiciousOperation
 from django.utils.encoding import smart_bytes
 
 
@@ -90,6 +91,12 @@ def _get_hash_format(json_body):
 
 
 def _grab_keyfile(cert_url):
+    cert_url_origin = f'https://sns.{settings.AWS_REGION}.amazonaws.com/'
+    if not (cert_url.startswith(cert_url_origin)):
+        raise SuspiciousOperation(
+            f'SNS SigningCertURL "{cert_url}" did not start with "{cert_url_origin}"'
+        )
+
     key_cache = caches[getattr(settings, 'AWS_SNS_KEY_CACHE', 'default')]
 
     pemfile = key_cache.get(cert_url)

--- a/emails/tests/sns_tests.py
+++ b/emails/tests/sns_tests.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+from django.core.exceptions import SuspiciousOperation
+from django.test import TestCase
+
+from ..sns import _grab_keyfile
+
+
+class GrabKeyfileTest(TestCase):
+    @patch('emails.sns.urlopen')
+    def test_grab_keyfile_checks_cert_url_origin(self, mock_urlopen):
+        cert_url = 'https://sns.us-east-1.amazonaws.com/SimpleNotificationService-7ff5318490ec183fbaddaa2a969abfda.pem'
+        assert mock_urlopen.called_once_with(cert_url)
+
+        with self.assertRaises(SuspiciousOperation):
+            cert_url = 'https://attacker.com/cert.pem'
+            _grab_keyfile(cert_url)


### PR DESCRIPTION
This PR fixes #1724.

How to test:
Probably easiest to test on dev, unless you have [set up end-to-end local dev](https://github.com/mozilla/fx-private-relay/blob/main/docs/end-to-end-local-dev.md).
1. Try to send an email to an email alias
   * [ ] The email should still properly send
2. Try to POST to `/emails/sns-inbound` with a bad signing cert url.
   * With ngrok, go the the request from step 1 and choose "Replay with modifications"
   * Change the `SigningCertUrl` value to something malicious like `https://attacker.com/malicious_cert.pem`
   * The request should return 400 SuspiciousOperation error

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).