### PR TITLE
Consistently position block level descriptions

### DIFF
--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
@@ -232,6 +232,7 @@ $trackLineHeight: 4px;
     }
 
     .value-description-content {
+      width: $content-xs;
       display: flex;
       flex-direction: column;
       gap: $spacing-xs;

--- a/frontend/src/components/dashboard/aliases/images/umbrella-closed.svg
+++ b/frontend/src/components/dashboard/aliases/images/umbrella-closed.svg
@@ -1,4 +1,4 @@
-<svg width="54" height="91" viewBox="0 0 54 91" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="104" height="91" viewBox="0 0 54 91" fill="none" xmlns="http://www.w3.org/2000/svg">
 <circle opacity="0.4" cx="27" cy="51" r="27" fill="#ECECEC"/>
 <rect x="26.0635" y="63.097" width="1.88349" height="5.17961" fill="#9A5BFF"/>
 <rect x="25.1211" y="68.7476" width="3.76699" height="11.7718" fill="#EF6FFF"/>

--- a/frontend/src/components/dashboard/aliases/images/umbrella-semi.svg
+++ b/frontend/src/components/dashboard/aliases/images/umbrella-semi.svg
@@ -1,4 +1,4 @@
-<svg width="54" height="87" viewBox="0 0 54 87" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="104" height="87" viewBox="0 0 54 87" fill="none" xmlns="http://www.w3.org/2000/svg">
 <circle opacity="0.4" cx="27" cy="48" r="27" fill="#ECECEC"/>
 <rect x="26.1631" y="60.1957" width="1.78261" height="4.90217" fill="#C4C4C4"/>
 <rect x="25.2715" y="65.5435" width="3.56522" height="11.1413" fill="#EF6FFF"/>


### PR DESCRIPTION
The descriptions of each block level (none, promotionals, all) on
large screens used to be of different widths, and their "umbrella"
illustrations would switch positions. Now, the grey circle in the
background of those illustrations will remain in the same place.

This PR fixes #1739.

How to test: change blocking level for an alias on a wide screen, and notice how the illustration stays at a consistent position. Compare before:

https://user-images.githubusercontent.com/4251/178042590-ef6b1ef9-5a4d-46cc-811d-98e9fbb5bd10.mp4

and after:

https://user-images.githubusercontent.com/4251/178042615-566c1601-6afc-4a76-9ac9-c7160c494126.mp4


- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual bug
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
