### PR TITLE
Limit mask rename announcement to relevant locales

### DIFF
--- a/frontend/src/components/layout/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/whatsnew/WhatsNewMenu.tsx
@@ -38,6 +38,7 @@ import { ProfileData } from "../../../hooks/api/profile";
 import { WhatsNewDashboard } from "./WhatsNewDashboard";
 import { useAddonData } from "../../../hooks/addon";
 import { isUsingFirefox } from "../../../functions/userAgent";
+import { getLocale } from "../../../functions/getLocale";
 
 export type WhatsNewEntry = {
   title: string;
@@ -185,7 +186,32 @@ export const WhatsNewMenu = (props: Props) => {
       day: 19,
     },
   };
-  entries.push(aliasToMask);
+  // Not all localisations transitioned from "alias" to "mask", so only show this
+  // announcement for those of which we _know_ did:
+  if (
+    [
+      "en",
+      "en-gb",
+      "nl",
+      "fy-nl",
+      "zh-tw",
+      "es-es",
+      "es-mx",
+      "de",
+      "pt-br",
+      "sv-se",
+      "el",
+      "hu",
+      "ia",
+      "id",
+      "it",
+      "sk",
+      "skr",
+      "uk",
+    ].includes(getLocale(l10n).toLowerCase())
+  ) {
+    entries.push(aliasToMask);
+  }
 
   entries.sort(entriesDescByDateSorter);
 


### PR DESCRIPTION
The announcement about the rename of aliases to masks should only be shown in languages that actually applied the rename. I'd [applied this change before](https://github.com/mozilla/fx-private-relay/pull/1746#issuecomment-1103691386), but it looks like a force push removed that :/

Additionally, compared to then, I added a couple more languages, since locales in which the transition was not done were asked not to translate the announcement, so by checking those strings, I could verify which locales _had_ made the change.

How to test:

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A (they're a bit painful to make, since showing the announcement depends on the current date, which is variable in tests)
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
