### PR TITLE
Use updated string for tips area

### DIFF
--- a/frontend/src/components/dashboard/tips/Tips.tsx
+++ b/frontend/src/components/dashboard/tips/Tips.tsx
@@ -41,7 +41,7 @@ export const Tips = (props: Props) => {
     `tips_customAlias_${props.profile.id}`
   );
   tips.push({
-    title: l10n.getString("tips-custom-alias-heading"),
+    title: l10n.getString("tips-custom-alias-heading-2"),
     content: (
       <CustomAliasTip subdomain={props.profile.subdomain ?? undefined} />
     ),


### PR DESCRIPTION
I think #1672 has been open since before the content refresh, and thus missed that the string used had been changed since.

How to test: with a Premium account, verify that the tips area doesn't look like this:

![image](https://user-images.githubusercontent.com/4251/167879072-175fad1f-7f79-441d-871b-628cc8ea3835.png)

but like this:

![image](https://user-images.githubusercontent.com/4251/167879255-0b59928b-743f-424b-bb7d-737a7a128fd3.png)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
