### PR TITLE
MPP-1980 - Fix issue where toast banner obstructs nav items on desktop

### DIFF
--- a/frontend/src/components/layout/Layout.module.scss
+++ b/frontend/src/components/layout/Layout.module.scss
@@ -27,6 +27,11 @@
 // Allows us to dynamically set the background color based on Toast container state
 $toastify-toast-close-button: var(--toast-close-button);
 
+// Targets the toast container and sets max-width to prevent it from obstructing nav items on larger screens.
+.toast-container {
+  max-width: $content-xl;
+}
+
 .toast {
   @include text-body-sm;
   text-align: center;

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -181,6 +181,7 @@ export const Layout = (props: Props) => {
           transition={Slide}
           hideProgressBar={true}
           autoClose={5000}
+          className={styles["toast-container"]}
           toastClassName={`Toastify__toast ${styles.toast}`}
           closeButton={(closeToastObject) =>
             closeToastButton(closeToastObject.closeToast)


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->
This fixes an issue where the toast container obstructs navigation links when they're visible because the container is bigger than its children (95% width)

This PR fixes MPP-1980

**How to test:**

Try clicking on a navigation item in desktop mode after triggering a toast notification. 

An easy way is to visit the settings page after logging in and click on save. Try clicking on a nav item and you should be able to do so. 

https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net/accounts/settings/ 

<!-- When adding a new feature: -->

# New feature description



# Screenshot (if applicable)
**Not working:** 
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/3924990/169852854-91cebca6-9011-4d7a-8849-08d171aba4da.png">


**Working:** 
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/3924990/169852628-d7c5f5d3-c2f3-4efe-ab6e-e6bbebcf8ce7.png">

 