### PR TITLE
Match casing for auto-detected countries

### DIFF
--- a/frontend/src/pages/premium/waitlist.page.tsx
+++ b/frontend/src/pages/premium/waitlist.page.tsx
@@ -19,8 +19,8 @@ const PremiumWaitlist: NextPage = () => {
   const currentLocale = getLocale(l10n);
   const runtimeData = useRuntimeData();
   const currentCountry =
-    runtimeData.data?.PREMIUM_PLANS.country_code ??
-    (currentLocale.split("-")[1] as string | undefined);
+    runtimeData.data?.PREMIUM_PLANS.country_code.toUpperCase() ??
+    (currentLocale.split("-")[1]?.toUpperCase() as string | undefined);
   const [country, setCountry] = useState<string>();
   const [locale, setLocale] = useState<string>(
     supportedLocales.find(


### PR DESCRIPTION
While the country list uses uppercase country codes, the country
code detected for the user can be in lower-case, thereby not
pre-selecting the correct entry in the `<select>` list.

This would result in nothing in the `<select>` being preselected (i.e. the first entry, Afghanistan, would be shown), even though in our state the detected (lowercase) country code would still be set. This meant that leaving the `<select>` at the default would submit a different country than the one you thought (Afghanistan).

How to test: [go to /premium/waitlist](https://deploy-preview-1892--fx-relay-demo.netlify.app/premium/waitlist/). Note that your country (or the one detected from your Accept-Language) is being properly preselected now, and also send in the HTTP request to basket in the Network tab of your browser's devtools.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
