### PR TITLE
Ensure labels are saved even with add-on present

### DIFF
--- a/frontend/__mocks__/hooks/localLabels.ts
+++ b/frontend/__mocks__/hooks/localLabels.ts
@@ -14,7 +14,7 @@ const mockedUseLocalLabels = useLocalLabels as jest.MockedFunction<
   typeof useLocalLabels
 >;
 
-export function getReturnValueWhenEnabled(
+export function getReturnValueWithAddon(
   localLabels: Array<Partial<LocalLabel>> = [],
   callback: SetLocalLabel = jest.fn()
 ): LocalLabelHook {
@@ -29,20 +29,20 @@ export function getReturnValueWhenEnabled(
     callback,
   ];
 }
-export function getReturnValueWhenDisabled(
+export function getReturnValueWithoutAddon(
   callback: SetLocalLabel = jest.fn()
 ): NotEnabled {
   return [null, callback];
 }
 
 export const setMockLocalLabels = (
-  returnValue: LocalLabelHook | NotEnabled = getReturnValueWhenDisabled()
+  returnValue: LocalLabelHook | NotEnabled = getReturnValueWithoutAddon()
 ) => {
   mockedUseLocalLabels.mockReturnValue(returnValue);
 };
 
 export const setMockLocalLabelsOnce = (
-  returnValue: LocalLabelHook | NotEnabled = getReturnValueWhenDisabled()
+  returnValue: LocalLabelHook | NotEnabled = getReturnValueWithoutAddon()
 ) => {
   mockedUseLocalLabels.mockReturnValueOnce(returnValue);
 };

--- a/frontend/src/components/dashboard/aliases/AliasList.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.test.tsx
@@ -16,7 +16,7 @@ describe("<AliasList>", () => {
     const updateCallback = jest.fn();
     const storeLocalLabelCallback = jest.fn();
     LocalLabelsMock.setMockLocalLabelsOnce(
-      LocalLabelsMock.getReturnValueWhenDisabled(storeLocalLabelCallback)
+      LocalLabelsMock.getReturnValueWithoutAddon(storeLocalLabelCallback)
     );
     render(
       <AliasList
@@ -43,7 +43,7 @@ describe("<AliasList>", () => {
     const updateCallback = jest.fn();
     const storeLocalLabelCallback = jest.fn();
     LocalLabelsMock.setMockLocalLabelsOnce(
-      LocalLabelsMock.getReturnValueWhenEnabled([], storeLocalLabelCallback)
+      LocalLabelsMock.getReturnValueWithAddon([], storeLocalLabelCallback)
     );
     render(
       <AliasList
@@ -69,9 +69,36 @@ describe("<AliasList>", () => {
     );
   });
 
+  it("sends a request to the back-end to update the label if server-side label storage is enabled, even if the add-on is present", async () => {
+    const updateCallback = jest.fn();
+    const storeLocalLabelCallback = jest.fn();
+    LocalLabelsMock.setMockLocalLabelsOnce(
+      LocalLabelsMock.getReturnValueWithAddon([], storeLocalLabelCallback)
+    );
+    render(
+      <AliasList
+        aliases={[getMockRandomAlias()]}
+        onUpdate={updateCallback}
+        onCreate={jest.fn()}
+        onDelete={jest.fn()}
+        profile={getMockProfileData({ server_storage: true })}
+        user={{ email: "arbitrary@example.com" }}
+      />
+    );
+
+    const labelField = screen.getByRole("textbox");
+    userEvent.type(labelField, "Some label");
+    userEvent.tab();
+
+    expect(updateCallback).toHaveBeenCalledWith(expect.anything(), {
+      description: "Some label",
+    });
+    expect(storeLocalLabelCallback).not.toHaveBeenCalled();
+  });
+
   it("does not provide the option to edit the label if server-side storage is disabled, and local storage is not available (i.e. the user does not have the add-on)", async () => {
     LocalLabelsMock.setMockLocalLabelsOnce(
-      LocalLabelsMock.getReturnValueWhenDisabled()
+      LocalLabelsMock.getReturnValueWithoutAddon()
     );
     render(
       <AliasList

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -68,7 +68,8 @@ export const AliasList = (props: Props) => {
     const onUpdate = (updatedFields: Partial<AliasData>) => {
       if (
         localLabels !== null &&
-        typeof updatedFields.description === "string"
+        typeof updatedFields.description === "string" &&
+        props.profile.server_storage === false
       ) {
         storeLocalLabel(alias, updatedFields.description);
         delete updatedFields.description;


### PR DESCRIPTION
This PR fixes #1954, or the bug that that was attempting to back out (now reported, this fixes #1970). It resulted in labels not getting saved even with server-side storage enabled - but only when the add-on is installed.

The mistake I made before was to think that `useLocalLabels` would
return `null` for the local labels if server-side storage of labels
was disabled. However, that was not the case: it would return
`null` if the user did not have the add-on installed. Otherwise, it
would simply return an empty array.

The fix was to only store labels locally (and avoid sending them to
the server) if the user has actually disabled server-side label
storage.

How to test: run locally on 127.0... (i.e. `npm run watch`), and run the extension locally (`npm run web-ext-run`). On an account with server-side label storage enabled, you should be able to see a non-empty PATCH request being sent to the API containing your label. Before this change, that request would be empty.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
