### PR TITLE
MPP-1833 Filter buttons have different sizes.

### DIFF
--- a/frontend/src/components/dashboard/aliases/CategoryFilter.module.scss
+++ b/frontend/src/components/dashboard/aliases/CategoryFilter.module.scss
@@ -49,18 +49,17 @@
 
     .buttons {
       display: flex;
-      align-items: center;
+      flex-direction: column-reverse;
+      gap: $spacing-sm;
 
       button[type="reset"] {
         background-color: $color-white;
         color: $color-dark-gray-10;
         border: 2px solid $color-light-gray-40;
         border-radius: $border-radius-sm;
-        font-weight: 700;
-        padding: $spacing-sm $spacing-2xl;
+        padding: $spacing-sm $spacing-lg;
         line-height: 1.25;
         cursor: pointer;
-        margin-right: $spacing-lg;
 
         &:hover {
           color: $color-blue-60;


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #1810 
 
<!-- When adding a new feature: -->

# New feature description

Following how we’ve handled other UI, we make both buttons full width, and stack them. 

Old state: 
<img width="234" alt="image" src="https://user-images.githubusercontent.com/3924990/175518883-2de86876-f277-4039-a4d4-ead79d76c95f.png">


# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/3924990/175518686-ce76d85f-6a18-4c1f-9cc7-bdcfb045399f.png)

# How to test

1. Navigate to Relay page and log in.
2. Go to aliases list and click the filter button above it.
3. Observe the "Reset" and "Apply" buttons.


# Checklist

- [ ] l10n dependencies have been merged, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
