### PR TITLE
MPP-1747: Allow querystring overrides of /emails/wrapped_email_test

### DIFF
--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -1,6 +1,6 @@
 {% load ftl %}
 {% load email_extras %}
-{% withftl bundle='privaterelay.ftl_bundles.main' language=recipient_profile.language %}
+{% withftl bundle='privaterelay.ftl_bundles.main' language=language %}
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -59,11 +59,11 @@
                     <br><a href="{{ survey_link }}" target="_blank" rel="noopener noreferrer" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">{{ survey_text }}</a>.
                     {% endif %}
                   {% endif %}
-                  {% if recipient_profile.has_premium %}
+                  {% if has_premium %}
                     <br />
                     <img alt="" width="24" style="display: inline-block; margin-bottom: 0px; width: 24px;"  src="{{ SITE_ORIGIN }}/static/images/email-images/tip-purple.png" />
                     {% ftlmsg 'forwarded-email-header-cc-notice-2' %}
-                  {% elif not recipient_profile.has_premium and recipient_profile.fxa_locale_in_premium_country %}
+                  {% elif not has_premium and in_premium_country %}
                     {% bold_violet_link SITE_ORIGIN|add:'/premium?utm_source=emails&utm_medium=email&utm_campaign=alias-email&utm_content=header' 'Firefox Relay Premium' as premium_link %}
                     <br />
                     <img width="15" height="15" src="{{ SITE_ORIGIN }}/static/images/email-images/smile-purple.png" style="display: inline-block; width: 15px;" alt="" />
@@ -100,7 +100,7 @@
               <td align="center" style="line-height: 150%; padding-left: 20px; padding-right: 20px;">
                 <p style="display: inline-block; padding-top: 0; font-size: 13px; color: #363959; font-family: sans-serif; padding-left: 20px; padding-right: 20px; margin-top: 0; margin-bottom: 0;">
                   <a href="{{ SITE_ORIGIN }}/accounts/profile?utm_source=emails&utm_medium=email&utm_campaign=alias-email" target="_blank" rel="noopener noreferrer" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">{% ftlmsg 'forwarded-email-footer-2' %}</a>
-                  {% if not recipient_profile.has_premium and recipient_profile.fxa_locale_in_premium_country %}
+                  {% if not has_premium and in_premium_country %}
                     |
                     <a href="{{ SITE_ORIGIN }}/premium?utm_source=emails&utm_medium=email&utm_campaign=alias-email&utm_content=footer" target="_blank" rel="noopener noreferrer" style="font-family: sans-serif; color: #20123a; text-decoration: underline; font-weight: bolder; font-size: 13px;">{% ftlmsg 'forwarded-email-footer-premium-banner' %}</a>
                   {% endif %}

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -997,7 +997,8 @@ class RecordReceiptVerdictsTests(SimpleTestCase):
         assert mm.get_records() == self.expected_records("a_state", overrides)
 
 
