### PR TITLE
MPP-2104 Put tracker removal UI behind a flag.

### DIFF
--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -25,6 +25,7 @@ import { useLocalLabels } from "../../hooks/localLabels";
 import { AliasData, useAliases } from "../../hooks/api/aliases";
 import { useRuntimeData } from "../../hooks/api/runtimeData";
 import { useAddonData } from "../../hooks/addon";
+import { flagIsActive } from "../../functions/waffle";
 
 const Settings: NextPage = () => {
   const runtimeData = useRuntimeData();
@@ -151,7 +152,8 @@ const Settings: NextPage = () => {
   // when the profiles API actually returns a property `remove_level_one_email_trackers`.
   // Once it does, the commit that introduced this comment can be reverted.
   const trackerRemovalSetting =
-    typeof profile.remove_level_one_email_trackers === "boolean" ? (
+    typeof profile.remove_level_one_email_trackers === "boolean" &&
+    flagIsActive(runtimeData.data, "tracker_removal") ? (
       <div className={styles.field}>
         <h2 className={styles["field-heading"]}>
           <span className={styles["field-heading-icon-wrapper"]}>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #2115   
 
<!-- When adding a new feature: -->

# New feature description
We place the UI for tracker removal setting behind a flag using new `flagIsActive` function (kudos to @groovecoder) 

# Screenshot (if applicable)

Not applicable.

# How to test

Toggling `tracker_removal` flag on and off dictates whether this UI is rendered or not.  

# Checklist

- [ ] l10n dependencies have been merged, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
