### PR TITLE
Strip email trackers mpp 1662

### DIFF
--- a/emails/management/commands/get_or_create_user_group.py
+++ b/emails/management/commands/get_or_create_user_group.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+
+from django.contrib.auth.models import Group
+
+
+class Command(BaseCommand):
+    help = 'Create user group.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('group_name', nargs=1)
+
+    def handle(self, *args, **options):
+        new_group, created = Group.objects.get_or_create(name=options['group_name'][0])
+        group_details = f"{new_group.name} with Group ID: {new_group.id}."
+        if created:
+            self.stdout.write("SUCCESS: created " + group_details)
+        else:
+            self.stdout.write("SUCCESS: fetched " + group_details)

--- a/emails/management/commands/update_user_group.py
+++ b/emails/management/commands/update_user_group.py
@@ -16,4 +16,4 @@ class Command(BaseCommand):
         for user in user_qs:
             set_user_group(user)
             update_count += 1
-        self.stdout.write(f"Updated {update_count} users group.")
+        self.stdout.write(f"Updated {update_count} users' group.")

--- a/emails/management/commands/update_user_group.py
+++ b/emails/management/commands/update_user_group.py
@@ -1,0 +1,19 @@
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+
+from emails.utils import set_user_group
+
+class Command(BaseCommand):
+    help = 'Update existing user group who are Mozillians'
+
+    def add_arguments(self, parser):
+        parser.add_argument('email_domain', nargs=1)
+
+    def handle(self, *args, **options):
+        email_domain = options['email_domain'][0]
+        user_qs = User.objects.filter(email__endswith=email_domain)
+        update_count = 0
+        for user in user_qs:
+            set_user_group(user)
+            update_count += 1
+        self.stdout.write(f"Updated {update_count} users group.")

--- a/emails/signals.py
+++ b/emails/signals.py
@@ -4,12 +4,14 @@ from django.core.exceptions import SuspiciousOperation
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
-from .models import DomainAddress, Profile, RelayAddress
+from emails.models import DomainAddress, Profile, RelayAddress
+from emails.utils import set_user_group
 
 
 @receiver(post_save, sender=User)
 def create_user_profile(sender, instance, created, **kwargs):
     if created:
+        set_user_group(instance)
         Profile.objects.create(user=instance)
 
 

--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -71,7 +71,7 @@
                     {{ premium_header_banner|safe }}
                   {% endif %}
                   {% if email_tracker_study_link %}
-                    <br><a href="{{ email_tracker_study_link }}" target="_blank" rel="noopener noreferrer" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">Report breakage.</a>.
+                    <br><a href="{{ email_tracker_study_link }}" target="_blank" rel="noopener noreferrer" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">Report breakage</a>.
                   {% endif %}
                 </p>
               </td>

--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -70,6 +70,9 @@
                     {% ftlmsg 'forwarded-email-header-premium-banner' premium_link=premium_link as premium_header_banner %}
                     {{ premium_header_banner|safe }}
                   {% endif %}
+                  {% if email_tracker %}
+                    <br> Strict: {{ email_tracker.strict }} General Removed: {{ email_tracker.general }}
+                  {% endif %}
                 </p>
               </td>
             </tr>

--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -70,8 +70,8 @@
                     {% ftlmsg 'forwarded-email-header-premium-banner' premium_link=premium_link as premium_header_banner %}
                     {{ premium_header_banner|safe }}
                   {% endif %}
-                  {% if email_tracker %}
-                    <br> Strict: {{ email_tracker.strict }} General Removed: {{ email_tracker.general }}
+                  {% if email_tracker_study_link %}
+                    <br><a href="{{ email_tracker_study_link }}" target="_blank" rel="noopener noreferrer" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">Report breakage.</a>.
                   {% endif %}
                 </p>
               </td>

--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -5,11 +5,14 @@ from django.test import (
     TestCase,
     override_settings
 )
+from unittest.mock import patch
 
 from emails.models import get_domains_from_settings
