### PR TITLE
Fix local login url

### DIFF
--- a/frontend/src/hooks/fxaFlowTracker.test.ts
+++ b/frontend/src/hooks/fxaFlowTracker.test.ts
@@ -1,0 +1,54 @@
+import { mockConfigModule } from "../../__mocks__/configMock";
+import { getLoginUrl } from "./fxaFlowTracker";
+
+jest.mock("../config.ts", () => mockConfigModule);
+
+describe("getLoginUrl", () => {
+  it("appends flow data", () => {
+    const mockRuntimeConfig = mockConfigModule.getRuntimeConfig();
+    mockConfigModule.getRuntimeConfig.mockReturnValueOnce({
+      ...mockRuntimeConfig,
+      fxaLoginUrl: "https://mock-login.com",
+    });
+    expect(
+      getLoginUrl("some_entrypoint", {
+        flowBeginTime: "1990-11-12T13:37:42.000Z",
+        flowId: "some_flow_id",
+      })
+    ).toBe(
+      "https://mock-login.com/?form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=1990-11-12T13%3A37%3A42.000Z"
+    );
+  });
+
+  it("preserves existing query parameters", () => {
+    const mockRuntimeConfig = mockConfigModule.getRuntimeConfig();
+    mockConfigModule.getRuntimeConfig.mockReturnValueOnce({
+      ...mockRuntimeConfig,
+      fxaLoginUrl: "https://mock-login.com/?some_query=param",
+    });
+    expect(
+      getLoginUrl("some_entrypoint", {
+        flowBeginTime: "1990-11-12T13:37:42.000Z",
+        flowId: "some_flow_id",
+      })
+    ).toBe(
+      "https://mock-login.com/?some_query=param&form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=1990-11-12T13%3A37%3A42.000Z"
+    );
+  });
+
+  it("keeps relative URLs relative", () => {
+    const mockRuntimeConfig = mockConfigModule.getRuntimeConfig();
+    mockConfigModule.getRuntimeConfig.mockReturnValueOnce({
+      ...mockRuntimeConfig,
+      fxaLoginUrl: "/login",
+    });
+    expect(
+      getLoginUrl("some_entrypoint", {
+        flowBeginTime: "1990-11-12T13:37:42.000Z",
+        flowId: "some_flow_id",
+      })
+    ).toBe(
+      "/login?form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=1990-11-12T13%3A37%3A42.000Z"
+    );
+  });
+});

--- a/frontend/src/hooks/fxaFlowTracker.ts
+++ b/frontend/src/hooks/fxaFlowTracker.ts
@@ -74,10 +74,11 @@ export function useFxaFlowTracker(
 }
 
 export function getLoginUrl(entrypoint: string, flowData?: FlowData): string {
+  const loginUrl = getRuntimeConfig().fxaLoginUrl;
   // document is undefined when prerendering the website,
   // so just use the production URL there:
   const urlObject = new URL(
-    getRuntimeConfig().fxaLoginUrl,
+    loginUrl,
     typeof document !== "undefined"
       ? document.location.origin
       : "https://relay.firefox.com"
@@ -89,5 +90,11 @@ export function getLoginUrl(entrypoint: string, flowData?: FlowData): string {
     urlObject.searchParams.append("flowBeginTime", flowData.flowBeginTime);
   }
 
-  return urlObject.href;
+  const fullUrl = urlObject.href;
+  // If the configured fxaLoginUrl was a relative URL,
+  // the URL we return should be relative as well, rather than potentially
+  // including the `https://relay.firefox.com` we set as the base URL so that
+  // the `URL()` constructor could parse it:
+  const newLoginUrl = fullUrl.substring(fullUrl.indexOf(loginUrl));
+  return newLoginUrl;
 }

--- a/frontend/src/hooks/fxaFlowTracker.ts
+++ b/frontend/src/hooks/fxaFlowTracker.ts
@@ -41,28 +41,31 @@ export function useFxaFlowTracker(
       nonInteraction: true,
     });
 
-    // Note: there's no `.catch`; if we can't contact the metrics endpoint,
-    // we accept not being able to measure this.
     fetch(
       `${fxaOrigin}/metrics-flow?form_type=other&entrypoint=${encodeURIComponent(
         args.entrypoint
       )}&utm_source=${encodeURIComponent(document.location.host)}`
-    ).then(async (response) => {
-      if (!response.ok) {
-        return;
-      }
-      const data = await response.json();
-      if (
-        typeof data.flowId !== "string" ||
-        typeof data.flowBeginTime !== "string"
-      ) {
-        return;
-      }
-      setFlowData({
-        flowBeginTime: data.flowBeginTime,
-        flowId: data.flowId,
+    )
+      .then(async (response) => {
+        if (!response.ok) {
+          return;
+        }
+        const data = await response.json();
+        if (
+          typeof data.flowId !== "string" ||
+          typeof data.flowBeginTime !== "string"
+        ) {
+          return;
+        }
+        setFlowData({
+          flowBeginTime: data.flowBeginTime,
+          flowId: data.flowId,
+        });
+      })
+      .catch(() => {
+        // Do nothing; if we can't contact the metrics endpoint,
+        // we accept not being able to measure this.
       });
-    });
 
     // We don't want to trigger sending an event when `args` change;
     // only when the element does or does not come into view do we


### PR DESCRIPTION
This PR fixes https://github.com/mozilla/fx-private-relay/commit/8060fc4eb823de715323780c1918e8ff0a49f87c#r73241769: the generated login URL when running on 127.0.0.1 would point to relay.firefox.com.

How to test: run the app locally, served by Django (i.e. using `npm run watch` on 127.0.0.1:8000). Verify that the "Sign in" and "Sign up" links on the header do not point to production.

I also fixed an error that would show up when running with the dev server, where an empty exception handler wasn't actually an empty exception handler: 4ee351b6cff7166f77ace53e7b44e39767063ef4

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
