### PR TITLE
Use document.location to determine the referrer

### DIFF
--- a/frontend/src/components/layout/AppPicker.tsx
+++ b/frontend/src/components/layout/AppPicker.tsx
@@ -84,7 +84,11 @@ const getProducts = (referringSiteUrl: string) => ({
 export const AppPicker = (props: { theme?: LayoutProps["theme"] } = {}) => {
   const { l10n } = useLocalization();
 
-  const products = getProducts(getRuntimeConfig().frontendOrigin);
+  const products = getProducts(
+    typeof document !== "undefined"
+      ? document.location.host
+      : "relay.firefox.com"
+  );
   const linkRefs: Record<
     keyof typeof products,
     RefObject<HTMLAnchorElement>


### PR DESCRIPTION
This PR fixes #562.

How to test: open the app picker. The `utm_source` parameter on links in there should be set to the current website now (rather than the empty string that it was on stage).

![image](https://user-images.githubusercontent.com/4251/162723804-19a98c2a-0b39-4c6a-89be-fe0619caacc7.png)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A (Would need to mock `document.location`, so very implementation-specific.)
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
