### PR TITLE
Indicator when tracker removal is enabled

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -128,3 +128,6 @@ whatsnew-feature-tracker-removal-description = Now { -brand-name-relay } can rem
 profile-label-trackers-removed = Trackers removed
 profile-trackers-removed-tooltip-part1 = With tracker removal enabled, common email trackers will be removed from your forwarded emails.
 profile-trackers-removed-tooltip-part2 = Important: Sometimes removing trackers may cause your email to look broken, because the trackers are often contained within images.
+# This is a button that, when clicked, will open a tooltip with profile-indicator-tracker-removal-tooltip ("Currently removing email trackers").
+profile-indicator-tracker-removal-alt = Tracker removal
+profile-indicator-tracker-removal-tooltip = Currently removing email trackers

--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -32,10 +32,57 @@ $toggleTransitionDuration: 200ms;
 }
 
 .controls {
-  display: grid;
-  grid-template-columns: 1fr;
-  row-gap: $spacing-xs;
+  display: flex;
+  gap: $spacing-xs;
   align-items: center;
+  flex-wrap: wrap;
+}
+
+$trackerRemovalIndicatorWidth: 20px;
+.tracker-removal-indicator-wrapper {
+  position: relative;
+  width: $trackerRemovalIndicatorWidth;
+
+  button {
+    border-style: none;
+    background-color: transparent;
+    color: $color-grey-30;
+    display: flex;
+    align-items: center;
+  }
+
+  $arrowWidth: 6px;
+  .tracker-removal-indicator-tooltip {
+    position: absolute;
+    box-shadow: $box-shadow-sm;
+    padding: $spacing-md;
+    background-color: $color-white;
+    border-radius: $border-radius-md;
+    width: $content-xs;
+    top: calc(-50% - $spacing-md / 2);
+    left: $trackerRemovalIndicatorWidth + $spacing-sm + $arrowWidth;
+    // Overlap <LabelEditor>, which is relatively positioned:
+    z-index: 1;
+
+    &::before {
+      content: "";
+      height: $arrowWidth * 2;
+      width: $arrowWidth * 2;
+      position: absolute;
+      top: calc(50% - $arrowWidth);
+      left: $arrowWidth * -1;
+      transform: rotate(45deg);
+      background-color: $color-white;
+    }
+  }
+}
+
+.label-editor-wrapper {
+  flex: 1 0 auto;
+  // Grows to push the mask address to the next line when present,
+  // but not so much to push itself down below the
+  // `.tracker-removal-indicator-wrapper` if present:
+  width: calc(100% - $trackerRemovalIndicatorWidth - $spacing-xs);
 }
 
 .copy-controls {
@@ -117,6 +164,7 @@ $toggleTransitionDuration: 200ms;
 .block-level-label-wrapper {
   display: none;
   align-items: center;
+  flex: 1 0 auto;
 
   @media screen and #{$mq-md} {
     display: flex;
@@ -128,6 +176,8 @@ $toggleTransitionDuration: 200ms;
     border-radius: $border-radius-sm;
     padding: $spacing-sm;
     font-weight: 600;
+    flex: 1 0 auto;
+    text-align: center;
 
     &.block-level-all-label {
       color: $color-light-gray-70;

--- a/frontend/src/components/dashboard/aliases/Alias.tsx
+++ b/frontend/src/components/dashboard/aliases/Alias.tsx
@@ -26,6 +26,7 @@ import { getRuntimeConfig } from "../../../config";
 import { getLocale } from "../../../functions/getLocale";
 import { BlockLevel, BlockLevelSlider } from "./BlockLevelSlider";
 import { RuntimeData } from "../../../hooks/api/runtimeData";
+import { HideIcon } from "../../Icons";
 
 export type Props = {
   alias: AliasData;
@@ -66,10 +67,12 @@ export const Alias = (props: Props) => {
   };
 
   const labelEditor = props.showLabelEditor ? (
-    <LabelEditor
-      label={props.alias.description}
-      onSubmit={(newLabel) => props.onUpdate({ description: newLabel })}
-    />
+    <div className={styles["label-editor-wrapper"]}>
+      <LabelEditor
+        label={props.alias.description}
+        onSubmit={(newLabel) => props.onUpdate({ description: newLabel })}
+      />
+    </div>
   ) : null;
 
   let backgroundImage = undefined;
@@ -145,6 +148,10 @@ export const Alias = (props: Props) => {
     >
       <div className={styles["main-data"]}>
         <div className={styles.controls}>
+          <TrackerRemovalIndicator
+            alias={props.alias}
+            profile={props.profile}
+          />
           {labelEditor}
           <span className={styles["copy-controls"]}>
             <span className={styles["copy-button-wrapper"]}>
@@ -441,4 +448,44 @@ const BlockLevelLabel = (props: BlockLevelLabelProps) => {
   }
 
   return null;
+};
+
+type TrackerRemovalIndicatorProps = {
+  alias: AliasData;
+  profile: ProfileData;
+};
+const TrackerRemovalIndicator = (props: TrackerRemovalIndicatorProps) => {
+  const { l10n } = useLocalization();
+  const tooltipState = useTooltipTriggerState({ delay: 0 });
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const { triggerProps, tooltipProps: triggerTooltipProps } = useTooltipTrigger(
+    {},
+    tooltipState,
+    triggerRef
+  );
+  const { tooltipProps } = useTooltip(triggerTooltipProps, tooltipState);
+
+  if (!isBlockingLevelOneTrackers(props.alias, props.profile)) {
+    return null;
+  }
+
+  return (
+    <span className={styles["tracker-removal-indicator-wrapper"]}>
+      <button
+        ref={triggerRef}
+        {...triggerProps}
+        aria-label={l10n.getString("profile-indicator-tracker-removal-alt")}
+      >
+        <HideIcon alt="" />
+      </button>
+      {tooltipState.isOpen && (
+        <span
+          className={styles["tracker-removal-indicator-tooltip"]}
+          {...mergeProps(triggerTooltipProps, tooltipProps)}
+        >
+          {l10n.getString("profile-indicator-tracker-removal-tooltip")}
+        </span>
+      )}
+    </span>
+  );
 };


### PR DESCRIPTION
# New feature description

This adds an indicator next to masks when tracker blocking is enabled. Tracker blocking will first only be available to set profile-wide, and this indicator will only appear if that is enabled.

Later, we'll probably add mask-specific settings. When that is added, d069fbfd3834a03c491773f50fb48f291eccdbe3 will ensure that the indicator is only shown for masks that have it enabled.

Note that when the back-end has not yet [implemented tracker blocking](https://github.com/mozilla/fx-private-relay/pull/2078), the new UI will not be visible. Use the mock API to see it (the `full` user has it enabled for their masks).

Note that I've attempted to split out the tracker blocking work in as small pieces as possible, though there's still some overlap in the different PRs. If it looks like things are missing, the complete work is available in the branch [`trackerblocking-all`](https://github.com/mozilla/fx-private-relay/tree/trackerblocking-all).

# Screenshot (if applicable)

![](https://user-images.githubusercontent.com/4251/174631710-d775afeb-efb3-45a6-8034-40b4052ef84a.png)

# How to test

Open [the mock site with the user `full`](https://deploy-preview-2099--fx-relay-demo.netlify.app/?mockId=full). There should be an "eye" icon in front of their masks that shows a tooltip on hover. Check that it displays correctly both when label storage is enabled, as well as when it's disabled.

# Checklist

- [ ] l10n dependencies have been merged, if any. - Submitted here: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/91
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
