### PR TITLE
Stop processing on invalid SNS topic ARN or message type, allow multiple topics

### DIFF
--- a/emails/management/commands/process_emails_from_sqs.py
+++ b/emails/management/commands/process_emails_from_sqs.py
@@ -413,7 +413,12 @@ class Command(BaseCommand):
 
         topic_arn = verified_json_body["TopicArn"]
         message_type = verified_json_body["Type"]
-        validate_sns_header(topic_arn, message_type)
+        error_details = validate_sns_header(topic_arn, message_type)
+        if error_details:
+            results["success"] = False
+            results.update(error_details)
+            return results
+
         try:
             _sns_inbound_logic(topic_arn, message_type, verified_json_body)
         except ClientError as e:

--- a/emails/tests/mgmt_process_emails_from_sqs_tests.py
+++ b/emails/tests/mgmt_process_emails_from_sqs_tests.py
@@ -61,7 +61,7 @@ def mock_sns_inbound_logic():
 
 @pytest.fixture(autouse=True)
 def use_test_topic_arn(settings):
-    settings.AWS_SNS_TOPIC = TEST_SNS_MESSAGE['TopicArn']
+    settings.AWS_SNS_TOPIC = {TEST_SNS_MESSAGE['TopicArn']}
     return settings
 
 
@@ -251,7 +251,7 @@ def test_process_queue_verify_from_sns_raises_keyerror(mock_verify_from_sns):
 
 def test_process_queue_verify_sns_header_fails(use_test_topic_arn):
     """Invalid SNS headers fail."""
-    use_test_topic_arn.AWS_SNS_TOPIC="arn:aws:sns:us-east-1:111122223333:not-relay"
+    use_test_topic_arn.AWS_SNS_TOPIC={"arn:aws:sns:us-east-1:111122223333:not-relay"}
     msg = fake_sqs_message(json.dumps(TEST_SNS_MESSAGE))
     res = Command(queue=fake_queue([msg], []), max_seconds=3).process_queue()
     assert res["total_messages"] == 1

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -720,7 +720,8 @@ class GetAttachmentTests(TestCase):
 
 
 TEST_AWS_SNS_TOPIC = "arn:aws:sns:us-east-1:111222333:relay"
-@override_settings(AWS_SNS_TOPIC=TEST_AWS_SNS_TOPIC)
+TEST_AWS_SNS_TOPIC2 = TEST_AWS_SNS_TOPIC + "-alt"
+@override_settings(AWS_SNS_TOPIC={TEST_AWS_SNS_TOPIC, TEST_AWS_SNS_TOPIC2})
 class ValidateSnsHeaderTests(SimpleTestCase):
 
     def test_valid_headers(self):
@@ -732,7 +733,7 @@ class ValidateSnsHeaderTests(SimpleTestCase):
         assert ret == {
             "error": "Received SNS request without Topic ARN.",
             "received_topic_arn": "''",
-            "supported_topic_arn": TEST_AWS_SNS_TOPIC,
+            "supported_topic_arn": [TEST_AWS_SNS_TOPIC, TEST_AWS_SNS_TOPIC2],
             "received_sns_type": "Notification",
             "supported_sns_types": ["SubscriptionConfirmation", "Notification"],
         }
@@ -742,7 +743,7 @@ class ValidateSnsHeaderTests(SimpleTestCase):
         assert ret["error"] == "Received SNS message for wrong topic."
 
     def test_no_message_type(self):
-        ret = validate_sns_header(TEST_AWS_SNS_TOPIC, None)
+        ret = validate_sns_header(TEST_AWS_SNS_TOPIC2, None)
         assert ret["error"] == "Received SNS request without Message Type."
 
     def test_unsupported_message_type(self):
@@ -750,7 +751,7 @@ class ValidateSnsHeaderTests(SimpleTestCase):
         assert ret["error"] == "Received SNS message for unsupported Type: UnsubscribeConfirmation"
 
 
