### PR TITLE
Fix #1654 MPP-1781: Add SITE_ORIGIN to faq url in email header

### DIFF
--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -49,9 +49,11 @@
                   {% if has_attachment %}
                       {% ftlmsg 'nav-faq' as faq_text %}
                       {% url 'faq' as faq_url %}
-                      {% bold_violet_link faq_url faq_text as faq_link %}
-                      {% ftlmsg 'forwarded-email-header-attachment' faq_link=faq_link size='10' unit='MB' as forwarded_email_wrap_attachment %}
-                      {{ forwarded_email_wrap_attachment|safe }}
+                      {% with SITE_ORIGIN|add:faq_url as faq_url %}
+                          {% bold_violet_link faq_url faq_text as faq_link %}
+                          {% ftlmsg 'forwarded-email-header-attachment' faq_link=faq_link size='10' unit='MB' as forwarded_email_wrap_attachment %}
+                          {{ forwarded_email_wrap_attachment|safe }}
+                      {% endwith %}
                   {% else %}
                     {% if survey_text and survey_link %}
                     <br><a href="{{ survey_link }}" target="_blank" rel="noopener noreferrer" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">{{ survey_text }}</a>.

--- a/emails/views.py
+++ b/emails/views.py
@@ -68,7 +68,7 @@ class InReplyToNotFound(Exception):
 def wrapped_email_test(request):
     html_content = '<p><strong>strong</strong></p><hr><p>plain</p>'
     display_email = 'test@relay.firefox.com'
-    attachments = None
+    attachments = ['fdsa']
     user_profile = Profile.objects.order_by('?').first()
     test_email_context = {
         'original_html': html_content,


### PR DESCRIPTION
This PR fixes #1654 MPP-1781.

How to test:
1. Go to http://127.0.0.1:8000/emails/wrapped_email_test
2. Inspect the "FAQ" link
   * [ ] Verify the `href` value is the FULL url `http://127.0.0.1:8000/faq` (previously it was just `/faq`)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
