### PR TITLE
Block release builds on untranslatable strings

### DIFF
--- a/frontend/src/functions/getL10n.ts
+++ b/frontend/src/functions/getL10n.ts
@@ -58,22 +58,31 @@ export function getL10n() {
           pendingTranslations
         );
         bundle.addResource(pendingTranslationsResource);
-        if (process.env.NEXT_PUBLIC_DEBUG === "true") {
-          const pendingTranslationsIds = pendingTranslationsResource.body.map(
-            (stringData) => stringData.id
-          );
-          const mergedEnglishTranslationIds = RESOURCES.en.body.map(
-            (stringData) => stringData.id
-          );
-          const unmergedStrings = pendingTranslationsIds.filter(
-            (id) => !mergedEnglishTranslationIds.includes(id)
-          );
-          if (unmergedStrings.length > 0) {
-            console.warn(
-              "The following strings have not yet been merged into the l10n repository, and thus cannot be translated yet:",
-              unmergedStrings
+        const pendingTranslationsIds = pendingTranslationsResource.body.map(
+          (stringData) => stringData.id
+        );
+        const mergedEnglishTranslationIds = RESOURCES.en.body.map(
+          (stringData) => stringData.id
+        );
+        const unmergedStrings = pendingTranslationsIds.filter(
+          (id) => !mergedEnglishTranslationIds.includes(id)
+        );
+        if (unmergedStrings.length > 0) {
+          if (
+            typeof process.env.CIRCLE_TAG === "string" &&
+            process.env.CIRCLE_TAG.length > 0
+          ) {
+            // When building a release that might go to production,
+            // missing strings should be a blocking error:
+            throw new Error(
+              "The following strings have not yet been merged into the l10n repository, and thus cannot be translated yet:\n" +
+                JSON.stringify(unmergedStrings, undefined, 2)
             );
           }
+          console.warn(
+            "The following strings have not yet been merged into the l10n repository, and thus cannot be translated yet:",
+            unmergedStrings
+          );
         }
       }
       yield bundle;


### PR DESCRIPTION
Rather than just logging this as a warning in debug mode, with this
change it always gets logged when some strings have not been merged
into the submodule yet, and builds are actually broken off if it's
a build in CircleCI triggered by a new Git tag (i.e. it's a build
that will go to stage and could eventually end up in production).

How to test: run `npm run build` with a string in `pendingTranslations.ftl` that has not yet been submitted to the l10n repository. (There's actually one in there right now that [I just submitted](https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/83).) It should only show a warning. Now try to do the same with Circle's env vars for a Git tag (e.g. `CIRCLE_TAG="v3.5.1" npm run build`) and see that it fails.

**Note:** this does mean that we cannot push to stage until all strings are merged, and additionally, it means that builds that succeed in `main` may suddenly start failing when we push a new tag, so I'm not yet entirely convinced that this is desirable. But we can discuss that as a team.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
