### PR TITLE
MPP-2008: Drop second checkout from heroku postbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint:css": "stylelint static/scss/",
     "lint:fix-css": "stylelint --fix static/scss/",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "heroku-postbuild": "git clone https://github.com/mozilla-l10n/fx-private-relay-l10n.git privaterelay/locales; cd frontend; NODE_ENV=\"development\" npm ci; npm run build"
+    "heroku-postbuild": "cd frontend; NODE_ENV=\"development\" npm ci; npm run build"
   },
   "volta": {
     "node": "14.18.1",


### PR DESCRIPTION
Heroku automatically checks out the submodule as one of the first steps of building after a new push, so the removed command fails every time.>

This PR fixes #1984 / MPP-2008

How to test:

* See a recent build, verify that it works like #1984.
* If needed, push this branch to Heroku, and see that the build is successful.