### PR TITLE
Small styling refinements

### DIFF
--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -336,6 +336,7 @@ $trackerRemovalIndicatorWidth: 20px;
 }
 
 .expand-toggle {
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
 

--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -238,6 +238,12 @@ $trackerRemovalIndicatorWidth: 20px;
       // Prevent other .stat-wrapper elements from overlapping this tooltip:
       z-index: 2;
 
+      @media screen and #{$mq-lg} {
+        // The wrapper doesn't span the full width on large screens,
+        // so limiting the tooltip to its wrapper's size makes it too thin:
+        max-width: unset;
+      }
+
       &::before {
         content: "";
         height: 2 * $arrowWidth;


### PR DESCRIPTION
This PR fixes #1920, and an issue I just saw myself.

How to test: make sure that tooltips no longer [look](https://deploy-preview-2107--fx-relay-demo.netlify.app/?mockId=some) like this on large screens:

![image](https://user-images.githubusercontent.com/4251/175026964-f4f979d0-843b-42d3-93e7-2866adf399e2.png)

And also that the collapse arrows don't get smaller and smaller (until they're invisible) as the screen size decreases.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A - layout issues
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
