### PR TITLE
Use server-side redirect to send user to dashboard

### DIFF
--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -50,6 +50,20 @@ class FxAToRequest:
         return self.get_response(request)
 
 
+class RedirectRootIfLoggedIn:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        # To prevent showing a flash of the landing page when a user is logged
+        # in, use a server-side redirect to send them to the dashboard,
+        # rather than handling that on the client-side:
+        if (request.path == '/' and request.user.is_authenticated):
+            return redirect('accounts/profile/')
+        return response
+
+
 class AddDetectedCountryToResponseHeaders:
     def __init__(self, get_response):
         self.get_response = get_response

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -241,13 +241,14 @@ if DEBUG:
 
 MIDDLEWARE += [
     'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'privaterelay.middleware.RedirectRootIfLoggedIn',
     'csp.middleware.CSPMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 


### PR DESCRIPTION
This adds middleware that runs before WhiteNoise serves the
front-end, and redirects the user to the dashboard if they're
logged in and visiting the root, rather than the old situation in
which they would first see a flash of the landing page, to be
followed by a client-side redirect when JS had loaded and an API
request was performed to find the user logged in.

I'm somewhat afraid to touch the middleware order, especially since [the WhiteNoise docs say](https://whitenoise.evans.io/en/stable/django.html#enable-whitenoise) that it should be placed _before_ all other middleware, which this moves away from even more - maybe that affects performance? In other words, I'd like some more eyes on that part in particular.

How to test: log in, then visit the root (i.e. http://127.0.0.1:8000/), and look at the Network tab of your browser devtools. Instead of it just loading the page and updating the URL client-side, like it currently does on production:

![image](https://user-images.githubusercontent.com/4251/164267940-09e2881e-dd8a-4613-a8b6-1911b13b1a74.png)

it should instead do a 302 redirect to `/accounts/profile/`, and only _then_ load the page:

![image](https://user-images.githubusercontent.com/4251/164268049-51d70ac5-ce07-4687-871f-3a9056cb0baf.png)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - Don't know how to.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