-def test_wrapped_email_test_from_profile(db, rf):
+@pytest.mark.django_db
+def test_wrapped_email_test_from_profile(rf):
     user = baker.make(User)
     baker.make(
         SocialAccount,

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -4,6 +4,7 @@ import glob
 import io
 import json
 import os
+import re
 from unittest.mock import patch, Mock
 
 from django.contrib.auth.models import User
@@ -1010,12 +1011,12 @@ def test_wrapped_email_test_from_profile(rf):
     request.user = user
     response = wrapped_email_test(request)
     assert response.status_code == 200
-    html = response.content.decode()
-    assert "<dt>language</dt>\n    <dd>de</dd>" in html
-    assert "<dt>has_premium</dt>\n    <dd>No</dd>" in html
-    assert "<dt>in_premium_country</dt>\n    <dd>Yes</dd>" in html
-    assert "<dt>has_attachment</dt>\n    <dd>Yes</dd>" in html
-    assert "<dt>has_email_tracker_study_link</dt>\n    <dd>No</dd>" in html
+    no_space_html = re.sub(r"\s+", "", response.content.decode())
+    assert "<dt>language</dt><dd>de</dd>" in no_space_html
+    assert "<dt>has_premium</dt><dd>No</dd>" in no_space_html
+    assert "<dt>in_premium_country</dt><dd>Yes</dd>" in no_space_html
+    assert "<dt>has_attachment</dt><dd>Yes</dd>" in no_space_html
+    assert "<dt>has_email_tracker_study_link</dt><dd>No</dd>" in no_space_html
 
 
 @pytest.mark.parametrize("language", ("en", "fy-NL", "ja"))
@@ -1041,13 +1042,15 @@ def test_wrapped_email_test(
     request = rf.get("/emails/wrapped_email_test", data=data)
     response = wrapped_email_test(request)
     assert response.status_code == 200
-    html = response.content.decode()
-    assert f"<dt>language</dt>\n    <dd>{language}</dd>" in html
-    assert f"<dt>has_premium</dt>\n    <dd>{has_premium}</dd>" in html
-    assert f"<dt>in_premium_country</dt>\n    <dd>{in_premium_country}</dd>" in html
-    assert f"<dt>has_attachment</dt>\n    <dd>{has_attachment}</dd>" in html
-    assert f"<dt>has_attachment</dt>\n    <dd>{has_attachment}</dd>" in html
+    no_space_html = re.sub(r"\s+", "", response.content.decode())
+    assert f"<dt>language</dt><dd>{language}</dd>" in no_space_html
+    assert f"<dt>has_premium</dt><dd>{has_premium}</dd>" in no_space_html
     assert (
-        "<dt>has_email_tracker_study_link</dt>\n"
-        f"    <dd>{has_email_tracker_study_link}</dd>"
-    ) in html
+        f"<dt>in_premium_country</dt><dd>{in_premium_country}</dd>"
+    ) in no_space_html
+    assert f"<dt>has_attachment</dt><dd>{has_attachment}</dd>" in no_space_html
+    assert f"<dt>has_attachment</dt><dd>{has_attachment}</dd>" in no_space_html
+    assert (
+        "<dt>has_email_tracker_study_link</dt>"
+        f"<dd>{has_email_tracker_study_link}</dd>"
+    ) in no_space_html

--- a/emails/views.py
+++ b/emails/views.py
@@ -77,7 +77,6 @@ def wrap_html_email(
     language,
     has_premium,
     in_premium_country,
-    email_to,
     display_email,
     has_attachment,
     email_tracker_study_link=None,
@@ -88,11 +87,9 @@ def wrap_html_email(
         "language": language,
         "has_premium": has_premium,
         "in_premium_country": in_premium_country,
-        "email_to": email_to,
         "display_email": display_email,
         "has_attachment": has_attachment,
         "email_tracker_study_link": email_tracker_study_link,
-
         "SITE_ORIGIN": settings.SITE_ORIGIN,
         "survey_text": settings.RECRUITMENT_EMAIL_BANNER_TEXT,
         "survey_link": settings.RECRUITMENT_EMAIL_BANNER_LINK,
@@ -178,7 +175,6 @@ def wrapped_email_test(request):
         in_premium_country=in_premium_country,
         email_tracker_study_link=email_tracker_study_link,
         display_email="test@relay.firefox.com",
-        email_to="unused",
         has_attachment=has_attachment,
     )
     return HttpResponse(wrapped_email)
@@ -585,7 +581,6 @@ def _sns_message(message_json):
             language=user_profile.language,
             has_premium=user_profile.has_premium,
             in_premium_country=user_profile.fxa_locale_in_premium_country,
-            email_to=to_address,
             email_tracker_study_link=email_tracker_study_link,
             display_email=display_email,
             has_attachment=bool(attachments),

--- a/emails/views.py
+++ b/emails/views.py
@@ -10,8 +10,10 @@ import os
 import re
 import shlex
 from tempfile import SpooledTemporaryFile
+from textwrap import dedent
 
 from botocore.exceptions import ClientError
+from decouple import strtobool
 from sentry_sdk import capture_message
 from markus.utils import generate_tag
 from waffle import sample_is_active
@@ -26,6 +28,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.html import escape
 from django.views.decorators.csrf import csrf_exempt
 
 from .models import (
@@ -71,7 +74,9 @@ class InReplyToNotFound(Exception):
 
 def wrap_html_email(
     original_html,
-    recipient_profile,
+    language,
+    has_premium,
+    in_premium_country,
     email_to,
     display_email,
     has_attachment,
@@ -80,7 +85,9 @@ def wrap_html_email(
     """Add Relay banners, surveys, etc. to an HTML email"""
     email_context = {
         "original_html": original_html,
-        "recipient_profile": recipient_profile,
+        "language": language,
+        "has_premium": has_premium,
+        "in_premium_country": in_premium_country,
         "email_to": email_to,
         "display_email": display_email,
         "has_attachment": has_attachment,
@@ -94,14 +101,85 @@ def wrap_html_email(
 
 
 def wrapped_email_test(request):
-    html_content = "<p><strong>strong</strong></p><hr><p>plain</p>"
-    user_profile = Profile.objects.order_by("?").first()
+    """
+    Demonstrate rendering of forwarded HTML emails.
+
+    Settings like language can be given in the querystring, otherwise settings
+    come from a randomly chosen profile.
+    """
+
+    if all(
+        key in request.GET
+        for key in ("language", "has_premium", "in_premium_country", "has_attachment")
+    ):
+        user_profile = None
+    else:
+        user_profile = Profile.objects.order_by("?").first()
+
+    if "language" in request.GET:
+        language = request.GET["language"]
+    else:
+        assert user_profile is not None
+        language = user_profile.language
+
+    if "has_premium" in request.GET:
+        has_premium = strtobool(request.GET["has_premium"])
+    else:
+        assert user_profile is not None
+        has_premium = user_profile.has_premium
+
+    if "in_premium_country" in request.GET:
+        in_premium_country = strtobool(request.GET["in_premium_country"])
+    else:
+        assert user_profile is not None
+        in_premium_country = user_profile.fxa_locale_in_premium_country
+
+    if "has_attachment" in request.GET:
+        has_attachment = strtobool(request.GET["has_attachment"])
+    else:
+        has_attachment = True
+
+    if "has_email_tracker_study_link" in request.GET:
+        has_email_tracker_study_link = strtobool(
+            request.GET["has_email_tracker_study_link"]
+        )
+    else:
+        has_email_tracker_study_link = False
+    if has_email_tracker_study_link:
+        email_tracker_study_link = "https://example.com/fake_survey_link"
+    else:
+        email_tracker_study_link = ""
+
+    html_content = dedent(
+        f"""\
+    <p>
+      <strong>Email rendering Test</strong>
+    </p>
+    <p>Settings:</p>
+    <dl>
+      <dt>language</dt>
+        <dd>{escape(language)}</dd>
+      <dt>has_premium</dt>
+        <dd>{"Yes" if has_premium else "No"}</dd>
+      <dt>in_premium_country</dt>
+        <dd>{"Yes" if in_premium_country else "No"}</dd>
+      <dt>has_attachment</dt>
+        <dd>{"Yes" if has_attachment else "No"}</dd>
+      <dt>has_email_tracker_study_link</dt>
+        <dd>{"Yes" if has_email_tracker_study_link else "No"}</dd>
+    </dl>
+    """
+    )
+
     wrapped_email = wrap_html_email(
         original_html=html_content,
-        recipient_profile=user_profile,
+        language=language,
+        has_premium=has_premium,
+        in_premium_country=in_premium_country,
+        email_tracker_study_link=email_tracker_study_link,
         display_email="test@relay.firefox.com",
         email_to="unused",
-        has_attachment=True,
+        has_attachment=has_attachment,
     )
     return HttpResponse(wrapped_email)
 
@@ -504,7 +582,9 @@ def _sns_message(message_json):
 
         wrapped_html = wrap_html_email(
             original_html=html_content,
-            recipient_profile=user_profile,
+            language=user_profile.language,
+            has_premium=user_profile.has_premium,
+            in_premium_country=user_profile.fxa_locale_in_premium_country,
             email_to=to_address,
             email_tracker_study_link=email_tracker_study_link,
             display_email=display_email,


### PR DESCRIPTION
This PR expands the `/emails/wrapped_email_test` view (only available when `DEBUG=True`), to allow it to be overridden by querystring parameters. Previously, all parameters were selected from a random `Profile`. This makes it easier to interactively view the email banners for different settings.

This includes centralizing the logic in a new function `wrap_html_email`, and changing the template to take context like `language` and `has_premium` rather than reading them from a `Profile` object.

The settings (all optional) are:

* `language`: Any code, including unsupported ones like `ja`
* `has_premium`: `Yes` (or `1` or `true`) or `No` (or `0` or `false`)
* `in_premium_country`: `Yes` / `No`
* `has_attachment`: `Yes` / `No`
* `has_email_tracker_study_link`: `Yes` / `No` (uses fake link to example.com)

How to test:
* Ensure emails are still forwarded
* Try some wrapped emails variants, like:
   - http://127.0.0.1:8000/emails/wrapped_email_test
   - http://127.0.0.1:8000/emails/wrapped_email_test?language=fr
   - http://127.0.0.1:8000/emails/wrapped_email_test?language=ja (English fallback)
   - http://127.0.0.1:8000/emails/wrapped_email_test?has_attachment=0 (no message about attachment sizes)
   - http://127.0.0.1:8000/emails/wrapped_email_test?has_premium=0&in_premium_country=no - (no note about upgrading)
   - http://127.0.0.1:8000/emails/wrapped_email_test?has_premium=0&in_premium_country=yes - (has note about upgrading)
   - http://127.0.0.1:8000/emails/wrapped_email_test?has_email_tracker_study_link=1 (has Report Breakage link, goes to example.com)
