### PR TITLE
WIP: Try native Python builds in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ workflows:
 
       - python_job:
           name: python style check
-          command: set -x && black --check .
+          command: set -e && black --check .
           filters:
             tags:
               only: /.*/
@@ -391,7 +391,7 @@ workflows:
 
       - python_job:
           name: python type check
-          command: set -x && mypy .
+          command: set -e && mypy .
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,10 +106,11 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
         environment:
-          TEST_DATABASE_URL: postgresql://postgres@localhost
+          DATABASE_URL: postgresql://postgres:6edef2d746f2274cab951a452d5fc13d@localhost/circle
       - image: cimg/postgres:14.2
         environment:
           POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: 6edef2d746f2274cab951a452d5fc13d
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -119,6 +120,17 @@ jobs:
       - run: git submodule update --init
       - python/install-packages:
           pkg-manager: pip
+      - run:
+          name: install dockerize
+          command: |
+            wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz &&
+            sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz &&
+            rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          environment:
+            DOCKERIZE_VERSION: v0.6.1
+      - run:
+          name: wait for the database
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run: pytest .
 
   build_test_backend:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,21 +377,21 @@ workflows:
 
       - python_job:
           name: python style check
-          command: black --check .
+          command: set -x && black --check .
           filters:
             tags:
               only: /.*/
 
       - python_job:
           name: python lint
-          command: flake8 .
+          command: flake8 --exit-zero .
           filters:
             tags:
               only: /.*/
 
       - python_job:
           name: python type check
-          command: mypy .
+          command: set -x && mypy .
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,28 @@ jobs:
             - test-results/frontend-coverage/lcov-prefixed.info
             - test-results/frontend-coverage/coveralls.json
 
+  python_test_postgres:
+    docker:
+      - image: cimg/python:3.9.10
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+        environment:
+          TEST_DATABASE_URL: postgresql://postgres@localhost
+      - image: cimg/postgres:14.2
+        environment:
+          POSTGRES_USER: postgres
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    steps:
+      - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
+      - python/install-packages:
+          pkg-manager: pip
+      - run: pytest .
+
   build_test_backend:
     docker:
       - image: docker:stable-git
@@ -279,11 +301,10 @@ workflows:
             tags:
               only: /.*/
 
-      - python/test:
-          version: 3.9.10
-          pre-install-steps:
-            - run: git submodule sync
-            - run: git submodule update --init
+      - python_test_postgres:
+          filters:
+            tags:
+              only: /.*/
 
       - build_test_backend:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,14 @@ commands:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
+executors:
+  python:
+    docker:
+      - image: cimg/python:3.9.10
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+
 
 jobs:
   build_frontend:
@@ -149,11 +157,7 @@ jobs:
           path: test-report
 
   python_test_sqlite:
-    docker:
-      - image: cimg/python:3.9.10
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+    executor: python
     steps:
       - checkout_with_submodules
       - python/install-packages:
@@ -171,6 +175,19 @@ jobs:
             DATABASE_URL: "sqlite:///$PWD/db.sqlite3"
       - store_test_results:
           path: test-report
+
+  python_job:
+    executor: python
+    parameters:
+      command:
+        description: "What command should the job run?"
+        default: "exit 1"
+        type: string
+    steps:
+      - checkout_with_submodules
+      - python/install-packages:
+          pkg-manager: pip
+      - run: << parameters.command >>
 
   build_test_backend:
     docker:
@@ -354,6 +371,27 @@ workflows:
               only: /.*/
 
       - python_test_sqlite:
+          filters:
+            tags:
+              only: /.*/
+
+      - python_job:
+          name: python style check
+          command: black --check .
+          filters:
+            tags:
+              only: /.*/
+
+      - python_job:
+          name: python lint
+          command: flake8 .
+          filters:
+            tags:
+              only: /.*/
+
+      - python_job:
+          name: python type check
+          command: mypy .
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ jobs:
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: 6edef2d746f2274cab951a452d5fc13d
+          POSTGRES_DB: circle
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -136,7 +137,7 @@ jobs:
             DATABASE_URL: postgresql://postgres:6edef2d746f2274cab951a452d5fc13d@localhost/circle
       - run:
           name: Run tests
-          command: pytest . -sx
+          command: pytest .
           environment:
             DATABASE_URL: postgresql://postgres:6edef2d746f2274cab951a452d5fc13d@localhost/circle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ jobs:
           name: Wait for the database
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run: python3 ./manage.py diffsettings
+      - run: echo "$DATABASE_URL"
       - run: pytest . -sx
 
   build_test_backend:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,8 @@ jobs:
                 name: << parameters.command >> (failure allowed)
                 command: |
                   set +x
