### PR TITLE
#2045 ⁃ Hamburger menu is not fixed on the page on mobile

### DIFF
--- a/frontend/src/components/layout/Layout.module.scss
+++ b/frontend/src/components/layout/Layout.module.scss
@@ -2,6 +2,8 @@
 @import "~@mozilla-protocol/core/protocol/css/includes/lib";
 
 .wrapper {
+  // Mobile menu is fixed so this padding offsets that spacing
+  padding-top: 75px;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -22,6 +24,11 @@
 
   --toastify-toast-min-height: $layout-md;
   --toastify-toast-max-height: $layout-md;
+
+  @media screen and #{$mq-md} {
+    // We set padding to zero as we set position for menu to sticky for non-mobile users.
+    padding-top: 0;
+  }
 }
 
 // Allows us to dynamically set the background color based on Toast container state
@@ -141,7 +148,7 @@ $toastify-toast-close-button: var(--toast-close-button);
 }
 
 .header {
-  position: sticky;
+  position: fixed;
   left: 0;
   top: 0;
   // The sticky position causes a new stacking context,
@@ -161,6 +168,7 @@ $toastify-toast-close-button: var(--toast-close-button);
   box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.06);
 
   @media screen and #{$mq-md} {
+    position: sticky;
     grid-template-areas: "logoWrapper navWrapper appPickerWrapper userMenuWrapper";
   }
 

--- a/frontend/src/components/layout/Layout.module.scss
+++ b/frontend/src/components/layout/Layout.module.scss
@@ -2,7 +2,7 @@
 @import "~@mozilla-protocol/core/protocol/css/includes/lib";
 
 .wrapper {
-  // Mobile menu is fixed so this padding offsets that spacing
+  // Mobile menu is fixed. This padding offsets the height of the menu and pushes content down (so its not hidden).
   padding-top: 75px;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/layout/Layout.module.scss
+++ b/frontend/src/components/layout/Layout.module.scss
@@ -2,11 +2,9 @@
 @import "~@mozilla-protocol/core/protocol/css/includes/lib";
 
 .wrapper {
-  // Mobile menu is fixed. This padding offsets the height of the menu and pushes content down (so its not hidden).
-  padding-top: 75px;
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: auto;
 
   // See https://fkhadra.github.io/react-toastify/how-to-style#override-css-variables
   --toastify-toast-width: 95%;
@@ -148,7 +146,7 @@ $toastify-toast-close-button: var(--toast-close-button);
 }
 
 .header {
-  position: fixed;
+  position: sticky;
   left: 0;
   top: 0;
   // The sticky position causes a new stacking context,
@@ -168,7 +166,6 @@ $toastify-toast-close-button: var(--toast-close-button);
   box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.06);
 
   @media screen and #{$mq-md} {
-    position: sticky;
     grid-template-areas: "logoWrapper navWrapper appPickerWrapper userMenuWrapper";
   }
 

--- a/frontend/src/components/layout/navigation/MobileNavigation.module.scss
+++ b/frontend/src/components/layout/navigation/MobileNavigation.module.scss
@@ -16,7 +16,6 @@
   transform: translateY(-100%);
   background-color: $color-white;
   box-shadow: $box-shadow-lg;
-  position: relative;
   left: 0;
   width: 100%;
 

--- a/frontend/src/components/layout/navigation/MobileNavigation.module.scss
+++ b/frontend/src/components/layout/navigation/MobileNavigation.module.scss
@@ -14,7 +14,7 @@
   transform: translateY(-100%);
   background-color: $color-white;
   box-shadow: $box-shadow-lg;
-  position: absolute;
+  position: fixed;
   left: 0;
   width: 100%;
 

--- a/frontend/src/components/layout/navigation/MobileNavigation.module.scss
+++ b/frontend/src/components/layout/navigation/MobileNavigation.module.scss
@@ -3,7 +3,8 @@
 
 .mobile-menu {
   width: 100%;
-  position: relative;
+  position: sticky;
+  top: 76px; // threshold for mobile menu - height of header
   // z-index of 1 (so it overlaps content)
   // allows menu to slide under main navigation header
   z-index: 1;
@@ -14,7 +15,7 @@
   transform: translateY(-100%);
   background-color: $color-white;
   box-shadow: $box-shadow-lg;
-  position: fixed;
+  position: relative;
   left: 0;
   width: 100%;
 

--- a/frontend/src/components/layout/navigation/MobileNavigation.module.scss
+++ b/frontend/src/components/layout/navigation/MobileNavigation.module.scss
@@ -5,6 +5,7 @@
   width: 100%;
   position: sticky;
   top: 76px; // threshold for mobile menu - height of header
+  height: 0; // prevents element from pushing main elements down
   // z-index of 1 (so it overlaps content)
   // allows menu to slide under main navigation header
   z-index: 1;


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-2045

<!-- When adding a new feature: -->

# New feature description
This makes it so the mobile menu follows you when in mobile menu (under 768px actually)


# Screenshot (if applicable)

<img width="293" alt="image" src="https://user-images.githubusercontent.com/3924990/174452786-6ef24c67-772c-4958-ad73-0c2336b5759a.png">


# How to test
1. [Visit any page](https://deploy-preview-2090--fx-relay-demo.netlify.app/accounts/profile/) in mobile mode 
2. Scroll/Drag the page - menu should follow you.

# Checklist

- [ ] l10n dependencies have been merged, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
