### PR TITLE
Fix tab order for the string filter toggle button

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -165,8 +165,6 @@ export const AliasList = (props: Props) => {
             {aliases.length}/{props.aliases.length}
           </span>
         </div>
-
-        {categoryFilter}
         <button
           onClick={() => setStringFilterVisible(!stringFilterVisible)}
           title={l10n.getString("banner-register-subdomain-button-search")}
@@ -179,6 +177,7 @@ export const AliasList = (props: Props) => {
             height={20}
           />
         </button>
+        {categoryFilter}
         <div className={styles["new-alias-button"]}>
           <AliasGenerationButton
             aliases={props.aliases}


### PR DESCRIPTION
Even though it's displayed *before* the category filter button, in
the source it was present *after* it, and hence also followed it in
the tab order.

Before:

![image](https://user-images.githubusercontent.com/4251/171156242-3b60b373-e990-4c8e-bf55-114a9ce864cb.png)

After:

![image](https://user-images.githubusercontent.com/4251/171156289-06d2b339-9d61-4ae2-8a9a-c60d62f912aa.png)

How to test: resize your viewport to mobile dimensions, then try to reach the filter button by pressing <Tab>. The search toggle button should come first.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
