### PR TITLE
Send notifications to the add-on on events

### DIFF
--- a/frontend/__mocks__/hooks/addon.ts
+++ b/frontend/__mocks__/hooks/addon.ts
@@ -14,7 +14,6 @@ function getReturnValue(
   return {
     sendEvent: jest.fn(),
     present: false,
-    isLoggedIn: false,
     localLabels: [],
     ...addonData,
   };

--- a/frontend/__mocks__/hooks/api/aliases.ts
+++ b/frontend/__mocks__/hooks/api/aliases.ts
@@ -111,9 +111,15 @@ function getReturnValue(
       mutate: jest.fn(),
       data: customAliasData,
     },
-    create: callbacks?.creater || jest.fn(),
-    update: callbacks?.updater || jest.fn(),
-    delete: callbacks?.deleter || jest.fn(),
+    create:
+      callbacks?.creater ||
+      jest.fn(() => Promise.resolve({ ok: true } as unknown as Response)),
+    update:
+      callbacks?.updater ||
+      jest.fn(() => Promise.resolve({ ok: true } as unknown as Response)),
+    delete:
+      callbacks?.deleter ||
+      jest.fn(() => Promise.resolve({ ok: true } as unknown as Response)),
   };
 }
 

--- a/frontend/src/hooks/addon.ts
+++ b/frontend/src/hooks/addon.ts
@@ -30,7 +30,7 @@ export type AddonData = Partial<{
    */
   localLabels: LocalLabel[];
 }> & {
-  sendEvent: (type: string, data: object) => void;
+  sendEvent: (type: string, data?: object) => void;
 };
 
 const defaultAddonData: AddonData = {
@@ -93,7 +93,7 @@ const attributeParsers: Record<
  */
 const parseAddonData = (addonElement: HTMLElement): AddonData => {
   let addonData: AddonData = {
-    sendEvent: (type, data) => {
+    sendEvent: (type, data = {}) => {
       addonElement.dispatchEvent(
         new CustomEvent("website", { detail: { ...data, type: type } })
       );

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -34,12 +34,14 @@ import { toast } from "react-toastify";
 import { getLocale } from "../../functions/getLocale";
 import { InfoTooltip } from "../../components/InfoTooltip";
 import { AddonData } from "../../components/dashboard/AddonData";
+import { useAddonData } from "../../hooks/addon";
 
 const Profile: NextPage = () => {
   const runtimeData = useRuntimeData();
   const profileData = useProfiles();
   const userData = useUsers();
   const aliasData = useAliases();
+  const addonData = useAddonData();
   const { l10n } = useLocalization();
   const bottomBannerSubscriptionLinkRef = useGaViewPing({
     category: "Purchase Button",
@@ -89,6 +91,7 @@ const Profile: NextPage = () => {
         { type: "error" }
       );
     }
+    addonData.sendEvent("subdomainClaimed", { subdomain: customSubdomain });
   };
 
   const allAliases = getAllAliases(
@@ -145,6 +148,7 @@ const Profile: NextPage = () => {
           "Immediately caught to land in the same code path as failed requests."
         );
       }
+      addonData.sendEvent("aliasListUpdate");
     } catch (error) {
       toast(l10n.getString("error-mask-create-failed"), { type: "error" });
     }
@@ -179,6 +183,7 @@ const Profile: NextPage = () => {
           "Immediately caught to land in the same code path as failed requests."
         );
       }
+      addonData.sendEvent("aliasListUpdate");
     } catch (error: unknown) {
       toast(
         l10n.getString("error-mask-delete-failed", {

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -16,6 +16,7 @@ import { getRuntimeConfig } from "../../config";
 import { useLocalLabels } from "../../hooks/localLabels";
 import { AliasData, useAliases } from "../../hooks/api/aliases";
 import { useRuntimeData } from "../../hooks/api/runtimeData";
+import { useAddonData } from "../../hooks/addon";
 
 const Settings: NextPage = () => {
   const runtimeData = useRuntimeData();
@@ -23,6 +24,7 @@ const Settings: NextPage = () => {
   const { l10n } = useLocalization();
   const [localLabels] = useLocalLabels();
   const aliasData = useAliases();
+  const addonData = useAddonData();
   const [labelCollectionEnabled, setLabelCollectionEnabled] = useState(
     profileData.data?.[0].server_storage
   );
@@ -92,6 +94,12 @@ const Settings: NextPage = () => {
       }
 
       toast(l10n.getString("success-settings-update"), { type: "success" });
+
+      if (profileData.data?.[0].server_storage !== labelCollectionEnabled) {
+        // If the user has changed their preference w.r.t. server storage of address labels,
+        // notify the add-on about it:
+        addonData.sendEvent("serverStorageChange");
+      }
     } catch (e) {
       toast(l10n.getString("error-settings-update"), { type: "error" });
     }

--- a/frontend/src/pages/accounts/settings.test.tsx
+++ b/frontend/src/pages/accounts/settings.test.tsx
@@ -9,6 +9,7 @@ import { mockConfigModule } from "../../../__mocks__/configMock";
 import { setMockProfileData } from "../../../__mocks__/hooks/api/profile";
 import { setMockAliasesData } from "../../../__mocks__/hooks/api/aliases";
 import { setMockRuntimeData } from "../../../__mocks__/hooks/api/runtimeData";
+import { setMockAddonData } from "../../../__mocks__/hooks/addon";
 
 // Important: make sure mocks are imported *before* the page under test:
 import Settings from "./settings.page";
@@ -21,6 +22,7 @@ jest.mock("../../config.ts", () => mockConfigModule);
 setMockAliasesData();
 setMockProfileData();
 setMockRuntimeData();
+setMockAddonData();
 
 describe("The settings screen", () => {
   describe("under axe accessibility testing", () => {
@@ -80,5 +82,47 @@ describe("The settings screen", () => {
     const bannerHeading = screen.queryByRole("alert");
 
     expect(bannerHeading).not.toBeInTheDocument();
+  });
+
+  it("notifies the add-on when the user toggles server-side label storage off", async () => {
+    const addonNotifier = jest.fn();
+    setMockAddonData({ sendEvent: addonNotifier });
+    setMockProfileData({ server_storage: true });
+    render(<Settings />);
+
+    await userEvent.click(
+      screen.getByLabelText(
+        "l10n string: [setting-label-collection-description-2], with vars: {}"
+      )
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: "l10n string: [settings-button-save-label], with vars: {}",
+      })
+    );
+
+    expect(addonNotifier).toHaveBeenCalledWith("serverStorageChange");
+  });
+
+  it("notifies the add-on when the user toggles server-side label storage on", async () => {
+    const addonNotifier = jest.fn();
+    setMockAddonData({ sendEvent: addonNotifier });
+    setMockProfileData({ server_storage: false });
+    render(<Settings />);
+
+    await userEvent.click(
+      screen.getByLabelText(
+        "l10n string: [setting-label-collection-description-2], with vars: {}"
+      )
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: "l10n string: [settings-button-save-label], with vars: {}",
+      })
+    );
+
+    expect(addonNotifier).toHaveBeenCalledWith("serverStorageChange");
   });
 });


### PR DESCRIPTION
The add-on might want to be notified for certain actions performed
on the website, to update its local cache of data. Here I added
three events:

- serverStorageChange, fired whenever the user toggles their
  preference for storing labels on the server.
- subdomainClaimed, fired when the user registers their subdomain.
- aliasListUpdate, fired whenever the user adds or removes a mask.

This is the website part of the approach described here: https://github.com/mozilla/fx-private-relay-add-on/pull/335#issuecomment-1129134041.

# Screenshot (if applicable)

Not applicable.

# How to test

I've got a separate PR for the add-on; I'll add instructions there: https://github.com/mozilla/fx-private-relay-add-on/pull/336

# Checklist

- [x] l10n dependencies have been merged, if any.
- [ ] All acceptance criteria are met. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
