### PR TITLE
Profile-wide counts of blocked trackers

### DIFF
--- a/frontend/__mocks__/hooks/api/profile.ts
+++ b/frontend/__mocks__/hooks/api/profile.ts
@@ -1,6 +1,7 @@
 import {
   ProfileData,
   ProfileUpdateFn,
+  SetSubdomainFn,
   useProfiles,
 } from "../../../src/hooks/api/profile";
 
@@ -19,6 +20,7 @@ export function getMockProfileData(profileData?: MockData): ProfileData {
     has_premium: false,
     id: 0,
     server_storage: true,
+    remove_level_one_email_trackers: false,
     subdomain: null,
     onboarding_state: 3,
     avatar: "",
@@ -26,12 +28,17 @@ export function getMockProfileData(profileData?: MockData): ProfileData {
     bounce_status: [false, ""],
     next_email_try: "2022-04-02T13:37:00Z",
     api_token: "",
+    emails_blocked: 0,
+    emails_forwarded: 0,
+    emails_replied: 0,
+    num_level_one_trackers_blocked_in_deleted_address: 0,
     ...profileData,
   };
 }
 
 type Callbacks = {
   updater?: ProfileUpdateFn;
+  setSubdomain: SetSubdomainFn;
 };
 function getReturnValue(
   profileData?: MockData,
@@ -42,6 +49,7 @@ function getReturnValue(
     mutate: jest.fn(),
     update: callbacks?.updater ?? jest.fn(),
     data: [getMockProfileData(profileData)],
+    setSubdomain: callbacks?.setSubdomain ?? jest.fn(),
   };
 }
 

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -124,6 +124,12 @@ whatsnew-feature-tracker-removal-heading = Introducing email tracker removal
 whatsnew-feature-tracker-removal-snippet = Now { -brand-name-relay } can remove common email trackers from emails forwarded…
 whatsnew-feature-tracker-removal-description = Now { -brand-name-relay } can remove common email trackers from emails forwarded to you, helping you stay invisible to advertisers.
 
+profile-stat-learn-more = Learn more
+profile-stat-learn-more-close = Close
+# This is displayed in small under a number in a large font indicating the number of trackers that have been removed from all emails sent to all of a user's masks
+profile-stat-label-trackers-removed = Trackers removed
+profile-stat-label-trackers-learn-more-part1 = Enabling tracker removal will remove common email trackers from your forwarded emails.
+profile-stat-label-trackers-learn-more-part2 = Important: Sometimes removing trackers may cause your email to look broken, because the trackers are often contained within images.
 # This is displayed in small under a number in a large font indicating the number of trackers that have been removed from all emails sent to a particular mask
 profile-label-trackers-removed = Trackers removed
 profile-trackers-removed-tooltip-part1 = With tracker removal enabled, common email trackers will be removed from your forwarded emails.

