### PR TITLE
Also expose add-on data while onboarding

### DIFF
--- a/frontend/src/components/dashboard/AddonData.tsx
+++ b/frontend/src/components/dashboard/AddonData.tsx
@@ -1,0 +1,40 @@
+import { getPlan, isPremiumAvailableInCountry } from "../../functions/getPlan";
+import { AliasData } from "../../hooks/api/aliases";
+import { ProfileData } from "../../hooks/api/profile";
+import { RuntimeData } from "../../hooks/api/runtimeData";
+
+export type Props = {
+  profile: ProfileData;
+  runtimeData: RuntimeData;
+  aliases: AliasData[];
+  totalForwardedEmails: number;
+  totalBlockedEmails: number;
+};
+
+export const AddonData = (props: Props) => {
+  return (
+    <firefox-private-relay-addon-data
+      // #profile-main is used by the add-on to look up the API token.
+      // TODO: Make it look for this custom element instead.
+      id="profile-main"
+      data-api-token={props.profile.api_token}
+      data-has-premium={props.profile.has_premium}
+      data-fxa-subscriptions-url={`${props.runtimeData.FXA_ORIGIN}/subscriptions`}
+      data-premium-prod-id={props.runtimeData.PREMIUM_PRODUCT_ID}
+      data-premium-price-id={
+        isPremiumAvailableInCountry(props.runtimeData)
+          ? getPlan(props.runtimeData).id
+          : undefined
+      }
+      data-aliases-used-val={props.aliases.length}
+      data-emails-forwarded-val={props.totalForwardedEmails}
+      data-emails-blocked-val={props.totalBlockedEmails}
+      data-premium-subdomain-set={
+        typeof props.profile.subdomain === "string"
+          ? props.profile.subdomain
+          : "None"
+      }
+      data-premium-enabled="True"
+    ></firefox-private-relay-addon-data>
+  );
+};

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -19,7 +19,6 @@ import { ProfileBanners } from "../../components/dashboard/ProfileBanners";
 import { LinkButton } from "../../components/Button";
 import { useRuntimeData } from "../../hooks/api/runtimeData";
 import {
-  getPlan,
   getPremiumSubscribeLink,
   isPremiumAvailableInCountry,
 } from "../../functions/getPlan";
@@ -34,6 +33,7 @@ import { clearCookie, getCookie } from "../../functions/cookies";
 import { toast } from "react-toastify";
 import { getLocale } from "../../functions/getLocale";
 import { InfoTooltip } from "../../components/InfoTooltip";
+import { AddonData } from "../../components/dashboard/AddonData";
 
 const Profile: NextPage = () => {
   const runtimeData = useRuntimeData();
@@ -91,6 +91,20 @@ const Profile: NextPage = () => {
     }
   };
 
+  const allAliases = getAllAliases(
+    aliasData.randomAliasData.data,
+    aliasData.customAliasData.data
+  );
+
+  const totalBlockedEmails = allAliases.reduce(
+    (count, alias) => count + alias.num_blocked,
+    0
+  );
+  const totalForwardedEmails = allAliases.reduce(
+    (count, alias) => count + alias.num_forwarded,
+    0
+  );
+
   if (
     profile.has_premium &&
     profile.onboarding_state < getRuntimeConfig().maxOnboardingAvailable
@@ -102,13 +116,22 @@ const Profile: NextPage = () => {
     };
 
     return (
-      <Layout>
-        <PremiumOnboarding
+      <>
+        <AddonData
+          aliases={allAliases}
           profile={profile}
-          onNextStep={onNextStep}
-          onPickSubdomain={setCustomSubdomain}
+          runtimeData={runtimeData.data}
+          totalBlockedEmails={totalBlockedEmails}
+          totalForwardedEmails={totalForwardedEmails}
         />
-      </Layout>
+        <Layout>
+          <PremiumOnboarding
+            profile={profile}
+            onNextStep={onNextStep}
+            onPickSubdomain={setCustomSubdomain}
+          />
+        </Layout>
+      </>
     );
   }
 
@@ -165,20 +188,6 @@ const Profile: NextPage = () => {
       );
     }
   };
