### PR TITLE
MPP-1956: Handle empty healthcheck JSON

### DIFF
--- a/emails/management/commands/check_health.py
+++ b/emails/management/commands/check_health.py
@@ -84,7 +84,11 @@ class Command(CommandFromDjangoSettings):
         * The timestamp doesn't include timezone data
         """
         context = {"success": False, "healthcheck_path": healthcheck_file.name}
-        data = json.load(healthcheck_file)
+        try:
+            data = json.load(healthcheck_file)
+        except json.JSONDecodeError as e:
+            context["error"] = repr(e)
+            return context
 
         context["data"] = data
         raw_timestamp = data["timestamp"]

--- a/emails/tests/mgmt_check_health_tests.py
+++ b/emails/tests/mgmt_check_health_tests.py
@@ -64,6 +64,21 @@ def test_check_health_too_old(test_settings, caplog):
     ]
 
 
+def test_check_health_empty_json(test_settings, caplog):
+    """check health fails when the JSON is empty."""
+    path = test_settings.PROCESS_EMAIL_HEALTHCHECK_PATH
+    path.touch()
+    with pytest.raises(CommandError) as excinfo:
+        call_command("check_health")
+    assert str(excinfo.value) == (
+        "Healthcheck failed:"
+        " JSONDecodeError('Expecting value: line 1 column 1 (char 0)')"
+    )
+    assert caplog.record_tuples == [
+        ("eventsinfo.check_health", logging.ERROR, "Healthcheck failed")
+    ]
+
+
 def test_check_health_failed_no_logs(test_settings, caplog):
     """check health failure do not log at verbosity=0."""
     path = test_settings.PROCESS_EMAIL_HEALTHCHECK_PATH


### PR DESCRIPTION
Catch ``JSONDecodeError``, which is raised when the the healthcheck JSON is empty or invalid. Continue treating as a health failure.

@groovecoder, [you were right](https://github.com/mozilla/fx-private-relay/pull/1867#discussion_r864907794). Again. You see why I tend to count your nits as must fixes?

This PR fixes #1921 / MPP-1956.

How to test:

```
echo "" > tmp/healthcheck.json
./manage.py check_health
```

returns something like:
```
CommandError: Healthcheck failed: JSONDecodeError('Expecting value: line 2 column 1 (char 1)')
```

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).