### PR TITLE
Separate the query param properly

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -480,7 +480,7 @@ def _sns_message(message_json):
                 'https://www.surveygizmo.com/s3/6837234/Relay-General-Email-Tracker-Removal-2022?'
                 + f'general-found={general_count}&'
                 + f'general-removed={removed_count}&'
-                + f'strict-found={strict_count}'
+                + f'strict-found={strict_count}&'
                 + f'control={control}'
             )
         


### PR DESCRIPTION
How to test:
## Check emails with "Report breakage" in header has &control
1. Send an email to Relay account with Mozilla email address
2. Check the relayed email has "Report breakage"
3. Hover over the link and check that it ends with `&control=True` or `&control=False`

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
