### PR TITLE
Only show Custom Mask tip to Premium users

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -15,7 +15,7 @@ const runtimeConfigs = {
     maxOnboardingAvailable: 3,
     featureFlags: {
       // Also add keys here to RuntimeConfig in src/config.ts
-      tips: false,
+      tips: true,
       generateCustomAliasMenu: true,
       generateCustomAliasSubdomain: false,
       interviewRecruitment: false,

--- a/frontend/src/components/dashboard/tips/Tips.tsx
+++ b/frontend/src/components/dashboard/tips/Tips.tsx
@@ -40,13 +40,15 @@ export const Tips = (props: Props) => {
   const customAliasDismissal = useLocalDismissal(
     `tips_customAlias_${props.profile.id}`
   );
-  tips.push({
-    title: l10n.getString("tips-custom-alias-heading-2"),
-    content: (
-      <CustomAliasTip subdomain={props.profile.subdomain ?? undefined} />
-    ),
-    dismissal: customAliasDismissal,
-  });
+  if (props.profile.has_premium) {
+    tips.push({
+      title: l10n.getString("tips-custom-alias-heading-2"),
+      content: (
+        <CustomAliasTip subdomain={props.profile.subdomain ?? undefined} />
+      ),
+      dismissal: customAliasDismissal,
+    });
+  }
 
   if (tips.length === 0 || getRuntimeConfig().featureFlags.tips !== true) {
     return null;


### PR DESCRIPTION
This PR fixes #1942.

How to test: sign in as a free user - you should see no tips. As a Premium user, you should see the tip on how to create a custom mask.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
