### PR TITLE
check request.COOKIES for session cookie

### DIFF
--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -4,6 +4,7 @@ import time
 import markus
 from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
 
+from django.conf import settings
 from django.contrib.auth import logout
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -55,12 +56,15 @@ class RedirectRootIfLoggedIn:
         self.get_response = get_response
 
     def __call__(self, request):
-        response = self.get_response(request)
         # To prevent showing a flash of the landing page when a user is logged
         # in, use a server-side redirect to send them to the dashboard,
         # rather than handling that on the client-side:
-        if (request.path == '/' and request.user.is_authenticated):
+        if (request.path == '/' and
+            settings.SESSION_COOKIE_NAME in request.COOKIES
+           ):
             return redirect('accounts/profile/')
+
+        response = self.get_response(request)
         return response
 
 

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -241,14 +241,14 @@ if DEBUG:
 
 MIDDLEWARE += [
     'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'privaterelay.middleware.RedirectRootIfLoggedIn',
     'csp.middleware.CSPMiddleware',
+    'privaterelay.middleware.RedirectRootIfLoggedIn',
     'whitenoise.middleware.WhiteNoiseMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 


### PR DESCRIPTION
We want to keep Session and Authentication middleware AFTER Whitenoise,
so we're not running the session & auth logic on every request for
static files. But we also want to redirect logged-in users to
/accounts/profile/ BEFORE they see a flash of not-logged-in content on
the React index.html.

So, rather than check for request.user, which depends on the Session and
Authentication middleware running first, we can check if there's any
session cookie in the request at all - which indicates the user is
signed-in.

This fixes the flash-of-unauthenticated-content with a light-weight
middleware that is easier on the requests for static files.