### PR TITLE
Remove Italian from list of locales with "masks"

### DIFF
--- a/frontend/src/components/layout/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/whatsnew/WhatsNewMenu.tsx
@@ -204,7 +204,6 @@ export const WhatsNewMenu = (props: Props) => {
       "hu",
       "ia",
       "id",
-      "it",
       "sk",
       "skr",
       "uk",

--- a/frontend/src/components/layout/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/whatsnew/WhatsNewMenu.tsx
@@ -202,8 +202,6 @@ export const WhatsNewMenu = (props: Props) => {
       "sv-se",
       "el",
       "hu",
-      "ia",
-      "id",
       "sk",
       "skr",
       "uk",


### PR DESCRIPTION
There was a comment next to the announcement to leave it in English if a locale did not change "alias" to "mask".
They were translated in Italian, but the change is not made there.

How to test: set your browser locale to "Italian", and verify that there's no announcement about changing aliases to masks.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