--- a/frontend/src/apiMocks/mockData.ts
+++ b/frontend/src/apiMocks/mockData.ts
@@ -51,6 +51,7 @@ export const profiles: Record<typeof mockIds[number], ProfileData> = {
     emails_blocked: 0,
     emails_forwarded: 0,
     emails_replied: 0,
+    num_level_one_trackers_blocked_in_deleted_address: 0,
   },
   onboarding: {
     api_token: "onboarding",
@@ -67,6 +68,7 @@ export const profiles: Record<typeof mockIds[number], ProfileData> = {
     emails_blocked: 0,
     emails_forwarded: 0,
     emails_replied: 0,
+    num_level_one_trackers_blocked_in_deleted_address: 0,
   },
   some: {
     api_token: "some",
@@ -80,9 +82,10 @@ export const profiles: Record<typeof mockIds[number], ProfileData> = {
     onboarding_state: 3,
     server_storage: true,
     subdomain: null,
-    emails_blocked: 0,
-    emails_forwarded: 0,
-    emails_replied: 0,
+    emails_blocked: 424284,
+    emails_forwarded: 1337,
+    emails_replied: 40,
+    num_level_one_trackers_blocked_in_deleted_address: 72,
   },
   full: {
     api_token: "full",
@@ -96,9 +99,10 @@ export const profiles: Record<typeof mockIds[number], ProfileData> = {
     onboarding_state: 3,
     server_storage: true,
     subdomain: "mydomain",
-    emails_blocked: 0,
-    emails_forwarded: 0,
-    emails_replied: 0,
+    emails_blocked: 848526,
+    emails_forwarded: 1337,
+    emails_replied: 9631,
+    num_level_one_trackers_blocked_in_deleted_address: 1409,
   },
 };
 export const relayaddresses: Record<typeof mockIds[number], RandomAliasData[]> =

--- a/frontend/src/hooks/api/profile.ts
+++ b/frontend/src/hooks/api/profile.ts
@@ -17,6 +17,7 @@ export type ProfileData = {
   emails_blocked: number;
   emails_forwarded: number;
   emails_replied: number;
+  num_level_one_trackers_blocked_in_deleted_address: number;
 };
 
 export type ProfilesData = [ProfileData];

--- a/frontend/src/pages/accounts/profile.module.scss
+++ b/frontend/src/pages/accounts/profile.module.scss
@@ -5,14 +5,14 @@
 .header {
   background-color: $color-light-gray-05;
   width: 100%;
-  padding: $spacing-lg 0;
+  padding: $spacing-md 0;
 
   .header-wrapper {
     display: flex;
     flex-direction: column;
     gap: $spacing-md;
 
-    @media screen and #{$mq-md} {
+    @media screen and #{$mq-lg} {
       flex-direction: row;
       align-items: center;
     }
@@ -21,7 +21,7 @@
       flex: 1 0 auto;
       display: flex;
       flex-direction: column;
-      gap: $spacing-md;
+      gap: $spacing-sm;
 
       .greeting {
         @include text-body-xl;
@@ -48,31 +48,136 @@
     }
 
     .account-stats {
-      display: flex;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: $spacing-md;
       text-align: center;
       justify-content: space-evenly;
 
+      @media screen and #{$mq-md} {
+        display: flex;
+      }
+
       .stat {
+        flex: 1 0 auto;
         display: flex;
         flex-direction: column;
         align-items: center;
         justify-content: space-between;
-        padding: 0 $spacing-md;
-        border-right: 1px solid $color-light-gray-20;
+        gap: $spacing-xs;
+        padding: $spacing-md;
+        background-color: $color-white;
+        border: 1px solid $color-light-gray-20;
+        border-radius: $border-radius-md;
+        position: relative;
 
-        &:last-child {
-          border-right: 0 none transparent;
+        @media screen and #{$mq-lg} {
+          // On small screens, stats have a border and all that, but since
+          // Protocol doesn't have max-width media queries, we need to unset
+          // all those for larger screens:
+          border-style: none;
+          border-right-style: solid;
+          border-radius: 0;
+          background-color: transparent;
+          padding-block: 0;
+
+          &:last-child {
+            border-right-style: none;
+          }
         }
 
         .label {
+          @include text-body-sm;
           color: $color-dark-gray-10;
         }
 
         .value {
-          @include text-title-sm;
+          @include text-title-xs;
           font-family: $font-stack-firefox;
           font-weight: 700;
           padding: $spacing-xs 0;
+          flex: 1 0 auto;
+          display: flex;
+          flex-direction: column;
+
+          .learn-more-wrapper {
+            @include text-body-sm;
+            font-weight: 400;
+
+            .open-button {
+              background-color: transparent;
+              border-style: none;
+              border-radius: $border-radius-lg;
+              color: $color-blue-50;
+              padding-inline: $spacing-md;
+              font-family: $font-stack-base;
+              font-weight: 500;
+              cursor: pointer;
+
+              &:hover {
+                background-color: $color-grey-10;
+              }
+            }
+
+            &.is-open .open-button {
+              background-color: $color-grey-10;
+            }
+
+            .close-button {
+              align-self: end;
+              background-color: transparent;
+              border-style: none;
+              border-radius: $border-radius-sm;
+              float: right;
+              padding: 0;
+              cursor: pointer;
+
+              &:hover {
+                color: $color-blue-50;
+              }
+            }
+
+            .learn-more-tooltip {
+              padding: $spacing-md;
+              background-color: $color-white;
+              width: $content-sm;
+              // On small screens, the tooltip should span the full width,
+              // minus the padding around `.stat` elements (i.e. the value of
+              // `gap` for `.account-stats`):
+              max-width: calc(100vw - $spacing-md * 2);
+              box-shadow: $box-shadow-sm;
+              border-radius: $border-radius-sm;
+              text-align: start;
+
+              p + p {
+                // Not using `gap` on the parent becase we don't want space
+                // between the close button and the first paragraph:
+                margin-top: $spacing-md;
+              }
+            }
+          }
+        }
+
+        // odd `.stat` elements are on the left-hand side on small screens,
+        // so we align the tooltip to its left border:
+        &:nth-child(odd) .learn-more-tooltip {
+          left: 0;
+        }
+
+        // even `.stat` elements are on the left-hand side on small screens,
+        // so we align the tooltip to its right border:
+        &:nth-child(even) .learn-more-tooltip {
+          right: 0;
+        }
+
+        @media screen and #{$mq-md} {
+          // On medium-sized screens, the `.stat` items are in a row,
+          // so only the first element should have the tooltip aligned to its
+          // left-hand side:
+          &:not(:first-child):nth-child(odd) .learn-more-tooltip {
+            left: unset;
+            right: 0;
+          }
         }
       }
     }

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -74,10 +74,10 @@ const Settings: NextPage = () => {
   // i.e. not when it is off on page load.
   const labelCollectionWarning =
     labelCollectionDisabledWarningToggles > 1 && !labelCollectionEnabled ? (
-      <aside role="alert" className={styles["field-warning"]}>
+      <div role="alert" className={styles["field-warning"]}>
         <img src={infoTriangleIcon.src} alt="" width={20} />
         <p>{l10n.getString("setting-label-collection-off-warning-2")}</p>
-      </aside>
+      </div>
     ) : null;
 
   const saveSettings: FormEventHandler = async (event) => {
@@ -173,10 +173,10 @@ const Settings: NextPage = () => {
               <p>{l10n.getString("setting-tracker-removal-note")}</p>
             </label>
           </div>
-          <aside role="alert" className={styles["field-warning"]}>
+          <div className={styles["field-warning"]}>
             <img src={infoTriangleIcon.src} alt="" width={20} />
             <p>{l10n.getString("setting-tracker-removal-warning")}</p>
-          </aside>
+          </div>
         </div>
       </div>
     ) : null;


### PR DESCRIPTION
# New feature description

This adds a count of how many trackers have been blocked in total at the top of the user's profile.

Note that the back-end does not yet provide this data; the UI will not be visible until it does. Use the mock API to see the UI today.

Note that I've attempted to split out the tracker blocking work in as small pieces as possible, though there's still some overlap in the different PRs. If it looks like things are missing, the complete work is available in the branch [`trackerblocking-all`](https://github.com/mozilla/fx-private-relay/tree/trackerblocking-all).

# Screenshot (if applicable)

![](https://user-images.githubusercontent.com/4251/174631614-6ce4944a-ec94-4667-95e5-c29b390417e9.png)

![image](https://user-images.githubusercontent.com/4251/174638812-9773bc9b-8869-49cc-ae56-e545a39a04af.png)

# How to test

[Open the mock site with the user `full`](https://deploy-preview-2101--fx-relay-demo.netlify.app/?mockId=full). There should be a count at the top of the profile.

Also note that this implements the mobile view for profile-wide stats.

# Checklist

- [ ] l10n dependencies have been merged, if any. - Submitted here: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/91
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
