### PR TITLE
Use API-provided total counts

### DIFF
--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -99,15 +99,6 @@ const Profile: NextPage = () => {
     aliasData.customAliasData.data
   );
 
-  const totalBlockedEmails = allAliases.reduce(
-    (count, alias) => count + alias.num_blocked,
-    0
-  );
-  const totalForwardedEmails = allAliases.reduce(
-    (count, alias) => count + alias.num_forwarded,
-    0
-  );
-
   if (
     profile.has_premium &&
     profile.onboarding_state < getRuntimeConfig().maxOnboardingAvailable
@@ -124,8 +115,8 @@ const Profile: NextPage = () => {
           aliases={allAliases}
           profile={profile}
           runtimeData={runtimeData.data}
-          totalBlockedEmails={totalBlockedEmails}
-          totalForwardedEmails={totalForwardedEmails}
+          totalBlockedEmails={profile.emails_blocked}
+          totalForwardedEmails={profile.emails_forwarded}
         />
         <Layout>
           <PremiumOnboarding
@@ -269,7 +260,7 @@ const Profile: NextPage = () => {
               {l10n.getString("profile-stat-label-blocked")}
             </dt>
             <dd className={styles.value}>
-              {numberFormatter.format(totalBlockedEmails)}
+              {numberFormatter.format(profile.emails_blocked)}
             </dd>
           </div>
           <div className={styles.stat}>
@@ -277,7 +268,7 @@ const Profile: NextPage = () => {
               {l10n.getString("profile-stat-label-forwarded")}
             </dt>
             <dd className={styles.value}>
-              {numberFormatter.format(totalForwardedEmails)}
+              {numberFormatter.format(profile.emails_forwarded)}
             </dd>
           </div>
         </dl>
@@ -341,8 +332,8 @@ const Profile: NextPage = () => {
         aliases={allAliases}
         profile={profile}
         runtimeData={runtimeData.data}
-        totalBlockedEmails={totalBlockedEmails}
-        totalForwardedEmails={totalForwardedEmails}
+        totalBlockedEmails={profile.emails_blocked}
+        totalForwardedEmails={profile.emails_forwarded}
       />
       <Layout>
         <main className={styles["profile-wrapper"]}>

--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -107,7 +107,7 @@ describe("The dashboard", () => {
   });
 
   it("shows a count of total emails forwarded for Premium users", () => {
-    setMockProfileDataOnce({ has_premium: true });
+    setMockProfileDataOnce({ has_premium: true, emails_forwarded: 42 });
     setMockAliasesDataOnce({
       random: [
         getMockRandomAlias({ address: "address1", num_forwarded: 7 }),
@@ -127,7 +127,7 @@ describe("The dashboard", () => {
   });
 
   it("shows a count of total emails blocked for Premium users", () => {
-    setMockProfileDataOnce({ has_premium: true });
+    setMockProfileDataOnce({ has_premium: true, emails_blocked: 50 });
     setMockAliasesDataOnce({
       random: [
         getMockRandomAlias({ address: "address1", num_blocked: 13 }),
@@ -144,6 +144,41 @@ describe("The dashboard", () => {
     // https://github.com/testing-library/dom-testing-library/issues/1083
     // eslint-disable-next-line testing-library/no-node-access
     expect(countOf50.parentElement?.textContent).toMatch("50");
+  });
+
+  it("uses the count of total emails blocked/forwarded from the back-end, even when that count includes deleted masks and therefore does not agree with the individual mask counts", () => {
+    setMockProfileDataOnce({
+      has_premium: true,
+      emails_forwarded: 50,
+      emails_blocked: 72,
+    });
+    setMockAliasesDataOnce({
+      random: [
+        getMockRandomAlias({
+          address: "address1",
+          num_forwarded: 7,
+          num_blocked: 13,
+        }),
+        getMockRandomAlias({
+          address: "address2",
+          num_forwarded: 35,
+          num_blocked: 37,
+        }),
+      ],
+      custom: [],
+    });
+    render(<Profile />);
+
+    const countOf50 = screen.getByText(/profile-stat-label-forwarded/);
+    const countOf72 = screen.getByText(/profile-stat-label-blocked/);
+
+    // Unfortunately we can't select by role=definition to directly query for
+    // the parent item, so we'll have to make do with this crutch. See:
+    // https://github.com/testing-library/dom-testing-library/issues/1083
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(countOf50.parentElement?.textContent).toMatch("50");
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(countOf72.parentElement?.textContent).toMatch("72");
   });
 
   it("shows the domain search form for Premium users that do not have a domain yet", () => {


### PR DESCRIPTION
This PR fixes #1917.

The number of forwarded and blocked emails should not decrease when
deleting a mask, so we can't just iterate over the counts of the
individual, non-deleted masks.

How to test: delete a mask that has more than 0 emails forwarded/blocked (you can change this locally via http://127.0.0.1:8000/admin/), then verify that the count of emails blocked/forwarded at the top of the dashboard did not decrease:

![image](https://user-images.githubusercontent.com/4251/173527061-7a29c5f3-f60f-47e8-8c64-f8e4269e0a15.png)

(Note: checks are failing due to #2079, but they succeed with that.)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
