### PR TITLE
Fix two remaining references to "aliases"

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -2,6 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+banner-download-install-chrome-extension-copy-2 = The { -brand-name-firefox-relay } extension for { -brand-name-chrome } makes creating and using masks even easier.
+multi-part-onboarding-premium-chrome-extension-get-description-2 = The { -brand-name-firefox-relay } extension for { -brand-name-chrome } makes creating and using email masks even easier.
+
 # This copy (and the term "critical email") is not final yet:
 tips-critical-emails-heading = Critical email forwarding
 # This copy (and the term "critical email") is not final yet:

--- a/frontend/src/components/dashboard/PremiumOnboarding.tsx
+++ b/frontend/src/components/dashboard/PremiumOnboarding.tsx
@@ -468,7 +468,7 @@ const getAddonDescriptionProps = () => {
       headerMessageId:
         "multi-part-onboarding-premium-chrome-extension-get-title",
       paragraphMessageId:
-        "multi-part-onboarding-premium-chrome-extension-get-description",
+        "multi-part-onboarding-premium-chrome-extension-get-description-2",
       linkHref:
         "https://chrome.google.com/webstore/detail/firefox-relay/lknpoadjjkjcmjhbjpcljdednccbldeb?utm_source=fx-relay&utm_medium=onboarding&utm_campaign=install-addon",
       linkMessageId:

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -186,7 +186,7 @@ const NoChromeExtensionBanner = () => {
       }}
       hiddenWithAddon={true}
     >
-      <p>{l10n.getString("banner-download-install-chrome-extension-copy")}</p>
+      <p>{l10n.getString("banner-download-install-chrome-extension-copy-2")}</p>
     </Banner>
   );
 };


### PR DESCRIPTION
I caught these after removing all deprecated strings and checking
for remaining mentions of aliases, so with these two, we should
have them all.

How to test: there should be no more mentions of aliases, even when in Chrome without the extension.

- [x] l10n changes have been submitted to the l10n repository, if any. https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/77
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
