### PR TITLE
Don't retry auth requests when logged out

### DIFF
--- a/frontend/src/apiMocks/handlers.ts
+++ b/frontend/src/apiMocks/handlers.ts
@@ -65,7 +65,7 @@ export function getHandlers(
   addGetHandler("/api/v1/users/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
-      return res(ctx.status(400));
+      return res(ctx.status(403));
     }
 
     return res(ctx.status(200), ctx.json([users[mockId]]));
@@ -103,7 +103,7 @@ export function getHandlers(
   addGetHandler("/api/v1/profiles/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
-      return res(ctx.status(400));
+      return res(ctx.status(403));
     }
 
     return res(ctx.status(200), ctx.json([profiles[mockId]]));

--- a/frontend/src/hooks/api/api.ts
+++ b/frontend/src/hooks/api/api.ts
@@ -57,7 +57,7 @@ export const apiFetch = async (
 const fetcher: Fetcher = async (route: string, init?: RequestInit) => {
   const response = await apiFetch(route, init);
   if (!response.ok) {
-    throw new Error(`${response.status}: ${response.statusText}`);
+    throw new FetchError(response);
   }
   const data: unknown = await response.json();
   return data;
@@ -66,16 +66,25 @@ const fetcher: Fetcher = async (route: string, init?: RequestInit) => {
 /**
  * Make calls to our API using [SWR](https://swr.vercel.app). Generally wrapped in endpoint-specific hooks, e.g. {@link useProfiles}.
  */
-export function useApiV1<Data = unknown, Error = unknown>(
+export function useApiV1<Data = unknown>(
   route: string,
   swrOptions: Partial<PublicConfiguration> = {}
-): SWRResponse<Data, Error> {
+): SWRResponse<Data, FetchError> {
   // TODO: Also use the sessionId cookie in the key,
   //       to ensure no data is cached from different users?
   //       (This is currently enforced by doing a full page refresh when logging out.)
   const result = useSWR(route, fetcher, {
     revalidateOnFocus: false,
     ...swrOptions,
-  }) as SWRResponse<Data, Error>;
+  }) as SWRResponse<Data, FetchError>;
   return result;
+}
+
+export class FetchError extends Error {
+  readonly response: Response;
+
+  constructor(response: Response) {
+    super();
+    this.response = response;
+  }
 }

--- a/frontend/src/hooks/api/user.ts
+++ b/frontend/src/hooks/api/user.ts
@@ -1,5 +1,5 @@
-import { SWRResponse } from "swr";
-import { useApiV1 } from "./api";
+import { SWRResponse, SWRConfig } from "swr";
+import { FetchError, useApiV1 } from "./api";
 
 export type UserData = {
   email: string;
@@ -11,6 +11,27 @@ export type UsersData = [UserData];
  * Fetch the user's user data (primarily their email address) from our API using [SWR](https://swr.vercel.app).
  */
 export function useUsers() {
-  const users: SWRResponse<UsersData, unknown> = useApiV1("/users/");
+  const users: SWRResponse<UsersData, unknown> = useApiV1("/users/", {
+    onErrorRetry: (
+      error: unknown | FetchError,
+      key,
+      config,
+      revalidate,
+      revalidateOpts
+    ) => {
+      if (error instanceof FetchError && error.response.status === 403) {
+        // When the user is not logged in, this API returns a 403.
+        // If so, do not retry.
+        return;
+      }
+      SWRConfig.default.onErrorRetry(
+        error,
+        key,
+        config,
+        revalidate,
+        revalidateOpts
+      );
+    },
+  });
   return users;
 }


### PR DESCRIPTION
We make requests to /api/v1/profiles/ and /api/v1/users/ to
determine whether the user is currently logged in. When the user is
not logged in, those requests will return a 403, as expected.
However, that means those requests do not need to be retried, which
is SWR's default behaviour for failed requests.

The `onErrorRetry` option is documented at
https://swr.vercel.app/docs/error-handling#error-retry.

How to test: open the landing page when not logged in. You should only see one (403'd) request to the profiles and users endpoints each, even after waiting a bit.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, config only
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
