### PR TITLE
Use environment-specific Basket URLs

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -3,6 +3,7 @@ FXA_OAUTH_ENDPOINT=https://oauth.stage.mozaws.net/v1
 FXA_PROFILE_ENDPOINT=https://profile.stage.mozaws.net/v1
 FXA_BASE_ORIGIN=https://accounts.stage.mozaws.net
 GOOGLE_ANALYTICS_ID="UA-77033033-33"
+BASKET_ORIGIN="https://basket-dev.allizom.org"
 SECRET_KEY=unsafe-secret-key-for-dev-envs
 ADMIN_ENABLED=
 DEBUG=True

--- a/api/views.py
+++ b/api/views.py
@@ -13,7 +13,7 @@ from emails.models import (
     Profile,
     RelayAddress
 )
-from privaterelay.settings import FXA_BASE_ORIGIN, GOOGLE_ANALYTICS_ID, PREMIUM_PROD_ID
+from privaterelay.settings import BASKET_ORIGIN, FXA_BASE_ORIGIN, GOOGLE_ANALYTICS_ID, PREMIUM_PROD_ID
 from privaterelay.utils import get_premium_countries_info_from_request
 
 from .permissions import IsOwner
@@ -117,5 +117,6 @@ def runtime_data(request):
             "GOOGLE_ANALYTICS_ID": GOOGLE_ANALYTICS_ID,
             "PREMIUM_PRODUCT_ID": PREMIUM_PROD_ID,
             "PREMIUM_PLANS": get_premium_countries_info_from_request(request),
+            "BASKET_ORIGIN": BASKET_ORIGIN,
         }
     )

