### PR TITLE
MPP-1985: In email task, periodically run `gc.collect()`

### DIFF
--- a/emails/management/commands/process_emails_from_sqs.py
+++ b/emails/management/commands/process_emails_from_sqs.py
@@ -12,7 +12,6 @@ https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.h
 from datetime import datetime, timezone
 from urllib.parse import urlsplit
 import json
-import io
 import logging
 import shlex
 import time
@@ -23,10 +22,10 @@ from codetiming import Timer
 from markus.utils import generate_tag
 import OpenSSL
 
-from django.conf import settings
 from django.core.management.base import CommandError
 
-from emails.views import _sns_inbound_logic, validate_sns_header, verify_from_sns
+from emails.sns import verify_from_sns
+from emails.views import _sns_inbound_logic, validate_sns_header
 from emails.utils import incr_if_enabled, gauge_if_enabled
 from emails.management.command_from_django_settings import (
     CommandFromDjangoSettings,

--- a/emails/management/commands/process_emails_from_sqs.py
+++ b/emails/management/commands/process_emails_from_sqs.py
@@ -11,6 +11,7 @@ https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.h
 
 from datetime import datetime, timezone
 from urllib.parse import urlsplit
+import gc
 import json
 import logging
 import shlex
@@ -197,6 +198,8 @@ class Command(CommandFromDjangoSettings):
                 )
 
                 self.cycles += 1
+                gc.collect()  # Force garbage collection of boto3 SQS client resources
+
             except KeyboardInterrupt:
                 self.halt_requested = True
                 exit_on = "interrupt"


### PR DESCRIPTION
* Remove some unused imports, and import `verify_from_sns` directly from `emails.sns`. I've been playing with `flake8` and `isort`, which identified these and several other issues. These seem like minimal ones that could be confirmed by inspection.
* Run `gc.collect()` each processing cycle, to allow cleanup of boto3 resources (SQS and S3 clients) before Kubernetes kills the task for exceeding memory limits.

This PR addresses #1963 / MPP-1985. Running in a Kubernetes deployment will be needed to see the impact on memory usage.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
