### PR TITLE
Refer directly to non-Django paths

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -25,7 +25,6 @@ from django.db import transaction
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
-from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 
 from .models import (
@@ -503,7 +502,7 @@ def _sns_message(message_json):
         attachment_msg = (
             "Firefox Relay supports email forwarding (including attachments) "
             "of email up to 150KB in size. To learn more visit {site}{faq}\n"
-        ).format(site=settings.SITE_ORIGIN, faq=reverse("faq"))
+        ).format(site=settings.SITE_ORIGIN, faq="/faq/")
         relay_header_text = (
             "This email was sent to your alias "
             "{alias}. To stop receiving emails sent to this alias, "

--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -7,7 +7,6 @@ from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
 from django.conf import settings
 from django.contrib.auth import logout
 from django.shortcuts import redirect
-from django.urls import reverse
 
 from allauth.socialaccount.models import SocialToken
 from allauth.socialaccount.providers.fxa.views import FirefoxAccountsOAuth2Adapter
@@ -41,7 +40,7 @@ class FxAToRequest:
                 update_social_token(social_token, new_token)
             except (CustomOAuth2Error, NoSocialToken):
                 logout(request)
-                return redirect(reverse("home"))
+                return redirect("/")
 
         request.fxa_account = fxa_account
         return self.get_response(request)

--- a/privaterelay/urls.py
+++ b/privaterelay/urls.py
@@ -36,12 +36,6 @@ urlpatterns = [
     path("accounts/profile/refresh", views.profile_refresh, name="profile_refresh"),
     path("accounts/", include("allauth.urls")),
     path("api/", include("api.urls")),
-    # This route is still referred to in wrapped_email.html, so leave it in
-    # (even though the FAQ is no longer rendered by Django):
-    path("faq", views.faq, name="faq"),
-    # This route is still referred to in middleware.py, so leave it in
-    # (even though the homepage is no longer rendered by Django):
-    path("", views.home, name="home"),
 ]
 
 if settings.DEBUG:

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -48,20 +48,6 @@ logger = logging.getLogger("events")
 info_logger = logging.getLogger("eventsinfo")
 
 
-def home(request):
-    if request.user and not request.user.is_anonymous:
-        return redirect(reverse("profile"))
-
-    return render(request, "home.html")
-
-
-def faq(request):
-    context = {}
-    if request.user and not request.user.is_anonymous:
-        context.update({"user_profile": request.user.profile_set.first()})
-    return render(request, "faq.html", context)
-
-
 @lru_cache(maxsize=None)
 def _get_fxa(request):
     return request.user.socialaccount_set.filter(provider="fxa").first()


### PR DESCRIPTION
As discussed in https://github.com/mozilla/fx-private-relay/pull/1891#discussion_r881689812.

`reverse` is useful to maintain links even if URLs change (which
they shouldn't!), but since we were maintaining views that never
get rendered (because they're replaced by static HTML, not rendered
by Django), that benefit no longer plays out.

How to test: Note that I don't know how to actually encounter those two instances of `reverse`, so I haven't been able to verify that this does what it looks like it's doing...

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
