### PR TITLE
Fix logging out when using the dev server locally

### DIFF
--- a/frontend/src/pages/index.page.tsx
+++ b/frontend/src/pages/index.page.tsx
@@ -35,7 +35,7 @@ const Home: NextPage = () => {
     label: "home-hero-cta",
   });
 
-  if (typeof userData.data?.[0] === "object") {
+  if (typeof userData.data?.[0] === "object" && !userData.error) {
     router.push("/accounts/profile/");
   }
 

--- a/frontend/src/pages/mock/logout.page.tsx
+++ b/frontend/src/pages/mock/logout.page.tsx
@@ -3,10 +3,14 @@ import { useRouter } from "next/router";
 import { MouseEventHandler } from "react";
 import { getRuntimeConfig } from "../../config";
 import { authenticatedFetch } from "../../hooks/api/api";
+import { useProfiles } from "../../hooks/api/profile";
+import { useUsers } from "../../hooks/api/user";
 import styles from "./mockSession.module.scss";
 
 const MockLogout: NextPage = () => {
   const router = useRouter();
+  const profiles = useProfiles();
+  const users = useUsers();
 
   const onLogout: MouseEventHandler = async (event) => {
     event.preventDefault();
@@ -19,6 +23,9 @@ const MockLogout: NextPage = () => {
       method: "GET",
       redirect: "manual",
     });
+    // Revalidate account data to reflect logged out status:
+    await profiles.mutate();
+    await users.mutate();
 
     router.push("/");
   };


### PR DESCRIPTION
On the production website, a logout redirects the user to Firefox
Accounts, thereby inducing a full page refresh. However, when
mocking that logout flow locally, we remain in the context of the
Single-Page App, and therefore user data remained cached in memory.
This change forces a revalidation of user data after clearing the
session key, which then results in that data no longer being
available and thus the user's logged-out status being properly
recognised.

It also more thoroughly detects whether the user is logged in on
the homepage, by not only checking if user data is available, but
also that refetching it did not result in an error (which it does
if the user is logged out).

How to test: run the dev server (`npm run dev`), log in as a user, then log out again. Observe that the "Sign up" and "Sign in" buttons in the top menu are present without refreshing, as opposed to them disappearing like they do on `main`.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug: No, mocking both the router and the user API for what is otherwise a static page felt like overkill, but let me know if you disagree.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
