### PR TITLE
Clickable label for the "Block Promotional emails" track stop

### DIFF
--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
@@ -138,7 +138,7 @@ $trackLineHeight: 4px;
           margin-top: calc(-1 * #{$iconHeight} - var(--thumbDiameter));
           padding-bottom: $spacing-sm;
           // The image should not take up space within the track stop,
-          // so that the lock icon from .trackStopPromotional can be properly
+          // so that the lock icon from .track-stop-promotional can be properly
           // centered:
           position: absolute;
         }
@@ -288,30 +288,60 @@ $trackLineHeight: 4px;
         var(--thumbDiameter) + #{$trackLineHeight} + #{$stopLabelHeight * 1.5}
       );
     }
-    .track-stop-promotional {
-      color: $color-light-gray-70;
+    .promotional-ghost-track-stop {
+      position: absolute;
+      top: 0;
+      left: 33%;
+      width: 33%;
+      // This is like the regular .track's bottom padding, but with
+      // $stopLabelHeight multiplied by 1.5, because there's a "(Premium only)"
+      // line in a smaller font below the "Promotionals" label for free users:
+      height: calc(
+        var(--thumbDiameter) + #{$trackLineHeight} + #{$stopLabelHeight * 1.5}
+      );
+      background-color: transparent;
       border-style: none;
+      cursor: pointer;
 
-      &:hover {
-        // The standard background colour, because this can't be selected
-        // by a free user:
-        background-color: $color-light-gray-20;
-      }
-
-      p {
+      .track-stop-promotional {
         color: $color-light-gray-70;
-        text-align: center;
+        border-style: none;
 
-        .premium-only-marker {
-          @include text-body-xs;
-          color: $color-purple-50;
+        &:hover {
+          // The standard background colour, because this can't be selected
+          // by a free user:
+          background-color: $color-light-gray-20;
+        }
+
+        p {
+          color: $color-light-gray-70;
+          text-align: center;
+
+          .premium-only-marker {
+            @include text-body-xs;
+            color: $color-purple-50;
+          }
+        }
+
+        &.is-selected {
+          p,
+          .lock-icon {
+            color: $color-purple-50;
+          }
         }
       }
 
-      &.is-selected {
-        p,
-        .lock-icon {
-          color: $color-purple-50;
+      &:hover {
+        p {
+          color: $color-purple-30;
+        }
+      }
+
+      &:focus {
+        outline: none;
+
+        .track-stop {
+          outline: 2px solid $color-blue-50;
         }
       }
     }

--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.tsx
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.tsx
@@ -116,6 +116,26 @@ export const BlockLevelSlider = (props: Props) => {
               <img src={UmbrellaClosedMobile.src} alt="" />
               <p aria-hidden="true">{getLabelForBlockLevel("none", l10n)}</p>
             </div>
+            {/*
+              Only show the "Promotionals" track stop to Premium users.
+              Free users will instead see a button that looks like it,
+              but actually informs them of its only being available to Premium
+              users (i.e. <PromotionalTrackStopGhost>)
+             */}
+            {props.hasPremium ? (
+              <div
+                className={getTrackStopClassNames(
+                  props.alias,
+                  sliderState,
+                  "promotional"
+                )}
+              >
+                <img src={UmbrellaSemiMobile.src} alt="" />
+                <p aria-hidden="true">
+                  {getLabelForBlockLevel("promotional", l10n)}
+                </p>
+              </div>
+            ) : null}
             <div
               className={getTrackStopClassNames(
                 props.alias,
@@ -134,19 +154,21 @@ export const BlockLevelSlider = (props: Props) => {
             track. If it were located inside it, clicking it would be
             interpreted as a click on the slider track.
             */}
-          <PromotionalTrackStop
-            alias={props.alias}
-            sliderState={sliderState}
-            hasPremium={props.hasPremium}
-            premiumAvailableInCountry={props.premiumAvailableInCountry}
-          >
-            <img src={UmbrellaSemiMobile.src} alt="" />
-            {lockIcon}
-            <p>
-              {getLabelForBlockLevel("promotional", l10n)}
-              {premiumOnlyMarker}
-            </p>
-          </PromotionalTrackStop>
+          {!props.hasPremium ? (
+            <PromotionalTrackStopGhost
+              alias={props.alias}
+              sliderState={sliderState}
+              hasPremium={props.hasPremium}
+              premiumAvailableInCountry={props.premiumAvailableInCountry}
+            >
+              <img src={UmbrellaSemiMobile.src} alt="" />
+              {lockIcon}
+              <p>
+                {getLabelForBlockLevel("promotional", l10n)}
+                {premiumOnlyMarker}
+              </p>
+            </PromotionalTrackStopGhost>
+          ) : null}
         </div>
       </div>
       <VisuallyHidden>
@@ -258,18 +280,18 @@ const BlockLevelIllustration = (props: { level: BlockLevel }) => {
   return <img src={UmbrellaOpen.src} height={UmbrellaOpen.height} alt="" />;
 };
 
-type PromotionalTrackStopProps = {
+type PromotionalTrackStopGhostProps = {
   alias: AliasData;
   sliderState: SliderState;
-  hasPremium: boolean;
   premiumAvailableInCountry: boolean;
   children: ReactNode;
 };
 /**
- * This is a regular track stop for Premium users, but turns into a tooltip
- * trigger for non-Premium users.
+ * Pretends to be the regular track stop to enable promotional email blocking,
+ * but is actually a button that triggers a tooltip displaying that promotional
+ * email blocking is only available to Premium users.
  */
-const PromotionalTrackStop = (props: PromotionalTrackStopProps) => {
+const PromotionalTrackStopGhost = (props: PromotionalTrackStopGhostProps) => {
   const overlayTriggerState = useOverlayTriggerState({});
   const triggerRef = useRef<HTMLButtonElement>(null);
 
@@ -285,44 +307,30 @@ const PromotionalTrackStop = (props: PromotionalTrackStopProps) => {
     triggerRef
   );
 
-  if (!props.hasPremium) {
-    return (
-      <span className={styles.wrapper}>
-        <button
-          {...buttonProps}
-          {...triggerProps}
-          ref={triggerRef}
-          type="button"
-          className={`${styles["track-stop"]} ${
-            styles["track-stop-promotional"]
-          } ${overlayTriggerState.isOpen ? styles["is-selected"] : ""}`}
-        >
-          {props.children}
-        </button>
-        {overlayTriggerState.isOpen && (
-          <OverlayContainer>
-            <PromotionalTooltip
-              onClose={overlayTriggerState.close}
-              triggerRef={triggerRef}
-              overlayProps={overlayProps}
-              premiumAvailableInCountry={props.premiumAvailableInCountry}
-            />
-          </OverlayContainer>
-        )}
-      </span>
-    );
-  }
-
   return (
-    <div
-      className={getTrackStopClassNames(
-        props.alias,
-        props.sliderState,
-        "promotional"
+    <span className={styles.wrapper}>
+      <button
+        {...buttonProps}
+        {...triggerProps}
+        ref={triggerRef}
+        type="button"
+        className={`${styles["track-stop"]} ${
+          styles["track-stop-promotional"]
+        } ${overlayTriggerState.isOpen ? styles["is-selected"] : ""}`}
+      >
+        {props.children}
+      </button>
+      {overlayTriggerState.isOpen && (
+        <OverlayContainer>
+          <PromotionalTooltip
+            onClose={overlayTriggerState.close}
+            triggerRef={triggerRef}
+            overlayProps={overlayProps}
+            premiumAvailableInCountry={props.premiumAvailableInCountry}
+          />
+        </OverlayContainer>
       )}
-    >
-      {props.children}
-    </div>
+    </span>
   );
 };
 

--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.tsx
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.tsx
@@ -149,7 +149,7 @@ export const BlockLevelSlider = (props: Props) => {
             <Thumb sliderState={sliderState} trackRef={trackRef} />
           </div>
           {/*
-            <PromotionalTrackStop> is located outside of div.track,
+            <PromotionalTrackStopGhost> is located outside of div.track,
             because for free users it has a tooltip that is not part of the
             track. If it were located inside it, clicking it would be
             interpreted as a click on the slider track.
@@ -158,7 +158,6 @@ export const BlockLevelSlider = (props: Props) => {
             <PromotionalTrackStopGhost
               alias={props.alias}
               sliderState={sliderState}
-              hasPremium={props.hasPremium}
               premiumAvailableInCountry={props.premiumAvailableInCountry}
             >
               <img src={UmbrellaSemiMobile.src} alt="" />
@@ -314,11 +313,15 @@ const PromotionalTrackStopGhost = (props: PromotionalTrackStopGhostProps) => {
         {...triggerProps}
         ref={triggerRef}
         type="button"
-        className={`${styles["track-stop"]} ${
-          styles["track-stop-promotional"]
-        } ${overlayTriggerState.isOpen ? styles["is-selected"] : ""}`}
+        className={styles["promotional-ghost-track-stop"]}
       >
-        {props.children}
+        <span
+          className={`${styles["track-stop"]} ${
+            styles["track-stop-promotional"]
+          } ${overlayTriggerState.isOpen ? styles["is-selected"] : ""}`}
+        >
+          {props.children}
+        </span>
       </button>
       {overlayTriggerState.isOpen && (
         <OverlayContainer>
@@ -356,7 +359,7 @@ const PromotionalTooltip = (props: PromotionalTooltipProps) => {
     targetRef: props.triggerRef,
     overlayRef: overlayRef,
     placement: "bottom left",
-    offset: 60,
+    offset: 10,
   }).overlayProps;
 
   const closeButtonRef = useRef<HTMLButtonElement>(null);


### PR DESCRIPTION
This PR fixes #2033 and fixes #2045.

To look like a regular track stop, the ghost button was resized to
the small circle of a track stop, with the label displayed outside
of it. However, that meant that only that small circle was the
actual, clickable button.

Now, I added a <span> that looks like the track stop, and made the
button span a full one-third of the slider, and the same height, so
that it can fully encompass both the track stop and its label.

I also limited what's now called the `<PromotionalTrackStopGhost>` to only be shown for free users, where it has the weird behaviour of not actually being part of the slider and having a tooltip show up when it's clicked. For Premium users, Promo-blocking now has a regular track stop again, just like blocking nothing or everything.

How to test: for Premium users, promo-blocking should keep working exactly the same as blocking nothing or everything. For free users, you should now be able to click the word "Promotionals" just like the circle above it to activate the popup.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A - no business logic.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
