### PR TITLE
 Toast notification for Signed in/out users

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -112,3 +112,6 @@ whatsnew-feature-forward-some-description = { -brand-name-relay-premium } allows
 whatsnew-feature-alias-to-mask-heading = Aliases are now masks
 whatsnew-feature-alias-to-mask-snippet = Notice a change? We’re now calling aliases “masks” to make { -brand-name-firefox-relay }…
 whatsnew-feature-alias-to-mask-description = Notice a change? We’re now calling aliases “masks” to make { -brand-name-firefox-relay } easier to use and open the door for new features.
+
+success-signed-out-message = You have signed out.
+success-signed-in-message = Successfully signed in as 

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -114,4 +114,5 @@ whatsnew-feature-alias-to-mask-snippet = Notice a change? We’re now calling al
 whatsnew-feature-alias-to-mask-description = Notice a change? We’re now calling aliases “masks” to make { -brand-name-firefox-relay } easier to use and open the door for new features.
 
 success-signed-out-message = You have signed out.
-success-signed-in-message = Successfully signed in as 
+success-signed-in-message = Successfully signed in as
+

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -114,5 +114,6 @@ whatsnew-feature-alias-to-mask-snippet = Notice a change? We’re now calling al
 whatsnew-feature-alias-to-mask-description = Notice a change? We’re now calling aliases “masks” to make { -brand-name-firefox-relay } easier to use and open the door for new features.
 
 success-signed-out-message = You have signed out.
-success-signed-in-message = Successfully signed in as
+success-signed-in-message = Successfully signed in as { $username }.
+
 

--- a/frontend/src/components/layout/Layout.module.scss
+++ b/frontend/src/components/layout/Layout.module.scss
@@ -7,7 +7,7 @@
 
   // See https://fkhadra.github.io/react-toastify/how-to-style#override-css-variables
   --toastify-toast-width: 95%;
-  --toastify-color-success: #{$color-green-60};
+  --toastify-color-success: #{$color-green-50};
   --toastify-text-color-success: #{$color-white};
   --toastify-color-error: #{$color-red-50};
   --toastify-text-color-error: #{$color-white};

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -26,6 +26,7 @@ import { InterviewRecruitment } from "./InterviewRecruitment";
 import { WhatsNewMenu } from "./whatsnew/WhatsNewMenu";
 import { makeToast } from "./Toast";
 import { useUsers } from "../../hooks/api/user";
+import { users } from "../../apiMocks/mockData";
 
 export type Props = {
   children: ReactNode;
@@ -43,8 +44,10 @@ export const Layout = (props: Props) => {
   const usersData = useUsers().data?.[0];
 
   useEffect(() => {
-    makeToast(l10n, usersData);
-  }, []);
+    if (typeof usersData !== "undefined") {
+      makeToast(l10n, usersData);
+    }
+  }, [l10n, usersData]);
 
   const isDark =
     typeof props.theme !== "undefined"

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -25,6 +25,7 @@ import { CsatSurvey } from "./CsatSurvey";
 import { InterviewRecruitment } from "./InterviewRecruitment";
 import { WhatsNewMenu } from "./whatsnew/WhatsNewMenu";
 import { makeToast } from "./Toast";
