### PR TITLE
Fix expected type from the FxA flow tracker

### DIFF
--- a/frontend/src/apiMocks/handlers.ts
+++ b/frontend/src/apiMocks/handlers.ts
@@ -289,7 +289,7 @@ export function getHandlers(
         ctx.status(200),
         ctx.json({
           flowId: "mock-flow-id",
-          flowBeginTime: new Date(Date.now()).toISOString(),
+          flowBeginTime: Date.now(),
         })
       );
     })

--- a/frontend/src/hooks/fxaFlowTracker.ts
+++ b/frontend/src/hooks/fxaFlowTracker.ts
@@ -11,7 +11,7 @@ export type FxaFlowTrackerArgs = Omit<
 
 export type FlowData = {
   flowId: string;
-  flowBeginTime: string;
+  flowBeginTime: number;
 };
 
 /**
@@ -53,7 +53,7 @@ export function useFxaFlowTracker(
         const data = await response.json();
         if (
           typeof data.flowId !== "string" ||
-          typeof data.flowBeginTime !== "string"
+          typeof data.flowBeginTime !== "number"
         ) {
           return;
         }
@@ -90,7 +90,10 @@ export function getLoginUrl(entrypoint: string, flowData?: FlowData): string {
   urlObject.searchParams.append("entrypoint", entrypoint);
   if (flowData) {
     urlObject.searchParams.append("flowId", flowData.flowId);
-    urlObject.searchParams.append("flowBeginTime", flowData.flowBeginTime);
+    urlObject.searchParams.append(
+      "flowBeginTime",
+      flowData.flowBeginTime.toString()
+    );
   }
 
   const fullUrl = urlObject.href;


### PR DESCRIPTION
When getting flow parameters from Firefox Accounts, we were
expecting a string for `flowBeginTime`, but it turns out to be a
number. Since we bailed out on an unexpected type, this meant the
parameters were not appended.

This PR fixes #1807.

How to test: on relay.firefox.com, take a look at the response from https://accounts.firefox.com/metrics-flow. Now on the site with mocked-out APIs, you can see that the response aligns with it, and the parameters get appended to the sign in/up links in the header successfully. (Also, without this change, but with the updated mock, the behaviour is the same as in production, i.e. no error, but no query params either.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug. (Well, updated mock.)
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
