### PR TITLE
Fail `build_test_backend` when a test fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,8 +156,8 @@ jobs:
               /bin/sh -c \
                 "chmod 0777 /tmp/workspace && \
                  chown 10001:10001 /tmp/workspace"
-            # Run coverage tests, outputting the results in XML format
-            docker run \
+            # Run coverage tests, outputting the results in XML format, capture exit code
+            (docker run \
               --entrypoint "/bin/bash" \
               --volumes-from workspace-test-results \
               fx-private-relay \
@@ -172,12 +172,18 @@ jobs:
                    --cov-fail-under=60 \
                    --cov-branch \
                    --junitxml=/tmp/workspace/test-results/pytest/results.xml ; \
+                 TEST_STATUS=$?
                  mv coverage.xml /tmp/workspace/test-results/backend-coverage/results.xml ; \
-                 mv .coverage /tmp/workspace/test-results/backend-coverage/.coverage'
+                 mv .coverage /tmp/workspace/test-results/backend-coverage/.coverage; \
+                 exit $TEST_STATUS')
+            TEST_STATUS=$?
 
             # Copy results to local disk
             mkdir --parents /tmp/workspace/
             docker cp workspace-test-results:/tmp/workspace/test-results /tmp/workspace
+
+            # Exit with test error code
+            exit $TEST_STATUS
 
       - store_test_results:
           path: /tmp/workspace/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,27 +156,30 @@ jobs:
               /bin/sh -c \
                 "chmod 0777 /tmp/workspace && \
                  chown 10001:10001 /tmp/workspace"
+
             # Run coverage tests, outputting the results in XML format, capture exit code
-            (docker run \
+            set +e
+            docker run \
               --entrypoint "/bin/bash" \
               --volumes-from workspace-test-results \
               fx-private-relay \
               -c \
                 'mkdir --parents /tmp/workspace/test-results/pytest && \
                  mkdir --parents /tmp/workspace/test-results/backend-coverage && \
-                 /app/.local/bin/pytest \
+                 (/app/.local/bin/pytest \
                    --cov=. \
                    --cov-config=.coveragerc \
                    --cov-report=term-missing \
                    --cov-report=xml \
                    --cov-fail-under=60 \
                    --cov-branch \
-                   --junitxml=/tmp/workspace/test-results/pytest/results.xml ; \
+                   --junitxml=/tmp/workspace/test-results/pytest/results.xml) ; \
                  TEST_STATUS=$?
                  mv coverage.xml /tmp/workspace/test-results/backend-coverage/results.xml ; \
                  mv .coverage /tmp/workspace/test-results/backend-coverage/.coverage; \
-                 exit $TEST_STATUS')
+                 exit $TEST_STATUS'
             TEST_STATUS=$?
+            set -e
 
             # Copy results to local disk
             mkdir --parents /tmp/workspace/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,18 +166,18 @@ jobs:
               -c \
                 'mkdir --parents /tmp/workspace/test-results/pytest && \
                  mkdir --parents /tmp/workspace/test-results/backend-coverage && \
-                 (/app/.local/bin/pytest \
+                 /app/.local/bin/pytest \
                    --cov=. \
                    --cov-config=.coveragerc \
                    --cov-report=term-missing \
                    --cov-report=xml \
                    --cov-fail-under=60 \
                    --cov-branch \
-                   --junitxml=/tmp/workspace/test-results/pytest/results.xml) ; \
-                 TEST_STATUS=$?
+                   --junitxml=/tmp/workspace/test-results/pytest/results.xml ; \
+                 STATUS=$?
                  mv coverage.xml /tmp/workspace/test-results/backend-coverage/results.xml ; \
                  mv .coverage /tmp/workspace/test-results/backend-coverage/.coverage; \
-                 exit $TEST_STATUS'
+                 exit $STATUS'
             TEST_STATUS=$?
             set -e
 

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -56,3 +56,8 @@ class PremiumPlanIDTest(TestCase):
 
         plan_id = premium_plan_id('fi', 'fi')
         assert plan_id == plans['euro']['fi']['id']
+
+
+def test_circleci_failure():
+    """Test that a test failure will fail the CircleCI build (issue #1778)"""
+    assert 0 == 1

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -56,8 +56,3 @@ class PremiumPlanIDTest(TestCase):
 
         plan_id = premium_plan_id('fi', 'fi')
         assert plan_id == plans['euro']['fi']['id']
-
-
-def test_circleci_failure():
-    """Test that a test failure will fail the CircleCI build (issue #1778)"""
-    assert 0 == 1


### PR DESCRIPTION
This PR fixes #1778, by ensuring the return code from running tests is the exit code of the `Test Code` step.

How to test:
* Failing test fails build, and has test results - see [build 4811](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/4811)
* Passing tests pass build - see [build 4812](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/4812)