### PR TITLE
Don’t expand alias cards that aren’t newly created by default

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -73,6 +73,10 @@ export const AliasList = (props: Props) => {
       return props.onUpdate(alias, updatedFields);
     };
 
+    const isExistingAlias = existingAliases.some(
+      (existingAlias) => existingAlias.id === alias.id
+    );
+
     return (
       <li
         className={styles["alias-card-wrapper"]}
@@ -84,7 +88,7 @@ export const AliasList = (props: Props) => {
           profile={props.profile}
           onUpdate={onUpdate}
           onDelete={() => props.onDelete(alias)}
-          defaultOpen={!existingAliases.includes(alias)}
+          defaultOpen={!isExistingAlias}
           showLabelEditor={props.profile.server_storage || localLabels !== null}
         />
       </li>


### PR DESCRIPTION
This PR fixes #1863.

How to test:

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).