### PR TITLE
Bold second line of API context settings

### DIFF
--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -264,12 +264,9 @@ const Settings: NextPage = () => {
                     </div>
                     <div className={styles["settings-api-key-copy"]}>
                       {l10n.getString("settings-api-key-description")}{" "}
-                      <Localized
-                        id="settings-api-key-description-bolded"
-                        elems={{ b: <b /> }}
-                      >
-                        <span className={styles["settings-api-key-copy"]} />
-                      </Localized>
+                      <b>
+                        {l10n.getString("settings-api-key-description-bolded")}
+                      </b>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -1,4 +1,4 @@
-import { Localized, useLocalization } from "@fluent/react";
+import { useLocalization } from "@fluent/react";
 import type { NextPage } from "next";
 import {
   FormEventHandler,


### PR DESCRIPTION

This PR unblocks MPP-2048 by bolding the second line in the API context setting.

<img width="728" alt="image" src="https://user-images.githubusercontent.com/13066134/177351074-735d2280-4663-4c0b-a140-3500e1408524.png">


How to test:

On the settings page, check that the API description has its last sentence bolded.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
