### PR TITLE
Allow Next.js to add styles inline

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -86,7 +86,7 @@ CSP_SCRIPT_SRC = (
 # if settings.DEBUG:
 #     CSP_SCRIPT_SRC += ("'unsafe-inline'",)
 
-CSP_STYLE_SRC = ("'self'",)
+CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")
 # TODO: Add with silk
 # if settings.DEBUG:
 #     CSP_STYLE_SRC += ("'unsafe-inline'",)


### PR DESCRIPTION
When switching pages, Next.js loads the relevant styles on-demand to avoid bloating the initial bundle. These styles are injected as inline styles, so our Content Security Policy should allow for that. This setting should be a lot safer for styles than if it were used for scripts.

How to test: Before this PR, run the Django server with React enabled, then switch pages - you'll see the styles disappearing (this can also be tested out on stage). With this PR, the styles should be applied just fine.