+from emails import utils
 from emails.utils import (
     generate_relay_From,
     get_email_domain_from_settings,
+    remove_trackers,
 )
 
 from .models_tests import make_premium_test_user

--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -148,7 +148,7 @@ class RemoveTrackers(TestCase):
         )
         changed_content, general_removed, general_count, strict_count = remove_trackers(content)
 
-        # assert changed_content == self.expected_content
+        assert changed_content == self.expected_content.replace('"', "'")
         assert general_removed == 2
         assert general_count == 2
         assert strict_count == 0

--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -136,7 +136,7 @@ class RemoveTrackers(TestCase):
         )
         changed_content, general_removed, general_count, strict_count = remove_trackers(content)
 
-        # assert changed_content == self.expected_content
+        assert changed_content == self.expected_content
         assert general_removed == 2
         assert general_count == 2
         assert strict_count == 0

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -397,7 +397,7 @@ def convert_domains_to_regex_patterns(domain_pattern):
 
 def remove_trackers(html_content, level='general'):
     trackers = GENERAL_TRACKERS if level == 'general' else STRICT_TRACKERS
-    tracker_count = 0
+    tracker_removed = 0
     changed_content = html_content
 
     general_detail = count_tracker(html_content, GENERAL_TRACKERS)
@@ -406,13 +406,14 @@ def remove_trackers(html_content, level='general'):
     for tracker in trackers:
         pattern = convert_domains_to_regex_patterns(tracker)
         changed_content, matched = re.subn(pattern, f'\g<1>{settings.SITE_ORIGIN}/faq\g<1>', changed_content)
-        tracker_count += matched
+        tracker_removed += matched
 
     
-    incr_if_enabled('tracker_foxfooding.general_count', tracker_count)
+    incr_if_enabled(f'tracker_foxfooding.{level}_removed_count', tracker_removed)
+    incr_if_enabled('tracker_foxfooding.general_count', general_detail['count'])
     incr_if_enabled('tracker_foxfooding.strict_count', strict_detail['count'])
     study_logger.info(
         'email_tracker_foxfooding_summary',
-        extra={'general': general_detail, 'strict': strict_detail}
+        extra={'level': level, 'tracker_removed': tracker_removed, 'general': general_detail, 'strict': strict_detail}
     )
-    return changed_content, tracker_count, strict_detail['count']
+    return changed_content, tracker_removed, general_detail['count'], strict_detail['count']

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -364,7 +364,10 @@ def set_user_group(user):
         'mozillafoundation.org': 'mozilla_foundation',
         'getpocket.com': 'pocket'
     }
-    internal_group_qs = Group.objects.filter(name=group_attribute.get(email_domain))
+    group_name = group_attribute.get(email_domain)
+    if not group_name:
+        return None
+    internal_group_qs = Group.objects.filter(name=group_name)
     internal_group = internal_group_qs.first()
     if internal_group is None:
         return None

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -356,7 +356,9 @@ def remove_message_from_s3(bucket, object_key):
     return False
 
 def set_user_group(user):
-    email_domain = user.email.split('@')[1]
+    email_domain = ''
+    if '@' in user.email:
+        email_domain = user.email.split('@')[1]
     group_attribute = {
         'mozilla.com': 'mozilla_corporation',
         'mozillafoundation.org': 'mozilla_foundation',

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -393,7 +393,7 @@ def count_all_trackers(html_content):
     )
 
 def convert_domains_to_regex_patterns(domain_pattern):
-    return '(["])(\\S*://\\S*.' + domain_pattern + '\\S*)\\1'
+    return '(["\'])(\\S*://(\\S*\.)*' + re.escape(domain_pattern) + '\\S*)\\1'
 
 def remove_trackers(html_content, level='general'):
     trackers = GENERAL_TRACKERS if level == 'general' else STRICT_TRACKERS

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -356,9 +356,9 @@ def remove_message_from_s3(bucket, object_key):
     return False
 
 def set_user_group(user):
