### PR TITLE
Fix #2034  - Change Bento icon color to white

### DIFF
--- a/frontend/src/components/layout/navigation/AppPicker.module.scss
+++ b/frontend/src/components/layout/navigation/AppPicker.module.scss
@@ -18,6 +18,7 @@
   border-radius: $border-radius-sm;
 
   svg {
+    fill: $color-white;
     color: $color-white;
 
     &.premium {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #2034

Preview:
<img width="1548" alt="image" src="https://user-images.githubusercontent.com/13066134/171963381-8d13b707-3b55-435f-bd34-680c921d54b5.png">

How to test:
Check that the bento icon is white on the landing page, and on the free user's dashboard.
