### PR TITLE
Replace Premium Upsell banner to Loyalist List Firefox banner 

### DIFF
--- a/frontend/src/components/Banner.module.scss
+++ b/frontend/src/components/Banner.module.scss
@@ -41,6 +41,11 @@
 .highlight-wrapper {
   display: flex;
   background-color: $color-white;
+  flex-wrap: wrap;
+
+  .title-text {
+    flex: 1 0 50%;
+  }
 
   .banner:not(.promo) & {
     padding: $spacing-xs $spacing-lg $spacing-md;
@@ -96,6 +101,35 @@
     &:focus {
       outline: none;
       text-decoration: underline;
+    }
+  }
+}
+
+// For Loyalist upsell
+.cta-large-button {
+  margin: $spacing-xl 0 $spacing-md $spacing-md;
+  align-self: center;
+
+  @media screen and #{$mq-md} {
+    align-self: center;
+    margin: 0 0 0 auto;
+    padding-left: $spacing-md;
+  }
+
+  a {
+    padding: $spacing-md $spacing-lg;
+    font-weight: 700;
+    background: $color-blue-50;
+    color: $color-white;
+    border-radius: $border-radius-sm;
+
+    &:hover {
+      color: $color-blue-40;
+    }
+
+    &:focus {
+      border-radius: 1px;
+      box-shadow: 0px 0px 0px $spacing-xs #0060df40; // $color-blue-40 40% opacity
     }
   }
 }

--- a/frontend/src/components/Banner.module.scss
+++ b/frontend/src/components/Banner.module.scss
@@ -1,5 +1,6 @@
 @import "../styles/tokens.scss";
 @import "~@mozilla-protocol/core/protocol/css/includes/lib";
+@import "~@mozilla-protocol/core/protocol/css/includes/forms/lib";
 
 .banner {
   border-radius: $border-radius-md;
@@ -124,12 +125,15 @@
     border-radius: $border-radius-sm;
 
     &:hover {
-      color: $color-blue-40;
+      background-color: $color-blue-60;
+      color: $color-white;
     }
 
     &:focus {
-      border-radius: 1px;
-      box-shadow: 0px 0px 0px $spacing-xs #0060df40; // $color-blue-40 40% opacity
+      border-color: $button-border-color-focus;
+      box-shadow: $field-focus-ring;
+      color: $color-white;
+      outline: none;
     }
   }
 }

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -18,6 +18,12 @@ export type BannerProps = {
     onClick?: () => void;
     gaViewPing?: Parameters<typeof useGaViewPing>[0];
   };
+  ctaLargeButton?: {
+    target: string;
+    content: string;
+    onClick?: () => void;
+    gaViewPing?: Parameters<typeof useGaViewPing>[0];
+  };
   /**
    * See {@link useLocalDismissal}; determines whether and for how long the user can dismiss this banner.
    */
@@ -70,6 +76,20 @@ export const Banner = (props: BannerProps) => {
     </div>
   ) : null;
 
