### PR TITLE
Make elements in collapsed cards unfocusable

### DIFF
--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -218,12 +218,15 @@ $toggleTransitionDuration: 200ms;
   display: flex;
   flex-direction: column;
   gap: $spacing-md;
+  // Make sure hidden elements are unfocusable:
+  visibility: hidden;
 
   .is-expanded & {
     // An arbitrary high value that allows it to expand to its full height:
     max-height: 100vh;
     border-color: $color-light-gray-30;
     padding: $spacing-sm 0;
+    visibility: visible;
   }
 
   .row {


### PR DESCRIPTION
Previously, if you focused the expand/collapse button on a card,
then pressed tab again, you would focus the block level slider;
i.e. if you then pressed the right arrow key, the block level would
increase. With this change, pressing tab with the expand button
focused will move you to the next expand/collapse button.

How to test: press tab with the expand/collapse button of a mask focused. Compare [with this fix](https://deploy-preview-2057--fx-relay-demo.netlify.app/?mockId=some) vs [without this fix](https://fx-relay-demo.netlify.app/?mockId=some).

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A, layout bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
