### PR TITLE
Use correct label to accompany the subdomain

### DIFF
--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -192,7 +192,7 @@ const Profile: NextPage = () => {
   const subdomainMessage =
     typeof profile.subdomain === "string" ? (
       <>
-        <span>{l10n.getString("profile-label-domain")}</span>
+        <span>{l10n.getString("profile-label-subdomain")}</span>
         <span className={styles["profile-registered-domain-value"]}>
           <SubdomainIndicator
             subdomain={profile.subdomain}


### PR DESCRIPTION
This ID accidentally got reverted when presumably resolving a conflict at https://github.com/mozilla/fx-private-relay/pull/1789/files#diff-b914de445be22e5e7e1ac82e28e2ec635fd7cae3778759d047777d231cad9e2dR186

I encountered this in production:

![image](https://user-images.githubusercontent.com/4251/167368376-bd6c0817-1f1e-4836-9d7d-d37a90f9b640.png)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
