### PR TITLE
Add CSP header to Whitenoise files

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -491,6 +491,15 @@ else:
 
 WHITENOISE_INDEX_FILE = True
 
+
+def add_csp_headers(headers, path, url):
+    from csp.utils import build_policy
+    if "Content-Security-Policy" not in headers:
+        headers['Content-Security-Policy'] = build_policy()
+
+WHITENOISE_ADD_HEADERS_FUNCTION = add_csp_headers
+
+
 # for dev statics, we use django-gulp during runserver.
 # for stage/prod statics, we run "gulp build" in docker.
 # so, squelch django-gulp in prod so it doesn't run gulp during collectstatic:


### PR DESCRIPTION
WhiteNoise serves the React root file, and CSP is needed to ensure the remaining assets are loaded.

This uses [WHITENOISE_ADD_HEADERS_FUNCTION](http://whitenoise.evans.io/en/stable/django.html#WHITENOISE_ADD_HEADERS_FUNCTION) and the undocumented [csp.utils.build_policy](https://github.com/mozilla/django-csp/blob/main/csp/utils.py).

# How to test

* Build the React toolchain, or put a basic file at `frontend/out/index.html`
* Run `SERVE_REACT=1 ./manage.py runserver 8000`.
* Run `curl -I http://127.0.0.1:8000/`, and look at the `Content-Security-Policy` header:
   - Before this PR - No header
   - After this PR - `connect-src 'self' https://www.google-analytics.com/ https://accounts.firefox.com https://location.services.mozilla.com; style-src 'self'; default-src 'self'; script-src 'self' https://www.google-analytics.com/; img-src 'self' mozillausercontent.com https://profile.stage.mozaws.net`