### PR TITLE
Fix filtering by local labels

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -44,30 +44,32 @@ export const AliasList = (props: Props) => {
     return null;
   }
 
-  const aliases = sortAliases(
-    filterAliases(props.aliases, {
-      ...categoryFilters,
-      string: stringFilterInput,
-    })
-  );
-
-  const aliasCards = aliases.map((alias) => {
+  const aliasesWithLocalLabels = props.aliases.map((alias) => {
     const aliasWithLocalLabel = { ...alias };
     if (
       alias.description.length === 0 &&
       props.profile.server_storage === false &&
       localLabels !== null
     ) {
-      const type = isRandomAlias(alias) ? "random" : "custom";
       const localLabel = localLabels.find(
         (localLabel) =>
-          localLabel.id === alias.id && localLabel.mask_type === type
+          localLabel.id === alias.id && localLabel.mask_type === alias.mask_type
       );
       if (localLabel !== undefined) {
         aliasWithLocalLabel.description = localLabel.description;
       }
     }
+    return aliasWithLocalLabel;
+  });
 
+  const aliases = sortAliases(
+    filterAliases(aliasesWithLocalLabels, {
+      ...categoryFilters,
+      string: stringFilterInput,
+    })
+  );
+
+  const aliasCards = aliases.map((alias) => {
     const onUpdate = (updatedFields: Partial<AliasData>) => {
       if (
         localLabels !== null &&
@@ -90,7 +92,7 @@ export const AliasList = (props: Props) => {
         key={alias.address + isRandomAlias(alias)}
       >
         <Alias
-          alias={aliasWithLocalLabel}
+          alias={alias}
           user={props.user}
           profile={props.profile}
           onUpdate={onUpdate}

--- a/frontend/src/components/dashboard/aliases/LabelEditor.tsx
+++ b/frontend/src/components/dashboard/aliases/LabelEditor.tsx
@@ -29,7 +29,8 @@ export const LabelEditor = (props: Props) => {
 
   useEffect(() => {
     setLabelJustUpdated(true);
-    setTimeout(() => setLabelJustUpdated(false), 1000);
+    const updateTimeout = setTimeout(() => setLabelJustUpdated(false), 1000);
+    return () => clearTimeout(updateTimeout);
   }, [props.label]);
 
   const onSubmit: FormEventHandler = (event) => {


### PR DESCRIPTION
This PR fixes #2008. We used to apply the locally-stored labels to the mask data *after*
applying the filter. This flips that around.

How to test: disable server-side label storage. Add labels with the extension, then enter that label in the search field. (Make sure to run on 127.0.0.1, so that the extension becomes active.) As follows:

https://user-images.githubusercontent.com/4251/171151940-670520b0-82ff-42cd-8f2a-831459fd7012.mp4

I also fixed the one warning we used to get when running the front-end tests about updating an unmounted component in 5d481203ee895da3589067abf0d0384659c9999c.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
