### PR TITLE
Add feature flag to disable the Tips

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -15,6 +15,7 @@ const runtimeConfigs = {
     maxOnboardingAvailable: 3,
     featureFlags: {
       // Also add keys here to RuntimeConfig in src/config.ts
+      tips: false,
       generateCustomAliasMenu: true,
       generateCustomAliasSubdomain: false,
       interviewRecruitment: false,

--- a/frontend/src/components/dashboard/tips/Tips.tsx
+++ b/frontend/src/components/dashboard/tips/Tips.tsx
@@ -48,7 +48,7 @@ export const Tips = (props: Props) => {
     dismissal: customAliasDismissal,
   });
 
-  if (tips.length === 0) {
+  if (tips.length === 0 || getRuntimeConfig().featureFlags.tips !== true) {
     return null;
   }
 

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -18,6 +18,7 @@ export type RuntimeConfig = {
   googleAnalyticsId: `UA-${number}-${number}`;
   maxOnboardingAvailable: number;
   featureFlags: Record<
+    | "tips"
     | "generateCustomAliasMenu"
     | "generateCustomAliasSubdomain"
     | "interviewRecruitment"


### PR DESCRIPTION
# New feature description

This adds a feature flag to easily disable the tips area, so that it can be deployed to production without being released to users (since it hasn't been QA'd yet).

# Screenshot (if applicable)

Not applicable.

# How to test

Open the dashboard with a Premium account. The Tips area at the bottom should not be shown if the feature flag is `false` or not set, and it should be shown if it's `true`.

# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
