### PR TITLE
Add API key field and copy to clipboard logic on settings page

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -25,6 +25,8 @@ landing-use-cases-signups-hero-content2 = Before you complete that next signup, 
 banner-download-install-chrome-extension-copy-2 = The { -brand-name-firefox-relay } extension for { -brand-name-chrome } makes creating and using masks even easier.
 multi-part-onboarding-premium-chrome-extension-get-description-2 = The { -brand-name-firefox-relay } extension for { -brand-name-chrome } makes creating and using email masks even easier.
 
+setting-api-key-copied = Copied!
+
 profile-promo-email-blocking-option-promotionals-premiumonly-marker = ({ -brand-name-premium } only)
 profile-promo-email-blocking-description-promotionals-locked-label = Available to { -brand-name-relay-premium } subscribers
 profile-promo-email-blocking-description-promotionals-locked-cta = Upgrade now

--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -95,16 +95,14 @@ $toggleTransitionDuration: 200ms;
     background-color: $color-violet-30;
     color: $color-white;
     border-radius: $border-radius-md;
-    padding: $spacing-xs;
+    padding: 0 $spacing-xs;
     // By allowing this to overlap other elements,
     // we don't need to reserve empty space for it.
     // Otherwise, this empty space would push the
     // .expand-toggle out of the card on small screens:
     position: absolute;
-    left: 50%;
+    left: $spacing-xs;
     top: 0;
-    // right: 0;
-    transform: translateX(-50%) translateY(-100%);
 
     &.is-shown {
       pointer-events: auto;

--- a/frontend/src/pages/accounts/settings.module.scss
+++ b/frontend/src/pages/accounts/settings.module.scss
@@ -50,36 +50,46 @@
   padding-bottom: $spacing-xl;
 }
 
+$field-gap: $spacing-lg;
+
 .settings-form {
   box-shadow: $box-shadow-sm;
   border-radius: $border-radius-md;
   padding: $spacing-md;
   background-color: white;
+  display: flex;
+  flex-direction: column;
+  gap: $field-gap;
 }
 
 .field {
   border-bottom: 1px solid $color-light-gray-20;
-  padding-bottom: $spacing-sm;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-sm;
+  // padding-bottom is used to have the same gap between the form field and the
+  // bottom border, as the form field has to the bottom border of the form field
+  // preceding it (via `.settings-form`'s `gap`).
+  padding-bottom: $field-gap;
 }
 
 .field-heading {
   @include text-title-3xs;
   color: $color-dark-gray-50;
   font-weight: 400;
-  padding-bottom: $spacing-md;
   flex-basis: 0;
+  min-width: $layout-xl;
 }
 
 .field-content {
   display: flex;
   flex-direction: column;
   gap: $spacing-md;
-  padding-bottom: $spacing-md;
 
   .field-control {
     display: flex;
     align-items: flex-start;
-    gap: $spacing-md;
+    gap: $spacing-sm;
 
     input {
       margin-top: $spacing-xs;
@@ -102,8 +112,82 @@
 }
 
 .controls {
-  padding-top: $spacing-md;
   text-align: center;
+}
+
+.copy-api-key-content {
+  display: flex;
+  flex-direction: row;
+  gap: $spacing-md;
+  align-items: center;
+}
+
+.copy-api-key-display {
+  padding: $spacing-sm $spacing-md;
+  background-color: $color-grey-05;
+  border: 0;
+  outline: 1px solid $color-grey-20;
+  border-radius: $border-radius-md;
+  white-space: nowrap;
+  overflow: hidden;
+  font-family: monospace;
+}
+
+.copy-button-wrapper {
+  display: flex;
+  flex-direction: row;
+  gap: $spacing-xs;
+  position: relative;
+
+  .copy-button {
+    display: block;
+    appearance: none;
+    border: 0;
+    background-color: transparent;
+    text-align: center;
+    cursor: pointer;
+
+    img {
+      opacity: 0.5;
+      width: $layout-xs;
+    }
+
+    &:hover {
+      img {
+        opacity: 1;
+      }
+    }
+  }
+
+  .copied-confirmation {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 2s;
+    background-color: $color-violet-30;
+    color: $color-white;
+    border-radius: $border-radius-md;
+    padding: 0 $spacing-xs;
+    // On small screens, there's not enough room for the "Copied!"
+    // notification to the right of the copy button, so it's absolutely
+    // positioned to overlap the copy button.
+    position: absolute;
+    right: 0;
+    // Position this in the middle of its container
+    top: 50%;
+    transform: translateY(-50%);
+
+    &.is-shown {
+      pointer-events: auto;
+      opacity: 1;
+      // Don't fade in when appearing:
+      transition: opacity 0s;
+    }
+
+    @media screen and #{$mq-sm} {
+      position: static;
+      transform: none;
+    }
+  }
 }
 
 @media screen and #{$mq-md} {
@@ -125,7 +209,7 @@
   }
 
   .field {
-    display: flex;
+    flex-direction: row;
     gap: $spacing-2xl;
   }
 
