### PR TITLE
MPP-1920: Detect SocialAccount without a token

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -501,7 +501,7 @@ class RelayAddress(models.Model):
                     break
                 self.address = address_default()
             profile.update_abuse_metric(address_created=True)
-        if (not profile.server_storage):
+        if not profile.server_storage:
             self.description = ""
             self.generated_for = ""
             self.used_on = ""
@@ -594,7 +594,7 @@ class DomainAddress(models.Model):
             check_user_can_make_domain_address(user_profile)
             user_profile.update_abuse_metric(address_created=True)
         # TODO: validate user is premium to set block_list_emails
-        if (not user_profile.server_storage):
+        if not user_profile.server_storage:
             self.description = ""
         return super().save(*args, **kwargs)
 

--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -95,8 +95,10 @@ class FormattingToolsTest(TestCase):
         )
         assert formatted_from_address == expected_formatted_from
 
-    @override_settings(RELAY_FROM_ADDRESS="noreply@relaytests.com",
-                       NEW_RELAY_FROM_ADDRESS="new_from@relaytests.com")
+    @override_settings(
+        RELAY_FROM_ADDRESS="noreply@relaytests.com",
+        NEW_RELAY_FROM_ADDRESS="new_from@relaytests.com",
+    )
     def test_generate_relay_From_with_new_from_user(self):
         free_user = make_free_test_user()
         new_from_flag = Flag.objects.create(name=NEW_FROM_ADDRESS_FLAG_NAME)
@@ -116,8 +118,10 @@ class FormattingToolsTest(TestCase):
         # WTF? TestCase tearDown doesn't clear out this waffle flag?
         new_from_flag.users.remove(free_user)
 
-    @override_settings(RELAY_FROM_ADDRESS="noreply@relaytests.com",
-                       NEW_RELAY_FROM_ADDRESS="new_from@relaytests.com")
+    @override_settings(
+        RELAY_FROM_ADDRESS="noreply@relaytests.com",
+        NEW_RELAY_FROM_ADDRESS="new_from@relaytests.com",
+    )
     def test_generate_relay_From_with_non_flagged_user(self):
         free_user = make_free_test_user()
         Flag.objects.create(name=NEW_FROM_ADDRESS_FLAG_NAME)
@@ -134,8 +138,10 @@ class FormattingToolsTest(TestCase):
         )
         assert formatted_from_address == expected_formatted_from
 
-    @override_settings(RELAY_FROM_ADDRESS="noreply@relaytests.com",
-                       NEW_RELAY_FROM_ADDRESS="new_from@relaytests.com")
+    @override_settings(
+        RELAY_FROM_ADDRESS="noreply@relaytests.com",
+        NEW_RELAY_FROM_ADDRESS="new_from@relaytests.com",
+    )
     def test_generate_relay_From_with_no_user_profile_somehow(self):
         free_user = baker.make(User)
         Flag.objects.create(name=NEW_FROM_ADDRESS_FLAG_NAME)

--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from allauth.socialaccount.models import SocialToken
 from allauth.socialaccount.providers.fxa.views import FirefoxAccountsOAuth2Adapter
 
-from .views import _get_oauth2_session, update_social_token
+from .views import _get_oauth2_session, update_social_token, NoSocialToken
 
 metrics = markus.get_metrics("fx-private-relay")
 
@@ -39,7 +39,7 @@ class FxAToRequest:
                     FirefoxAccountsOAuth2Adapter.access_token_url
                 )
                 update_social_token(social_token, new_token)
-            except CustomOAuth2Error:
+            except (CustomOAuth2Error, NoSocialToken):
                 logout(request)
                 return redirect(reverse("home"))
 

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -7,7 +7,15 @@ from allauth.socialaccount.models import SocialAccount
 from allauth.account.models import EmailAddress
 from model_bakery import baker
 
-from ..views import _update_all_data
+from ..views import _update_all_data, NoSocialToken
+
+
+def test_no_social_token():
+    exception = NoSocialToken("account_id")
+    assert repr(exception) == 'NoSocialToken("account_id")'
+    assert (
+        str(exception) == 'NoSocialToken: The SocialAccount "account_id" has no token.'
+    )
 
 
 class UpdateExtraDataAndEmailTest(TestCase):


### PR DESCRIPTION
Raise a new exception ``NoSocialToken`` when attempting to fetch a FxA user's profile with no associated token. ``SocialAccounts`` without a token are common on the development server (over half), but does not happen in production (confirmed by @moz-astults).

Fixes #1850 / MPP-1920.

There are no tests of the full `/fxa_rp_events` view, and it would take significant time to write them and fix existing issues. Since this is a dev-only issue, I held my nose and skipped the view tests (for now).

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

