### PR TITLE
Fix conditional label storage

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -119,7 +119,7 @@ class Profile(models.Model):
         # appropriate server-stored Relay address data.
         if not self.server_storage:
             relay_addresses = RelayAddress.objects.filter(user=self.user)
-            relay_addresses.update(description="", generated_for="")
+            relay_addresses.update(description="", generated_for="", used_on="")
         return ret
 
     @property
@@ -504,6 +504,7 @@ class RelayAddress(models.Model):
         if (not profile.server_storage):
             self.description = ""
             self.generated_for = ""
+            self.used_on = ""
         return super().save(*args, **kwargs)
 
     @property

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -253,12 +253,15 @@ class RelayAddressTest(TestCase):
         relay_address = RelayAddress.objects.create(user=self.storageless_user)
         assert relay_address.description == ""
         assert relay_address.generated_for == ""
+        assert relay_address.used_on == ""
         relay_address.description = "Arbitrary description"
         relay_address.generated_for = "https://example.com"
+        relay_address.used_on = "https://example.com"
         relay_address.save()
         relay_address.refresh_from_db()
         assert relay_address.description == ""
         assert relay_address.generated_for == ""
+        assert relay_address.used_on == ""
 
 
 class ProfileTest(TestCase):
@@ -631,26 +634,31 @@ class ProfileTest(TestCase):
     def test_save_server_storage_true_doesnt_delete_data(self):
         test_desc = "test description"
         test_generated_for = "secret.com"
+        test_used_on = "secret.com"
         relay_address = baker.make(
             RelayAddress,
             user=self.profile.user,
             description=test_desc,
             generated_for=test_generated_for,
+            used_on=test_used_on,
         )
         self.profile.server_storage = True
         self.profile.save()
 
         assert relay_address.description == test_desc
         assert relay_address.generated_for == test_generated_for
+        assert relay_address.used_on == test_used_on
 
     def test_save_server_storage_false_deletes_data(self):
         test_desc = "test description"
         test_generated_for = "secret.com"
+        test_used_on = "secret.com"
         relay_address = baker.make(
             RelayAddress,
             user=self.profile.user,
             description=test_desc,
             generated_for=test_generated_for,
+            used_on=test_used_on,
         )
         self.profile.server_storage = False
         self.profile.save()
@@ -658,6 +666,7 @@ class ProfileTest(TestCase):
         relay_address.refresh_from_db()
         assert relay_address.description == ""
         assert relay_address.generated_for == ""
+        assert relay_address.used_on == ""
 
     def test_save_server_storage_false_deletes_ALL_data(self):
         test_desc = "test description"

--- a/frontend/__mocks__/hooks/localLabels.ts
+++ b/frontend/__mocks__/hooks/localLabels.ts
@@ -1,0 +1,48 @@
+import {
+  LocalLabel,
+  LocalLabelHook,
+  NotEnabled,
+  SetLocalLabel,
+  useLocalLabels,
+} from "../../src/hooks/localLabels";
+
+jest.mock("../../src/hooks/localLabels");
+
+// We know that `jest.mock` has turned `useAddonData` into a mock function,
+// but TypeScript can't — so we tell it using a type assertion:
+const mockedUseLocalLabels = useLocalLabels as jest.MockedFunction<
+  typeof useLocalLabels
+>;
+
+export function getReturnValueWhenEnabled(
+  localLabels: Array<Partial<LocalLabel>> = [],
+  callback: SetLocalLabel = jest.fn()
+): LocalLabelHook {
+  return [
+    localLabels.map((localLabel, i) => ({
+      description: "Arbitrary description",
+      generated_for: "https://example.com",
+      id: i,
+      type: "random",
+      ...localLabel,
+    })),
+    callback,
+  ];
+}
+export function getReturnValueWhenDisabled(
+  callback: SetLocalLabel = jest.fn()
+): NotEnabled {
+  return [null, callback];
+}
+
+export const setMockLocalLabels = (
+  returnValue: LocalLabelHook | NotEnabled = getReturnValueWhenDisabled()
+) => {
+  mockedUseLocalLabels.mockReturnValue(returnValue);
+};
+
+export const setMockLocalLabelsOnce = (
+  returnValue: LocalLabelHook | NotEnabled = getReturnValueWhenDisabled()
+) => {
+  mockedUseLocalLabels.mockReturnValueOnce(returnValue);
+};

