### PR TITLE
Remove cached data when logging out

### DIFF
--- a/frontend/src/pages/mock/logout.page.tsx
+++ b/frontend/src/pages/mock/logout.page.tsx
@@ -1,6 +1,7 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import { MouseEventHandler } from "react";
+import { useSWRConfig } from "swr";
 import { getRuntimeConfig } from "../../config";
 import { authenticatedFetch } from "../../hooks/api/api";
 import { useProfiles } from "../../hooks/api/profile";
@@ -11,6 +12,7 @@ const MockLogout: NextPage = () => {
   const router = useRouter();
   const profiles = useProfiles();
   const users = useUsers();
+  const { cache } = useSWRConfig();
 
   const onLogout: MouseEventHandler = async (event) => {
     event.preventDefault();
@@ -23,7 +25,11 @@ const MockLogout: NextPage = () => {
       method: "GET",
       redirect: "manual",
     });
-    // Revalidate account data to reflect logged out status:
+    // Revalidate account data to reflect logged out status.
+    // Note that the `clear` method exists, even though it's not exposed on the
+    // type yet:
+    // https://github.com/vercel/swr/issues/161#issuecomment-1079198998
+    (cache as unknown as { clear: () => void }).clear();
     await profiles.mutate();
     await users.mutate();
 


### PR DESCRIPTION
This is a follow-up to https://github.com/mozilla/fx-private-relay/pull/1777#pullrequestreview-942422686 by @groovecoder.

Although we now properly detect that a user is logged out after
mocking logout, the user's data would still be cached, such as the
fact that they're a Premium user, causing the header to still be
in the Premium theme.

With this change, user data is also cleared.

Note that this only affected when running using the dev server, as
authentication in production involves full page reloads and hence
the clearing of all in-memory data.

How to test: Log in as a Premium user when running using the dev server. Now logout. Observe that the "Sign up" and "Sign in" buttons are visible again, and that the header is now dark.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. No, mocking both the router and the user API for what is otherwise a static page felt like overkill, but let me know if you disagree.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
