### PR TITLE
Add optional django-silk

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .env
 .envrc
 *.sqlite3
+*.prof
 node_modules
 env/
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .envrc
 *.sqlite3
+*.prof
 node_modules
 env/
 __pycache__

--- a/privaterelay/urls.py
+++ b/privaterelay/urls.py
@@ -62,8 +62,10 @@ if settings.DEBUG:
     urlpatterns += [
         path('__debug__/', include(debug_toolbar.urls)),
         path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
-#        path('silk/', include('silk.urls', namespace='silk')),
     ]
+if settings.USE_SILK:
+    import silk
+    urlpatterns.append(path('silk/', include('silk.urls', namespace='silk')))
 
 if settings.ADMIN_ENABLED:
     urlpatterns += [


### PR DESCRIPTION
[Silk](https://github.com/jazzband/django-silk) is a live profiling and inspection tool for Django, suitable for local development. It is disabled when ``DEBUG=False``. It is also disabled when running tests, since it adds database queries for writing profile data to the database, using the mechanism suggested at https://github.com/pytest-dev/pytest/issues/9502.

This is based on https://gist.github.com/groovecoder/5d2963d753cdfa690507a415b565dbaa

To use it, you need to manually install silk:

```
pip install django-silk
```

After a `runserver` restart, it will be detected and enabled in Django settings.

This replaces PR #1809, which was on my fork so CI didn't run.