### PR TITLE
Enable flag for tip

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -15,7 +15,7 @@ const runtimeConfigs = {
     maxOnboardingAvailable: 3,
     featureFlags: {
       // Also add keys here to RuntimeConfig in src/config.ts
-      tips: false,
+      tips: true,
       generateCustomAliasMenu: true,
       generateCustomAliasSubdomain: false,
       interviewRecruitment: false,


### PR DESCRIPTION
Following #1937, re-enabling the flag to test tip component on the profile dashboard.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
