### PR TITLE
MPP-2015: Fallback to "en", non-premium when a user has no FxA account

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -124,7 +124,7 @@ class Profile(models.Model):
 
     @property
     def language(self):
-        if self.fxa.extra_data.get("locale"):
+        if self.fxa and self.fxa.extra_data.get("locale"):
             for accept_lang, _ in parse_accept_lang_header(
                 self.fxa.extra_data.get("locale")
             ):

--- a/emails/models.py
+++ b/emails/models.py
@@ -141,7 +141,7 @@ class Profile(models.Model):
     # sending an email, this method can be useful.
     @property
     def fxa_locale_in_premium_country(self):
-        if self.fxa.extra_data.get("locale"):
+        if self.fxa and self.fxa.extra_data.get("locale"):
             accept_langs = parse_accept_lang_header(self.fxa.extra_data.get("locale"))
             if (
                 len(accept_langs) >= 1

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -764,6 +764,9 @@ class ProfileTest(TestCase):
         )
         assert self.profile.fxa_locale_in_premium_country is False
 
+    def test_locale_in_premium_country_returns_False_if_no_fxa_account(self):
+        assert self.profile.fxa_locale_in_premium_country is False
+
     @override_settings(
         PREMIUM_RELEASE_DATE=datetime.fromisoformat("2021-10-27 17:00:00+00:00")
     )

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -712,6 +712,9 @@ class ProfileTest(TestCase):
         baker.make(SocialAccount, user=self.profile.user, provider="fxa")
         assert self.profile.language == "en"
 
+    def test_language_with_no_fxa_locale_returns_default_en(self):
+        assert self.profile.language == "en"
+
     def test_language_with_fxa_locale_de_returns_de(self):
         baker.make(
             SocialAccount,


### PR DESCRIPTION
 When a user doesn't have an associated FxA account, fallback to "en" (English) for the language, and that Premium is not available in their country. This happens rarely in production (0-7 times a day), but often in a fresh development environment.

This PR fixes issue #2000 / MPP-2015.

How to test:

* Install a local development environment, reset the database (delete or rename `db.sqlite3`), go through the setup steps, and add just a superuser.
* On `main`, start the server and go to http://127.0.0.1:8000/emails/wrapped_email_test . You should get the debug exception page, `AttributeError at /emails/wrapped_email_test`, `'NoneType' object has no attribute 'extra_data'`.
* Switch to this branch, restart the server to reload the template and caches.
* Go to http://127.0.0.1:8000/emails/wrapped_email_test, you should see the test email page in English, with no message "Upgrade to Firefox Relay Premium..."