### PR TITLE
MPP-1747: Ignore Fluent errors in Sentry, expand translations docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,15 @@ Please refer to our [coding standards](docs/coding-standards.md) for code styles
     ```
 
 ### Working with translations
+The following docs will get you started with development, include creating new
+strings to translate.  See [Translation and Localization](docs/translations.md)
+for general information on Relay localization.
+
 #### Getting the latest translations
 We use a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
 for translated message files. The `--recurse-submodules` step of installation
 should bring the message files into your working directory already, but you may
-want also want to udpate the translations after install. The easiest way to do
+want also want to update the translations after install. The easiest way to do
 that is:
 
 * `git submodule update --remote`
@@ -116,7 +120,7 @@ You can then open a pull request from the `message-updates-yyyymmdd` branch to
 [the l10n repo](https://github.com/mozilla-l10n/fx-private-relay-l10n) `main` branch.
 
 If you're not yet ready to submit some strings for translation, you can
-tentatively add them to frontend/pendingTranslations.ftl. Strings in that file
+tentatively add them to `frontend/pendingTranslations.ftl`. Strings in that file
 will show up until strings with the same ID are added to the l10n repository.
 
 #### Commit translations for release
@@ -131,6 +135,9 @@ You can then commit and push to set the app repository to the updated version
 of the translations submodule:
 
 * `git push`
+
+An automated process updates the submodule daily, bringing in any new changes
+and translations from the Localization Team.
 
 ### Recommended: Enable Firefox Accounts authentication
 To enable Firefox Accounts authentication on your local server, you can use the

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ that is:
 
 * `git submodule update --remote`
 
+To update the submodule automatically when running `git pull` or other commands:
+
+* `git config --global submodule.recurse true`
+
 #### Add/update messages for translation
 The `privaterelay/locales` directory is a git repository like any other, so to
 make changes to the messages:

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -14,9 +14,10 @@ commit, bringing in any new translations or other changes from the localization
 team.
 
 The translation bundles use the [Fluent format](https://projectfluent.org/).
-They are also included in the Docker image, and read by the email processing
-apps at runtime. They are also embedded in the JavaScript during the build
-process, so that the website text is translated.
+They are included in the Docker image that is deployed to the stage and
+production environments, and read by the email processing apps at runtime. They
+are also embedded in the JavaScript during the build process, so that the
+website text is translated.
 
 The user's desired language is stored with their Firefox Account, which uses
 the `Accept-Language` header provided by the browser. If there is a matching

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -3,6 +3,7 @@ Translations are maintained in separate repositories that are managed by the
 [Mozilla Localization Team](https://github.com/mozilla-l10n). There is a
 Pontoon project for the
 [Relay Website](https://pontoon.mozilla.org/projects/firefox-relay-website/)
+(which includes strings for the back-end email forwarding task)
 and for the
 [Add-on](https://pontoon.mozilla.org/projects/firefox-relay-add-on/). More
 than 20 languages are supported.
@@ -19,15 +20,23 @@ production environments, and read by the email processing apps at runtime. They
 are also embedded in the JavaScript during the build process, so that the
 website text is translated.
 
-The user's desired language is stored with their Firefox Account, which uses
-the `Accept-Language` header provided by the browser. If there is a matching
-supported language, it is used for the website, add-on, and in email. If there
-is no matching supported language, we fall back to English (`en`).
+The user's desired language is parsed from the `Accept-Language` header,
+provided by their browser. When the user signs up for a Firefox Account, their
+`Accept-Language` header is captured, and this is used for translated headers in
+forwarded emails. When a user visits the Relay website or uses the add-on,
+their current `Accept-Language` header is used.
 
-The application logs an error when a translation is missing. These logs (with
-log name `django_ftl.message_errors`) can be processed in BigQuery to find
-issues with supported languages and to measure the popularity of unsupported
-languages.
+There may not be an exact match between the desired language and those
+supported by Firefox Relay. The website uses
+[@fluent/langneg](https://github.com/projectfluent/fluent.js/tree/master/fluent-langneg)
+to determine the best match. The email forwarding code uses custom Python. In
+either case, if there is no best match, we fall back to English (`en`).
+
+The email forwarding code logs an error when a translation is missing. These
+logs (with log name `django_ftl.message_errors`) can be processed in BigQuery
+to find issues with supported languages and to measure the popularity of
+unsupported languages. There are no logs for missing translations in the
+website front-end or the add-on.
 
 See "Working with translations" in the project README.md for instructions on
 working with translations, such as adding new strings.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,32 @@
+# Translation and Localization
+Translations are maintained in separate repositories that are managed by the
+[Mozilla Localization Team](https://github.com/mozilla-l10n). There is a
+Pontoon project for the
+[Relay Website](https://pontoon.mozilla.org/projects/firefox-relay-website/)
+and for the
+[Add-on](https://pontoon.mozilla.org/projects/firefox-relay-add-on/). More
+than 20 languages are supported.
+
+The translation repositories are included as submodules, such as
+`privaterelay/locales`. The submodule refers to a specific commit in the
+separate repository. A GitHub action periodically updates this to the latest
+commit, bringing in any new translations or other changes from the localization
+team.
+
+The translation bundles use the [Fluent format](https://projectfluent.org/).
+They are also included in the Docker image, and read by the email processing
+apps at runtime. They are also embedded in the JavaScript during the build
+process, so that the website text is translated.
+
+The user's desired language is stored with their Firefox Account, which uses
+the `Accept-Language` header provided by the browser. If there is a matching
+supported language, it is used for the website, add-on, and in email. If there
+is no matching supported language, we fall back to English (`en`).
+
+The application logs an error when a translation is missing. These logs (with
+log name `django_ftl.message_errors`) can be processed in BigQuery to find
+issues with supported languages and to measure the popularity of unsupported
+languages.
+
+See "Working with translations" in the project README.md for instructions on
+working with translations, such as adding new strings.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -38,5 +38,6 @@ to find issues with supported languages and to measure the popularity of
 unsupported languages. There are no logs for missing translations in the
 website front-end or the add-on.
 
-See "Working with translations" in the project README.md for instructions on
-working with translations, such as adding new strings.
+See "Working with translations" in the project
+[README.md](../README.md#working-with-translations) for instructions on working
+with translations, such as adding new strings.

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -694,6 +694,10 @@ ignore_logger("request.summary")
 # Security scanner attempts, no action required
 # Can be re-enabled when hostname allow list implemented at the load balancer
 ignore_logger("django.security.DisallowedHost")
+# Fluent errors, mostly when a translation is unavailable for the locale.
+# It is more effective to process these from logs using BigQuery than to track
+# as events in Sentry.
+ignore_logger("django_ftl.message_errors")
 
 markus.configure(
     backends=[


### PR DESCRIPTION
Ignore `django_ftl.message_errors` logger, which Fluent uses when a string is unavailable in the requested language. These errors are not easy to parse as Sentry events, and we are ignoring them at the moment. Instead, we'll start parsing the logs into reports about recent errors. The report is Mozilla-only, so I've linked to it in internal docs rather than in the public repo.

This PR fixes issue #1618 / MPP-1747 by no longer sending these errors to Sentry. This is a similar fix to other "ignore logs" fixes, like the duplicate `request.summary` fix in PR #1620. I don't think it should be tested locally.

It also includes some new documentation about Translation and Localization, that I'd like reviewers to read for correctness.