-@override_settings(AWS_SNS_TOPIC=EMAIL_SNS_BODIES['s3_stored']['TopicArn'])
+@override_settings(AWS_SNS_TOPIC={EMAIL_SNS_BODIES['s3_stored']['TopicArn']})
 class SnsInboundViewSimpleTests(SimpleTestCase):
     """Tests for /emails/sns_inbound that do not require database access."""
 

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -748,7 +748,7 @@ class ValidateSnsHeaderTests(SimpleTestCase):
 
     def test_unsupported_message_type(self):
         ret = validate_sns_header(TEST_AWS_SNS_TOPIC, "UnsubscribeConfirmation")
-        assert ret["error"] == "Received SNS message for unsupported Type: UnsubscribeConfirmation"
+        assert ret["error"] == "Received SNS message for unsupported Type."
 
 
 @override_settings(AWS_SNS_TOPIC={EMAIL_SNS_BODIES['s3_stored']['TopicArn']})
@@ -828,4 +828,4 @@ class SnsInboundViewSimpleTests(SimpleTestCase):
             HTTP_X_AMZ_SNS_MESSAGE_TYPE="UnsubscribeConfirmation",
         )
         assert ret.status_code == 400
-        assert ret.content == b"Received SNS message for unsupported Type: UnsubscribeConfirmation"
+        assert ret.content == b"Received SNS message for unsupported Type."

--- a/emails/views.py
+++ b/emails/views.py
@@ -230,7 +230,7 @@ def validate_sns_header(topic_arn, message_type):
     """
     if not topic_arn:
         error = "Received SNS request without Topic ARN."
-    elif topic_arn != settings.AWS_SNS_TOPIC:
+    elif topic_arn not in settings.AWS_SNS_TOPIC:
         error = "Received SNS message for wrong topic."
     elif not message_type:
         error = "Received SNS request without Message Type."
@@ -243,7 +243,7 @@ def validate_sns_header(topic_arn, message_type):
         return {
             "error": error,
             "received_topic_arn": shlex.quote(topic_arn),
-            "supported_topic_arn": settings.AWS_SNS_TOPIC,
+            "supported_topic_arn": sorted(settings.AWS_SNS_TOPIC),
             "received_sns_type": shlex.quote(message_type),
             "supported_sns_types": SUPPORTED_SNS_TYPES,
         }

--- a/emails/views.py
+++ b/emails/views.py
@@ -235,7 +235,7 @@ def validate_sns_header(topic_arn, message_type):
     elif not message_type:
         error = "Received SNS request without Message Type."
     elif message_type not in SUPPORTED_SNS_TYPES:
-        error = f"Received SNS message for unsupported Type: {shlex.quote(message_type)}"
+        error = "Received SNS message for unsupported Type."
     else:
         error = None
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -211,8 +211,10 @@ def sns_inbound(request):
     message_type = request.headers.get('X-Amz-Sns-Message-Type', None)
 
     # Validates header
-    # TODO: we are not returning the Http Response from the method call below
-    validate_sns_header(topic_arn, message_type)
+    error_details = validate_sns_header(topic_arn, message_type)
+    if error_details:
+        logger.error('validate_sns_header_error', extra=error_details)
+        return HttpResponse(error_details['error'], status=400)
 
     json_body = json.loads(request.body)
     verified_json_body = verify_from_sns(json_body)
@@ -220,41 +222,32 @@ def sns_inbound(request):
 
 
 def validate_sns_header(topic_arn, message_type):
-    if not topic_arn:
-        logger.error('SNS inbound request without X-Amz-Sns-Topic-Arn')
-        return HttpResponse(
-            'Received SNS request without Topic ARN.', status=400
-        )
-    if topic_arn != settings.AWS_SNS_TOPIC:
-        logger.error(
-            'SNS message for wrong ARN',
-            extra={
-                'configured_arn': settings.AWS_SNS_TOPIC,
-                'received_arn': shlex.quote(topic_arn),
-            }
-        )
-        return HttpResponse(
-            'Received SNS message for wrong topic.', status=400
-        )
+    """
+    Validate Topic ARN and SNS Message Type.
 
