### PR TITLE
MPP-1967: Fix logout page

### DIFF
--- a/privaterelay/templates/account/logout.html
+++ b/privaterelay/templates/account/logout.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "base.html" %}
 
 {% load ftl %}
 {% ftlconf bundle='privaterelay.ftl_bundles.main' %}

--- a/privaterelay/templates/base.html
+++ b/privaterelay/templates/base.html
@@ -16,7 +16,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="{% ftlmsg 'meta-description-2' %}" />
-    <title>{% ftlmsg 'meta-title' %}</title>
+    <title>{% block head_title %}{% ftlmsg 'meta-title' %}{% endblock %}</title>
     <link rel="stylesheet" href="{% static 'css/app.css' %}">
     <link rel="icon" type="image/svg+xml" href="{% static 'images/logos/relay-logo-dark.svg' %}">
     <link rel="shortcut icon" href="{%  static 'images/favicon.ico' %}">


### PR DESCRIPTION
Base the logout page on ``base.html``, so that FTL strings are available.

This PR fixes #1931 / MPP-1967

How to test:

1. On current main, change this line in `privaterelay/settings.py`:

    https://github.com/mozilla/fx-private-relay/blob/94c3866f508c50609e6a597487b68f57cb8c7aa8/privaterelay/settings.py#L625

    to 

    ```python
    ACCOUNT_LOGOUT_ON_GET = False
    ```

    This will get you into production mode, but while still having the debug error pages.

2. Still on main, start your local server
3. Login or create an account. You should be on http://127.0.0.1:8000/accounts/profile/
4. Change to http://127.0.0.1:8000/accounts/logout/. You should get the Debug error screen, with the error "ValueError at /accounts/logout/" - "No bundle set for ftl - use ftlconf/withftl to set bundle"
5. Checkout this branch, making the settings change again if needed.
6. Run the server, login, return to http://127.0.0.1:8000/accounts/profile/
7. Change to http://127.0.0.1:8000/accounts/logout/. You should see this somewhat ugly but working page:

![logout-working](https://user-images.githubusercontent.com/286017/167730571-eef2161e-30e3-4f49-94b7-593ab4461848.png)

8. Clicking "Sign Out" will sign you out.

In production the "Sign Out" action is usually a `POST`, which avoids this page.