### PR TITLE
Hide Premium availability news for Premium users

### DIFF
--- a/frontend/src/components/layout/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/whatsnew/WhatsNewMenu.tsx
@@ -241,7 +241,10 @@ export const WhatsNewMenu = (props: Props) => {
       day: 17,
     },
   };
-  if (props.runtimeData?.PREMIUM_PLANS.country_code.toLowerCase() === "se") {
+  if (
+    props.runtimeData?.PREMIUM_PLANS.country_code.toLowerCase() === "se" &&
+    !props.profile.has_premium
+  ) {
     entries.push(premiumInSweden);
   }
 
@@ -270,7 +273,10 @@ export const WhatsNewMenu = (props: Props) => {
       day: 17,
     },
   };
-  if (props.runtimeData?.PREMIUM_PLANS.country_code.toLowerCase() === "fi") {
+  if (
+    props.runtimeData?.PREMIUM_PLANS.country_code.toLowerCase() === "fi" &&
+    !props.profile.has_premium
+  ) {
     entries.push(premiumInFinland);
   }
 


### PR DESCRIPTION
Users that have Premium already don't need to see an announcement that it is now available in their country - clearly, they know.

How to test: set your Accept-Language to a Sweden or Finland locale, then open the site. With Premium, you shouldn't see an announcement. Without Premium, you should. (Note: this doesn't work on the mocked site, because the mock says that you're in the Netherlands.)

# Checklist

- [x] l10n dependencies have been merged, if any. - Just now: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/81
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