--- a/frontend/__mocks__/hooks/api/runtimeData.ts
+++ b/frontend/__mocks__/hooks/api/runtimeData.ts
@@ -13,8 +13,8 @@ const mockedUseRuntimeData = useRuntimeData as jest.MockedFunction<
 
 export function getMockRuntimeDataWithPremium(): RuntimeData {
   return {
-    FXA_ORIGIN: "https://example.com",
-    BASKET_ORIGIN: "https://example.com",
+    FXA_ORIGIN: "https://fxa-mock.com",
+    BASKET_ORIGIN: "https://basket-mock.com",
     GOOGLE_ANALYTICS_ID: "UA-123456789-0",
     PREMIUM_PRODUCT_ID: "prod_123456789",
     PREMIUM_PLANS: {
@@ -34,8 +34,8 @@ export function getMockRuntimeDataWithPremium(): RuntimeData {
 }
 export function getMockRuntimeDataWithoutPremium(): RuntimeData {
   return {
-    FXA_ORIGIN: "https://example.com",
-    BASKET_ORIGIN: "https://example.com",
+    FXA_ORIGIN: "https://fxa-mock.com",
+    BASKET_ORIGIN: "https://basket-mock.com",
     GOOGLE_ANALYTICS_ID: "UA-123456789-0",
     PREMIUM_PRODUCT_ID: "prod_123456789",
     PREMIUM_PLANS: {

--- a/frontend/__mocks__/hooks/api/runtimeData.ts
+++ b/frontend/__mocks__/hooks/api/runtimeData.ts
@@ -14,6 +14,7 @@ const mockedUseRuntimeData = useRuntimeData as jest.MockedFunction<
 export function getMockRuntimeDataWithPremium(): RuntimeData {
   return {
     FXA_ORIGIN: "https://example.com",
+    BASKET_ORIGIN: "https://basket.mozilla.org",
     GOOGLE_ANALYTICS_ID: "UA-123456789-0",
     PREMIUM_PRODUCT_ID: "prod_123456789",
     PREMIUM_PLANS: {
@@ -34,6 +35,7 @@ export function getMockRuntimeDataWithPremium(): RuntimeData {
 export function getMockRuntimeDataWithoutPremium(): RuntimeData {
   return {
     FXA_ORIGIN: "https://example.com",
+    BASKET_ORIGIN: "https://basket.mozilla.org",
     GOOGLE_ANALYTICS_ID: "UA-123456789-0",
     PREMIUM_PRODUCT_ID: "prod_123456789",
     PREMIUM_PLANS: {

--- a/frontend/__mocks__/hooks/api/runtimeData.ts
+++ b/frontend/__mocks__/hooks/api/runtimeData.ts
@@ -14,7 +14,7 @@ const mockedUseRuntimeData = useRuntimeData as jest.MockedFunction<
 export function getMockRuntimeDataWithPremium(): RuntimeData {
   return {
     FXA_ORIGIN: "https://example.com",
-    BASKET_ORIGIN: "https://basket.mozilla.org",
+    BASKET_ORIGIN: "https://example.com",
     GOOGLE_ANALYTICS_ID: "UA-123456789-0",
     PREMIUM_PRODUCT_ID: "prod_123456789",
     PREMIUM_PLANS: {
@@ -35,7 +35,7 @@ export function getMockRuntimeDataWithPremium(): RuntimeData {
 export function getMockRuntimeDataWithoutPremium(): RuntimeData {
   return {
     FXA_ORIGIN: "https://example.com",
-    BASKET_ORIGIN: "https://basket.mozilla.org",
+    BASKET_ORIGIN: "https://example.com",
     GOOGLE_ANALYTICS_ID: "UA-123456789-0",
     PREMIUM_PRODUCT_ID: "prod_123456789",
     PREMIUM_PLANS: {

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -7,7 +7,6 @@ const runtimeConfigs = {
     frontendOrigin: "",
     fxaLoginUrl: "/accounts/fxa/login/?process=login",
     fxaLogoutUrl: "/accounts/logout/",
-    basketOrigin: "https://basket.mozilla.org",
     emailSizeLimitNumber: 10,
     emailSizeLimitUnit: "MB",
     maxFreeAliases: 5,
@@ -37,7 +36,6 @@ runtimeConfigs.development = {
   frontendOrigin: "http://localhost:3000",
   fxaLoginUrl: "http://localhost:3000/mock/login",
   fxaLogoutUrl: "http://localhost:3000/mock/logout",
-  basketOrigin: "https://basket-dev.allizom.org",
 };
 
 // This configuration is for the setup where the front-end is built and served
@@ -49,7 +47,6 @@ runtimeConfigs.apimock = {
   frontendOrigin: "",
   fxaLoginUrl: "/mock/login",
   fxaLogoutUrl: "/mock/logout",
-  basketOrigin: "https://basket-dev.allizom.org",
 };
 
 /** @type {(config: import('next').NextConfig) => import('next').NextConfig} */

--- a/frontend/src/apiMocks/mockData.ts
+++ b/frontend/src/apiMocks/mockData.ts
@@ -7,8 +7,8 @@ export const mockIds = ["empty", "onboarding", "some", "full"] as const;
 
 // This is the same for all mock users, at this time:
 export const runtimeData: RuntimeData = {
-  FXA_ORIGIN: "https://example.com",
-  BASKET_ORIGIN: "https://example.com",
+  FXA_ORIGIN: "https://fxa-mock.com",
+  BASKET_ORIGIN: "https://basket-mock.com",
   GOOGLE_ANALYTICS_ID: "UA-123456789-0",
   PREMIUM_PRODUCT_ID: "prod_123456789",
   PREMIUM_PLANS: {

--- a/frontend/src/apiMocks/mockData.ts
+++ b/frontend/src/apiMocks/mockData.ts
@@ -8,6 +8,7 @@ export const mockIds = ["empty", "onboarding", "some", "full"] as const;
 // This is the same for all mock users, at this time:
 export const runtimeData: RuntimeData = {
   FXA_ORIGIN: "https://example.com",
+  BASKET_ORIGIN: "https://example.com",
   GOOGLE_ANALYTICS_ID: "UA-123456789-0",
   PREMIUM_PRODUCT_ID: "prod_123456789",
   PREMIUM_PLANS: {

--- a/frontend/src/components/waitlist/countryPicker.tsx
+++ b/frontend/src/components/waitlist/countryPicker.tsx
@@ -13,9 +13,8 @@ type Territories = {
     }
   >;
 };
-export const CountryPicker = (
-  props: SelectHTMLAttributes<HTMLSelectElement>
-) => {
+export type Props = SelectHTMLAttributes<HTMLSelectElement>;
+export const CountryPicker = (props: Props) => {
   const { l10n } = useLocalization();
   const currentLocale = getLocale(l10n);
   const [localeDisplayNames, setLocaleDisplayNames] =

--- a/frontend/src/components/waitlist/localePicker.tsx
+++ b/frontend/src/components/waitlist/localePicker.tsx
@@ -13,7 +13,7 @@ type Languages = {
     }
   >;
 };
-type Props = SelectHTMLAttributes<HTMLSelectElement> & {
+export type Props = SelectHTMLAttributes<HTMLSelectElement> & {
   supportedLocales: string[];
 };
 export const LocalePicker = ({ supportedLocales, ...selectProps }: Props) => {

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -11,7 +11,6 @@ export type RuntimeConfig = {
   frontendOrigin: string;
   fxaLoginUrl: string;
   fxaLogoutUrl: string;
-  basketOrigin: string;
   emailSizeLimitNumber: number;
   emailSizeLimitUnit: string;
   maxFreeAliases: number;

--- a/frontend/src/hooks/api/runtimeData.ts
+++ b/frontend/src/hooks/api/runtimeData.ts
@@ -17,6 +17,7 @@ export type RuntimeData = {
   GOOGLE_ANALYTICS_ID: `UA-${number}-${number}`;
   PREMIUM_PRODUCT_ID: `prod_${string}`;
   PREMIUM_PLANS: PremiumPlans;
+  BASKET_ORIGIN: string;
 };
 
 /**

--- a/frontend/src/pages/premium/waitlist.page.tsx
+++ b/frontend/src/pages/premium/waitlist.page.tsx
@@ -19,9 +19,10 @@ const PremiumWaitlist: NextPage = () => {
   const { l10n } = useLocalization();
   const currentLocale = getLocale(l10n);
   const runtimeData = useRuntimeData();
-  const currentCountry: string | undefined =
-    runtimeData.data?.PREMIUM_PLANS.country_code ?? currentLocale.split("-")[1];
-  const [country, setCountry] = useState<string>(currentCountry ?? "US");
+  const currentCountry =
+    runtimeData.data?.PREMIUM_PLANS.country_code ??
+    (currentLocale.split("-")[1] as string | undefined);
+  const [country, setCountry] = useState<string>();
   const [locale, setLocale] = useState<string>(
     supportedLocales.find(
       (supportedLocale) =>
@@ -56,7 +57,7 @@ const PremiumWaitlist: NextPage = () => {
     try {
       const response = await subscribe({
         email: email,
-        countryCode: country,
+        countryCode: country ?? currentCountry ?? "US",
         locale: locale,
         detectedCountry: currentCountry,
       });
@@ -95,7 +96,7 @@ const PremiumWaitlist: NextPage = () => {
                 type="email"
                 name="email"
                 id="email"
-                value={email}
+                value={email ?? ""}
                 required={true}
                 onChange={(event) => setEmail(event.target.value)}
                 placeholder={l10n.getString(
@@ -111,7 +112,7 @@ const PremiumWaitlist: NextPage = () => {
               <CountryPicker
                 name="country"
                 id="country"
-                value={country}
+                value={country ?? currentCountry ?? "US"}
                 onChange={(event) =>
                   setCountry(
                     event.target.selectedOptions.item(0)?.value ?? country

--- a/frontend/src/pages/premium/waitlist.test.tsx
+++ b/frontend/src/pages/premium/waitlist.test.tsx
@@ -54,6 +54,30 @@ describe("The waitlist", () => {
     });
   });
 
+  it("sends the user's email to Basket", async () => {
+    render(<PremiumWaitlist />);
+
+    const emailInput = screen.getByLabelText(
+      "l10n string: [waitlist-control-email-label], with vars: {}"
+    );
+    userEvent.clear(emailInput);
+    userEvent.type(emailInput, "some_email@example.com");
+
+    const submitButton = screen.getByRole("button", {
+      name: "l10n string: [waitlist-submit-label], with vars: {}",
+    });
+    userEvent.click(submitButton);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://basket.mozilla.org/news/subscribe/",
+      expect.objectContaining({ body: expect.stringContaining("") })
+    );
+    const requestBody = (global.fetch as jest.Mock).mock.calls[0][1].body;
+    const params = new URLSearchParams(requestBody);
+    expect(params.get("email")).toBe("some_email@example.com");
+  });
+
   it("uses the Basket URL set by the back-end", async () => {
     setMockRuntimeData({ BASKET_ORIGIN: "https://some-basket-url.com" });
     render(<PremiumWaitlist />);

--- a/frontend/src/pages/premium/waitlist.test.tsx
+++ b/frontend/src/pages/premium/waitlist.test.tsx
@@ -83,7 +83,7 @@ describe("The waitlist", () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({ body: expect.stringContaining("") })
+      expect.objectContaining({ body: expect.any(String) })
     );
     const requestBody = (global.fetch as jest.Mock).mock.calls[0][1].body;
     const params = new URLSearchParams(requestBody);

--- a/frontend/src/pages/premium/waitlist.test.tsx
+++ b/frontend/src/pages/premium/waitlist.test.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
+import { type Props as CountryPickerProps } from "../../components/waitlist/countryPicker";
+import { type Props as LocalePickerProps } from "../../components/waitlist/localePicker";
 import { mockFluentReact } from "../../../__mocks__/modules/fluent__react";
 import { mockNextRouter } from "../../../__mocks__/modules/next__router";
 import { mockConfigModule } from "../../../__mocks__/configMock";
@@ -16,13 +18,21 @@ jest.mock("next/router", () => mockNextRouter);
 jest.mock("../../config.ts", () => mockConfigModule);
 jest.mock("../../hooks/gaViewPing.ts");
 jest.mock("../../components/waitlist/countryPicker.tsx", () => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  CountryPicker: (props: any) => <select {...props} />,
+  // We're mocking out the country picker because it dynamically imports the
+  // list of available countries, which would make the test pretty cumbersome
+  // while waiting for the promise to resolve.
+  // Since it's otherwise just a `<select>` element, we can just mock it out by
+  // an empty <select>.
+  CountryPicker: (props: CountryPickerProps) => <select {...props} />,
 }));
 jest.mock("../../components/waitlist/localePicker.tsx", () => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  LocalePicker: (allProps: any) => {
-    const props = {
+  // We're mocking out the locale picker because it dynamically imports the
+  // list of available countries, which would make the test pretty cumbersome
+  // while waiting for the promise to resolve.
+  // Since it's otherwise just a `<select>` element, we can just mock it out by
+  // an empty <select>.
+  LocalePicker: (allProps: LocalePickerProps) => {
+    const props: Partial<LocalePickerProps> = {
       ...allProps,
     };
     delete props.supportedLocales;

--- a/frontend/src/pages/premium/waitlist.test.tsx
+++ b/frontend/src/pages/premium/waitlist.test.tsx
@@ -80,7 +80,7 @@ describe("The waitlist", () => {
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith(
-      "https://basket.mozilla.org/news/subscribe/",
+      expect.any(String),
       expect.objectContaining({ body: expect.stringContaining("") })
     );
     const requestBody = (global.fetch as jest.Mock).mock.calls[0][1].body;

--- a/frontend/src/pages/premium/waitlist.test.tsx
+++ b/frontend/src/pages/premium/waitlist.test.tsx
@@ -19,16 +19,18 @@ jest.mock("../../config.ts", () => mockConfigModule);
 jest.mock("../../hooks/gaViewPing.ts");
 jest.mock("../../components/waitlist/countryPicker.tsx", () => ({
   // We're mocking out the country picker because it dynamically imports the
-  // list of available countries, which would make the test pretty cumbersome
-  // while waiting for the promise to resolve.
+  // list of available countries, which would mean the test would have to mock
+  // out that import's Promise and wait for that to resolve, distracting from
+  // the actual test code.
   // Since it's otherwise just a `<select>` element, we can just mock it out by
   // an empty <select>.
   CountryPicker: (props: CountryPickerProps) => <select {...props} />,
 }));
 jest.mock("../../components/waitlist/localePicker.tsx", () => ({
   // We're mocking out the locale picker because it dynamically imports the
-  // list of available countries, which would make the test pretty cumbersome
-  // while waiting for the promise to resolve.
+  // list of available countries, which would mean the test would have to mock
+  // out that import's Promise and wait for that to resolve, distracting from
+  // the actual test code.
   // Since it's otherwise just a `<select>` element, we can just mock it out by
   // an empty <select>.
   LocalePicker: (allProps: LocalePickerProps) => {

--- a/frontend/src/pages/premium/waitlist.test.tsx
+++ b/frontend/src/pages/premium/waitlist.test.tsx
@@ -1,9 +1,13 @@
 import React from "react";
-import { act, render } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import { mockFluentReact } from "../../../__mocks__/modules/fluent__react";
 import { mockNextRouter } from "../../../__mocks__/modules/next__router";
 import { mockConfigModule } from "../../../__mocks__/configMock";
+import { setMockRuntimeData } from "../../../__mocks__/hooks/api/runtimeData";
+import { setMockUserData } from "../../../__mocks__/hooks/api/user";
+import { setMockProfileData } from "../../../__mocks__/hooks/api/profile";
 
 import PremiumWaitlist from "./waitlist.page";
 
@@ -11,6 +15,30 @@ jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("next/router", () => mockNextRouter);
 jest.mock("../../config.ts", () => mockConfigModule);
 jest.mock("../../hooks/gaViewPing.ts");
+jest.mock("../../components/waitlist/countryPicker.tsx", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  CountryPicker: (props: any) => <select {...props} />,
+}));
+jest.mock("../../components/waitlist/localePicker.tsx", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  LocalePicker: (allProps: any) => {
+    const props = {
+      ...allProps,
+    };
+    delete props.supportedLocales;
+    return <select {...props} />;
+  },
+}));
+
+setMockRuntimeData();
+setMockUserData();
+setMockProfileData();
+
+global.fetch = jest.fn();
+
+beforeEach(() => {
+  (global.fetch as jest.Mock).mockClear();
+});
 
 describe("The waitlist", () => {
   describe("under axe accessibility testing", () => {
@@ -24,5 +52,29 @@ describe("The waitlist", () => {
 
       expect(results).toHaveNoViolations();
     });
+  });
+
+  it("uses the Basket URL set by the back-end", async () => {
+    setMockRuntimeData({ BASKET_ORIGIN: "https://some-basket-url.com" });
+    render(<PremiumWaitlist />);
+
+    const emailInput = screen.getByLabelText(
+      "l10n string: [waitlist-control-email-label], with vars: {}"
+    );
+    userEvent.clear(emailInput);
+    userEvent.type(emailInput, "arbitrary_email@example.com");
+
+    const submitButton = screen.getByRole("button", {
+      name: "l10n string: [waitlist-submit-label], with vars: {}",
+    });
+    userEvent.click(submitButton);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://some-basket-url.com/news/subscribe/",
+      expect.anything()
+    );
+    // Restore the original runtime data mocks:
+    setMockRuntimeData();
   });
 });

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -569,6 +569,7 @@ FXA_BASE_ORIGIN = config('FXA_BASE_ORIGIN', 'https://accounts.firefox.com')
 FXA_SETTINGS_URL = config('FXA_SETTINGS_URL', f'{FXA_BASE_ORIGIN}/settings')
 FXA_SUBSCRIPTIONS_URL = config('FXA_SUBSCRIPTIONS_URL', f'{FXA_BASE_ORIGIN}/subscriptions')
 FXA_SUPPORT_URL = config('FXA_SUPPORT_URL', f'{FXA_BASE_ORIGIN}/support/')
+BASKET_ORIGIN = config('BASKET_ORIGIN', 'https://basket.mozilla.org')
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
[The request](https://mozilla.slack.com/archives/CUU5EC46L/p1651163577447129?thread_ts=1651096179.335249&cid=CUU5EC46L) was for our stage environment to point to the dev environment of Basket, whereas before we only did so when running locally. Therefore, this PR makes it so that we fetch the relevant Basket URL from the back-end, where it can be set with environment variables.

I also fixed a bug in which the country detected for a user would not be used, because we'd already set the value to the country derived from the user's Accept language. (Only uncovered on stage because that's where we have proper location-detection.)

How to test:

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