-    if not message_type:
-        logger.error('SNS inbound request without X-Amz-Sns-Message-Type')
-        return HttpResponse(
-            'Received SNS request without Message Type.', status=400
-        )
-    if message_type not in SUPPORTED_SNS_TYPES:
-        logger.error(
-            'SNS message for unsupported type',
-            extra={
-                'supported_sns_types': SUPPORTED_SNS_TYPES,
-                'message_type': shlex.quote(message_type),
-            }
-        )
-        return HttpResponse(
-            'Received SNS message for unsupported Type: %s' %
-            html.escape(shlex.quote(message_type)),
-            status=400
-        )
+    If an error is detected, the return is a dictionary of error details.
+    If no error is detected, the return is None.
+    """
+    if not topic_arn:
+        error = "Received SNS request without Topic ARN."
+    elif topic_arn != settings.AWS_SNS_TOPIC:
+        error = "Received SNS message for wrong topic."
+    elif not message_type:
+        error = "Received SNS request without Message Type."
+    elif message_type not in SUPPORTED_SNS_TYPES:
+        error = f"Received SNS message for unsupported Type: {shlex.quote(message_type)}"
+    else:
+        error = None
+
+    if error:
+        return {
+            "error": error,
+            "received_topic_arn": shlex.quote(topic_arn),
+            "supported_topic_arn": settings.AWS_SNS_TOPIC,
+            "received_sns_type": shlex.quote(message_type),
+            "supported_sns_types": SUPPORTED_SNS_TYPES,
+        }
+    return None
 
 
 def _sns_inbound_logic(topic_arn, message_type, json_body):

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -17,7 +17,7 @@ from datetime import datetime
 # This needs to be before markus, which imports pytest
 IN_PYTEST = "pytest" in sys.modules
 
-from decouple import config
+from decouple import config, Csv
 import markus
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
@@ -148,7 +148,7 @@ ADMIN_ENABLED = config('ADMIN_ENABLED', False, cast=bool)
 AWS_REGION = config('AWS_REGION', None)
 AWS_ACCESS_KEY_ID = config('AWS_ACCESS_KEY_ID', None)
 AWS_SECRET_ACCESS_KEY = config('AWS_SECRET_ACCESS_KEY', None)
-AWS_SNS_TOPIC = config('AWS_SNS_TOPIC', None)
+AWS_SNS_TOPIC = set(config('AWS_SNS_TOPIC', '', cast=Csv()))
 AWS_SNS_KEY_CACHE = config('AWS_SNS_KEY_CACHE', 'default')
 AWS_SES_CONFIGSET = config('AWS_SES_CONFIGSET', None)
 AWS_SQS_EMAIL_QUEUE_URL = config('AWS_SQS_EMAIL_QUEUE_URL', None)


### PR DESCRIPTION
This PR is follow-on work for issue https://github.com/mozilla/fx-private-relay/issues/364, and ~~step 1~~ fixes [MPP-1802](https://mozilla-hub.atlassian.net/browse/MPP-1802) (allow multiple SNS topics)

How to test:

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

I [searched the logs](https://cloudlogging.app.goo.gl/UDMpoiDAbTS8kK9N6), and found one entry from the last 14 days with the query:

```
severity=ERROR
resource.labels.container_name="fxprivaterelay"
jsonPayload.Type=("events" OR "eventsinfo")
jsonPayload.Fields.msg: "SNS"
```

It was `SNS inbound request without X-Amz-Sns-Topic-Arn`, which I believe means someone visited the URL rather than SNS POSTing to it. It is possible that we should special-case that, or disallow a GET request.


I thought about splitting this into two parts, and can still do that for review:

* Part 1: Add tests for SNS header validation, and stop processing on invalid headers
* Part 2: Allow `AWS_SNS_TOPIC` to have multiple values by making it a CSV

I can split into two parts if desired for review.