### PR TITLE
Handle unexpected SNS message types in `_sns_notifications`

### DIFF
--- a/emails/tests/fixtures/subscription_confirmation_invalid_sns_body.json
+++ b/emails/tests/fixtures/subscription_confirmation_invalid_sns_body.json
@@ -1,0 +1,12 @@
+{
+  "Type" : "SubscriptionConfirmation",
+  "MessageId" : "7f46a153-88ff-4d95-91f5-188d2b695155",
+  "Token" : "2336412f37fb687f5d51e6e2425dacbbab295a4858a33cdb6a8cb0ebfce2003796d8ff517616ab3f7b3399952cfecff575466f243a7004fee6c6ee158d69719622e8a10033953c30ea660bf52dd13c456e97af0a5676a6415184c0d6c0091ee11f983a5072b0a316e97b121fbb6d6d0ff4a9e274e17d276ff754786d34bf6d22",
+  "TopicArn" : "arn:aws:sns:us-east-1:032756942992:dev-relay-2022-04",
+  "Message" : "You have chosen to subscribe to the topic arn:aws:sns:us-east-1:032756942992:dev-relay-2022-04.\nTo confirm the subscription, visit the SubscribeURL included in this message.",
+  "SubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:us-east-1:032756942992:dev-relay-2022-04&Token=2336412f37fb687f5d51e6e2425dacbbab295a4858a33cdb6a8cb0ebfce2003796d8ff517616ab3f7b3399952cfecff575466f243a7004fee6c6ee158d69719622e8a10033953c30ea660bf52dd13c456e97af0a5676a6415184c0d6c0091ee11f983a5072b0a316e97b121fbb6d6d0ff4a9e274e17d276ff754786d34bf6d22",
+  "Timestamp" : "2022-04-19T20:25:48.950Z",
+  "SignatureVersion" : "1",
+  "Signature" : "egOmUc2HSvcni68vkpptBY1O9AQiUaJEdXgKQw+sk0FR1GPtIE3R7Kqg0LSnWCD/Bsa7ICtgNu7WaCnC31CCcBjPOcVDikJicmz8RhOFhEASrVFTVF9HBfx6fKSjGXsROp0cPWSzohlM3DtlZfQGle+A8issehAL4k8+CpPsTkkZX/DIf455zJCJdkiW4kIUjAHsBUQFHpi6GUcjJ2jg4tssneE+lqoXDZLnPFulj+YSfw1jA3qWb5+sTyB8oXRiOoi2cQERi4vcBqcM2MlQxwkob2fmfS5Sq+TH4ancUGOsDxW7+kclkUAc89k4oulYSL2QUeVbbos+i+L0/LfFog==",
+  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-7ff5318490ec183fbaddaa2a969abfda.pem"
+}

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -376,7 +376,6 @@ class SNSNotificationInvalidMessageTest(TestCase):
         response = _sns_notification(json_body)
         assert response.status_code == 400
 
-    @pytest.mark.xfail(reason="raises JSONDecodeError")
     def test_subscription_confirmation(self):
         """A subscription confirmation returns a 400 error"""
         json_body = INVALID_SNS_BODIES['subscription_confirmation']

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -382,7 +382,6 @@ class SNSNotificationInvalidMessageTest(TestCase):
         response = _sns_notification(json_body)
         assert response.status_code == 400
 
-    @pytest.mark.xfail(reason="raises TypeError: expected string or bytes-like object")
     def test_notification_type_complaint(self):
         """A notificationType of complaint returns a 400 error"""
         # Manual json_body because no instances captured, from

--- a/emails/views.py
+++ b/emails/views.py
@@ -307,7 +307,7 @@ def _sns_notification(json_body):
             extra={
                 'notification_type': shlex.quote(notification_type),
                 'event_type': shlex.quote(event_type),
-                'keys': shlex.quote(list(message_json.keys())),
+                'keys': [shlex.quote(key) for key in message_json.keys()],
             },
         )
         return HttpResponse(

--- a/emails/views.py
+++ b/emails/views.py
@@ -284,7 +284,18 @@ def _sns_inbound_logic(topic_arn, message_type, json_body):
 
 
 def _sns_notification(json_body):
-    message_json = json.loads(json_body['Message'])
+    try:
+        message_json = json.loads(json_body["Message"])
+    except JSONDecodeError:
+        logger.error(
+            "SNS notification has non-JSON message body",
+            extra={"content": shlex.quote(json_body['Message'])},
+        )
+        return HttpResponse(
+            "Received SNS notification with non-JSON body",
+            status=400
+        )
+
     event_type = message_json.get('eventType')
     notification_type = message_json.get('notificationType')
     if (


### PR DESCRIPTION
This PR fixes #1812, aka MPP-1885.

How to test:

- [x] I've added a unit test to test for potential regressions of this bug.

I think in both these cases, we're prefer to log the entire `json_body`, so we have access to the confirmation URL or the complaint. However, in the past we've preferred to not log this in case it is large or has sensitive information.