### PR TITLE
Fix class syntax for the phone nav link

### DIFF
--- a/frontend/src/components/layout/navigation/Navigation.tsx
+++ b/frontend/src/components/layout/navigation/Navigation.tsx
@@ -41,7 +41,7 @@ export const Navigation = (props: Props) => {
   const phoneLink = isFlagActive(runtimeData.data, "phones") ? (
     <Link href="/phone">
       <a
-        className={`$styles.link} ${
+        className={`${styles.link} ${
           router.pathname === "/phone" ? styles["is-active"] : null
         }`}
       >


### PR DESCRIPTION
I noticed that the style of the phone link in the header looked a bit off:

![image](https://user-images.githubusercontent.com/4251/177176753-561bad51-585c-4940-981d-c05f4c5fe79f.png)

Turns out there was a typo in the class name. This is what it looks like with `.link` actually applied:

![image](https://user-images.githubusercontent.com/4251/177176732-1b508960-a27b-43e1-b463-4abc61843def.png)

I expect that this will also fix #2148, although since the link is not present in Lloan's new `<MobileNavigation>` component, that does mean there will be no link at all to the phone page. Not sure if there should be one already, given that it's not complete anyway.

How to test: check that the menu item looks correctly, and that its `<a>` tag does not have the following class like it does on stage: `$styles.link}`.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, layout bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
