### PR TITLE
Fix #2002 - Prevent anchor links from scrolling behind sticky / fixed header

### DIFF
--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -33,6 +33,7 @@ body,
 
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: $layout-xl;
 
   @media (prefers-reduced-motion) {
     & {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #2002

How to test:

Be signed in into a Premium Firefox Relay account; Have at least one mask created; Do NOT have a Custom Subdomain. 

When selecting the "Get your email subdomain" CTA, the page should scroll down to the Custom Subdomain banner without  its content being hidden beneath the fixed header.


https://user-images.githubusercontent.com/13066134/172459399-512ccb39-6719-459a-9aad-41c98a3571d3.mov


- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
