### PR TITLE
Header fixes

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -21,7 +21,7 @@ const runtimeConfigs = {
       criticalEmailsTip: false,
       addonSigninTip: false,
       interviewRecruitment: false,
-      csatSurvey: false,
+      csatSurvey: true,
     },
   },
 };

--- a/frontend/src/components/layout/Layout.module.scss
+++ b/frontend/src/components/layout/Layout.module.scss
@@ -22,6 +22,7 @@
 
 .header {
   position: sticky;
+  top: 0;
   // The sticky position causes a new stacking context,
   // which is stacked below elements lower in the document
   // with their own stacking contexts (specifically,
@@ -95,6 +96,7 @@
     }
   }
   &.is-light {
+    background-color: $color-white;
     color: $color-grey-40;
   }
 

--- a/frontend/src/components/layout/Layout.module.scss
+++ b/frontend/src/components/layout/Layout.module.scss
@@ -94,6 +94,9 @@
       color: $color-light-gray-30;
     }
   }
+  &.is-light {
+    color: $color-grey-40;
+  }
 
   @media screen and #{$mq-md} {
     .logo {

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -43,7 +43,7 @@ export const Layout = (props: Props) => {
     typeof props.theme !== "undefined"
       ? props.theme === "free"
       : !profiles.data?.[0].has_premium;
-  const darkClass = isDark ? styles["is-dark"] : "";
+  const darkClass = isDark ? styles["is-dark"] : styles["is-light"];
   const premiumLogo = isDark ? logoTypePremiumLight : logoTypePremiumDark;
   const regularLogo = isDark ? logoTypeLight : logoTypeDark;
   // The Premium logo is always shown if the user has Premium

--- a/frontend/src/components/layout/Navigation.module.scss
+++ b/frontend/src/components/layout/Navigation.module.scss
@@ -6,7 +6,7 @@
   justify-content: flex-end;
   width: 100%;
   padding: $spacing-sm $spacing-md;
-  gap: $spacing-md;
+  gap: $spacing-lg;
 }
 
 .link {

--- a/frontend/src/components/layout/UserMenu.module.scss
+++ b/frontend/src/components/layout/UserMenu.module.scss
@@ -101,6 +101,7 @@
 
       img {
         margin-right: $spacing-md;
+        width: 16px;
       }
 
       &:hover {

--- a/frontend/src/components/layout/whatsnew/WhatsNewDashboard.module.scss
+++ b/frontend/src/components/layout/whatsnew/WhatsNewDashboard.module.scss
@@ -65,6 +65,10 @@
     }
   }
 
+  .content {
+    padding-bottom: $spacing-sm;
+  }
+
   .footer-controls {
     padding: $spacing-xs $spacing-md;
 
@@ -72,6 +76,7 @@
       display: flex;
       align-items: center;
       border-top: 1px solid $color-light-gray-20;
+      padding: $spacing-sm 0;
 
       .start {
         flex: 1 0 0;

--- a/frontend/src/components/layout/whatsnew/WhatsNewDashboard.tsx
+++ b/frontend/src/components/layout/whatsnew/WhatsNewDashboard.tsx
@@ -116,11 +116,13 @@ const Tabs = (props: TabProps) => {
           <CloseIcon alt={l10n.getString("whatsnew-close-label")} />
         </button>
       </header>
-      {props.expandedEntry ? (
-        props.expandedEntry.content
-      ) : (
-        <TabContent key={tabListState.selectedKey} state={tabListState} />
-      )}
+      <div className={styles.content}>
+        {props.expandedEntry ? (
+          props.expandedEntry.content
+        ) : (
+          <TabContent key={tabListState.selectedKey} state={tabListState} />
+        )}
+      </div>
       {footer}
     </section>
   );

--- a/frontend/src/components/layout/whatsnew/WhatsNewList.module.scss
+++ b/frontend/src/components/layout/whatsnew/WhatsNewList.module.scss
@@ -4,7 +4,8 @@
 .empty-message {
   display: flex;
   flex-direction: column;
-  padding: $spacing-lg;
+  padding-top: $spacing-lg;
+  padding-bottom: $spacing-2xl;
   gap: $spacing-lg;
   align-items: center;
   text-align: center;

--- a/frontend/src/components/layout/whatsnew/WhatsNewList.module.scss
+++ b/frontend/src/components/layout/whatsnew/WhatsNewList.module.scss
@@ -35,7 +35,7 @@
     &:focus {
       outline: none;
 
-      h3 {
+      &:not(:hover) h3 {
         text-decoration: underline;
       }
     }

--- a/frontend/src/components/layout/whatsnew/WhatsNewMenu.module.scss
+++ b/frontend/src/components/layout/whatsnew/WhatsNewMenu.module.scss
@@ -45,16 +45,8 @@
     width: 12px;
     position: absolute;
     top: -6px;
-    right: $spacing-md;
+    right: $spacing-lg;
     transform: rotate(45deg);
     background-color: $color-white;
-
-    @media screen and #{$mq-md} {
-      // On a small screen, there are no app and user menu's to the right of the
-      // trigger, so the arrow has to be pretty much on the right-hand side.
-      // However, on a wider screen, it should be roughly at a third of the
-      // width to align with the trigger:
-      right: calc($content-sm / 3);
-    }
   }
 }

--- a/frontend/src/components/layout/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/whatsnew/WhatsNewMenu.tsx
@@ -185,7 +185,7 @@ export const WhatsNewMenu = (props: Props) => {
   const positionProps = useOverlayPosition({
     targetRef: triggerRef,
     overlayRef: overlayRef,
-    placement: "bottom",
+    placement: "bottom end",
     offset: 10,
     isOpen: triggerState.isOpen,
   }).overlayProps;


### PR DESCRIPTION
Bundling a couple of the requested UI changes for the header in a single PR. This:

- Increases the padding at the bottom of the "What's new" dropdown.
- Makes icons in the user menu smaller.
- Lightens the header font for new Premium users.
- Makes the header sticky.
- Increases horizontal padding for menu iems.
- Better aligns the chevron of the "What's new menu". (Properly attaching that is still a pain though, I don't think we have a better strategy other than spitballing the offset a bit, do we?)
- Remove underlines from hovered "What's new" entries.

~~I haven't figured out yet how to remove the underline in the "What's new" menu without removing it on focus (which Eduardo is fine with). I'll update this PR if I do.~~