### PR TITLE
Clarify a workaround

### DIFF
--- a/frontend/src/components/layout/navigation/AppPicker.module.scss
+++ b/frontend/src/components/layout/navigation/AppPicker.module.scss
@@ -18,6 +18,11 @@
   border-radius: $border-radius-sm;
 
   svg {
+    // The `fill` shouldn't be necessary; `color` should apply the correct colour
+    // due to the Bento icon's setting its fill to `currentcolor` in its style
+    // attribute. However, for some reason that attribute appears to get removed
+    // in the built website. See
+    // https://github.com/mozilla/fx-private-relay/pull/2036#discussion_r893270078
     fill: $color-white;
     color: $color-white;
 


### PR DESCRIPTION
Since the workaround appears not to be needed, and nothing appears
broken when it's removed, I've added a comment that clarifies how
to reproduce the error, so future readers know why the workaround
is there and when it can be removed.

This is a followup to https://github.com/mozilla/fx-private-relay/pull/2036#discussion_r893270078, since it does appear to fix the issue (at least for the Bento icon - the mobile menu icons are still the wrong colour).
