### PR TITLE
Fix #1737 - Add Finland and Sweden to Interstitial page

### DIFF
--- a/frontend/src/pages/premium.page.tsx
+++ b/frontend/src/pages/premium.page.tsx
@@ -81,7 +81,7 @@ const PremiumPromo: NextPage = () => {
   ) : (
     <Button
       disabled={true}
-      title={l10n.getString("premium-promo-availability-warning")}
+      title={l10n.getString("premium-promo-availability-warning-2")}
     >
       {l10n.getString("premium-promo-hero-cta")}
     </Button>
@@ -124,7 +124,7 @@ const PremiumPromo: NextPage = () => {
               <p />
             </Localized>
             {cta}
-            <p>{l10n.getString("premium-promo-availability-warning")}</p>
+            <p>{l10n.getString("premium-promo-availability-warning-2")}</p>
           </div>
           <div className={styles["demo-phone"]}>
             <DemoPhone


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #1737

<!-- When adding a new feature: -->

# New feature description
Adds Finland and Sweden to the list.


# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/13066134/162263059-043a54c6-9316-4c69-b9b5-7de5aabd3543.png)


# How to test
Go to `localhost:3000/premium` and check that the list of countries include Finland and Sweden.


# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
