### PR TITLE
Mobile/Tablet Breakpoint Issues

### DIFF
--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.module.scss
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.module.scss
@@ -38,6 +38,7 @@
       gap: $spacing-lg;
       padding: $spacing-lg $spacing-sm;
       border-bottom: 1px solid $color-light-gray-20;
+      word-break: break-word;
 
       .warning-icon {
         color: $color-pink-30;

--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -107,10 +107,12 @@ $toggleTransitionDuration: 200ms;
 .copy-controls {
   display: flex;
   align-items: center;
+  overflow: hidden;
 }
 
 .copy-button-wrapper {
   position: relative;
+  width: 100%;
 
   .copy-button {
     @include text-body-lg;
@@ -120,17 +122,26 @@ $toggleTransitionDuration: 200ms;
     border: 0px none transparent;
     cursor: pointer;
     padding: 0 $spacing-sm;
+    width: 100%;
+    flex-basis: 0;
 
     .address {
       font-family: $font-stack-firefox;
       overflow: hidden;
       text-overflow: ellipsis;
-      max-width: $content-md;
+      display: inline-block;
+      text-align: start;
+      flex-grow: 0;
+      flex-shrink: 1;
     }
 
     .copy-icon {
       padding: 0 $spacing-sm;
       opacity: 0.5;
+      display: inline-block;
+      flex-grow: 2;
+      flex-shrink: 0;
+      max-width: $layout-sm;
     }
 
     &:hover {

--- a/frontend/src/components/dashboard/aliases/AliasGenerationButton.module.scss
+++ b/frontend/src/components/dashboard/aliases/AliasGenerationButton.module.scss
@@ -9,6 +9,8 @@
   margin-top: $spacing-sm;
   // Move to the left by the amount of horizontal padding in .menu-item-wrapper:
   margin-left: -1 * $spacing-md;
+  // Align the popup to the edge of the screen at narrow widths
+  inset-inline-end: 0;
   background-color: $color-white;
   border-radius: $border-radius-md;
   box-shadow: $box-shadow-md;
@@ -16,6 +18,10 @@
   min-width: $content-xs;
   // Overlap the stats with position: relative in the alias cards:
   z-index: 2;
+
+  @media screen and #{$mq-xl} {
+    inset-inline-end: auto;
+  }
 
   .menu-item-wrapper {
     font-family: $font-stack-firefox;

--- a/frontend/src/pages/accounts/settings.module.scss
+++ b/frontend/src/pages/accounts/settings.module.scss
@@ -141,7 +141,7 @@
 @media screen and #{$mq-lg} {
   .field-heading {
     flex-basis: auto;
-    // Custom percentage to accomidate tablet/laptop screens
+    // Custom percentage to accommodate tablet/laptop screens
     width: 33%;
   }
 }

--- a/frontend/src/pages/accounts/settings.module.scss
+++ b/frontend/src/pages/accounts/settings.module.scss
@@ -14,6 +14,8 @@
   }
 
   ul {
+    // The list of links is hidden on mobile
+    display: none;
     list-style-type: none;
 
     li {
@@ -116,6 +118,10 @@
 
   .menu {
     width: $content-sm;
+
+    ul {
+      display: block;
+    }
   }
 
   .field {

--- a/frontend/src/pages/accounts/settings.module.scss
+++ b/frontend/src/pages/accounts/settings.module.scss
@@ -1,8 +1,42 @@
 @import "../../styles/tokens.scss";
 @import "~@mozilla-protocol/core/protocol/css/includes/lib";
 
+.settings-page {
+  display: flex;
+  flex-direction: column-reverse;
+}
+
 .menu {
-  display: none;
+  padding: $spacing-lg $spacing-lg 0;
+
+  h1 {
+    padding-bottom: $spacing-lg;
+  }
+
+  ul {
+    list-style-type: none;
+
+    li {
+      padding: $spacing-sm 0;
+    }
+
+    a {
+      @include text-body-lg;
+      display: flex;
+      align-items: center;
+      color: $color-dark-gray-50;
+      gap: $spacing-sm;
+
+      &:hover {
+        text-decoration: underline;
+      }
+
+      img {
+        // The size of text-body-lg, i.e. the same size as the containing <a>'s font:
+        width: remify(type-scale("body-lg-size"));
+      }
+    }
+  }
 }
 
 .main {
@@ -17,7 +51,7 @@
 .settings-form {
   box-shadow: $box-shadow-sm;
   border-radius: $border-radius-md;
-  padding: $spacing-lg $spacing-xl;
+  padding: $spacing-md;
   background-color: white;
 }
 
@@ -31,13 +65,23 @@
   color: $color-dark-gray-50;
   font-weight: 400;
   padding-bottom: $spacing-md;
+  flex-basis: 0;
 }
 
 .field-content {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-md;
+  padding-bottom: $spacing-md;
+
   .field-control {
     display: flex;
-    align-items: center;
-    gap: $spacing-sm;
+    align-items: flex-start;
+    gap: $spacing-md;
+
+    input {
+      margin-top: $spacing-xs;
+    }
 
     label {
       display: inline-block;
@@ -50,14 +94,13 @@
     align-items: flex-start;
     background-color: $color-light-gray-20;
     width: 100%;
-    margin-top: $spacing-lg;
     padding: $spacing-md $spacing-lg;
     border-radius: $border-radius-sm;
   }
 }
 
 .controls {
-  padding: $spacing-md 0;
+  padding-top: $spacing-md;
   text-align: center;
 }
 
@@ -67,51 +110,38 @@
     flex-direction: row-reverse;
   }
 
+  .settings-form {
+    padding: $spacing-lg;
+  }
+
   .menu {
-    display: block;
     width: $content-sm;
-    padding: $spacing-lg $spacing-lg;
-
-    h1 {
-      padding-bottom: $spacing-lg;
-    }
-
-    ul {
-      list-style-type: none;
-
-      li {
-        padding: $spacing-sm 0;
-      }
-
-      a {
-        @include text-body-lg;
-        display: flex;
-        align-items: center;
-        color: $color-dark-gray-50;
-        gap: $spacing-sm;
-
-        &:hover {
-          text-decoration: underline;
-        }
-
-        img {
-          // The size of text-body-lg, i.e. the same size as the containing <a>'s font:
-          width: remify(type-scale("body-lg-size"));
-        }
-      }
-    }
   }
 
   .field {
     display: flex;
+    gap: $spacing-2xl;
   }
 
   .field-heading {
-    width: $content-sm;
     flex-shrink: 0;
   }
 
   .controls {
+    padding-top: $spacing-lg;
     text-align: end;
+  }
+}
+@media screen and #{$mq-lg} {
+  .field-heading {
+    flex-basis: auto;
+    // Custom percentage to accomidate tablet/laptop screens
+    width: 33%;
+  }
+}
+@media screen and #{$mq-xl} {
+  .field-heading {
+    flex-basis: auto;
+    width: $content-sm;
   }
 }


### PR DESCRIPTION
Summary: 

This PR is CSS only! It addresses a few areas that overflow on mobile/tablet. 

The areas: 
- Generate new mask menu (premium only)
- Generate custom mask modal (premium only)
- Mask card (where the mask address is displayed and can be copied to clipboard)
- Settings page (specifically tablet breakpoint)  

This PR fixes #1780 

How to test:

- Set your width to mobile breakpoint sizes (~375px)
- Go to dashboard with a premium account that has registered a subdomain
- Create new custom mask
- Use a long string (example: customsubdomainmaskname)
- Expected: The page does not break max-width

## Screenshots

![Screenshot 2022-05-05 at 15-06-13 Firefox Relay](https://user-images.githubusercontent.com/2692333/167017213-6e51fe74-9b16-401e-a14a-10755a42479b.png)

![Screenshot 2022-05-05 at 15-05-56 Firefox Relay](https://user-images.githubusercontent.com/2692333/167017230-79b0c61f-e425-4133-b4d3-24604775a1f1.png)

![Screenshot 2022-05-05 at 15-05-40 Firefox Relay](https://user-images.githubusercontent.com/2692333/167017242-62dd4a12-49df-44e9-a4ff-7832e3ebf704.png)

![Screenshot 2022-05-05 at 15-05-04 Firefox Relay](https://user-images.githubusercontent.com/2692333/167017257-582d7527-1675-4d0f-a31e-59f4c1e971d3.png)

## Checklist

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