+import { useUsers } from "../../hooks/api/user";
 
 export type Props = {
   children: ReactNode;
@@ -39,9 +40,10 @@ export const Layout = (props: Props) => {
   const profiles = useProfiles();
   const isLoggedIn = useIsLoggedIn();
   const router = useRouter();
+  const usersData = useUsers().data?.[0];
 
   useEffect(() => {
-    makeToast(l10n);
+    makeToast(l10n, usersData);
   }, []);
 
   const isDark =

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -26,7 +26,6 @@ import { InterviewRecruitment } from "./InterviewRecruitment";
 import { WhatsNewMenu } from "./whatsnew/WhatsNewMenu";
 import { makeToast } from "./Toast";
 import { useUsers } from "../../hooks/api/user";
-import { users } from "../../apiMocks/mockData";
 
 export type Props = {
   children: ReactNode;

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -43,9 +43,7 @@ export const Layout = (props: Props) => {
   const usersData = useUsers().data?.[0];
 
   useEffect(() => {
-    if (typeof usersData !== "undefined") {
-      makeToast(l10n, usersData);
-    }
+    makeToast(l10n, usersData);
   }, [l10n, usersData]);
 
   const isDark =

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -24,6 +24,7 @@ import { getRuntimeConfig } from "../../config";
 import { CsatSurvey } from "./CsatSurvey";
 import { InterviewRecruitment } from "./InterviewRecruitment";
 import { WhatsNewMenu } from "./whatsnew/WhatsNewMenu";
+import { makeToast } from "./Toast";
 
 export type Props = {
   children: ReactNode;
@@ -34,6 +35,10 @@ export type Props = {
  * Standard page layout for Relay, wrapping its children in the relevant header and footer.
  */
 export const Layout = (props: Props) => {
+  useEffect(() => {
+    makeToast();
+  }, []);
+
   const { l10n } = useLocalization();
   const profiles = useProfiles();
   const isLoggedIn = useIsLoggedIn();

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -35,14 +35,14 @@ export type Props = {
  * Standard page layout for Relay, wrapping its children in the relevant header and footer.
  */
 export const Layout = (props: Props) => {
-  useEffect(() => {
-    makeToast();
-  }, []);
-
   const { l10n } = useLocalization();
   const profiles = useProfiles();
   const isLoggedIn = useIsLoggedIn();
   const router = useRouter();
+
+  useEffect(() => {
+    makeToast(l10n);
+  }, []);
 
   const isDark =
     typeof props.theme !== "undefined"
@@ -160,6 +160,7 @@ export const Layout = (props: Props) => {
           theme="colored"
           transition={Slide}
           autoClose={5000}
+          hideProgressBar={true}
           toastClassName={`Toastify__toast ${styles.toast}`}
         />
         <div className={styles.content}>{props.children}</div>

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -6,6 +6,7 @@ import styles from "./Navigation.module.scss";
 import { useIsLoggedIn } from "../../hooks/session";
 import { getRuntimeConfig } from "../../config";
 import { useGaViewPing } from "../../hooks/gaViewPing";
+import { setCookie } from "../../functions/cookies";
 
 /** Switch between the different pages of the Relay website. */
 export const Navigation = () => {
@@ -23,13 +24,14 @@ export const Navigation = () => {
     <a
       href={getRuntimeConfig().fxaLoginUrl}
       ref={signUpButtonRef}
-      onClick={() =>
+      onClick={() => {
         gaEvent({
           category: "Sign In",
           action: "Engage",
           label: "nav-profile-sign-up",
-        })
-      }
+        });
+        setCookie("user-sign-in", "true", { maxAgeInSeconds: 60 * 60 });
+      }}
       className={styles.link}
     >
       {l10n.getString("nav-profile-sign-up")}
@@ -44,13 +46,14 @@ export const Navigation = () => {
     <a
       href={getRuntimeConfig().fxaLoginUrl}
       ref={signInButtonRef}
-      onClick={() =>
+      onClick={() => {
         gaEvent({
           category: "Sign In",
           action: "Engage",
           label: "nav-profile-sign-in",
-        })
-      }
+        });
+        setCookie("user-sign-in", "true", { maxAgeInSeconds: 60 * 60 });
+      }}
       className={`${styles.link} ${styles["sign-in-button"]}`}
     >
       {l10n.getString("nav-profile-sign-in")}

--- a/frontend/src/components/layout/Toast.tsx
+++ b/frontend/src/components/layout/Toast.tsx
@@ -16,7 +16,7 @@ export function makeToast(l10n: ReactLocalization, usersData: UserData) {
   if (checkUserSignIn) {
     clearCookie("user-sign-in");
     return toast.success(
-      l10n.getString("success-signed-in-message") + "  " + usersData.email
+      l10n.getString("success-signed-in-message", { username: usersData.email })
     );
   }
 }

--- a/frontend/src/components/layout/Toast.tsx
+++ b/frontend/src/components/layout/Toast.tsx
@@ -3,7 +3,7 @@ import { toast } from "react-toastify";
 import { ReactLocalization } from "@fluent/react";
 import { UserData } from "../../hooks/api/user";
 
-export function makeToast(l10n: ReactLocalization, usersData: UserData) {
+export function makeToast(l10n: ReactLocalization, usersData?: UserData) {
   const checkUserSignOut = getCookie("user-sign-out");
 
   const checkUserSignIn = getCookie("user-sign-in");
@@ -13,7 +13,7 @@ export function makeToast(l10n: ReactLocalization, usersData: UserData) {
     return toast.success(l10n.getString("success-signed-out-message"));
   }
 
-  if (checkUserSignIn) {
+  if (checkUserSignIn && typeof usersData !== "undefined") {
     clearCookie("user-sign-in");
     return toast.success(
       l10n.getString("success-signed-in-message", { username: usersData.email })

--- a/frontend/src/components/layout/Toast.tsx
+++ b/frontend/src/components/layout/Toast.tsx
@@ -1,8 +1,9 @@
 import { clearCookie, getCookie } from "../../functions/cookies";
 import { toast } from "react-toastify";
 import { ReactLocalization } from "@fluent/react";
+import { UserData } from "../../hooks/api/user";
 
-export function makeToast(l10n: ReactLocalization, usersData: any) {
+export function makeToast(l10n: ReactLocalization, usersData: UserData) {
   const checkUserSignOut = getCookie("user-sign-out");
 
   const checkUserSignIn = getCookie("user-sign-in");

--- a/frontend/src/components/layout/Toast.tsx
+++ b/frontend/src/components/layout/Toast.tsx
@@ -2,7 +2,7 @@ import { clearCookie, getCookie } from "../../functions/cookies";
 import { toast } from "react-toastify";
 import { ReactLocalization } from "@fluent/react";
 
-export function makeToast(l10n: ReactLocalization) {
+export function makeToast(l10n: ReactLocalization, usersData: any) {
   const checkUserSignOut = getCookie("user-sign-out");
 
   const checkUserSignIn = getCookie("user-sign-in");
@@ -14,6 +14,8 @@ export function makeToast(l10n: ReactLocalization) {
 
   if (checkUserSignIn) {
     clearCookie("user-sign-in");
-    return toast.success(l10n.getString("success-signed-in-message"));
+    return toast.success(
+      l10n.getString("success-signed-in-message") + "  " + usersData.email
+    );
   }
 }

--- a/frontend/src/components/layout/Toast.tsx
+++ b/frontend/src/components/layout/Toast.tsx
@@ -1,18 +1,19 @@
 import { clearCookie, getCookie } from "../../functions/cookies";
 import { toast } from "react-toastify";
+import { ReactLocalization, useLocalization } from "@fluent/react";
 
-export function makeToast() {
+export function makeToast(l10n: ReactLocalization) {
   const checkUserSignOut = getCookie("user-sign-out");
 
   const checkUserSignIn = getCookie("user-sign-in");
 
   if (checkUserSignOut) {
     clearCookie("user-sign-out");
-    return toast.success("Successfully toasted!");
+    return toast.success(l10n.getString("success-signed-out-message"));
   }
 
   if (checkUserSignIn) {
     clearCookie("user-sign-in");
-    return toast.success("Successfully signed in");
+    return toast.success(l10n.getString("success-signed-in-message"));
   }
 }

--- a/frontend/src/components/layout/Toast.tsx
+++ b/frontend/src/components/layout/Toast.tsx
@@ -1,0 +1,18 @@
+import { clearCookie, getCookie } from "../../functions/cookies";
+import { toast } from "react-toastify";
+
+export function makeToast() {
+  const checkUserSignOut = getCookie("user-sign-out");
+
+  const checkUserSignIn = getCookie("user-sign-in");
+
+  if (checkUserSignOut) {
+    clearCookie("user-sign-out");
+    return toast.success("Successfully toasted!");
+  }
+
+  if (checkUserSignIn) {
+    clearCookie("user-sign-in");
+    return toast.success("Successfully signed in");
+  }
+}

--- a/frontend/src/components/layout/Toast.tsx
+++ b/frontend/src/components/layout/Toast.tsx
@@ -1,6 +1,6 @@
 import { clearCookie, getCookie } from "../../functions/cookies";
 import { toast } from "react-toastify";
-import { ReactLocalization, useLocalization } from "@fluent/react";
+import { ReactLocalization } from "@fluent/react";
 
 export function makeToast(l10n: ReactLocalization) {
   const checkUserSignOut = getCookie("user-sign-out");

--- a/frontend/src/components/layout/UserMenu.tsx
+++ b/frontend/src/components/layout/UserMenu.tsx
@@ -34,6 +34,7 @@ import { useProfiles } from "../../hooks/api/profile";
 import { getRuntimeConfig } from "../../config";
 import { getCsrfToken } from "../../functions/cookies";
 import { useRuntimeData } from "../../hooks/api/runtimeData";
+import { setCookie } from "../../functions/cookies";
 
 /**
  * Display the user's avatar, which can open a menu allowing the user to log out or go to their settings page.
@@ -85,6 +86,7 @@ export const UserMenu = () => {
         action: "Click",
         label: "Website Sign Out",
       });
+      setCookie("user-sign-out", "true", { maxAgeInSeconds: 60 * 60 });
       logoutFormRef.current?.submit();
     }
   };

--- a/frontend/src/pages/index.page.tsx
+++ b/frontend/src/pages/index.page.tsx
@@ -24,6 +24,7 @@ import { Plans } from "../components/landing/Plans";
 import { getPlan, isPremiumAvailableInCountry } from "../functions/getPlan";
 import { FaqAccordion } from "../components/landing/FaqAccordion";
 import { getRuntimeConfig } from "../config";
+import { setCookie } from "../functions/cookies";
 
 const Home: NextPage = () => {
   const { l10n } = useLocalization();
@@ -45,6 +46,7 @@ const Home: NextPage = () => {
       action: "Engage",
       label: "home-hero-cta",
     });
+    setCookie("user-sign-in", "true", { maxAgeInSeconds: 60 * 60 });
   };
 
   const plansSection = isPremiumAvailableInCountry(runtimeData.data) ? (


### PR DESCRIPTION
<!-- When adding a new feature: -->

 L10N pr: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/76

# New feature description
This adds the toast notification for signed in/out users.


# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/13066134/165045249-cd2ab28b-4b6a-4a03-b428-1ba183edaee6.png)
![image](https://user-images.githubusercontent.com/13066134/165045300-ec67d757-391c-4635-b684-84872bf0abff.png)


# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
