### PR TITLE
Show breakage warning with tracker removal enabled

### DIFF
--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -80,17 +80,6 @@ const Settings: NextPage = () => {
       </aside>
     ) : null;
 
-  // This warning should only be shown when the user currently does not have
-  // tracker removal enabled, regardless of whether they've toggled it on or off
-  // without saving their settings yet:
-  const trackerRemovalWarning =
-    profile.remove_email_tracker_default === false ? (
-      <aside role="alert" className={styles["field-warning"]}>
-        <img src={infoTriangleIcon.src} alt="" width={20} />
-        <p>{l10n.getString("setting-tracker-removal-warning")}</p>
-      </aside>
-    ) : null;
-
   const saveSettings: FormEventHandler = async (event) => {
     event.preventDefault();
 
@@ -184,7 +173,10 @@ const Settings: NextPage = () => {
               <p>{l10n.getString("setting-tracker-removal-note")}</p>
             </label>
           </div>
-          {trackerRemovalWarning}
+          <aside role="alert" className={styles["field-warning"]}>
+            <img src={infoTriangleIcon.src} alt="" width={20} />
+            <p>{l10n.getString("setting-tracker-removal-warning")}</p>
+          </aside>
         </div>
       </div>
     ) : null;


### PR DESCRIPTION
The warning on the settings page [should be displayed regardless of whether it's currently enabled](https://mozilla.slack.com/archives/G01CAHTUJ9L/p1655311646595179?thread_ts=1655236532.232939&cid=G01CAHTUJ9L):

![](https://user-images.githubusercontent.com/4251/174631771-b99e35e4-717b-4908-950f-6b3b93ee0db5.png)

Note that the back-end does not yet provide this data; the UI will not be visible until it does. Use the mock API to see the UI today.

Note that I've attempted to split out the tracker blocking work in as small pieces as possible, though there's still some overlap in the different PRs. If it looks like things are missing, the complete work is available in the branch [`trackerblocking-all`](https://github.com/mozilla/fx-private-relay/tree/trackerblocking-all).

How to test: open the settings page, verify that it's always shown.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
