### PR TITLE
fix ORIGIN_CHANNEL_MAP for local channel

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -50,7 +50,7 @@ SECRET_KEY = config("SECRET_KEY", None, cast=str)
 SITE_ORIGIN = config("SITE_ORIGIN", None)
 
 ORIGIN_CHANNEL_MAP = {
-    "127.0.0.1:8000": "local",
+    "http://127.0.0.1:8000": "local",
     "https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net": "dev",
     "https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net": "stage",
     "https://relay.firefox.com": "prod"


### PR DESCRIPTION
This PR fixes http://localhost:3000.

When I created `ORIGIN_CHANNEL_MAP` to control CORS headers per channel, I left out the `http://` for the `local` channel, which broke the CORS header that the `http://localhost:3000` next server needs.

How to test:
1. Go to http://localhost:3000/
2. Click "Sign in"
3. Log in with a token
4. [ ] It should work

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).