### PR TITLE
Update subdomain API mock 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Please refer to our [coding standards](docs/coding-standards.md) for code styles
     * On OSX: `brew install postgresql libpq`
     * On Fedora: `sudo dnf install libpq-devel python3-devel`
 * [SES](https://aws.amazon.com/ses/) if you want to send real emails
-* [Node 14.X](https://nodejs.org/en/download/) – Needed to compile the front-end
-  * [NPM](https://www.npmjs.com/)
+* [Volta](https://volta.sh/) – Sets up the right versions of Node and npm, needed to compile the front-end
 
 ### Install and Run the Site Locally
 

--- a/frontend/src/apiMocks/handlers.ts
+++ b/frontend/src/apiMocks/handlers.ts
@@ -67,7 +67,29 @@ export function getHandlers(
     return res(ctx.status(200), ctx.json([users[mockId]]));
   });
   addGetHandler("/accounts/profile/subdomain", (req, res, ctx) => {
+    if (req.url.searchParams.get("subdomain") === "not-available") {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          message: "error-subdomain-not-available",
+          subdomain: "not-available",
+        })
+      );
+    }
     return res(ctx.status(200), ctx.json({ available: true }));
+  });
+  addPostHandler("/accounts/profile/subdomain", (req, res, ctx) => {
+    const mockId = getMockId(req);
+    if (mockId === null) {
+      return res(ctx.status(400));
+    }
+    const body = req.body as string;
+    const data = new URLSearchParams(body);
+    profiles[mockId] = {
+      ...profiles[mockId],
+      subdomain: data.get("subdomain"),
+    };
+    return res(ctx.status(200));
   });
   addGetHandler("/api/v1/profiles/", (req, res, ctx) => {
     const mockId = getMockId(req);

--- a/frontend/src/apiMocks/handlers.ts
+++ b/frontend/src/apiMocks/handlers.ts
@@ -20,6 +20,7 @@ export function getHandlers(
     if (typeof authHeader !== "string") {
       return defaultMockId;
     }
+
     const token = authHeader.split(" ")[1];
     return mockIds.find((mockId) => mockId === token) ?? defaultMockId;
   };
@@ -56,16 +57,20 @@ export function getHandlers(
   addGetHandler("/accounts/logout", (_req, res, ctx) => {
     return res();
   });
+
   addGetHandler("/api/v1/runtime_data", (_req, res, ctx) => {
     return res(ctx.status(200), ctx.json(runtimeData));
   });
+
   addGetHandler("/api/v1/users/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
       return res(ctx.status(400));
     }
+
     return res(ctx.status(200), ctx.json([users[mockId]]));
   });
+
   addGetHandler("/accounts/profile/subdomain", (req, res, ctx) => {
     if (req.url.searchParams.get("subdomain") === "not-available") {
       return res(
@@ -76,13 +81,16 @@ export function getHandlers(
         })
       );
     }
+
     return res(ctx.status(200), ctx.json({ available: true }));
   });
+
   addPostHandler("/accounts/profile/subdomain", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
       return res(ctx.status(400));
     }
+
     const body = req.body as string;
     const data = new URLSearchParams(body);
     profiles[mockId] = {
@@ -91,18 +99,22 @@ export function getHandlers(
     };
     return res(ctx.status(200));
   });
+
   addGetHandler("/api/v1/profiles/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
       return res(ctx.status(400));
     }
+
     return res(ctx.status(200), ctx.json([profiles[mockId]]));
   });
+
   addPatchHandler("/api/v1/profiles/:id/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
       return res(ctx.status(400));
     }
+
     const body = req.body as Partial<ProfileData>;
     profiles[mockId] = {
       ...profiles[mockId],
@@ -110,18 +122,22 @@ export function getHandlers(
     };
     return res(ctx.status(200));
   });
+
   addGetHandler("/api/v1/relayaddresses/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
       return res(ctx.status(400));
     }
