### PR TITLE
Allow sending data to Basket in our Content Security Policy

### DIFF
--- a/frontend/src/apiMocks/handlers.ts
+++ b/frontend/src/apiMocks/handlers.ts
@@ -225,6 +225,11 @@ export function getHandlers(
     ownAddresses.splice(index, 1);
     return res(ctx.status(200));
   });
+  handlers.push(
+    rest.post("https://basket-mock.com/news/subscribe/", (_req, res, ctx) => {
+      return res(ctx.status(200), ctx.json({ status: "ok" }));
+    })
+  );
 
   return handlers;
 }

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -90,6 +90,8 @@ CSP_CONNECT_SRC = (
     'https://www.google-analytics.com/',
     'https://accounts.firefox.com',
     'https://location.services.mozilla.com',
+    'https://basket-dev.allizom.org',
+    'https://basket.mozilla.org',
 )
 CSP_DEFAULT_SRC = ("'self'",)
 CSP_SCRIPT_SRC = (

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -71,6 +71,7 @@ SECURE_BROWSER_XSS_FILTER = config('DJANGO_SECURE_BROWSER_XSS_FILTER', True)
 SESSION_COOKIE_SECURE = config(
     'DJANGO_SESSION_COOKIE_SECURE', False, cast=bool
 )
+BASKET_ORIGIN = config('BASKET_ORIGIN', 'https://basket.mozilla.org')
 # maps fxa profile hosts to respective avatar hosts for CSP
 AVATAR_IMG_SRC_MAP = {
     'https://profile.stage.mozaws.net/v1':      [
@@ -90,8 +91,7 @@ CSP_CONNECT_SRC = (
     'https://www.google-analytics.com/',
     'https://accounts.firefox.com',
     'https://location.services.mozilla.com',
-    'https://basket-dev.allizom.org',
-    'https://basket.mozilla.org',
+    BASKET_ORIGIN,
 )
 CSP_DEFAULT_SRC = ("'self'",)
 CSP_SCRIPT_SRC = (
@@ -571,7 +571,6 @@ FXA_BASE_ORIGIN = config('FXA_BASE_ORIGIN', 'https://accounts.firefox.com')
 FXA_SETTINGS_URL = config('FXA_SETTINGS_URL', f'{FXA_BASE_ORIGIN}/settings')
 FXA_SUBSCRIPTIONS_URL = config('FXA_SUBSCRIPTIONS_URL', f'{FXA_BASE_ORIGIN}/subscriptions')
 FXA_SUPPORT_URL = config('FXA_SUPPORT_URL', f'{FXA_BASE_ORIGIN}/support/')
-BASKET_ORIGIN = config('BASKET_ORIGIN', 'https://basket.mozilla.org')
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
(And I added a mock endpoint in the mock environment.)

How to test: run the waitlist from the server (i.e. `npm run watch` rather than `npm run dev`) - subscribing via http://127.0.0.1:8000/premium/waitlist/ should be successful now.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
