### PR TITLE
Re-implement FxA metrics flow calls

### DIFF
--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -44,7 +44,8 @@ Import tokens from [Protocol](https://protocol.mozilla.org).
 ## Add telemetry
 
 Uses [`react-ga`](https://www.npmjs.com/package/react-ga).
-See `useGaViewPing` and `trackPurchaseStart`.
+See `useGaViewPing` (and `useFxaFlowTracker` when measuring use of sign in/up
+links in particular) and `trackPurchaseStart`.
 
 ## Add/modify environment-specific data
 

--- a/frontend/__mocks__/hooks/fxaFlowTracker.ts
+++ b/frontend/__mocks__/hooks/fxaFlowTracker.ts
@@ -1,0 +1,6 @@
+export const mockUseFxaFlowTrackerModule = {
+  useFxaFlowTracker: jest.fn(() => {
+    // Tracker data can be undefined while runtime data is still loading:
+    return {};
+  }),
+};

--- a/frontend/__mocks__/hooks/fxaFlowTracker.ts
+++ b/frontend/__mocks__/hooks/fxaFlowTracker.ts
@@ -3,4 +3,5 @@ export const mockUseFxaFlowTrackerModule = {
     // Tracker data can be undefined while runtime data is still loading:
     return {};
   }),
+  getLoginUrl: jest.fn(() => "https://login-mock.com"),
 };

--- a/frontend/src/apiMocks/handlers.ts
+++ b/frontend/src/apiMocks/handlers.ts
@@ -230,6 +230,17 @@ export function getHandlers(
       return res(ctx.status(200), ctx.json({ status: "ok" }));
     })
   );
+  handlers.push(
+    rest.get("https://accounts.firefox.com/metrics-flow", (_req, res, ctx) => {
+      return res(
+        ctx.status(200),
+        ctx.json({
+          flowId: "mock-flow-id",
+          flowBeginTime: new Date(Date.now()).toISOString(),
+        })
+      );
+    })
+  );
 
   return handlers;
 }

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -5,7 +5,7 @@ import { event as gaEvent } from "react-ga";
 import styles from "./Navigation.module.scss";
 import { useIsLoggedIn } from "../../hooks/session";
 import { getRuntimeConfig } from "../../config";
