### PR TITLE
Add `no-cache, public` header to the homepage

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -526,7 +526,11 @@ WHITENOISE_INDEX_FILE = True
 # so that the `RedirectRootIfLoggedIn` middleware can kick in for logged-in
 # users.
 def set_index_cache_control_headers(headers, path, url):
-    if path == os.path.abspath("./frontend/out/index.html"):
+    if DEBUG:
+        home_path = os.path.join(BASE_DIR, "frontend/out", "index.html")
+    else:
+        home_path = os.path.join(STATIC_ROOT, "index.html")
+    if path == home_path:
         headers["Cache-Control"] = "no-cache, public"
 
 

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -519,6 +519,20 @@ MEDIA_URL = None
 
 WHITENOISE_INDEX_FILE = True
 
+
+# See
+# https://whitenoise.evans.io/en/stable/django.html#WHITENOISE_ADD_HEADERS_FUNCTION
+# Intended to ensure that the homepage does not get cached in our CDN,
+# so that the `RedirectRootIfLoggedIn` middleware can kick in for logged-in
+# users.
+def set_index_cache_control_headers(headers, path, url):
+    if path == os.path.abspath("./frontend/out/index.html"):
+        print("SETTING HEADER")
+        headers["Cache-Control"] = "no-cache, public"
+
+
+WHITENOISE_ADD_HEADERS_FUNCTION = set_index_cache_control_headers
+
 # for dev statics, we use django-gulp during runserver.
 # for stage/prod statics, we run "gulp build" in docker.
 # so, squelch django-gulp in prod so it doesn't run gulp during collectstatic:

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -527,7 +527,6 @@ WHITENOISE_INDEX_FILE = True
 # users.
 def set_index_cache_control_headers(headers, path, url):
     if path == os.path.abspath("./frontend/out/index.html"):
-        print("SETTING HEADER")
         headers["Cache-Control"] = "no-cache, public"
 
 


### PR DESCRIPTION
This should allow Django to kick in and redirect the user to their
dashboard if they are logged in. It should enable https://github.com/mozilla/fx-private-relay-add-on/pull/332 (and fix https://github.com/mozilla/fx-private-relay/pull/1816 not doing anything on prod at the moment).

How to test: This was suggested by Aaron, but since the cache only affects prod, I've only been able to verify that the correct cache headers are added when visiting 127.0.0.1:8000 while not logged in, and aren't changed for other resources.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
