### PR TITLE
Fix #1791 - Remove Zilla Slab font link

### DIFF
--- a/static/scss/app.scss
+++ b/static/scss/app.scss
@@ -11,7 +11,6 @@ $font-path: "/static/fonts";
 @import "includes/utils";
 @import "includes/fonts/inter-ui";
 @import "includes/fonts/metropolis";
-@import "includes/fonts/zilla-slab";
 
 // Components
 @import "components/banners";


### PR DESCRIPTION

This PR fixes #1791



# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
