### PR TITLE
Show the user that subdomains will be lowercased

### DIFF
--- a/frontend/__mocks__/modules/fluent__react.tsx
+++ b/frontend/__mocks__/modules/fluent__react.tsx
@@ -10,12 +10,19 @@ export const mockFluentReact = {
       },
     };
   },
-  Localized: (props: { children: ReactNode; vars?: Record<string, string> }) =>
+  Localized: (props: {
+    children: ReactNode;
+    id: string;
+    vars?: Record<string, string>;
+  }) =>
     isValidElement(props.children) ? (
       cloneElement(
         props.children,
         {},
-        <>[Localized with vars: {JSON.stringify(props.vars ?? {})}]</>
+        <>
+          [&lt;Localized&gt; with id [{props.id}] and vars:{" "}
+          {JSON.stringify(props.vars ?? {})}]
+        </>
       )
     ) : (
       <>Invalid Localized element (more than a single child element)</>

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -169,12 +169,12 @@ export const AliasList = (props: Props) => {
         </div>
         <button
           onClick={() => setStringFilterVisible(!stringFilterVisible)}
-          title={l10n.getString("banner-register-subdomain-button-search")}
+          title={l10n.getString("profile-filter-search-placeholder-2")}
           className={styles["string-filter-toggle"]}
         >
           <img
             src={searchIcon.src}
-            alt={l10n.getString("banner-register-subdomain-button-search")}
+            alt={l10n.getString("profile-filter-search-placeholder-2")}
             width={20}
             height={20}
           />

--- a/frontend/src/components/dashboard/subdomain/SearchForm.tsx
+++ b/frontend/src/components/dashboard/subdomain/SearchForm.tsx
@@ -31,12 +31,12 @@ export const SubdomainSearchForm = (props: Props) => {
       return;
     }
 
-    props.onPick(subdomainInput);
+    props.onPick(subdomainInput.toLowerCase());
   };
 
   const onInput: ChangeEventHandler<HTMLInputElement> = async (event) => {
     setSubdomainInput(event.target.value);
-    props.onType(event.target.value);
+    props.onType(event.target.value.toLowerCase());
   };
 
   return (

--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -45,6 +45,16 @@ jest.mock("react-intersection-observer", () => mockReactIntersectionObsever);
 jest.mock("../../config.ts", () => mockConfigModule);
 jest.mock("../../functions/renderDate.ts");
 jest.mock("../../functions/getLocale.ts", () => mockGetLocaleModule);
+jest.mock("../../hooks/api/api.ts", () => ({
+  // `authenticatedFetch` is currently only used to check whether a subdomain
+  // is available, so we're just mocking that:
+  authenticatedFetch: jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ available: true }),
+    })
+  ),
+}));
 jest.mock("../../hooks/gaViewPing.ts");
 jest.mock("../../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
 
@@ -180,6 +190,30 @@ describe("The dashboard", () => {
     );
 
     expect(domainSearchField).not.toBeInTheDocument();
+  });
+
+  it("shows that capital letters in searched-for subdomains will be lowercased", async () => {
+    setMockProfileDataOnce({ has_premium: true, subdomain: null });
+    render(<Profile />);
+
+    const domainSearchField = screen.getByLabelText(
+      "l10n string: [banner-choose-subdomain-input-placeholder-3], with vars: {}"
+    );
+
+    await userEvent.type(domainSearchField, "SpoNGeBoB");
+
+    const preview = screen.getByText("spongebob");
+    expect(preview).toBeInTheDocument();
+
+    const searchButton = screen.getByRole("button", {
+      name: "l10n string: [banner-register-subdomain-button-search], with vars: {}",
+    });
+    await userEvent.click(searchButton);
+
+    const subdomainDialog = screen.getByRole("dialog", {
+      name: '[<Localized> with id [modal-domain-register-available-2] and vars: {"subdomain":"spongebob","domain":"mozmail.com"}]',
+    });
+    expect(subdomainDialog).toBeInTheDocument();
   });
 
   it("shows a banner to download Firefox if using a different browser that does not support Chrome extensions", () => {
@@ -457,6 +491,35 @@ describe("The dashboard", () => {
     );
 
     expect(subdomainSearchField).toBeInTheDocument();
+  });
+
+  it("shows that searched-for subdomains will be lowercased in the second step of Premium onboarding", async () => {
+    setMockProfileDataOnce({
+      has_premium: true,
+      onboarding_state: 1,
+      subdomain: null,
+    });
+
+    render(<Profile />);
+
+    const subdomainSearchField = screen.getByLabelText(
+      "l10n string: [banner-choose-subdomain-input-placeholder-3], with vars: {}"
+    );
+
+    await userEvent.type(subdomainSearchField, "sPoNGeBob");
+
+    const preview = screen.getByText("spongebob");
+    expect(preview).toBeInTheDocument();
+
+    const searchButton = screen.getByRole("button", {
+      name: "l10n string: [banner-register-subdomain-button-search], with vars: {}",
+    });
+    await userEvent.click(searchButton);
+
+    const subdomainDialog = screen.getByRole("dialog", {
+      name: '[<Localized> with id [modal-domain-register-available-2] and vars: {"subdomain":"spongebob","domain":"mozmail.com"}]',
+    });
+    expect(subdomainDialog).toBeInTheDocument();
   });
 
   it("does not allow picking a subdomain in the second step of Premium onboarding if the user already has a subdomain", () => {


### PR DESCRIPTION
# New feature description

Fixes #1825.

In the preview of a user's chosen subdomain, this lowercases the chosen letters, to reflect what will happen when it's actually registered.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/173554070-7bfca9c9-0d7c-4a90-8a06-e80664dfb564.png)

![image](https://user-images.githubusercontent.com/4251/173554236-b59bade1-8695-4235-8ef0-1f2f2aad233d.png)

![image](https://user-images.githubusercontent.com/4251/173554284-8708784c-b541-4906-bb8b-861d630e0ed4.png)

![image](https://user-images.githubusercontent.com/4251/173554315-f0a4136c-6d59-4b45-81fa-27ff94ee1915.png)

# How to test

When picking a subdomain (either [in the onboarding flow](https://deploy-preview-2082--fx-relay-demo.netlify.app/?mockId=onboarding) or [the regular dashboard](https://deploy-preview-2082--fx-relay-demo.netlify.app/accounts/profile/?mockId=some)), type capital letters, then verify that it's lowercased everywhere but in the input field.

# Checklist

- [x] l10n dependencies have been merged, if any.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
