### PR TITLE
Remove transitionary "type" property on masks

### DIFF
--- a/frontend/src/hooks/localLabels.test.ts
+++ b/frontend/src/hooks/localLabels.test.ts
@@ -22,7 +22,6 @@ describe("useLocalLabels", () => {
       localLabels: [
         {
           id: 0,
-          type: "random",
           mask_type: "random",
           description: "Some description",
           generated_for: "https://example.com",
@@ -36,7 +35,6 @@ describe("useLocalLabels", () => {
     expect(labels).toStrictEqual([
       {
         id: 0,
-        type: "random",
         mask_type: "random",
         description: "Some description",
         generated_for: "https://example.com",
@@ -59,7 +57,6 @@ describe("useLocalLabels", () => {
       localLabels: [
         {
           id: 0,
-          type: "random",
           mask_type: "random",
           description: "Some description",
           generated_for: "https://example.com",
@@ -71,7 +68,6 @@ describe("useLocalLabels", () => {
       localLabels: [
         {
           id: 0,
-          type: "random",
           mask_type: "random",
           description: "Some description",
           generated_for: "https://example.com",
@@ -89,7 +85,6 @@ describe("useLocalLabels", () => {
     expect(newLabels).toStrictEqual([
       {
         id: 0,
-        type: "random",
         mask_type: "random",
         description: "Some new description",
         generated_for: "https://example.com",

--- a/frontend/src/hooks/localLabels.ts
+++ b/frontend/src/hooks/localLabels.ts
@@ -3,8 +3,12 @@ import { useAddonData } from "./addon";
 import { AliasData, isRandomAlias } from "./api/aliases";
 
 export type LocalLabel = {
-  /** `type` is to allow for a transition period while people migrate to a new add-on version that uses `mask_type` */
-  type: "random" | "custom";
+  /**
+   * A `random` mask is a mask for which the local part is determined by
+   * Relay, and the domain is common to all users' random masks.
+   * A `custom` mask is a mask for which the user can come up with arbitrary
+   * local parts, because the domain part is specific to that user.
+   */
   mask_type: "random" | "custom";
   id: number;
   description: string;
@@ -41,10 +45,7 @@ export function useLocalLabels(): LocalLabelHook | NotEnabled {
     // Replace existing labels for this alias:
     const oldLocalLabel = localLabels.find(
       (localLabel) =>
-        localLabel.id === alias.id &&
-        (localLabel.mask_type === maskType ||
-          (typeof localLabel.mask_type === "undefined" &&
-            localLabel.type === maskType))
+        localLabel.id === alias.id && localLabel.mask_type === maskType
     );
     const newLocalLabels = localLabels.filter(
       (localLabel) => localLabel !== oldLocalLabel
@@ -52,13 +53,11 @@ export function useLocalLabels(): LocalLabelHook | NotEnabled {
 
     newLocalLabels.push({
       id: alias.id,
-      type: maskType,
       mask_type: maskType,
       description: newLabel,
       generated_for: oldLocalLabel?.generated_for,
     });
     addonData.sendEvent("labelUpdate", {
-      type: maskType,
       mask_type: maskType,
       alias: alias,
       newLabel: newLabel,

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -93,9 +93,7 @@ const Settings: NextPage = () => {
         const uploadLocalLabel = (alias: AliasData) => {
           const localLabel = localLabels?.find(
             (localLabel) =>
-              (localLabel.mask_type === alias.mask_type ||
-                (typeof localLabel.mask_type === "undefined" &&
-                  localLabel.type === alias.mask_type)) &&
+              localLabel.mask_type === alias.mask_type &&
               localLabel.id === alias.id
           );
           if (typeof localLabel !== "undefined") {


### PR DESCRIPTION
This property was preserved to allow for a transitory period in
which people were still using an older add-on version that did not
preserve the API's equivalent `mask_type` property. But now that
pretty much everyone has the newer add-on version, we no longer
need the redundant `type` property:

![image](https://user-images.githubusercontent.com/4251/172362883-2cfa5827-2c7a-475b-aebf-bf1934f9b884.png)

This is the (independent) sister PR to https://github.com/mozilla/fx-private-relay-add-on/pull/361, and a follow-up to https://github.com/mozilla/fx-private-relay/pull/1990.

# Screenshot (if applicable)

Not applicable.

# How to test

There should be no changed behaviour compared to `main`, especially with server-side label storage turned off.

# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
