### PR TITLE
Update to Whitenoise 5.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ python-decouple==3.6
 pyOpenSSL==22.0.0
 requests==2.25.1
 sentry-sdk==1.5.12
-whitenoise==5.0.1
+whitenoise==5.3.0
 
 # phones app
 # phonenumbers==8.11.1


### PR DESCRIPTION
This should fix the following error [1], according to [2]:

    TypeError '>=' not supported between instances of 'NoneType' and 'tuple'

Dependabot did not catch this upgrade, because it is watching an
outdated repo [3].

[1] https://sentry.prod.mozaws.net/share/issue/e36430063a614ef3ae3dc8a377c1b5c6/
[2] https://whitenoise.evans.io/en/stable/changelog.html#id4
[3] https://github.com/github-community/community/discussions/17563

This PR fixes #2025.

How to test: I'm not entirely sure what all failure modes to test for are. I ran this locally, both with `DEBUG` set to `True` and to `False`, and observed no unexpected behaviour. We should primarily look for assets not being served correctly, for some value of correctly, I guess.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
