### PR TITLE
change ON_HEROKU to RELAY_CHANNEL and add Bitwarden QA origin

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,4 +1,3 @@
-RELAY_CHANNEL="local"
 FXA_OAUTH_ENDPOINT=https://oauth.stage.mozaws.net/v1
 FXA_PROFILE_ENDPOINT=https://profile.stage.mozaws.net/v1
 FXA_BASE_ORIGIN=https://accounts.stage.mozaws.net

--- a/.env-dist
+++ b/.env-dist
@@ -1,4 +1,4 @@
-ON_HEROKU=False
+RELAY_CHANNEL="local"
 FXA_OAUTH_ENDPOINT=https://oauth.stage.mozaws.net/v1
 FXA_PROFILE_ENDPOINT=https://profile.stage.mozaws.net/v1
 FXA_BASE_ORIGIN=https://accounts.stage.mozaws.net

--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -158,13 +158,13 @@ class FormattingToolsTest(TestCase):
         )
         assert formatted_from_address == expected_formatted_from
 
-    @override_settings(ON_HEROKU=True, SITE_ORIGIN="https://test.com")
-    def test_get_email_domain_from_settings_on_heroku(self):
+    @override_settings(RELAY_CHANNEL="dev", SITE_ORIGIN="https://test.com")
+    def test_get_email_domain_from_settings_on_dev(self):
         email_domain = get_email_domain_from_settings()
         assert "mail.test.com" == email_domain
 
-    @override_settings(ON_HEROKU=False, SITE_ORIGIN="https://test.com")
-    def test_get_email_domain_from_settings_not_on_heroku(self):
+    @override_settings(RELAY_CHANNEL="test", SITE_ORIGIN="https://test.com")
+    def test_get_email_domain_from_settings_not_on_dev(self):
         email_domain = get_email_domain_from_settings()
         assert "test.com" == email_domain
 

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -669,7 +669,7 @@ class SnsMessageTest(TestCase):
         assert response.status_code == 200
 
 
-@override_settings(SITE_ORIGIN="https://test.com", ON_HEROKU=False)
+@override_settings(SITE_ORIGIN="https://test.com", RELAY_CHANNEL="test")
 class GetAddressTest(TestCase):
     def setUp(self):
         self.service_domain = "test.com"

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -74,9 +74,9 @@ def gauge_if_enabled(name, value, tags=None):
 
 def get_email_domain_from_settings():
     email_network_locality = urlparse(settings.SITE_ORIGIN).netloc
-    # on Heroku we need to add "mail" prefix
+    # on dev server we need to add "mail" prefix
     # because we can’t publish MX records on Heroku
-    if settings.ON_HEROKU:
+    if settings.RELAY_CHANNEL == "dev":
         email_network_locality = f"mail.{email_network_locality}"
     return email_network_locality
 

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -48,7 +48,7 @@ TMP_DIR = os.path.join(BASE_DIR, "tmp")
 # defaulting to blank to be production-broken by default
 SECRET_KEY = config("SECRET_KEY", None, cast=str)
 
-ON_HEROKU = config("ON_HEROKU", False, cast=bool)
+RELAY_CHANNEL = config("RELAY_CHANNEL", "prod", cast=str)
 DEBUG = config("DEBUG", False, cast=bool)
 if DEBUG:
     INTERNAL_IPS = config("DJANGO_INTERNAL_IPS", default=[])
@@ -100,7 +100,7 @@ csp_style_values = ["'self'"]
 # Next.js dynamically inserts the relevant styles when switching pages,
 # by injecting them as inline styles. We need to explicitly allow those styles
 # in our Content Security Policy.
-if DEBUG:
+if RELAY_CHANNEL == "local":
     # When running locally, styles might get refreshed while the server is
     # running, so their hashes would get oudated. Hence, we just allow all of
     # them.
@@ -539,7 +539,7 @@ WHITENOISE_ADD_HEADERS_FUNCTION = set_index_cache_control_headers
 # for dev statics, we use django-gulp during runserver.
 # for stage/prod statics, we run "gulp build" in docker.
 # so, squelch django-gulp in prod so it doesn't run gulp during collectstatic:
-if not ON_HEROKU:
+if not RELAY_CHANNEL == "dev":
     GULP_PRODUCTION_COMMAND = ""
 
 SITE_ID = 1
@@ -645,9 +645,12 @@ ACCOUNT_LOGOUT_ON_GET = DEBUG
 CORS_ALLOWED_ORIGINS = [
     "https://vault.bitwarden.com",
 ]
+if RELAY_CHANNEL in ["local", "dev", "stage"]:
+    CORS_ALLOWED_ORIGINS += "https://vault.qa.bitwarden.pw/"
+
 CORS_URLS_REGEX = r"^/api/"
 CSRF_TRUSTED_ORIGINS = []
-if DEBUG:
+if RELAY_CHANNEL == "local":
     # In local development, the React UI can be served up from a different server
     # that needs to be allowed to make requests.
     # In production, the frontend is served by Django, is therefore on the same

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -47,8 +47,15 @@ TMP_DIR = os.path.join(BASE_DIR, "tmp")
 
 # defaulting to blank to be production-broken by default
 SECRET_KEY = config("SECRET_KEY", None, cast=str)
+SITE_ORIGIN = config("SITE_ORIGIN", None)
 
-RELAY_CHANNEL = config("RELAY_CHANNEL", "prod", cast=str)
+ORIGIN_CHANNEL_MAP = {
+    "127.0.0.1:8000": "local",
+    "https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net": "dev",
+    "https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net": "stage",
+    "https://relay.firefox.com": "prod"
+}
+RELAY_CHANNEL = ORIGIN_CHANNEL_MAP.get(SITE_ORIGIN, "prod")
 DEBUG = config("DEBUG", False, cast=bool)
 if DEBUG:
     INTERNAL_IPS = config("DJANGO_INTERNAL_IPS", default=[])
@@ -154,7 +161,6 @@ AWS_SQS_QUEUE_URL = config("AWS_SQS_QUEUE_URL", None)
 
 RELAY_FROM_ADDRESS = config("RELAY_FROM_ADDRESS", None)
 NEW_RELAY_FROM_ADDRESS = config("NEW_RELAY_FROM_ADDRESS")
-SITE_ORIGIN = config("SITE_ORIGIN", None)
 GOOGLE_ANALYTICS_ID = config("GOOGLE_ANALYTICS_ID", None)
 INCLUDE_VPN_BANNER = config("INCLUDE_VPN_BANNER", False, cast=bool)
 RECRUITMENT_BANNER_LINK = config("RECRUITMENT_BANNER_LINK", None)
@@ -646,7 +652,7 @@ CORS_ALLOWED_ORIGINS = [
     "https://vault.bitwarden.com",
 ]
 if RELAY_CHANNEL in ["local", "dev", "stage"]:
-    CORS_ALLOWED_ORIGINS += "https://vault.qa.bitwarden.pw/"
+    CORS_ALLOWED_ORIGINS += ["https://vault.qa.bitwarden.pw"]
 
 CORS_URLS_REGEX = r"^/api/"
 CSRF_TRUSTED_ORIGINS = []


### PR DESCRIPTION
Bitwarden Web Vault integrates Relay. So, our production server allows
the Bitwarden production origin. Our stage server should also allow
the Bitwarden stage origin.

How to test:
The real test will come from the real Bitwarden stage origin, so we can't test that part.

We *should* test to make sure that none of our other channel/deployment/environment-specific logic is broken. E.g., on the dev server, we should still prepend aliases with `mail`.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).