### PR TITLE
Validate custom addresses in the UI

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -103,6 +103,9 @@ fx-desktop-2 = { -brand-name-firefox } for Desktop
 fx-mobile-2 = { -brand-name-firefox } for Mobile
 fx-containers = { -brand-name-firefox } Containers
 
+modal-custom-alias-picker-form-prefix-spaces-warning = Spaces are not allowed in email masks.
+modal-custom-alias-picker-form-prefix-invalid-warning = Email masks can only contain lowercase letters, numbers, and hyphens, and may not start or end with a hyphen.
+
 ## Phone Page
 
 phone-headline = Introducing phone number masking

--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.test.tsx
@@ -1,0 +1,85 @@
+import { getAddressValidationMessage } from "./AddressPickerModal";
+
+describe("getAddressValidationMessage", () => {
+  it("returns `null` for valid addresses", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockL10n = { getString: jest.fn() } as any;
+    expect(getAddressValidationMessage("valid-address", mockL10n)).toBeNull();
+  });
+
+  it("returns `null` for valid single-character addresses", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockL10n = { getString: jest.fn() } as any;
+    expect(getAddressValidationMessage("a", mockL10n)).toBeNull();
+  });
+
+  it("returns a message specific to spaces when the address includes a space", () => {
+    const mockL10n = {
+      getString: jest.fn((id: string) => `String ID: ${id}`),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    expect(getAddressValidationMessage("invalid address", mockL10n)).toBe(
+      "String ID: modal-custom-alias-picker-form-prefix-spaces-warning"
+    );
+  });
+
+  it("returns a message specific to spaces when the address includes a space, even if there are other validation errors", () => {
+    const mockL10n = {
+      getString: jest.fn((id: string) => `String ID: ${id}`),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    expect(
+      getAddressValidationMessage("invalid address (╯ ͠° ͟ʖ ͡°)╯┻━┻ ", mockL10n)
+    ).toBe("String ID: modal-custom-alias-picker-form-prefix-spaces-warning");
+  });
+
+  it("returns a generic validation message on invalid characters", () => {
+    const mockL10n = {
+      getString: jest.fn((id: string) => `String ID: ${id}`),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    expect(getAddressValidationMessage("π", mockL10n)).toBe(
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning"
+    );
+  });
+
+  it("returns a generic validation message on capitalised characters", () => {
+    const mockL10n = {
+      getString: jest.fn((id: string) => `String ID: ${id}`),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    expect(getAddressValidationMessage("Invalid-address", mockL10n)).toBe(
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning"
+    );
+  });
+
+  it("returns a generic validation message when starting with a hyphen", () => {
+    const mockL10n = {
+      getString: jest.fn((id: string) => `String ID: ${id}`),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    expect(getAddressValidationMessage("-invalid-address", mockL10n)).toBe(
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning"
+    );
+  });
+
+  it("returns a generic validation message when ending in a hyphen", () => {
+    const mockL10n = {
+      getString: jest.fn((id: string) => `String ID: ${id}`),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    expect(getAddressValidationMessage("invalid-address-", mockL10n)).toBe(
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning"
+    );
+  });
+
+  it("returns a generic validation message for a hyphen-only address", () => {
+    const mockL10n = {
+      getString: jest.fn((id: string) => `String ID: ${id}`),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    expect(getAddressValidationMessage("-", mockL10n)).toBe(
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning"
+    );
+  });
+});


### PR DESCRIPTION
This is the front-end counterpart to https://github.com/mozilla/fx-private-relay/pull/2085. It uses the browser's native validation messages to report about invalid characters.

How to test: [in the custom mask dialog](https://deploy-preview-2086--fx-relay-demo.netlify.app/?mockId=full), try to enter a space, a capital letter, a hyphen at the start or end, or any other non-alphanumeric characters. You should see a warning message (with a custom one for spaces).

- [ ] l10n changes have been submitted to the l10n repository, if any. - Not yet, will do at the same time as tracker removal messages. But even untranslated, this will be an improvement over the current situation, and people are probably unlikely to try these anyway.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