+  const ctaLargeButton = props.ctaLargeButton ? (
+    <div className={styles["cta-large-button"]}>
+      <OutboundLink
+        to={props.ctaLargeButton.target}
+        eventLabel={props.ctaLargeButton.content}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={props.ctaLargeButton.onClick}
+      >
+        <span ref={ctaRef}>{props.ctaLargeButton.content}</span>
+      </OutboundLink>
+    </div>
+  ) : null;
+
   const dismissButton =
     typeof props.dismissal !== "undefined" ? (
       <button
@@ -93,11 +113,12 @@ export const Banner = (props: BannerProps) => {
     >
       <div className={`${styles["highlight-wrapper"]}`}>
         {illustration}
-        <div>
+        <div className={`${styles["title-text"]}`}>
           {title}
           {props.children}
           {cta}
         </div>
+        {ctaLargeButton}
       </div>
       {dismissButton}
     </div>

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -5,6 +5,7 @@ import FirefoxLogo from "../../../../static/images/logos/fx-logo.svg";
 import AddonIllustration from "../../../../static/images/banner-addon.svg";
 import RelayLogo from "../../../../static/images/placeholder-logo.svg";
 import {
+  getPlan,
   getPremiumSubscribeLink,
   isPremiumAvailableInCountry,
   RuntimeDataWithPremiumAvailable,
@@ -16,13 +17,15 @@ import {
 } from "../../functions/userAgent";
 import { ProfileData } from "../../hooks/api/profile";
 import { UserData } from "../../hooks/api/user";
-import { RuntimeData } from "../../hooks/api/runtimeData";
+import { RuntimeData } from "../../../src/hooks/api/runtimeData";
 import { Banner } from "../Banner";
 import { trackPurchaseStart } from "../../functions/trackPurchase";
 import { renderDate } from "../../functions/renderDate";
 import { SubdomainPicker } from "./SubdomainPicker";
 import { useMinViewportWidth } from "../../hooks/mediaQuery";
 import { AliasData } from "../../hooks/api/aliases";
+import { runtimeData } from "../../apiMocks/mockData";
+import { Plans } from "../landing/Plans";
 
 export type Props = {
   profile: ProfileData;
@@ -195,9 +198,10 @@ const NoChromeExtensionBanner = () => {
   );
 };
 
-// type NoPremiumBannerProps = {
-//   runtimeData: RuntimeDataWithPremiumAvailable;
-// };
+type NoPremiumBannerProps = {
+  runtimeData: RuntimeDataWithPremiumAvailable;
+};
+
 // const NoPremiumBanner = (props: NoPremiumBannerProps) => {
 //   const { l10n } = useLocalization();
 
@@ -229,11 +233,11 @@ const LoyalistPremiumBanner = (props: NoPremiumBannerProps) => {
     <Banner
       key="premium-banner"
       type="promo"
-      title="Get protection and support the internet"
+      title={l10n.getString("banner-upgrade-loyalist-headline")}
       illustration={<img src={FirefoxLogo.src} alt="" width={60} height={60} />}
       ctaLargeButton={{
         target: getPremiumSubscribeLink(props.runtimeData),
-        content: "Get more protection",
+        content: l10n.getString("banner-upgrade-loyalist-cta"),
         onClick: () => trackPurchaseStart(),
         gaViewPing: {
           category: "Purchase Button",
@@ -242,8 +246,9 @@ const LoyalistPremiumBanner = (props: NoPremiumBannerProps) => {
       }}
     >
       <p>
-        Protect your privacy while joining the fight for a better internet, all
-        for $0.99
+        {l10n.getString("banner-upgrade-loyalist-copy", {
+          monthly_price: getPlan(props.runtimeData).price,
+        })}
       </p>
     </Banner>
   );

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -2,6 +2,7 @@ import { Localized, useLocalization } from "@fluent/react";
 import { ReactNode } from "react";
 import styles from "./ProfileBanners.module.scss";
 import FirefoxLogo from "../../../../static/images/logos/fx-logo.svg";
+import RelayLogo from "../../../../static/images/placeholder-logo.svg";
 import AddonIllustration from "../../../../static/images/banner-addon.svg";
 import {
   getPlan,
@@ -199,29 +200,31 @@ type NoPremiumBannerProps = {
   runtimeData: RuntimeDataWithPremiumAvailable;
 };
 
-// const NoPremiumBanner = (props: NoPremiumBannerProps) => {
-//   const { l10n } = useLocalization();
+// Unused but left in for when we no longer want to use <LoyalistPremiumBanner>
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const NoPremiumBanner = (props: NoPremiumBannerProps) => {
+  const { l10n } = useLocalization();
 
-//   return (
-//     <Banner
-//       key="premium-banner"
-//       type="promo"
-//       title={l10n.getString("banner-upgrade-headline")}
-//       illustration={<img src={RelayLogo.src} alt="" width={60} height={60} />}
-//       cta={{
-//         target: getPremiumSubscribeLink(props.runtimeData),
-//         content: l10n.getString("banner-upgrade-cta"),
-//         onClick: () => trackPurchaseStart(),
-//         gaViewPing: {
-//           category: "Purchase Button",
-//           label: "profile-banner-promo",
-//         },
-//       }}
-//     >
-//       <p>{l10n.getString("banner-upgrade-copy-2")}</p>
-//     </Banner>
-//   );
-// };
+  return (
+    <Banner
+      key="premium-banner"
+      type="promo"
+      title={l10n.getString("banner-upgrade-headline")}
+      illustration={<img src={RelayLogo.src} alt="" width={60} height={60} />}
+      cta={{
+        target: getPremiumSubscribeLink(props.runtimeData),
+        content: l10n.getString("banner-upgrade-cta"),
+        onClick: () => trackPurchaseStart(),
+        gaViewPing: {
+          category: "Purchase Button",
+          label: "profile-banner-promo",
+        },
+      }}
+    >
+      <p>{l10n.getString("banner-upgrade-copy-2")}</p>
+    </Banner>
+  );
+};
 
 const LoyalistPremiumBanner = (props: NoPremiumBannerProps) => {
   const { l10n } = useLocalization();

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -93,7 +93,11 @@ export const ProfileBanners = (props: Props) => {
     props.aliases.length > 0
   ) {
     banners.push(
-      <NoPremiumBanner key="premium-banner" runtimeData={props.runtimeData} />
+      <LoyalistPremiumBanner
+        key="premium-banner"
+        runtimeData={props.runtimeData}
+      />
+      // <NoPremiumBanner key="premium-banner" runtimeData={props.runtimeData} />
     );
   }
 
@@ -214,6 +218,33 @@ const NoPremiumBanner = (props: NoPremiumBannerProps) => {
       }}
     >
       <p>{l10n.getString("banner-upgrade-copy-2")}</p>
+    </Banner>
+  );
+};
+
+const LoyalistPremiumBanner = (props: NoPremiumBannerProps) => {
+  const { l10n } = useLocalization();
+
+  return (
+    <Banner
+      key="premium-banner"
+      type="promo"
+      title="Get protection and support the internet"
+      illustration={<img src={FirefoxLogo.src} alt="" width={60} height={60} />}
+      ctaLargeButton={{
+        target: getPremiumSubscribeLink(props.runtimeData),
+        content: "Get more protection",
+        onClick: () => trackPurchaseStart(),
+        gaViewPing: {
+          category: "Purchase Button",
+          label: "profile-banner-loyalist-promo",
+        },
+      }}
+    >
+      <p>
+        Protect your privacy while joining the fight for a better internet, all
+        for $0.99
+      </p>
     </Banner>
   );
 };

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -195,32 +195,32 @@ const NoChromeExtensionBanner = () => {
   );
 };
 
-type NoPremiumBannerProps = {
-  runtimeData: RuntimeDataWithPremiumAvailable;
-};
-const NoPremiumBanner = (props: NoPremiumBannerProps) => {
-  const { l10n } = useLocalization();
+// type NoPremiumBannerProps = {
+//   runtimeData: RuntimeDataWithPremiumAvailable;
+// };
+// const NoPremiumBanner = (props: NoPremiumBannerProps) => {
+//   const { l10n } = useLocalization();
 
-  return (
-    <Banner
-      key="premium-banner"
-      type="promo"
-      title={l10n.getString("banner-upgrade-headline")}
-      illustration={<img src={RelayLogo.src} alt="" width={60} height={60} />}
-      cta={{
-        target: getPremiumSubscribeLink(props.runtimeData),
-        content: l10n.getString("banner-upgrade-cta"),
-        onClick: () => trackPurchaseStart(),
-        gaViewPing: {
-          category: "Purchase Button",
-          label: "profile-banner-promo",
-        },
-      }}
-    >
-      <p>{l10n.getString("banner-upgrade-copy-2")}</p>
-    </Banner>
-  );
-};
+//   return (
+//     <Banner
+//       key="premium-banner"
+//       type="promo"
+//       title={l10n.getString("banner-upgrade-headline")}
+//       illustration={<img src={RelayLogo.src} alt="" width={60} height={60} />}
+//       cta={{
+//         target: getPremiumSubscribeLink(props.runtimeData),
+//         content: l10n.getString("banner-upgrade-cta"),
+//         onClick: () => trackPurchaseStart(),
+//         gaViewPing: {
+//           category: "Purchase Button",
+//           label: "profile-banner-promo",
+//         },
+//       }}
+//     >
+//       <p>{l10n.getString("banner-upgrade-copy-2")}</p>
+//     </Banner>
+//   );
+// };
 
 const LoyalistPremiumBanner = (props: NoPremiumBannerProps) => {
   const { l10n } = useLocalization();

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -3,7 +3,6 @@ import { ReactNode } from "react";
 import styles from "./ProfileBanners.module.scss";
 import FirefoxLogo from "../../../../static/images/logos/fx-logo.svg";
 import AddonIllustration from "../../../../static/images/banner-addon.svg";
-import RelayLogo from "../../../../static/images/placeholder-logo.svg";
 import {
   getPlan,
   getPremiumSubscribeLink,
@@ -24,8 +23,6 @@ import { renderDate } from "../../functions/renderDate";
 import { SubdomainPicker } from "./SubdomainPicker";
 import { useMinViewportWidth } from "../../hooks/mediaQuery";
 import { AliasData } from "../../hooks/api/aliases";
-import { runtimeData } from "../../apiMocks/mockData";
-import { Plans } from "../landing/Plans";
 
 export type Props = {
   profile: ProfileData;

--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -332,7 +332,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const premiumBanner = screen.getByRole("link", {
-      name: "l10n string: [banner-upgrade-cta], with vars: {}",
+      name: "l10n string: [banner-upgrade-loyalist-cta], with vars: {}",
     });
 
     expect(premiumBanner).toBeInTheDocument();


### PR DESCRIPTION
<!-- When adding a new feature: -->

# New feature description
On the top dashboard, replace the upsell banner to focus more on supporting Mozilla and the mission while subscribing to Relay.


l10n: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/86/files
# Screenshot (if applicable)

Preview:
<img width="988" alt="image" src="https://user-images.githubusercontent.com/13066134/171473694-d8a26fbf-e2f2-44d2-9a2f-8de8a7e82cf3.png">
<img width="619" alt="image" src="https://user-images.githubusercontent.com/13066134/171473714-1939f071-1495-4e8b-8779-a3d7fbac1493.png">


# How to test

l10n pr : https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/86/files

On a free account, check that the premium banner has been replaced with the loyalist banner.



# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
