### PR TITLE
Add stylelint rule preventing shorthand overrides

### DIFF
--- a/frontend/.stylelintrc.cjs
+++ b/frontend/.stylelintrc.cjs
@@ -24,6 +24,7 @@ module.exports = {
     "at-rule-no-unknown": null,
     "block-opening-brace-newline-after": "always",
     "block-closing-brace-newline-after": "always",
+    "declaration-block-no-shorthand-property-overrides": true,
     "declaration-block-semicolon-newline-after": "always",
     "declaration-colon-space-after": "always-single-line",
     "declaration-colon-space-before": "never",


### PR DESCRIPTION
Enables declaration-block-no-shorthand-property-overrides, as suggested in https://github.com/mozilla/fx-private-relay/pull/1766/files/aa7a8efe8f2bb7c592c77ccfd361e3b14b14e369#r847442222. (Not sure if it was worth a separate PR, since @maxxcrawford suggested it and @codemist :+1:'d it, but better safe than sorry :slightly_smiling_face: )

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