@@ -134,7 +218,6 @@
   }
 
   .controls {
-    padding-top: $spacing-lg;
     text-align: end;
   }
 }

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -1,12 +1,20 @@
 import { useLocalization } from "@fluent/react";
 import type { NextPage } from "next";
-import { FormEventHandler, useEffect, useReducer, useState } from "react";
+import {
+  FormEventHandler,
+  MouseEventHandler,
+  useEffect,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import { toast } from "react-toastify";
 import styles from "./settings.module.scss";
 import { Layout } from "../../components/layout/Layout";
 import { Banner } from "../../components/Banner";
 import { useProfiles } from "../../hooks/api/profile";
 import messageIcon from "../../../../static/images/icon-message-purple.svg";
+import copyIcon from "../../../../static/images/copy-to-clipboard.svg";
 import helpIcon from "../../../../static/images/help-purple.svg";
 import performanceIcon from "../../../../static/images/performance-purple.svg";
 import infoTriangleIcon from "../../../../static/images/icon-orange-info-triangle.svg";
@@ -28,6 +36,8 @@ const Settings: NextPage = () => {
   const [labelCollectionEnabled, setLabelCollectionEnabled] = useState(
     profileData.data?.[0].server_storage
   );
+  const [justCopiedApiKey, setJustCopiedApiKey] = useState(false);
+  const apiKeyElementRef = useRef<HTMLInputElement>(null);
 
   const [
     labelCollectionDisabledWarningToggles,
@@ -125,6 +135,13 @@ const Settings: NextPage = () => {
     </li>
   ) : null;
 
+  const copyApiKeyToClipboard: MouseEventHandler<HTMLButtonElement> = () => {
+    navigator.clipboard.writeText(profile.api_token);
+    apiKeyElementRef.current?.select();
+    setJustCopiedApiKey(true);
+    setTimeout(() => setJustCopiedApiKey(false), 1000);
+  };
+
   return (
     <>
       <Layout>
@@ -155,6 +172,48 @@ const Settings: NextPage = () => {
                       </label>
                     </div>
                     {labelCollectionWarning}
+                  </div>
+                </div>
+                <div className={styles.field}>
+                  <h2 className={styles["field-heading"]}>
+                    <label htmlFor="api-key">
+                      {l10n.getString("setting-label-api-key")}
+                    </label>
+                  </h2>
+                  <div
+                    className={`${styles["copy-api-key-content"]} ${styles["field-content"]}`}
+                  >
+                    <input
+                      id="api-key"
+                      ref={apiKeyElementRef}
+                      className={styles["copy-api-key-display"]}
+                      value={profile.api_token}
+                      size={profile.api_token.length}
+                    />
+                    <span className={styles["copy-controls"]}>
+                      <span className={styles["copy-button-wrapper"]}>
+                        <button
+                          type="button"
+                          className={styles["copy-button"]}
+                          title={l10n.getString("settings-button-copy")}
+                          onClick={copyApiKeyToClipboard}
+                        >
+                          <img
+                            src={copyIcon.src}
+                            alt={l10n.getString("settings-button-copy")}
+                            className={styles["copy-icon"]}
+                          />
+                        </button>
+                        <span
+                          aria-hidden={!justCopiedApiKey}
+                          className={`${styles["copied-confirmation"]} ${
+                            justCopiedApiKey ? styles["is-shown"] : ""
+                          }`}
+                        >
+                          {l10n.getString("setting-api-key-copied")}
+                        </span>
+                      </span>
+                    </span>
                   </div>
                 </div>
                 <div className={styles.controls}>


### PR DESCRIPTION
Fixes: [MPP-2030](https://mozilla-hub.atlassian.net/browse/MPP-2030)

Notes: 
- I plan on writing a test. I found [this SO article](https://stackoverflow.com/questions/62351935/how-to-mock-navigator-clipboard-writetext-in-jest) to get me started. We also don't have one for the Alias page, so I'll add that as a chore. 

Testing steps: 
- Log in
- Go to /profile/settings page
- **Expected:** There should be a new row under "Privacy" called "API Key"
- Click the copy icon
- **Expected:** API key should be copied to clipboard

Screenshots: 

![Screenshot 2022-05-27 at 16-26-59 Firefox Relay](https://user-images.githubusercontent.com/2692333/170791443-f2448910-e1fc-4388-a4f0-002623a91fd6.png)

![Screenshot 2022-05-27 at 16-26-51 Firefox Relay](https://user-images.githubusercontent.com/2692333/170791460-b455e238-9ada-4037-82c6-da741fca91f7.png)

