### PR TITLE
MPP-2011: Use only select allauth paths

### DIFF
--- a/privaterelay/urls.py
+++ b/privaterelay/urls.py
@@ -17,8 +17,10 @@ from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 
-from . import views
+from allauth.account import views as allauth_views
+from allauth.socialaccount.providers.fxa import views as fxa_views
 
+from . import views
 
 urlpatterns = [
     # Dockerflow endpoint
@@ -28,11 +30,15 @@ urlpatterns = [
     # FXA endpoints
     path("fxa-rp-events", views.fxa_rp_events),
     path("metrics-event", views.metrics_event),
+    path("accounts/fxa/login/", fxa_views.oauth2_login, name="fxa_login"),
+    path(
+        "accounts/fxa/login/callback/", fxa_views.oauth2_callback, name="fxa_callback"
+    ),
+    path("accounts/logout/", allauth_views.logout, name="account_logout"),
     path(
         "accounts/profile/subdomain", views.profile_subdomain, name="profile_subdomain"
     ),
     path("accounts/profile/refresh", views.profile_refresh, name="profile_refresh"),
-    path("accounts/", include("allauth.urls")),
     path("api/", include("api.urls")),
     path("faq", views.faq, name="faq"),
 ]


### PR DESCRIPTION
Instead of including all the allauth URLs (which includes password reset, password login, social account managment, etc.), only include the URL patterns for:
    
* logout at `/accounts/logout/`
* FxA OAuth2 login at `/accounts/fxa/login/`
* FxA OAuth2 callback at `/accounts/fxa/login/callback/`

This PR fixes #1995 / MPP-2011

How to test:

- On a local dev environment, test log in and log out using FxA.
- In settings, change to `ACCOUNT_LOGOUT_ON_GET = False`, restart, and visit http://127.0.0.1:8000/accounts/logout/. The lightly styled logout page is displayed, and clicking on the link logs out.
- Visit http://127.0.0.1:8000/accounts/login/ . A 404 page is returned
- Visit http://127.0.0.1:8000/accounts/password/change/ . A 404 page is returned
- Visit http://127.0.0.1:8000/accounts/signup/ . A 404 page is returned