--- a/frontend/__mocks__/modules/fluent__react.tsx
+++ b/frontend/__mocks__/modules/fluent__react.tsx
@@ -6,7 +6,7 @@ export const mockFluentReact = {
       l10n: {
         getString: (id: string, vars?: Record<string, string>) =>
           `l10n string: [${id}], with vars: ${JSON.stringify(vars ?? {})}`,
-        bundles: [{ locales: "en-GB" }],
+        bundles: [{ locales: ["en-GB"] }],
       },
     };
   },

--- a/frontend/src/components/dashboard/aliases/AliasList.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.test.tsx
@@ -3,24 +3,21 @@ import userEvent from "@testing-library/user-event";
 import { mockConfigModule } from "../../../../__mocks__/configMock";
 import { getMockRandomAlias } from "../../../../__mocks__/hooks/api/aliases";
 import { getMockProfileData } from "../../../../__mocks__/hooks/api/profile";
-import {
-  getReturnValueWhenDisabled as getLocalLabelsWhenDisabled,
-  getReturnValueWhenEnabled as getLocalLabelsWhenEnabled,
-  setMockLocalLabels,
-  setMockLocalLabelsOnce,
-} from "../../../../__mocks__/hooks/localLabels";
+import * as LocalLabelsMock from "../../../../__mocks__/hooks/localLabels";
 import { mockFluentReact } from "../../../../__mocks__/modules/fluent__react";
 import { AliasList } from "./AliasList";
 
 jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("../../../config.ts", () => mockConfigModule);