-
-  const allAliases = getAllAliases(
-    aliasData.randomAliasData.data,
-    aliasData.customAliasData.data
-  );
-
-  const totalBlockedEmails = allAliases.reduce(
-    (count, alias) => count + alias.num_blocked,
-    0
-  );
-  const totalForwardedEmails = allAliases.reduce(
-    (count, alias) => count + alias.num_forwarded,
-    0
-  );
 
   const subdomainMessage =
     typeof profile.subdomain === "string" ? (
@@ -314,27 +323,13 @@ const Profile: NextPage = () => {
 
   return (
     <>
-      <firefox-private-relay-addon-data
-        // #profile-main is used by the add-on to look up the API token.
-        // TODO: Make it look for this custom element instead.
-        id="profile-main"
-        data-api-token={profile.api_token}
-        data-has-premium={profile.has_premium}
-        data-fxa-subscriptions-url={`${runtimeData.data.FXA_ORIGIN}/subscriptions`}
-        data-premium-prod-id={runtimeData.data.PREMIUM_PRODUCT_ID}
-        data-premium-price-id={
-          isPremiumAvailableInCountry(runtimeData.data)
-            ? getPlan(runtimeData.data).id
-            : undefined
-        }
-        data-aliases-used-val={allAliases.length}
-        data-emails-forwarded-val={totalForwardedEmails}
-        data-emails-blocked-val={totalBlockedEmails}
-        data-premium-subdomain-set={
-          typeof profile.subdomain === "string" ? profile.subdomain : "None"
-        }
-        data-premium-enabled="True"
-      ></firefox-private-relay-addon-data>
+      <AddonData
+        aliases={allAliases}
+        profile={profile}
+        runtimeData={runtimeData.data}
+        totalBlockedEmails={totalBlockedEmails}
+        totalForwardedEmails={totalForwardedEmails}
+      />
       <Layout>
         <main className={styles["profile-wrapper"]}>
           {stats}

--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -418,6 +418,24 @@ describe("The dashboard", () => {
     expect(onboardingHeading).not.toBeInTheDocument();
   });
 
+  it("exposes user data to the add-on when onboarding the user", () => {
+    setMockProfileDataOnce({ has_premium: true, onboarding_state: 0 });
+
+    const { container } = render(<Profile />);
+
+    // Since we're explicitly testing for something that's not visible to the user,
+    // but instead is for data exposed to the add-on which will explicitly be
+    // looking for this tag name, direct node access (i.e. mimicking the API
+    // used by the add-on) is fine here:
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    const addonDataElements = container.getElementsByTagName(
+      "firefox-private-relay-addon-data"
+    );
+
+    expect(addonDataElements).toHaveLength(1);
+    expect(addonDataElements[0]).toBeInTheDocument();
+  });
+
   it("allows picking a subdomain in the second step of the Premium onboarding", () => {
     setMockProfileDataOnce({
       has_premium: true,
@@ -702,6 +720,22 @@ describe("The dashboard", () => {
 
     const customAlias = screen.queryByText(/address3/);
     expect(customAlias).toBeInTheDocument();
+  });
+
+  it("exposes user data to the add-on", () => {
+    const { container } = render(<Profile />);
+
+    // Since we're explicitly testing for something that's not visible to the user,
+    // but instead is for data exposed to the add-on which will explicitly be
+    // looking for this tag name, direct node access (i.e. mimicking the API
+    // used by the add-on) is fine here:
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    const addonDataElements = container.getElementsByTagName(
+      "firefox-private-relay-addon-data"
+    );
+
+    expect(addonDataElements).toHaveLength(1);
+    expect(addonDataElements[0]).toBeInTheDocument();
   });
 
   describe("with the `generateCustomAlias` feature flag enabled", () => {


### PR DESCRIPTION
This PR fixes a bug I noticed when testing the add-on: if your user account is in the Premium onboarding state, and you then install the add-on, the add-on won't be able to read out user data to e.g. see whether the user has Premium, or how many aliases they have.

How to test: with a Premium account that is still in onboarding, install the add-on. Verify that the add-on reflects your login state successfully after signing in. (To compare, it should not show all your data when you do this in `main`. Also, one of the tests added in this PR fail there.)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