+
     return res(ctx.status(200), ctx.json(relayaddresses[mockId]));
   });
+
   addPostHandler("/api/v1/relayaddresses/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
       return res(ctx.status(400));
     }
+
     const body = req.body as Partial<RandomAliasData>;
     const ownAddresses = relayaddresses[mockId];
     const id = (ownAddresses[ownAddresses.length - 1]?.id ?? -1) + 1;
@@ -145,11 +161,13 @@ export function getHandlers(
     });
     return res(ctx.status(200));
   });
+
   addPatchHandler("/api/v1/relayaddresses/:id/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
       return res(ctx.status(400));
     }
+
     const ownAddresses = relayaddresses[mockId];
     const index = ownAddresses.findIndex(
       (address) => address.id === Number.parseInt(req.params.id as string, 10)
@@ -164,11 +182,13 @@ export function getHandlers(
     };
     return res(ctx.status(200));
   });
+
   addDeleteHandler("/api/v1/relayaddresses/:id/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
       return res(ctx.status(400));
     }
+
     const ownAddresses = relayaddresses[mockId];
     const index = ownAddresses.findIndex(
       (address) => address.id === Number.parseInt(req.params.id as string, 10)
@@ -176,21 +196,26 @@ export function getHandlers(
     if (index === -1) {
       return res(ctx.status(404));
     }
+
     ownAddresses.splice(index, 1);
     return res(ctx.status(200));
   });
+
   addGetHandler("/api/v1/domainaddresses/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
       return res(ctx.status(400));
     }
+
     return res(ctx.status(200), ctx.json(domainaddresses[mockId]));
   });
+
   addPostHandler("/api/v1/domainaddresses/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
       return res(ctx.status(400));
     }
+
     const body = req.body as Partial<CustomAliasData>;
     const ownAddresses = domainaddresses[mockId];
     const id = (ownAddresses[ownAddresses.length - 1]?.id ?? -1) + 1;
@@ -213,11 +238,13 @@ export function getHandlers(
     });
     return res(ctx.status(200));
   });
+
   addPatchHandler("/api/v1/domainaddresses/:id/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
       return res(ctx.status(400));
     }
+
     const ownAddresses = domainaddresses[mockId];
     const index = ownAddresses.findIndex(
       (address) => address.id === Number.parseInt(req.params.id as string, 10)
@@ -225,6 +252,7 @@ export function getHandlers(
     if (index === -1) {
       return res(ctx.status(404));
     }
+
     const body = req.body as Partial<CustomAliasData>;
     ownAddresses[index] = {
       ...ownAddresses[index],
@@ -232,11 +260,13 @@ export function getHandlers(
     };
     return res(ctx.status(200));
   });
+
   addDeleteHandler("/api/v1/domainaddresses/:id/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
       return res(ctx.status(400));
     }
+
     const ownAddresses = domainaddresses[mockId];
     const index = ownAddresses.findIndex(
       (address) => address.id === Number.parseInt(req.params.id as string, 10)
@@ -244,6 +274,7 @@ export function getHandlers(
     if (index === -1) {
       return res(ctx.status(404));
     }
+
     ownAddresses.splice(index, 1);
     return res(ctx.status(200));
   });


### PR DESCRIPTION
Since we're now using a special endpoint for the subdomain (see
https://github.com/mozilla/fx-private-relay/commit/f681d1f32c2d970a9e5312ec5f214dd713d99a3e), the mock for patching
the /profiles/ endpoint no longer suffice to mock registering a
subdomain.

I also updated the existing check-for-availability mock to report
no availability when picking the subdomain `not-available`.

And I snuck in a small README update to refer to Volta, to make it easier to all stick to the same JS toolchain.

How to test: try to register a subdomain [on the mock site](https://deploy-preview-1849--fx-relay-demo.netlify.app/?mockId=some). It should work now, as opposed to on [the current mock site](https://fx-relay-demo.netlify.app/?mockId=some). And for fun, try registering the domain `not-available` as well.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