-                  << parameters.command >> || echo "\n*** Command '<< parameters.command >>' failed! ***"
+                  << parameters.command >> ||
+                  echo "*** Command '<< parameters.command >>' failed, but it is allowed to fail. ***"
       - when:
           condition: << parameters.has_results >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@
 version: 2.1
 orbs:
   node: circleci/node@5.0.0
+  python: circleci/python@2.0.3
 jobs:
   build_frontend:
     docker:
@@ -277,6 +278,12 @@ workflows:
           filters:
             tags:
               only: /.*/
+
+      - python/test:
+          version: 3.9.10
+          pre-install-steps:
+            - run: git submodule sync
+            - run: git submodule update --init
 
       - build_test_backend:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,30 @@ jobs:
       - store_test_results:
           path: test-report
 
+  python_test_sqlite:
+    docker:
+      - image: cimg/python:3.9.10
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    steps:
+      - checkout_with_submodules
+      - python/install-packages:
+          pkg-manager: pip
+      - run:
+          name: Set test defaults
+          command: cp .env-dist .env
+      - run:
+          name: Create test-report directory
+          command: mkdir test-report
+      - run:
+          name: Run tests
+          command: pytest --junit-xml=test-report/report.xml .
+          environment:
+            DATABASE_URL: "sqlite:///$PWD/db.sqlite3"
+      - store_test_results:
+          path: test-report
+
   build_test_backend:
     docker:
       - image: docker:stable-git
@@ -325,6 +349,11 @@ workflows:
               only: /.*/
 
       - python_test_postgres:
+          filters:
+            tags:
+              only: /.*/
+
+      - python_test_sqlite:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,8 +105,6 @@ jobs:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
-        environment:
-          DATABASE_URL: postgresql://postgres:6edef2d746f2274cab951a452d5fc13d@localhost/circle
       - image: cimg/postgres:14.2
         environment:
           POSTGRES_USER: postgres
@@ -131,9 +129,16 @@ jobs:
       - run:
           name: Wait for the database
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run: python3 ./manage.py diffsettings
-      - run: echo "$DATABASE_URL"
-      - run: pytest . -sx
+      - run:
+          name: Check settings
+          command: python3 ./manage.py diffsettings
+          environment:
+            DATABASE_URL: postgresql://postgres:6edef2d746f2274cab951a452d5fc13d@localhost/circle
+      - run:
+          name: Run tests
+          command: pytest . -sx
+          environment:
+            DATABASE_URL: postgresql://postgres:6edef2d746f2274cab951a452d5fc13d@localhost/circle
 
   build_test_backend:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,11 +183,41 @@ jobs:
         description: "What command should the job run?"
         default: "exit 1"
         type: string
+      has_results:
+        description: "Job will place JUnit XML in job-results subfolder"
+        type: boolean
+        default: false
+      allow_fail:
+        description: "Allow the command to fail without failing job."
+        type: boolean
+        default: false
     steps:
       - checkout_with_submodules
       - python/install-packages:
           pkg-manager: pip
-      - run: << parameters.command >>
+      - when:
+          condition: << parameters.has_results >>
+          steps:
+            - run:
+              name: Create job-results directory
+              command: mkdir job-results
+      - unless:
+          condition: << parameters.allow_fail >>
+          steps:
+            - run: << parameters.command >>
+      - when:
+          condition: << parameters.allow_fail >>
+          steps:
+            - run:
+              name: << parameters.command >> (failure allowed)
+              command: |
+                set +x
+                << parameters.command >> || echo "\n*** Command '<< parameters.command >>' failed! ***"
+      - when:
+          condition: << parameters.has_results >>
+          steps:
+            - store_test_results:
+              path: job-results
 
   build_test_backend:
     docker:
@@ -377,21 +407,25 @@ workflows:
 
       - python_job:
           name: python style check
-          command: set +e && black --check . || echo "black failed, but continuing..."
+          command: black --check .
+          allow_fail: true
           filters:
             tags:
               only: /.*/
 
       - python_job:
           name: python lint
-          command: flake8 --exit-zero .
+          command: flake8 .
+          allow_fail: true
           filters:
             tags:
               only: /.*/
 
       - python_job:
           name: python type check
-          command: set +e && mypy --no-incremental . || echo "mypy failed, but continuing..."
+          command: mypy --no-incremental --junit-xml job-results/mypy.xml .
+          has_results: true
+          allow_fail: true
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,15 +134,15 @@ jobs:
           name: Set test defaults
           command: cp .env-dist .env
       - run:
-          name: Check settings
-          command: python3 ./manage.py diffsettings
-          environment:
-            DATABASE_URL: postgresql://postgres:6edef2d746f2274cab951a452d5fc13d@localhost/circle
+          name: Create test-report directory
+          command: mkdir test-report
       - run:
           name: Run tests
-          command: pytest .
+          command: pytest --junit-xml=test-report/report.xml .
           environment:
             DATABASE_URL: postgresql://postgres:6edef2d746f2274cab951a452d5fc13d@localhost/circle
