### PR TITLE
for MPP-1639: Add prefetch_related to Profile queries

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import User
 class PremiumValidatorsMixin:
     # the user must be premium to set block_list_emails=True
     def validate_block_list_emails(self, value):
-        if self.context['request'].user.profile_set.first().has_premium:
+        if self.context['request'].user.profile_set.prefetch_related('user__socialaccount_set').first().has_premium:
             return value
         raise exceptions.AuthenticationFailed(
             'Must be premium to set block_list_emails'

--- a/privaterelay/context_processors.py
+++ b/privaterelay/context_processors.py
@@ -52,7 +52,7 @@ def _get_fxa(request):
 def _get_csat_cookie_and_reason(request):
     if not request.user.is_authenticated:
         return None, None
-    profile = request.user.profile_set.first()
+    profile = request.user.profile_set.prefetch_related('user__socialaccount_set').first()
     first_visit = request.COOKIES.get(
         "first_visit", datetime.now(timezone.utc).isoformat()
     )


### PR DESCRIPTION
To eliminate the duplicate user socialaccount queries in the
/api/v1/relayaddresses endpoint, use Profile prefetch_related to fetch
those values in the single Profile query.

This PR is for MPP-1639.

How to test:
1. Visit http://127.0.0.1:8000/api/v1/relayaddresses/
   * It should still work

How to *really* test:
1. Add `django-silk` for profiling ...
   * https://github.com/jazzband/django-silk
   * https://gist.github.com/groovecoder/5d2963d753cdfa690507a415b565dbaa
2. Visit http://127.0.0.1:8000/api/v1/relayaddresses/
3. Visit http://127.0.0.1:8000/silk/
4. Click the request to `/api/v1/relayaddresses/`
5. Click "SQL at the top
   * Verify there are only 2 queries to `socialaccount_socialaccount` (There used to be 5)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).