### PR TITLE
Sample a portion of the foxfood emails we relay

### DIFF
--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -6,9 +6,9 @@ from django.test import (
     override_settings
 )
 from unittest.mock import patch
+from waffle.testutils import override_sample
 
 from emails.models import get_domains_from_settings
-from emails import utils
 from emails.utils import (
     generate_relay_From,
     get_email_domain_from_settings,
@@ -108,6 +108,7 @@ class FormattingToolsTest(TestCase):
         }
 
 @override_settings(SITE_ORIGIN='https://test.com')
+@override_sample('foxfood-tracker-removal-sample', active=True)
 @patch('emails.utils.GENERAL_TRACKERS', ['open.tracker.com'])
 @patch('emails.utils.STRICT_TRACKERS', ['strict.tracker.com'])
 class RemoveTrackers(TestCase):
@@ -122,57 +123,94 @@ class RemoveTrackers(TestCase):
             '<a href="https://open.tracker.com/foo/bar.html">A link</a>\n'
             + '<img src="https://open.tracker.com/foo/bar.jpg">An image</img>'
         )
-        changed_content, general_removed, general_count, strict_count = remove_trackers(content)
+        changed_content, control, study_details = remove_trackers(content)
+        general_removed = study_details['tracker_removed']
+        general_count = study_details['general']['count']
+        strict_count = study_details['strict']['count']
 
         assert changed_content == self.expected_content
         assert general_removed == 2
         assert general_count == 2
         assert strict_count == 0
+        assert control == False
     
     def test_complex_general_tracker_replaced_with_relay_content(self):
         content = (
             '<a href="https://foo.open.tracker.com/foo/bar.html">A link</a>\n'
             + '<img src="https://bar.open.tracker.com/foo/bar.jpg">An image</img>'
         )
-        changed_content, general_removed, general_count, strict_count = remove_trackers(content)
+        changed_content, control, study_details = remove_trackers(content)
+        general_removed = study_details['tracker_removed']
+        general_count = study_details['general']['count']
+        strict_count = study_details['strict']['count']
 
         assert changed_content == self.expected_content
         assert general_removed == 2
         assert general_count == 2
         assert strict_count == 0
+        assert control == False
 
     def test_complex_single_quote_general_tracker_replaced_with_relay_content(self):
         content = (
             '<a href=\'https://foo.open.tracker.com/foo/bar.html\'>A link</a>\n'
             + '<img src=\'https://bar.open.tracker.com/foo/bar.jpg\'>An image</img>'
         )
-        changed_content, general_removed, general_count, strict_count = remove_trackers(content)
+        changed_content, control, study_details = remove_trackers(content)
+        general_removed = study_details['tracker_removed']
+        general_count = study_details['general']['count']
+        strict_count = study_details['strict']['count']
 
         assert changed_content == self.expected_content.replace('"', "'")
         assert general_removed == 2
         assert general_count == 2
         assert strict_count == 0
+        assert control == False
     
     def test_no_tracker_replaced_with_relay_content(self):
         content = (
             '<a href="https://fooopen.tracker.com/foo/bar.html">A link</a>\n'
             + '<img src="https://baropen.tracker.com/foo/bar.jpg">An image</img>'
         )
-        changed_content, general_removed, general_count, strict_count = remove_trackers(content)
+        changed_content, control, study_details = remove_trackers(content)
+        general_removed = study_details['tracker_removed']
+        general_count = study_details['general']['count']
+        strict_count = study_details['strict']['count']
 
         assert changed_content == content
         assert general_removed == 0
         assert general_count == 2  # this is because the count uses search and not regex pattern
         assert strict_count == 0
+        assert control == False
 
     def test_simple_strict_tracker_found(self):
         content = (
             '<a href="https://strict.tracker.com/foo/bar.html">A link</a>\n'
             + '<img src="https://strict.tracker.com/foo/bar.jpg">An image</img>'
         )
-        changed_content, general_removed, general_count, strict_count = remove_trackers(content)
+        changed_content, control, study_details = remove_trackers(content)
+        general_removed = study_details['tracker_removed']
+        general_count = study_details['general']['count']
+        strict_count = study_details['strict']['count']
 
         assert changed_content == content
         assert general_removed == 0
         assert general_count == 0
         assert strict_count == 2
