### PR TITLE
Validate custom masks on submission

### DIFF
--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
@@ -70,6 +70,12 @@ export const AddressPickerModal = (props: Props) => {
   const onSubmit: FormEventHandler = (event) => {
     event.preventDefault();
 
+    const validationMessage = getAddressValidationMessage(address, l10n);
+    if (validationMessage) {
+      addressFieldRef.current?.setCustomValidity(validationMessage);
+      addressFieldRef.current?.reportValidity();
+      return;
+    }
     props.onPick(address.toLowerCase(), {
       blockPromotionals: promotionalsBlocking,
     });


### PR DESCRIPTION
So far we only validated on blur, which works if you click outside
the field to submit. However, if you press Enter while the cursor
is inside the address field, blur and hence validation would be
bypassed.

How to test: create a new custom mask with an invalid name (e.g. `!`), then press Enter to submit. It should reject the submission.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, calls browser logic
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/static/scss/libs/protocol/css/includes/tokens/dist/index.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
