### PR TITLE
Fix search icon being accidentally filled

### DIFF
--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -294,6 +294,7 @@ export const SearchIcon = ({
         fillRule="evenodd"
         clipRule="evenodd"
         d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15Z"
+        fill="none"
         stroke="currentColor"
         strokeWidth="1.23077"
       />


### PR DESCRIPTION
The search icon on mobile looked off since https://github.com/mozilla/fx-private-relay/pull/1998:

![image](https://user-images.githubusercontent.com/4251/176551628-0cdfb04e-a8db-4f0c-b69b-17ef192781ae.png)

This fixes it to look as intended again:

![image](https://user-images.githubusercontent.com/4251/176551698-aa7bdad5-f718-4ead-8ef2-6f29a4e5f408.png)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
