### PR TITLE
Add API Key settings page context

### DIFF
--- a/frontend/src/pages/accounts/settings.module.scss
+++ b/frontend/src/pages/accounts/settings.module.scss
@@ -117,6 +117,7 @@ $field-gap: $spacing-lg;
 
 .copy-api-key-content {
   display: flex;
+  flex-wrap: wrap;
   flex-direction: row;
   gap: $spacing-md;
   align-items: center;
@@ -131,6 +132,22 @@ $field-gap: $spacing-lg;
   white-space: nowrap;
   overflow: hidden;
   font-family: monospace;
+  max-width: 200px;
+  text-overflow: ellipsis;
+
+  @media screen and #{$mq-md} {
+    max-width: 350px;
+  }
+}
+
+.settings-api-key-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.settings-api-key-description {
+  width: 100%;
 }
 
 .copy-button-wrapper {
@@ -141,6 +158,7 @@ $field-gap: $spacing-lg;
 
   .copy-button {
     display: block;
+    padding-left: $spacing-md;
     appearance: none;
     border: 0;
     background-color: transparent;

--- a/frontend/src/pages/accounts/settings.module.scss
+++ b/frontend/src/pages/accounts/settings.module.scss
@@ -146,7 +146,7 @@ $field-gap: $spacing-lg;
   align-items: center;
 }
 
-.settings-api-key-description {
+.settings-api-key-copy {
   width: 100%;
 }
 

--- a/frontend/src/pages/accounts/settings.module.scss
+++ b/frontend/src/pages/accounts/settings.module.scss
@@ -144,6 +144,7 @@ $field-gap: $spacing-lg;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  gap: $spacing-sm;
 }
 
 .settings-api-key-copy {
@@ -158,7 +159,6 @@ $field-gap: $spacing-lg;
 
   .copy-button {
     display: block;
-    padding-left: $spacing-md;
     appearance: none;
     border: 0;
     background-color: transparent;

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -1,4 +1,4 @@
-import { useLocalization } from "@fluent/react";
+import { Localized, useLocalization } from "@fluent/react";
 import type { NextPage } from "next";
 import {
   FormEventHandler,
@@ -218,11 +218,13 @@ const Settings: NextPage = () => {
                       </span>
                     </div>
                     <div className={styles["settings-api-key-copy"]}>
-                      {l10n.getString("settings-api-key-description")}
-                      <b>
-                        {" "}
-                        {l10n.getString("settings-api-key-description-bolded")}
-                      </b>
+                      {l10n.getString("settings-api-key-description")}{" "}
+                      <Localized
+                        id="settings-api-key-description-bolded"
+                        elems={{ b: <b /> }}
+                      >
+                        <span className={styles["settings-api-key-copy"]} />
+                      </Localized>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -217,7 +217,7 @@ const Settings: NextPage = () => {
                         </span>
                       </span>
                     </div>
-                    <aside className={styles["settings-api-key-description"]}>
+                    <aside className={styles["settings-api-key-copy"]}>
                       {l10n.getString("settings-api-key-description")}
                       <b>
                         {" "}

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -183,38 +183,47 @@ const Settings: NextPage = () => {
                   <div
                     className={`${styles["copy-api-key-content"]} ${styles["field-content"]}`}
                   >
-                    <input
-                      id="api-key"
-                      ref={apiKeyElementRef}
-                      className={styles["copy-api-key-display"]}
-                      value={profile.api_token}
-                      size={profile.api_token.length}
-                      readOnly={true}
-                    />
-                    <span className={styles["copy-controls"]}>
-                      <span className={styles["copy-button-wrapper"]}>
-                        <button
-                          type="button"
-                          className={styles["copy-button"]}
-                          title={l10n.getString("settings-button-copy")}
-                          onClick={copyApiKeyToClipboard}
-                        >
-                          <img
-                            src={copyIcon.src}
-                            alt={l10n.getString("settings-button-copy")}
-                            className={styles["copy-icon"]}
-                          />
-                        </button>
-                        <span
-                          aria-hidden={!justCopiedApiKey}
-                          className={`${styles["copied-confirmation"]} ${
-                            justCopiedApiKey ? styles["is-shown"] : ""
-                          }`}
-                        >
-                          {l10n.getString("setting-api-key-copied")}
+                    <div className={styles["settings-api-key-wrapper"]}>
+                      <input
+                        id="api-key"
+                        ref={apiKeyElementRef}
+                        className={styles["copy-api-key-display"]}
+                        value={profile.api_token}
+                        size={profile.api_token.length}
+                        readOnly={true}
+                      />
+                      <span className={styles["copy-controls"]}>
+                        <span className={styles["copy-button-wrapper"]}>
+                          <button
+                            type="button"
+                            className={styles["copy-button"]}
+                            title={l10n.getString("settings-button-copy")}
+                            onClick={copyApiKeyToClipboard}
+                          >
+                            <img
+                              src={copyIcon.src}
+                              alt={l10n.getString("settings-button-copy")}
+                              className={styles["copy-icon"]}
+                            />
+                          </button>
+                          <span
+                            aria-hidden={!justCopiedApiKey}
+                            className={`${styles["copied-confirmation"]} ${
+                              justCopiedApiKey ? styles["is-shown"] : ""
+                            }`}
+                          >
+                            {l10n.getString("setting-api-key-copied")}
+                          </span>
                         </span>
                       </span>
-                    </span>
+                    </div>
+                    <aside className={styles["settings-api-key-description"]}>
+                      {l10n.getString("settings-api-key-description")}
+                      <b>
+                        {" "}
+                        {l10n.getString("settings-api-key-description-bolded")}
+                      </b>
+                    </aside>
                   </div>
                 </div>
                 <div className={styles.controls}>

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -217,12 +217,13 @@ const Settings: NextPage = () => {
                         </span>
                       </span>
                     </div>
-                    <aside className={styles["settings-api-key-copy"]}>
+                    <div className={styles["settings-api-key-copy"]}>
                       {l10n.getString("settings-api-key-description")}
                       <b>
+                        {" "}
                         {l10n.getString("settings-api-key-description-bolded")}
                       </b>
-                    </aside>
+                    </div>
                   </div>
                 </div>
                 <div className={styles.controls}>

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -220,7 +220,6 @@ const Settings: NextPage = () => {
                     <aside className={styles["settings-api-key-copy"]}>
                       {l10n.getString("settings-api-key-description")}
                       <b>
-                        {" "}
                         {l10n.getString("settings-api-key-description-bolded")}
                       </b>
                     </aside>


### PR DESCRIPTION
<!-- When adding a new feature: -->


# New feature description
This adds some context to the API key on the settings page.

l10n: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/88/files


# Screenshot (if applicable)
<img width="1105" alt="image" src="https://user-images.githubusercontent.com/13066134/172691175-f64f3a1d-c978-4647-a37f-8d685fdfea73.png">


# How to test



# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
