### PR TITLE
for ITSEC-233: add vault.bitwarden.com to CORS

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -625,7 +625,10 @@ REST_FRAMEWORK = {
 # an auth token:
 ACCOUNT_LOGOUT_ON_GET = DEBUG
 
-CORS_ALLOWED_ORIGINS = []
+CORS_ALLOWED_ORIGINS = [
+    "https://vault.bitwarden.com",
+]
+CORS_URLS_REGEX = r"^/api/"
 CSRF_TRUSTED_ORIGINS = []
 if DEBUG:
     # In local development, the React UI can be served up from a different server


### PR DESCRIPTION
This PR fixes [ITSEC-233](https://mozilla-hub.atlassian.net/browse/ITSEC-233).

How to test:
1. Check out this PR branch
2. Add another local test entry to `CORS_ALLOWED_ORIGINS` (e.g., I used `"http://localhost:6060",` [i.e., local Monitor])
3. Go to that new local test origin (e.g., http://localhost:6060)
   * Note: you'll need to make sure the origin is served with `http://127.0.0.1:8000` in its `Content-Security-Policy` header
5. Open a console in the page of the local test origin
6. Enter `fetch("http://127.0.0.1:8000/api/v1/relayaddresses/");`
   * [x] You might still see an error, but it will be a `403 Forbidden` error - not a `CORS Missing Allow Origin`
7. Enter `fetch("http://127.0.0.1:8000/accounts/profile");`
   * [x] You SHOULD see `CORS Missing Allow Origin` (Because we only want to add these headers to the /api/ urls)

- [ ] I've added or updated relevant docs in the docs/ directory.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).