### PR TITLE
Fix #2046 - Overlapping Blocking Icon on Tips

### DIFF
--- a/frontend/src/components/dashboard/tips/Tips.module.scss
+++ b/frontend/src/components/dashboard/tips/Tips.module.scss
@@ -52,6 +52,7 @@
   background-color: $color-white;
   width: $content-sm;
   max-width: calc(100% - $spacing-xl);
+  z-index: 1;
 
   .header {
     display: flex;


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #2046 

How to test:

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
