### PR TITLE
Use a special endpoint to set the subdomain

### DIFF
--- a/frontend/src/hooks/api/api.ts
+++ b/frontend/src/hooks/api/api.ts
@@ -23,8 +23,11 @@ export const authenticatedFetch = async (
     authToken = localStorage.getItem("authToken");
   }
   const headers = new Headers(init?.headers ?? undefined);
-  headers.set("Content-Type", "application/json");
-  headers.set("Accept", "application/json");
+  headers.set(
+    "Content-Type",
+    headers.get("Content-Type") ?? "application/json"
+  );
+  headers.set("Accept", headers.get("Accept") ?? "application/json");
   if (typeof authToken === "string") {
     headers.set("Authorization", `Token ${authToken}`);
   }

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -80,9 +80,7 @@ const Profile: NextPage = () => {
   }
 
   const setCustomSubdomain = async (customSubdomain: string) => {
-    const response = await profileData.update(profile.id, {
-      subdomain: customSubdomain,
-    });
+    const response = await profileData.setSubdomain(customSubdomain);
     if (!response.ok) {
       toast(
         l10n.getString("error-subdomain-not-available", {


### PR DESCRIPTION
When sending a PATCH to /profiles/, we directly modify the profile
table. However, that foregoes some additional actions performed in
the subdomain-specific endpoint that allow us to inform other
users when they're trying to register a taken subdomain.

This PR fixes #1770. I'm not sure if this is the best fix - ideally these checks would also be executed on the backend for PATCH requests. That said, it might be good to apply this first and then revert it if we have a lower-level fix later, to ensure that we don't have data loss (hashed domains) while we await that.

How to test: Register a new subdomain locally, then with a different user, try to register the same subdomain. You should now getting an error when looking it up, rather than when trying to register it.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A - bug is in backend.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