+      - store_test_results:
+          path: test-report
 
   build_test_backend:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,8 +199,8 @@ jobs:
           condition: << parameters.has_results >>
           steps:
             - run:
-              name: Create job-results directory
-              command: mkdir job-results
+                name: Create job-results directory
+                command: mkdir job-results
       - unless:
           condition: << parameters.allow_fail >>
           steps:
@@ -209,15 +209,15 @@ jobs:
           condition: << parameters.allow_fail >>
           steps:
             - run:
-              name: << parameters.command >> (failure allowed)
-              command: |
-                set +x
-                << parameters.command >> || echo "\n*** Command '<< parameters.command >>' failed! ***"
+                name: << parameters.command >> (failure allowed)
+                command: |
+                  set +x
+                  << parameters.command >> || echo "\n*** Command '<< parameters.command >>' failed! ***"
       - when:
           condition: << parameters.has_results >>
           steps:
             - store_test_results:
-              path: job-results
+                path: job-results
 
   build_test_backend:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,14 @@ version: 2.1
 orbs:
   node: circleci/node@5.0.0
   python: circleci/python@2.0.3
+commands:
+  checkout-relay:
+    description: Checkout Relay code and submodules
+    steps:
+      - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
+
 jobs:
   build_frontend:
     docker:
@@ -114,9 +122,7 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
     steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - checkout-relay
       - python/install-packages:
           pkg-manager: pip
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ workflows:
 
       - python_job:
           name: python style check
-          command: set -e && black --check .
+          command: set +e && black --check .
           filters:
             tags:
               only: /.*/
@@ -391,7 +391,7 @@ workflows:
 
       - python_job:
           name: python type check
-          command: set -e && mypy .
+          command: set +e && mypy --no-incremental .
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
       - python/install-packages:
           pkg-manager: pip
       - run:
-          name: install dockerize
+          name: Install dockerize
           command: |
             wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz &&
             sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz &&
@@ -129,9 +129,10 @@ jobs:
           environment:
             DOCKERIZE_VERSION: v0.6.1
       - run:
-          name: wait for the database
+          name: Wait for the database
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run: pytest .
+      - run: python3 ./manage.py diffsettings
+      - run: pytest . -sx
 
   build_test_backend:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,9 @@ jobs:
           name: Wait for the database
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
+          name: Set test defaults
+          command: cp .env-dist .env
+      - run:
           name: Check settings
           command: python3 ./manage.py diffsettings
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
   node: circleci/node@5.0.0
   python: circleci/python@2.0.3
 commands:
-  checkout-relay:
+  checkout_with_submodules:
     description: Checkout Relay code and submodules
     steps:
       - checkout
@@ -25,9 +25,7 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
     steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - checkout_with_submodules
       - node/install:
           node-version: '14'
       - node/install-packages:
@@ -122,7 +120,7 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASS
     steps:
-      - checkout-relay
+      - checkout_with_submodules
       - python/install-packages:
           pkg-manager: pip
       - run:
@@ -158,9 +156,7 @@ jobs:
           password: $DOCKER_PASS
     working_directory: /dockerflow
     steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - checkout_with_submodules
       - setup_remote_docker:
           # Use a version of Docker that works with Node, see
           # https://support.circleci.com/hc/en-us/articles/360050934711-Docker-build-fails-with-EPERM-operation-not-permitted-copyfile-when-using-node-14-9-0-or-later-
@@ -281,8 +277,6 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
       - run:
           name: Upload coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ workflows:
 
       - python_job:
           name: python style check
-          command: set +e && black --check .
+          command: set +e && black --check . || echo "black failed, but continuing..."
           filters:
             tags:
               only: /.*/
@@ -391,7 +391,7 @@ workflows:
 
       - python_job:
           name: python type check
-          command: set +e && mypy --no-incremental .
+          command: set +e && mypy --no-incremental . || echo "mypy failed, but continuing..."
           filters:
             tags:
               only: /.*/

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,12 @@ model-bakery==1.5.0
 pytest-cov==3.0.0
 pytest-django==3.9.0
 responses==0.17.0
+
+# linting
+black==22.3.0
+flake8==4.0.1
+mccabe==0.6.1
+pyflakes==2.4.0
+
+# types
+mypy==0.942


### PR DESCRIPTION
*Work in progress* - Trying out some things which may be dead ends. I hope to have a cleaner PR when it is ready for review.

Currently, we build the Docker image and run Python / pytest inside of it, for tests and coverage. It works, but CircleCI makes it challenging to re-use Docker images in other steps.

I hope to add more features to the build in the next few weeks:
* Check code formatting with `Black`
* Check linting with `flake8`
* Check typing with `mypy`

Rather than make the `build_test_backend` more complex, I'd like to run these check in parallel in Python-native builds, with environment caching etc.