-    email_domain = ''
-    if '@' in user.email:
-        email_domain = user.email.split('@')[1]
+    if '@' not in user.email:
+        return None
+    email_domain = user.email.split('@')[1]
     group_attribute = {
         'mozilla.com': 'mozilla_corporation',
         'mozillafoundation.org': 'mozilla_foundation',

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -399,7 +399,7 @@ def remove_trackers(html_content, level='general'):
     import re
     for tracker in trackers:
         pattern = convert_domains_to_regex_patterns(tracker)
-        changed_content, matched = re.subn(pattern, f'\g<1>{settings.SITE_ORIGIN}/faq', changed_content)
+        changed_content, matched = re.subn(pattern, f'\g<1>{settings.SITE_ORIGIN}/faq\g<1>', changed_content)
         tracker_count += matched
 
     strict_count = count_tracker(html_content, STRICT_TRACKERS)['count']

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -406,7 +406,7 @@ def remove_trackers(html_content, level='general'):
     incr_if_enabled('tracker_foxfooding.general_count', tracker_count)
     incr_if_enabled('tracker_foxfooding.strict_count', strict_count)
     study_logger.info(
-        'email_tracker_fodfooding_summary',
+        'email_tracker_foxfooding_summary',
         extra={'general': tracker_count, 'strict': strict_count}
     )
     return changed_content, tracker_count, strict_count

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -18,6 +18,7 @@ import logging
 
 from django.apps import apps
 from django.conf import settings
+from django.contrib.auth.models import Group
 from django.http import HttpResponse
 from django.template.defaultfilters import linebreaksbr, urlize
 from urllib.parse import urlparse
@@ -353,7 +354,18 @@ def remove_message_from_s3(bucket, object_key):
         incr_if_enabled('message_not_removed_from_s3', 1)
     return False
 
-
+def set_user_group(user):
+    email_domain = user.email.split('@')[1]
+    group_attribute = {
+        'mozilla.com': 'mozilla_corporation',
+        'mozillafoundation.org': 'mozilla_foundation',
+        'getpocket.com': 'pocket'
+    }
+    internal_group_qs = Group.objects.filter(name=group_attribute.get(email_domain))
+    internal_group = internal_group_qs.first()
+    if internal_group is None:
+        return None
+    internal_group.user_set.add(user)
 
 def count_tracker(html_content, trackers):
     tracker_total = 0

--- a/emails/views.py
+++ b/emails/views.py
@@ -454,6 +454,10 @@ def _sns_message(message_json):
         # we are returning a 503 so that SNS can retry the email processing
         return HttpResponse("Cannot fetch the message content from S3", status=503)
 
+    # sample tracker numbers
+    if sample_is_active('tracker-sample') and html_content:
+        count_all_trackers(html_content)
+
     # scramble alias so that clients don't recognize it
     # and apply default link styles
     display_email = re.sub('([@.:])', r'<span>\1</span>', to_address)
@@ -517,9 +521,6 @@ def _sns_message(message_json):
     address.save(
         update_fields=['num_forwarded', 'last_used_at']
     )
-    # successful email relayed count number of trackers
-    if sample_is_active('tracker-sample') and html_content:
-        count_all_trackers(html_content)
     return response
 
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -464,10 +464,10 @@ def _sns_message(message_json):
         incr_if_enabled('email_with_html_content', 1)
         foxfood_flag = Flag.objects.filter(name='foxfood').first()
         if foxfood_flag and foxfood_flag.is_active_for_user(address.user):
-            html_content, removed_count, strict_count = remove_trackers(html_content)
+            html_content, removed_count, general_count, strict_count = remove_trackers(html_content)
             email_tracker_study_link = (
                 'https://www.surveygizmo.com/s3/6837234/Relay-General-Email-Tracker-Removal-2022?'
-                + f'general-found={removed_count}&'
+                + f'general-found={general_count}&'
                 + f'general-removed={removed_count}&'
                 + f'strict-found={strict_count}'
             )

--- a/emails/views.py
+++ b/emails/views.py
@@ -466,7 +466,7 @@ def _sns_message(message_json):
         incr_if_enabled('email_with_html_content', 1)
         if foxfood_flag and foxfood_flag.is_active_for_user(address.user):
             html_content, removed_count, strict_count = remove_trackers(html_content)
-            email_tracker = (
+            email_tracker_study_link = (
                 'https://www.surveygizmo.com/s3/6837234/Relay-General-Email-Tracker-Removal-2022?'
                 + f'general-found={removed_count}&'
                 + f'general-removed={removed_count}&'

--- a/emails/views.py
+++ b/emails/views.py
@@ -63,8 +63,6 @@ from .sns import verify_from_sns, SUPPORTED_SNS_TYPES
 logger = logging.getLogger('events')
 info_logger = logging.getLogger('eventsinfo')
 
-foxfood_flag = Flag.objects.filter(name='foxfood').first()
-
 
 class InReplyToNotFound(Exception):
     def __init__(self, message="No In-Reply-To header."):
@@ -464,6 +462,7 @@ def _sns_message(message_json):
     email_tracker_study_link = ''
     if html_content:
         incr_if_enabled('email_with_html_content', 1)
+        foxfood_flag = Flag.objects.filter(name='foxfood').first()
         if foxfood_flag and foxfood_flag.is_active_for_user(address.user):
             html_content, removed_count, strict_count = remove_trackers(html_content)
             email_tracker_study_link = (

--- a/emails/views.py
+++ b/emails/views.py
@@ -63,7 +63,7 @@ from .sns import verify_from_sns, SUPPORTED_SNS_TYPES
 logger = logging.getLogger('events')
 info_logger = logging.getLogger('eventsinfo')
 
-foxfood_flag = Flag.objects.filter('foxfood').first()
+foxfood_flag = Flag.objects.filter(name='foxfood').first()
 
 
 class InReplyToNotFound(Exception):
@@ -461,16 +461,23 @@ def _sns_message(message_json):
     display_email = re.sub('([@.:])', r'<span>\1</span>', to_address)
 
     message_body = {}
+    email_tracker_study_link = ''
     if html_content:
         incr_if_enabled('email_with_html_content', 1)
         if foxfood_flag and foxfood_flag.is_active_for_user(address.user):
             html_content, removed_count, strict_count = remove_trackers(html_content)
+            email_tracker = (
+                'https://www.surveygizmo.com/s3/6837234/Relay-General-Email-Tracker-Removal-2022?'
+                + f'general-found={removed_count}&'
+                + f'general-removed={removed_count}&'
+                + f'strict-found={strict_count}'
+            )
         
         wrapped_html = render_to_string('emails/wrapped_email.html', {
             'original_html': html_content,
             'recipient_profile': user_profile,
             'email_to': to_address,
-            'email_tracker': {'strict': strict_count, 'general': removed_count},
+            'email_tracker_study_link': email_tracker_study_link,
             'display_email': display_email,
             'SITE_ORIGIN': settings.SITE_ORIGIN,
             'has_attachment': bool(attachments),


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #<issue ID>.

How to test:

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description
## To create user group for internal users from Mozilla Corporation, Foundation, and Pocket, run Django commands
```
./manage.py get_or_create_user_group mozilla_corporation
./manage.py get_or_create_user_group mozilla_foundation
./manage.py get_or_create_user_group pocket
```
Check this returns:
```
SUCCESS: created mozilla_corporation with Group ID: 1.
SUCCESS: created mozilla_foundation with Group ID: 2.
SUCCESS: created pocket with Group ID: 3.
```

## To set the user with the appropriate group based on their email domain:
```
./manage.py update_user_group mozilla.com
./manage.py update_user_group mozillafoundation.org
./manage.py update_user_group getpocket.com
```
And check that for every command it returns
```
Updated {num} users group.
```

## To create flag for Foxfooding
```
./manage.py waffle_flag foxfood --group=mozilla_corporation --create
```
Check that it returns:
```
Creating flag: foxfood
Setting name: foxfood
Setting everyone: None
Setting percent: None
Setting superusers: False
Setting staff: False
Setting authenticated: False
Setting group(s): ['mozilla_corporation']
Setting user(s): set()
Setting rollout: False
```

## To add specific user on Foxfood flag
In psql run:
```
SELECT id FROM auth_user WHERE email='email@address.com';
```
Get the id of the user and in the project run:
```
./manage.py waffle_flag foxfood --append --user=email@address.com
```
Check this returns:
```
Setting name: foxfood
Setting everyone: None
Setting percent: None
Setting superusers: False
Setting staff: False
Setting authenticated: False
Setting group(s): ['mozilla_corporation']
Setting user(s): {<User: new-user>}
```
For some reason even when using the flag `--append` doing:
```
./manage.py waffle_flag foxfood --append --user=email@address.com
```
replaces the previously added group on the flag. So to preserve we need to do something like:
```
./manage.py waffle_flag foxfood --append --user=email@address.com --group=mozilla_corporation
```

# Screenshot (if applicable)

Not applicable.

# How to test
## Before creating flag, emails are relayed successfully
1. Before running the commands send email to relay address
2. Check that email was sent without a problem

## After running the flag command and adding the mozilla_corporation group, email relayed for mozilla.com user strips tracker and adds breakage survey link
1. To create a user group for Mozilla Corporation users and add users with mozilla.com email address, run:
```
./manage.py get_or_create_user_group mozilla_corporation
./manage.py update_user_group mozilla.com
```
2. To create a flag that is active for Mozilla Corporation users run:
```
./manage.py waffle_flag foxfood --group=mozilla_corporation --create
```
3. Send an email to a Mozilla user
4. Check that the email header now has another link with the text "Report Breakage" and looks like
<img width="1405" alt="Screen Shot 2022-04-25 at 15 46 57" src="https://user-images.githubusercontent.com/25109943/165172103-00321ea2-cdc7-4f22-84dc-13675a2eec7f.png">
6. Check that trackers in the general category was replaced with /faq link
7. 5. Check that logging was done and looks like:
```
{"Timestamp": 1650918098061819904, "Type": "studymetrics", "Logger": "fx-private-relay", "Hostname": "hostname", "EnvVersion": "2.0", "Severity": 6,"Fields": {"level": "general", "tracker_removed": 0, "general": {"count": 2, "trackers": {"open.tracker.com": 2}}, "strict": {"count": 0, "trackers": {}}, "msg": "email_tracker_foxfooding_summary"}}
```

## Add a user to the `foxfood` flag using an email results in user's email stripped from general tracker and adds breakage survey link
1. To add the user to existing `foxfood` flag, run:
```
./manage.py waffle_flag foxfood --append --user=email@address.com --group=mozilla_corporation
```
2. Send an email to the user's Relay address
3. Check that the email header now has another link with the text "Report Breakage" and looks like
<img width="1405" alt="Screen Shot 2022-04-25 at 15 46 57" src="https://user-images.githubusercontent.com/25109943/165172103-00321ea2-cdc7-4f22-84dc-13675a2eec7f.png">
4. Check that trackers in the general category was replaced with /faq link
5. Check that logging was done and looks like:
```
{"Timestamp": 1650918098061819904, "Type": "studymetrics", "Logger": "fx-private-relay", "Hostname": "hostname", "EnvVersion": "2.0", "Severity": 6,"Fields": {"level": "general", "tracker_removed": 0, "general": {"count": 2, "trackers": {"open.tracker.com": 2}}, "strict": {"count": 0, "trackers": {}}, "msg": "email_tracker_foxfooding_summary"}}
```

## Users not in foxfood flag gets email relayed as normal
1. Send email to relay for a user who is not a Mozillian and NOT listed for users in flag
2. Check that relayed email does not have a header to "Report Breakage"
3. Check that email is relayed as it has
4. `email_tracker_foxfooding_summary` was NOT logged

# Checklist

- [ ] l10n dependencies have been merged, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

# Follow-up
- Remove user from group
- User email address update triggers removal or addition to Foxfood flag
-  `update_user_group` command distinguishes between users that were already in the group and new users added to the group
