### PR TITLE
Prevent Premium tooltip from expanding the slider

### DIFF
--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
@@ -42,7 +42,7 @@ $trackLineHeight: 4px;
       display: inline-block;
     }
 
-    .track {
+    .track-wrapper {
       // To absolutely position the track in the middle of the control, it needs
       // to be offset from the top by:
       // 1. the height of the icon on top of it ($iconHeight), plus
@@ -52,26 +52,59 @@ $trackLineHeight: 4px;
       --trackLineOffset: calc(
         #{$iconHeight} + (var(--thumbDiameter) / 2) - (#{$trackLineHeight} / 2)
       );
-      position: relative;
       width: 100%;
-      cursor: pointer;
+      position: relative;
       padding-top: $iconHeight;
-      // The thumb, its labels, and the track are absolutely positioned and thus
-      // don't take up space by default. Hence, we need to add bottom padding
-      // for them so no other content overlaps them:
-      // Note: when modifying this value, make sure to also modify it
-      // in the .isFree section down below:
-      padding-bottom: calc(
-        var(--thumbDiameter) + #{$trackLineHeight} + #{$stopLabelHeight}
-      );
 
-      .track-line {
-        position: absolute;
-        background-color: $color-light-gray-20;
-        height: $trackLineHeight;
-        top: var(--trackLineOffset);
-
+      .track {
         width: 100%;
+        cursor: pointer;
+        // The thumb, its labels, and the track are absolutely positioned and thus
+        // don't take up space by default. Hence, we need to add bottom padding
+        // for them so no other content overlaps them:
+        // Note: when modifying this value, make sure to also modify it
+        // in the .isFree section down below:
+        padding-bottom: calc(
+          var(--thumbDiameter) + #{$trackLineHeight} + #{$stopLabelHeight}
+        );
+
+        .track-line {
+          position: absolute;
+          background-color: $color-light-gray-20;
+          height: $trackLineHeight;
+          top: var(--trackLineOffset);
+          width: 100%;
+        }
+
+        .thumb-container {
+          position: absolute;
+          transform: translateX(-50%);
+          cursor: pointer;
+          // The thumb has a z-index of 1 to overlap .track-stop-promotional,
+          // which is also absolutely positioned but occurs later in the DOM,
+          // and therefore would overlap the thumb.
+          z-index: 1;
+
+          .thumb {
+            width: var(--thumbDiameter);
+            height: var(--thumbDiameter);
+            border-radius: 50%;
+            background-color: $color-violet-20;
+            border: 4px solid $color-violet-50;
+            box-shadow: $box-shadow-sm;
+
+            &.is-focused {
+              // The alpha value makes sure the lock icon is still visible for
+              // free users when the thumb is placed on the "Promotionals" level:
+              background-color: rgba($color-purple-30, 0.5);
+              border-color: $color-purple-60;
+            }
+            &.is-dragging {
+              // This class can be used if we want to style the thumb
+              // while it's being dragged.
+            }
+          }
+        }
       }
 
       .track-stop {
@@ -143,6 +176,8 @@ $trackLineHeight: 4px;
           // offset it by half of the width of the track, minus half its own
           // width:
           left: calc(50% - var(--thumbDiameter) / 2);
+          top: $iconHeight;
+          cursor: pointer;
         }
         &.track-stop-all {
           // To make the right-hand side of the track end in the middle, rather
@@ -152,36 +187,10 @@ $trackLineHeight: 4px;
         }
       }
 
-      .thumb-container {
-        position: absolute;
-        transform: translateX(-50%);
-        cursor: pointer;
-
-        .thumb {
-          width: var(--thumbDiameter);
-          height: var(--thumbDiameter);
-          border-radius: 50%;
-          background-color: $color-violet-20;
-          border: 4px solid $color-violet-50;
-          box-shadow: $box-shadow-sm;
-
-          &.is-focused {
-            // The alpha value makes sure the lock icon is still visible for
-            // free users when the thumb is placed on the "Promotionals" level:
-            background-color: rgba($color-purple-30, 0.5);
-            border-color: $color-purple-60;
-          }
-          &.is-dragging {
-            // This class can be used if we want to style the thumb
-            // while it's being dragged.
-          }
-        }
-      }
-
       @media screen and #{$mq-md} {
         padding-top: 0;
 
-        .track-line {
+        .track .track-line {
           // --trackLineOffset was calculated to include the height of the image
           // on top that accompanies track stops on small screens. However, on
           // large screens, that icon is not visible, so we need to subtract it
@@ -192,6 +201,10 @@ $trackLineHeight: 4px;
         .track-stop {
           img {
             display: none;
+          }
+
+          &.track-stop-promotional {
+            top: 0;
           }
         }
       }
@@ -274,32 +287,31 @@ $trackLineHeight: 4px;
       padding-bottom: calc(
         var(--thumbDiameter) + #{$trackLineHeight} + #{$stopLabelHeight * 1.5}
       );
+    }
+    .track-stop-promotional {
+      color: $color-light-gray-70;
+      border-style: none;
 
-      .track-stop-promotional {
+      &:hover {
+        // The standard background colour, because this can't be selected
+        // by a free user:
+        background-color: $color-light-gray-20;
+      }
+
+      p {
         color: $color-light-gray-70;
-        border-style: none;
+        text-align: center;
 
-        &:hover {
-          // The standard background colour, because this can't be selected
-          // by a free user:
-          background-color: $color-light-gray-20;
+        .premium-only-marker {
+          @include text-body-xs;
+          color: $color-purple-50;
         }
+      }
 
-        p {
-          color: $color-light-gray-70;
-          text-align: center;
-
-          .premium-only-marker {
-            @include text-body-xs;
-            color: $color-purple-50;
-          }
-        }
-
-        &.is-selected {
-          p,
-          .lock-icon {
-            color: $color-purple-50;
-          }
+      &.is-selected {
+        p,
+        .lock-icon {
+          color: $color-purple-50;
         }
       }
     }

--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.tsx
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.tsx
@@ -103,14 +103,37 @@ export const BlockLevelSlider = (props: Props) => {
         <label {...labelProps} className={styles["slider-label"]}>
           {sliderSettings.label}
         </label>
-        <div {...trackProps} ref={trackRef} className={styles.track}>
-          <div className={styles["track-line"]} />
-          <div
-            className={getTrackStopClassNames(props.alias, sliderState, "none")}
-          >
-            <img src={UmbrellaClosedMobile.src} alt="" />
-            <p aria-hidden="true">{getLabelForBlockLevel("none", l10n)}</p>
+        <div className={styles["track-wrapper"]}>
+          <div {...trackProps} ref={trackRef} className={styles.track}>
+            <div className={styles["track-line"]} />
+            <div
+              className={getTrackStopClassNames(
+                props.alias,
+                sliderState,
+                "none"
+              )}
+            >
+              <img src={UmbrellaClosedMobile.src} alt="" />
+              <p aria-hidden="true">{getLabelForBlockLevel("none", l10n)}</p>
+            </div>
+            <div
+              className={getTrackStopClassNames(
+                props.alias,
+                sliderState,
+                "all"
+              )}
+            >
+              <img src={UmbrellaOpenMobile.src} alt="" />
+              <p aria-hidden="true">{getLabelForBlockLevel("all", l10n)}</p>
+            </div>
+            <Thumb sliderState={sliderState} trackRef={trackRef} />
           </div>
+          {/*
+            <PromotionalTrackStop> is located outside of div.track,
+            because for free users it has a tooltip that is not part of the
+            track. If it were located inside it, clicking it would be
+            interpreted as a click on the slider track.
+            */}
           <PromotionalTrackStop
             alias={props.alias}
             sliderState={sliderState}
@@ -124,13 +147,6 @@ export const BlockLevelSlider = (props: Props) => {
               {premiumOnlyMarker}
             </p>
           </PromotionalTrackStop>
-          <div
-            className={getTrackStopClassNames(props.alias, sliderState, "all")}
-          >
-            <img src={UmbrellaOpenMobile.src} alt="" />
-            <p aria-hidden="true">{getLabelForBlockLevel("all", l10n)}</p>
-          </div>
-          <Thumb sliderState={sliderState} trackRef={trackRef} />
         </div>
       </div>
       <VisuallyHidden>


### PR DESCRIPTION
This PR fixes #2023.

When free users try to select promotional email blocking, we pop
up a tooltip that explains that they will need to upgrade to
Premium for that.

However, because the tooltip element was located inside the
slider's track, useSlider counted it as part of the slider, and
clicking it would change the slider value.

To solve this, I wrapped an element (.track-wrapper) around the
track, that contains both the track and the tooltip. Everything can
then be positioned relative to that wrapper instead of relative to
the track, without that track being considered the slider.

(Most of this complexity is due to the weird hybrid we have of both
a slider and a button that pretends that it is part of the slider,
but actually is not. Perhaps at some point we'll want to split up
<PromotionalTrackStop> into the "real" one that behaves as normal
for Premium users, and is simply hidden for non-Premium users, and
a button that *looks* like the real one, but actually is completely
separate from the slider.)

How to test: [with a free user](https://deploy-preview-2027--fx-relay-demo.netlify.app/?mockId=empty), expand a mask and click the track stop for promotional email blocking. This should open up a pop-up. Clicking anywhere on that pop-up should not affect the slider value (as opposed to [the current state](https://fx-relay-demo.netlify.app/?mockId=empty)).

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, UI bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
