### PR TITLE
Fix Heroku build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "licensecheck": "license-checker --excludePrivatePackages --production --onlyAllow 'MPL; MIT; BSD-3-Clause; BSD-2-Clause; 0BSD; Apache-2.0; ISC; Zlib; CC0; Unlicense; WTFPL; Unicode-DFS-2016;'",
     "test": "jest",
     "postinstall": "msw init public/ --save",
-    "prepare": "cd .. && husky install frontend/.husky"
+    "prepare": "if [ \"$ON_HEROKU\" != \"True\" ]; then cd .. && husky install frontend/.husky; fi"
   },
   "dependencies": {
     "@fluent/bundle": "^0.17.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "lint": "stylelint '**/*.scss' && prettier --check './src' && next lint",
     "licensecheck": "license-checker --excludePrivatePackages --production --onlyAllow 'MPL; MIT; BSD-3-Clause; BSD-2-Clause; 0BSD; Apache-2.0; ISC; Zlib; CC0; Unlicense; WTFPL; Unicode-DFS-2016;'",
     "test": "jest",
-    "postinstall": "msw init public/ --save",
+    "postinstall": "if type msw > /dev/null; then msw init public/ --save; else echo 'msw not installed'; fi",
     "prepare": "if [ \"$ON_HEROKU\" != \"True\" ]; then cd .. && husky install frontend/.husky; fi"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "frontend"
   ],
   "scripts": {
-    "heroku-postbuild": "git clone https://github.com/mozilla-l10n/fx-private-relay-l10n.git privaterelay/locales; cd frontend; NODE_ENV=\"development\" npm ci; npm run build"
+    "heroku-postbuild": "cd frontend; NODE_ENV=\"development\" npm ci; npm run build"
   },
   "homepage": "https://github.com/mozilla/fx-private-relay#readme"
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "frontend"
   ],
   "scripts": {
+    "heroku-prebuild": "printf '{\"commit\":\"%s\"}\n' \"$SOURCE_VERSION\" > version.json",
     "heroku-postbuild": "cd frontend; NODE_ENV=\"development\" npm ci; npm run build"
   },
   "homepage": "https://github.com/mozilla/fx-private-relay#readme"


### PR DESCRIPTION
The Heroku build was broken after removing the gulp tools. This fixes the Heroku build by allowing the `postinstall` script to continue when dev dependency `msw` is removed (it runs successfully during the `npm ci` step).

This PR has further Heroku changes:

* Skip adding the locales submodule, since Heroku takes care of installing it
* Skip installing `husky` in Heroku, since the source code does not include a `git` repo, required for husky
* Add a `version.json` file, so that https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/__version__ works (and so we can add it to https://whatsdeployed.io/s/xLS/mozilla/fx-private-relay)