-setMockLocalLabels();
+LocalLabelsMock.setMockLocalLabels();
 
 describe("<AliasList>", () => {
   it("sends a request to the back-end to update the label if server-side label storage is enabled", async () => {
     const updateCallback = jest.fn();
     const storeLocalLabelCallback = jest.fn();
-    setMockLocalLabelsOnce(getLocalLabelsWhenDisabled(storeLocalLabelCallback));
+    LocalLabelsMock.setMockLocalLabelsOnce(
+      LocalLabelsMock.getReturnValueWhenDisabled(storeLocalLabelCallback)
+    );
     render(
       <AliasList
         aliases={[getMockRandomAlias()]}
@@ -45,8 +42,8 @@ describe("<AliasList>", () => {
   it("does not send a request to the back-end to update the label if server-side label storage is not enabled", async () => {
     const updateCallback = jest.fn();
     const storeLocalLabelCallback = jest.fn();
-    setMockLocalLabelsOnce(
-      getLocalLabelsWhenEnabled([], storeLocalLabelCallback)
+    LocalLabelsMock.setMockLocalLabelsOnce(
+      LocalLabelsMock.getReturnValueWhenEnabled([], storeLocalLabelCallback)
     );
     render(
       <AliasList
@@ -73,7 +70,9 @@ describe("<AliasList>", () => {
   });
 
   it("does not provide the option to edit the label if server-side storage is disabled, and local storage is not available (i.e. the user does not have the add-on)", async () => {
-    setMockLocalLabelsOnce(getLocalLabelsWhenDisabled());
+    LocalLabelsMock.setMockLocalLabelsOnce(
+      LocalLabelsMock.getReturnValueWhenDisabled()
+    );
     render(
       <AliasList
         aliases={[getMockRandomAlias()]}

--- a/frontend/src/components/dashboard/aliases/AliasList.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { mockConfigModule } from "../../../../__mocks__/configMock";
+import { getMockRandomAlias } from "../../../../__mocks__/hooks/api/aliases";
+import { getMockProfileData } from "../../../../__mocks__/hooks/api/profile";
+import {
+  getReturnValueWhenDisabled as getLocalLabelsWhenDisabled,
+  getReturnValueWhenEnabled as getLocalLabelsWhenEnabled,
+  setMockLocalLabels,
+  setMockLocalLabelsOnce,
+} from "../../../../__mocks__/hooks/localLabels";
+import { mockFluentReact } from "../../../../__mocks__/modules/fluent__react";
+import { AliasList } from "./AliasList";
+
+jest.mock("@fluent/react", () => mockFluentReact);
+jest.mock("../../../config.ts", () => mockConfigModule);
+setMockLocalLabels();
+
+describe("<AliasList>", () => {
+  it("sends a request to the back-end to update the label if server-side label storage is enabled", async () => {
+    const updateCallback = jest.fn();
+    const storeLocalLabelCallback = jest.fn();
+    setMockLocalLabelsOnce(getLocalLabelsWhenDisabled(storeLocalLabelCallback));
+    render(
+      <AliasList
+        aliases={[getMockRandomAlias()]}
+        onUpdate={updateCallback}
+        onCreate={jest.fn()}
+        onDelete={jest.fn()}
+        profile={getMockProfileData({ server_storage: true })}
+        user={{ email: "arbitrary@example.com" }}
+      />
+    );
+
+    const labelField = screen.getByRole("textbox");
+    userEvent.type(labelField, "Some label");
+    userEvent.tab();
+
+    expect(updateCallback).toHaveBeenCalledWith(expect.anything(), {
+      description: "Some label",
+    });
+    expect(storeLocalLabelCallback).not.toHaveBeenCalled();
+  });
+
+  it("does not send a request to the back-end to update the label if server-side label storage is not enabled", async () => {
+    const updateCallback = jest.fn();
+    const storeLocalLabelCallback = jest.fn();
+    setMockLocalLabelsOnce(
+      getLocalLabelsWhenEnabled([], storeLocalLabelCallback)
+    );
+    render(
+      <AliasList
+        aliases={[getMockRandomAlias()]}
+        onUpdate={updateCallback}
+        onCreate={jest.fn()}
+        onDelete={jest.fn()}
+        profile={getMockProfileData({ server_storage: false })}
+        user={{ email: "arbitrary@example.com" }}
+      />
+    );
+
+    const labelField = screen.getByRole("textbox");
+    userEvent.type(labelField, "Some label");
+    userEvent.tab();
+
+    // The second argument is the list of updated fields;
+    // this should be empty, because we don't want to store the label server-side.
+    expect(updateCallback).toHaveBeenCalledWith(expect.anything(), {});
+    expect(storeLocalLabelCallback).toHaveBeenCalledWith(
+      expect.anything(),
+      "Some label"
+    );
+  });
+
+  it("does not provide the option to edit the label if server-side storage is disabled, and local storage is not available (i.e. the user does not have the add-on)", async () => {
+    setMockLocalLabelsOnce(getLocalLabelsWhenDisabled());
+    render(
+      <AliasList
+        aliases={[getMockRandomAlias()]}
+        onUpdate={jest.fn()}
+        onCreate={jest.fn()}
+        onDelete={jest.fn()}
+        profile={getMockProfileData({ server_storage: false })}
+        user={{ email: "arbitrary@example.com" }}
+      />
+    );
+
+    const labelField = screen.queryByRole("textbox");
+
+    expect(labelField).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -71,6 +71,7 @@ export const AliasList = (props: Props) => {
         typeof updatedFields.description === "string"
       ) {
         storeLocalLabel(alias, updatedFields.description);
+        delete updatedFields.description;
       }
       return props.onUpdate(alias, updatedFields);
     };


### PR DESCRIPTION
There's two parts to this fix:

- The API now scrubs labels when updating addresses if the user has disabled server storage
- The website now no longer sends them to the API if the user has disabled server storage

We'll probably also want a migration that scrubs labels for every account that has server storage disabled, but I think I'll need some help writing that.

How to test: when visiting the website with the add-on installed and server storage disabled, verify that `description` is currently not included in the PATCH request. (The PATCH request is currently empty; I can also add something to drop the entire request in case no fields are updated, if desired.)

Additionally, try modifying the PATCH request to change the `description` anyway; the back-end should not store it.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
