### PR TITLE
MPP-1935: Handle issues with In-Reply-To header

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -601,11 +601,13 @@ def _handle_reply(from_address, message_json, to_address):
     try:
         (lookup_key, encryption_key) = _get_keys_from_headers(mail["headers"])
     except InReplyToNotFound:
+        incr_if_enabled("reply_email_header_error", 1, tags=["detail:no-header"])
         return HttpResponse("No In-Reply-To header", status=400)
 
     try:
         reply_record = _get_reply_record_from_lookup_key(lookup_key)
     except Reply.DoesNotExist:
+        incr_if_enabled("reply_email_header_error", 1, tags=["detail:no-reply-record"])
         return HttpResponse("Unknown or stale In-Reply-To header", status=404)
 
     address = reply_record.address

--- a/emails/views.py
+++ b/emails/views.py
@@ -598,12 +598,20 @@ def _reply_allowed(from_address, to_address, reply_record):
 
 def _handle_reply(from_address, message_json, to_address):
     mail = message_json["mail"]
-    (lookup_key, encryption_key) = _get_keys_from_headers(mail["headers"])
-    reply_record = _get_reply_record_from_lookup_key(lookup_key)
+    try:
+        (lookup_key, encryption_key) = _get_keys_from_headers(mail["headers"])
+    except InReplyToNotFound:
+        return HttpResponse("No In-Reply-To header", status=400)
+
+    try:
+        reply_record = _get_reply_record_from_lookup_key(lookup_key)
+    except Reply.DoesNotExist:
+        return HttpResponse("Unknown or stale In-Reply-To header", status=404)
+
     address = reply_record.address
 
     if not _reply_allowed(from_address, to_address, reply_record):
-        return HttpResponse("Rely replies require a premium account", status=403)
+        return HttpResponse("Relay replies require a premium account", status=403)
 
     outbound_from_address = address.full_address
     decrypted_metadata = json.loads(


### PR DESCRIPTION
When a message is to "replies":
* Return a 400 if there is no ``In-Reply-To`` header
* Return a 404 if the ``Reply`` record is missing

In both cases, delete any S3-stored email, and remove it from the queue.

This issue has been filed many times!
 * fixes #1555
 * fixes #1619
 * fixes #1773
 * fixes #1888 
 * is tracked by MPP-1935

How to test:

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
