### PR TITLE
Pass the details for Foxfooding study to logger extra field

### DIFF
--- a/emails/utils.py
+++ b/emails/utils.py
@@ -419,8 +419,10 @@ def remove_trackers(html_content, level="general"):
         "general": general_detail,
         "strict": strict_detail,
     }
+    logger_details = {"level": level, "is_control": control}
+    logger_details.update(study_details)
     study_logger.info(
         "email_tracker_foxfooding_summary",
-        extra={"level": level, "is_control": control}.update(study_details),
+        extra=logger_details,
     )
     return changed_content, control, study_details


### PR DESCRIPTION
The bug was that `update()` returns None which meant `extra` was `None` before this change.

How to test:
## Logger details for `email_tracker_summary` show up when email is relayed to Foxfooding participant
1. Send an email to a Relay account with mozilla.com as the primary account
2. On the logger check that it following details like below exists:
```
Fields: {
  level: "general"
  tracker_removed: 0
  general: {
    count: 0
    trackers: {0}
  }
msg: "email_tracker_foxfooding_summary"
strict: {
  count: 0
  trackers: {0}
  }
}
```

- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).