-import { useGaViewPing } from "../../hooks/gaViewPing";
+import { useFxaFlowTracker } from "../../hooks/fxaFlowTracker";
 
 /** Switch between the different pages of the Relay website. */
 export const Navigation = () => {
@@ -15,14 +15,35 @@ export const Navigation = () => {
   const isLoggedIn = useIsLoggedIn();
   const homePath = isLoggedIn ? "/accounts/profile" : "/";
 
-  const signUpButtonRef = useGaViewPing({
+  const signUpFxaFlowTracker = useFxaFlowTracker({
     category: "Sign In",
     label: "nav-profile-sign-up",
+    entrypoint: "relay-sign-up-header",
   });
+  // document is undefined when prerendering the website,
+  // so just use the production URL there:
+  const signUpUrl = new URL(
+    getRuntimeConfig().fxaLoginUrl,
+    typeof document !== "undefined"
+      ? document.location.origin
+      : "https://relay.firefox.com"
+  );
+  signUpUrl.searchParams.append("form_type", "button");
+  signUpUrl.searchParams.append("entrypoint", "relay-sign-up-header");
+  if (signUpFxaFlowTracker.flowData) {
+    signUpUrl.searchParams.append(
+      "flowId",
+      signUpFxaFlowTracker.flowData.flowId
+    );
+    signUpUrl.searchParams.append(
+      "flowBeginTime",
+      signUpFxaFlowTracker.flowData.flowBeginTime
+    );
+  }
   const signUpButton = isLoggedIn ? null : (
     <a
-      href={getRuntimeConfig().fxaLoginUrl}
-      ref={signUpButtonRef}
+      href={signUpUrl.href}
+      ref={signUpFxaFlowTracker.ref}
       onClick={() =>
         gaEvent({
           category: "Sign In",
@@ -36,14 +57,35 @@ export const Navigation = () => {
     </a>
   );
 
-  const signInButtonRef = useGaViewPing({
+  const signInFxaFlowTracker = useFxaFlowTracker({
     category: "Sign In",
     label: "nav-profile-sign-in",
+    entrypoint: "relay-sign-in-header",
   });
+  // document is undefined when prerendering the website,
+  // so just use the production URL there:
+  const signInUrl = new URL(
+    getRuntimeConfig().fxaLoginUrl,
+    typeof document !== "undefined"
+      ? document.location.origin
+      : "https://relay.firefox.com"
+  );
+  signInUrl.searchParams.append("form_type", "button");
+  signInUrl.searchParams.append("entrypoint", "relay-sign-in-header");
+  if (signInFxaFlowTracker.flowData) {
+    signInUrl.searchParams.append(
+      "flowId",
+      signInFxaFlowTracker.flowData.flowId
+    );
+    signInUrl.searchParams.append(
+      "flowBeginTime",
+      signInFxaFlowTracker.flowData.flowBeginTime
+    );
+  }
   const signInButton = isLoggedIn ? null : (
     <a
-      href={getRuntimeConfig().fxaLoginUrl}
-      ref={signInButtonRef}
+      href={signInUrl.href}
+      ref={signInFxaFlowTracker.ref}
       onClick={() =>
         gaEvent({
           category: "Sign In",

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -4,8 +4,7 @@ import { useLocalization } from "@fluent/react";
 import { event as gaEvent } from "react-ga";
 import styles from "./Navigation.module.scss";
 import { useIsLoggedIn } from "../../hooks/session";
-import { getRuntimeConfig } from "../../config";
-import { useFxaFlowTracker } from "../../hooks/fxaFlowTracker";
+import { getLoginUrl, useFxaFlowTracker } from "../../hooks/fxaFlowTracker";
 
 /** Switch between the different pages of the Relay website. */
 export const Navigation = () => {
@@ -20,29 +19,13 @@ export const Navigation = () => {
     label: "nav-profile-sign-up",
     entrypoint: "relay-sign-up-header",
   });
-  // document is undefined when prerendering the website,
-  // so just use the production URL there:
-  const signUpUrl = new URL(
-    getRuntimeConfig().fxaLoginUrl,
-    typeof document !== "undefined"
-      ? document.location.origin
-      : "https://relay.firefox.com"
+  const signUpUrl = getLoginUrl(
+    "relay-sign-up-header",
+    signUpFxaFlowTracker.flowData
   );
-  signUpUrl.searchParams.append("form_type", "button");
-  signUpUrl.searchParams.append("entrypoint", "relay-sign-up-header");
-  if (signUpFxaFlowTracker.flowData) {
-    signUpUrl.searchParams.append(
-      "flowId",
-      signUpFxaFlowTracker.flowData.flowId
-    );
-    signUpUrl.searchParams.append(
-      "flowBeginTime",
-      signUpFxaFlowTracker.flowData.flowBeginTime
-    );
-  }
   const signUpButton = isLoggedIn ? null : (
     <a
-      href={signUpUrl.href}
+      href={signUpUrl}
       ref={signUpFxaFlowTracker.ref}
       onClick={() =>
         gaEvent({
@@ -62,29 +45,13 @@ export const Navigation = () => {
     label: "nav-profile-sign-in",
     entrypoint: "relay-sign-in-header",
   });
-  // document is undefined when prerendering the website,
-  // so just use the production URL there:
-  const signInUrl = new URL(
-    getRuntimeConfig().fxaLoginUrl,
-    typeof document !== "undefined"
-      ? document.location.origin
-      : "https://relay.firefox.com"
+  const signInUrl = getLoginUrl(
+    "relay-sign-in-header",
+    signInFxaFlowTracker.flowData
   );
-  signInUrl.searchParams.append("form_type", "button");
-  signInUrl.searchParams.append("entrypoint", "relay-sign-in-header");
-  if (signInFxaFlowTracker.flowData) {
-    signInUrl.searchParams.append(
-      "flowId",
-      signInFxaFlowTracker.flowData.flowId
-    );
-    signInUrl.searchParams.append(
-      "flowBeginTime",
-      signInFxaFlowTracker.flowData.flowBeginTime
-    );
-  }
   const signInButton = isLoggedIn ? null : (
     <a
-      href={signInUrl.href}
+      href={signInUrl}
       ref={signInFxaFlowTracker.ref}
       onClick={() =>
         gaEvent({

--- a/frontend/src/hooks/fxaFlowTracker.ts
+++ b/frontend/src/hooks/fxaFlowTracker.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import { event as gaEvent, EventArgs } from "react-ga";
+import { IntersectionOptions, useInView } from "react-intersection-observer";
+import { useRuntimeData } from "./api/runtimeData";
+
+export type FxaFlowTrackerArgs = Omit<
+  EventArgs,
+  "action" | "nonInteraction"
+> & { entrypoint: string };
+
+/**
+ * This is similar to {@see useGaViewPing}, but this also gives you a `flowId`
+ * and `flowBeginTime` that you can send to FxA to track sign-in/-up flows.
+ */
+export function useFxaFlowTracker(
+  args: FxaFlowTrackerArgs | null,
+  options?: IntersectionOptions
+) {
+  const runtimeData = useRuntimeData();
+  const [ref, inView] = useInView({ threshold: 1, ...options });
+  const [flowData, setFlowData] = useState<{
+    flowId: string;
+    flowBeginTime: string;
+  }>();
+
+  // If the API hasn't responded with the environment variables by the time this
+  // hook fires, we assume we're dealing with the production instance of FxA:
+  const fxaOrigin =
+    runtimeData.data?.FXA_ORIGIN ?? "https://accounts.firefox.com";
+
+  useEffect(() => {
+    if (args === null || !inView) {
+      return;
+    }
+    gaEvent({
+      ...args,
+      action: "View",
+      nonInteraction: true,
+    });
+
+    // Note: there's no `.catch`; if we can't contact the metrics endpoint,
+    // we accept not being able to measure this.
+    fetch(
+      `${fxaOrigin}/metrics-flow?form_type=other&entrypoint=${encodeURIComponent(
+        args.entrypoint
+      )}&utm_source=${encodeURIComponent(document.location.host)}`
+    ).then(async (response) => {
+      if (!response.ok) {
+        return;
+      }
+      const data = await response.json();
+      if (
+        typeof data.flowId !== "string" ||
+        typeof data.flowBeginTime !== "string"
+      ) {
+        return;
+      }
+      setFlowData({
+        flowBeginTime: data.flowBeginTime,
+        flowId: data.flowId,
+      });
+    });
+
+    // We don't want to trigger sending an event when `args` change;
+    // only when the element does or does not come into view do we
+    // send an event, with whatever the args are at that time:
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inView]);
+
+  return { flowData: flowData, ref: ref };
+}

--- a/frontend/src/pages/faq.test.tsx
+++ b/frontend/src/pages/faq.test.tsx
@@ -1,6 +1,7 @@
 import { act, render } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { mockConfigModule } from "../../__mocks__/configMock";
+import { mockUseFxaFlowTrackerModule } from "../../__mocks__/hooks/fxaFlowTracker";
 import { mockFluentReact } from "../../__mocks__/modules/fluent__react";
 import { mockNextRouter } from "../../__mocks__/modules/next__router";
 import { mockReactGa } from "../../__mocks__/modules/react-ga";
@@ -12,6 +13,7 @@ jest.mock("next/router", () => mockNextRouter);
 jest.mock("react-ga", () => mockReactGa);
 jest.mock("../config.ts", () => mockConfigModule);
 jest.mock("../hooks/gaViewPing.ts");
+jest.mock("../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
 
 describe("The page with Frequently Asked Questions", () => {
   describe("under axe accessibility testing", () => {

--- a/frontend/src/pages/index.test.tsx
+++ b/frontend/src/pages/index.test.tsx
@@ -1,6 +1,7 @@
 import { act, render } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { mockConfigModule } from "../../__mocks__/configMock";
+import { mockUseFxaFlowTrackerModule } from "../../__mocks__/hooks/fxaFlowTracker";
 import { mockFluentReact } from "../../__mocks__/modules/fluent__react";
 import { mockNextRouter } from "../../__mocks__/modules/next__router";
 import { mockReactGa } from "../../__mocks__/modules/react-ga";
@@ -12,6 +13,7 @@ jest.mock("next/router", () => mockNextRouter);
 jest.mock("react-ga", () => mockReactGa);
 jest.mock("../config.ts", () => mockConfigModule);
 jest.mock("../hooks/gaViewPing.ts");
+jest.mock("../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
 
 describe("The landing page", () => {
   describe("under axe accessibility testing", () => {

--- a/frontend/src/pages/premium.test.tsx
+++ b/frontend/src/pages/premium.test.tsx
@@ -1,6 +1,7 @@
 import { act, render } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { mockConfigModule } from "../../__mocks__/configMock";
+import { mockUseFxaFlowTrackerModule } from "../../__mocks__/hooks/fxaFlowTracker";
 import { mockFluentReact } from "../../__mocks__/modules/fluent__react";
 import { mockNextRouter } from "../../__mocks__/modules/next__router";
 import { mockReactGa } from "../../__mocks__/modules/react-ga";
@@ -12,6 +13,7 @@ jest.mock("next/router", () => mockNextRouter);
 jest.mock("react-ga", () => mockReactGa);
 jest.mock("../config.ts", () => mockConfigModule);
 jest.mock("../hooks/gaViewPing.ts");
+jest.mock("../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
 
 describe("The promotional page about Relay Premium", () => {
   describe("under axe accessibility testing", () => {

--- a/frontend/src/pages/premium/waitlist.test.tsx
+++ b/frontend/src/pages/premium/waitlist.test.tsx
@@ -10,13 +10,14 @@ import { mockConfigModule } from "../../../__mocks__/configMock";
 import { setMockRuntimeData } from "../../../__mocks__/hooks/api/runtimeData";
 import { setMockUserData } from "../../../__mocks__/hooks/api/user";
 import { setMockProfileData } from "../../../__mocks__/hooks/api/profile";
+import { mockUseFxaFlowTrackerModule } from "../../../__mocks__/hooks/fxaFlowTracker";
 
 import PremiumWaitlist from "./waitlist.page";
 
 jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("next/router", () => mockNextRouter);
 jest.mock("../../config.ts", () => mockConfigModule);
-jest.mock("../../hooks/gaViewPing.ts");
+jest.mock("../../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
 jest.mock("../../components/waitlist/countryPicker.tsx", () => ({
   // We're mocking out the country picker because it dynamically imports the
   // list of available countries, which would mean the test would have to mock


### PR DESCRIPTION
This essentially replicates the following PR in React:
https://github.com/mozilla/fx-private-relay/pull/348

In essence, the new `useFxaFlowTracker` hook does the same our `useGaViewPing` hook does, but in addition to sending an event to Google Analytics when the ref'ed element comes into view, it also sends a request to FxA's `/metrics-flow` to add an ID to the sign-in link.

This flow is not yet implemented for the "Sign up" button on the
homepage (not in the navigation), nor in the "Upgrade now" button
on the Premium promotional page (at /premium), but the same is true
for the old UI.

This PR also fixes #1807.

How to test: I don't think we can actually test this until it's on stage (possibly dev), since http://127.0.0.1:8000/ is not listed as an allowed origin in FxA's response headers. But you can at least verify that the requests are being made for the "sign up" and "sign in" button in the navigation, and that those buttons still work even if the parameters to add to them could not be retrieved.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - Adding a test to mock out FxA's ID and verify that it's added to the link feels like not worth the effort, but happy to reconsider.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
