### PR TITLE
Add 3rd party modules for phone app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ module = [
     "markus.utils",
     "oauthlib.oauth2.rfc6749.errors",
     "requests_oauthlib",
+    "twilio.rest",
+    "twilio.twiml.messaging_response",
     "waffle",
     "waffle.models",
     "waffle.testutils",
@@ -48,9 +50,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 # Optional modules or in-progress features
 module = [
-    "phonenumbers",
     "silk",
-    "twilio.rest",
-    "twilio.twiml.messaging_response",
 ]
 ignore_missing_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,8 +29,9 @@ sentry-sdk==1.6.0
 whitenoise==6.2.0
 
 # phones app
-# phonenumbers==8.11.1
-# twilio==6.35.1
+phonenumbers==8.12.48
+twilio==7.9.1
+vobject==0.9.6.1
 
 # tests
 coverage==6.4.1


### PR DESCRIPTION
Install the 3rd-party modules from PR #2026, which are needed when enabling the `phones` app.