+        assert control == False
+
+    @override_sample('foxfood-tracker-removal-sample', active=False)
+    def test_simple_general_strict_tracker_found_no_tracker_removed(self):
+        content = (
+            '<a href="https://foo.open.tracker.com/foo/bar.html">A link</a>\n'
+            + '<img src="https://strict.tracker.com/foo/bar.jpg">An image</img>'
+        )
+        changed_content, control, study_details = remove_trackers(content)
+        general_removed = study_details['tracker_removed']
+        general_count = study_details['general']['count']
+        strict_count = study_details['strict']['count']
+
+        assert changed_content == content
+        assert general_removed == 0
+        assert general_count == 1
+        assert strict_count == 1
+        assert control == True

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -408,7 +408,7 @@ def remove_trackers(html_content, level='general'):
     general_detail = count_tracker(html_content, GENERAL_TRACKERS)
     strict_detail = count_tracker(html_content, STRICT_TRACKERS)
     
-    if sample_is_active('foxfood-email-sample'):
+    if sample_is_active('foxfood-tracker-removal-sample'):
         control = False  # tracker is removed
         for tracker in trackers:
             pattern = convert_domains_to_regex_patterns(tracker)
@@ -424,4 +424,4 @@ def remove_trackers(html_content, level='general'):
         'email_tracker_foxfooding_summary',
         extra={'level': level}.update(study_details)
     )
-    return changed_content, study_details, control
+    return changed_content, control, study_details

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -422,6 +422,6 @@ def remove_trackers(html_content, level='general'):
     study_details = {'tracker_removed': tracker_removed, 'general': general_detail, 'strict': strict_detail}
     study_logger.info(
         'email_tracker_foxfooding_summary',
-        extra={'level': level, 'control': control}.update(study_details)
+        extra={'level': level, 'is_control': control}.update(study_details)
     )
     return changed_content, control, study_details

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -422,6 +422,6 @@ def remove_trackers(html_content, level='general'):
     study_details = {'tracker_removed': tracker_removed, 'general': general_detail, 'strict': strict_detail}
     study_logger.info(
         'email_tracker_foxfooding_summary',
-        extra={'level': level}.update(study_details)
+        extra={'level': level, 'control': control}.update(study_details)
     )
     return changed_content, control, study_details

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -16,6 +16,7 @@ import jwcrypto.jwe
 import jwcrypto.jwk
 import markus
 import logging
+from waffle import sample_is_active
 
 from django.apps import apps
 from django.conf import settings

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -406,10 +406,11 @@ def remove_trackers(html_content, level='general'):
     general_detail = count_tracker(html_content, GENERAL_TRACKERS)
     strict_detail = count_tracker(html_content, STRICT_TRACKERS)
     
-    for tracker in trackers:
-        pattern = convert_domains_to_regex_patterns(tracker)
-        changed_content, matched = re.subn(pattern, f'\g<1>{settings.SITE_ORIGIN}/faq\g<1>', changed_content)
-        tracker_removed += matched
+    if sample_is_active('foxfood-email-sample'):
+        for tracker in trackers:
+            pattern = convert_domains_to_regex_patterns(tracker)
+            changed_content, matched = re.subn(pattern, f'\g<1>{settings.SITE_ORIGIN}/faq\g<1>', changed_content)
+            tracker_removed += matched
 
     
     incr_if_enabled(f'tracker_foxfooding.{level}_removed_count', tracker_removed)

--- a/emails/views.py
+++ b/emails/views.py
@@ -472,12 +472,16 @@ def _sns_message(message_json):
         incr_if_enabled('email_with_html_content', 1)
         foxfood_flag = Flag.objects.filter(name='foxfood').first()
         if foxfood_flag and foxfood_flag.is_active_for_user(address.user):
-            html_content, removed_count, general_count, strict_count = remove_trackers(html_content)
+            html_content, control, study_details = remove_trackers(html_content)
+            removed_count = study_details['tracker_removed']
+            general_count = study_details['general']['count']
+            strict_count = study_details['strict']['count']
             email_tracker_study_link = (
                 'https://www.surveygizmo.com/s3/6837234/Relay-General-Email-Tracker-Removal-2022?'
                 + f'general-found={general_count}&'
                 + f'general-removed={removed_count}&'
                 + f'strict-found={strict_count}'
+                + f'control={control}'
             )
         
         wrapped_html = render_to_string('emails/wrapped_email.html', {


### PR DESCRIPTION
<!-- When adding a new feature: -->

# New feature description
Sample a portion of the email we relay in the Foxfooding so we can get an idea of what breakage without tracker removal looks like
```
./manage.py waffle_sample foxfood-tracker-removal-sample 50 --create
```
This will create a 50/50 split on emails we process in the foxfooding so we can get a control (base breakage) and tracker removal breakage (test breakage) report.

# Screenshot (if applicable)

Not applicable.

# How to test
n/a


# Checklist

- [ ] l10n dependencies have been merged, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
