### PR TITLE
Make the mobile menu stick when scrolling

### DIFF
--- a/frontend/src/components/layout/Layout.module.scss
+++ b/frontend/src/components/layout/Layout.module.scss
@@ -242,6 +242,23 @@ $toastify-toast-close-button: var(--toast-close-button);
   }
 }
 
+.non-header-wrapper {
+  // This `overflow` ensures that the `position: sticky` on `.mobile-menu`
+  // in <MobileNavigation> is sticky relative to this wrapper, i.e. will always
+  // stay below the header bar.
+  // For more info, see
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/position#sticky,
+  // and specifically:
+  // > Note that a sticky element "sticks" to its nearest ancestor that has a
+  // > "scrolling mechanism" (created when overflow is hidden, scroll, auto, or
+  // > overlay), even if that ancestor isn't the nearest actually scrolling
+  // > ancestor.
+  overflow: auto;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 .content {
   flex-grow: 2;
   display: flex;

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -138,14 +138,6 @@ export const Layout = (props: Props) => {
           </div>
         </header>
 
-        <MobileNavigation
-          mobileMenuExpanded={mobileMenuExpanded}
-          hasPremium={hasPremium}
-          isLoggedIn={isLoggedIn}
-          userEmail={usersData?.email}
-          userAvatar={profiles.data?.[0].avatar}
-        />
-
         <ToastContainer
           icon={false}
           position={toast.POSITION.TOP_CENTER}
@@ -157,59 +149,69 @@ export const Layout = (props: Props) => {
           toastClassName={`Toastify__toast ${styles.toast}`}
           closeButton={CloseToastButton}
         />
-        <div className={styles.content}>{props.children}</div>
-        <footer className={styles.footer}>
-          <a
-            href="https://www.mozilla.org"
-            className={styles["mozilla-logo"]}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img
-              src={mozillaLogo.src}
-              alt={l10n.getString("logo-mozilla-alt")}
-              width={120}
-            />
-          </a>
-          <ul className={styles.meta}>
-            <li>
-              <a
-                href="https://www.mozilla.org/privacy/firefox-relay/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {l10n.getString("nav-footer-privacy")}
-              </a>
-            </li>
-            <li>
-              <a
-                href="https://www.mozilla.org/about/legal/terms/firefox-relay/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {l10n.getString("nav-footer-relay-terms")}
-              </a>
-            </li>
-            <li>
-              <a
-                href="https://www.mozilla.org/about/legal/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {l10n.getString("nav-footer-legal")}
-              </a>
-            </li>
-            <li>
-              <a
-                href="https://github.com/mozilla/fx-private-relay"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                GitHub
-              </a>
-            </li>
-          </ul>
-        </footer>
+
+        <div className={styles["non-header-wrapper"]}>
+          <MobileNavigation
+            mobileMenuExpanded={mobileMenuExpanded}
+            hasPremium={hasPremium}
+            isLoggedIn={isLoggedIn}
+            userEmail={usersData?.email}
+            userAvatar={profiles.data?.[0].avatar}
+          />
+          <div className={styles.content}>{props.children}</div>
+          <footer className={styles.footer}>
+            <a
+              href="https://www.mozilla.org"
+              className={styles["mozilla-logo"]}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img
+                src={mozillaLogo.src}
+                alt={l10n.getString("logo-mozilla-alt")}
+                width={120}
+              />
+            </a>
+            <ul className={styles.meta}>
+              <li>
+                <a
+                  href="https://www.mozilla.org/privacy/firefox-relay/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {l10n.getString("nav-footer-privacy")}
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://www.mozilla.org/about/legal/terms/firefox-relay/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {l10n.getString("nav-footer-relay-terms")}
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://www.mozilla.org/about/legal/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {l10n.getString("nav-footer-legal")}
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/mozilla/fx-private-relay"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  GitHub
+                </a>
+              </li>
+            </ul>
+          </footer>
+        </div>
       </div>
     </>
   );

--- a/frontend/src/components/layout/navigation/MobileNavigation.module.scss
+++ b/frontend/src/components/layout/navigation/MobileNavigation.module.scss
@@ -3,7 +3,10 @@
 
 .mobile-menu {
   width: 100%;
-  position: relative;
+  position: sticky;
+  top: 0;
+  // `height: 0` prevents the menu from taking up space when it's not expanded:
+  height: 0;
   // z-index of 1 (so it overlaps content)
   // allows menu to slide under main navigation header
   z-index: 1;
@@ -14,8 +17,6 @@
   transform: translateY(-100%);
   background-color: $color-white;
   box-shadow: $box-shadow-lg;
-  position: absolute;
-  left: 0;
   width: 100%;
 
   &.not-active {

--- a/frontend/src/components/layout/navigation/MobileNavigation.module.scss
+++ b/frontend/src/components/layout/navigation/MobileNavigation.module.scss
@@ -84,6 +84,14 @@
     color: $color-grey-40;
     cursor: pointer;
 
+    @media screen and (max-height: 700px) {
+      // Because the menu is not scrollable (it stays in the same position while
+      // the content behind it scrolls), this makes it take up less space on
+      // screens without a tall viewport, to increase the odds of every item
+      // being visible:
+      padding: $spacing-md;
+    }
+
     &:hover {
       text-decoration: underline;
     }
@@ -116,6 +124,14 @@
     ),
     linear-gradient(90deg, #f73940 1.25%, #a83db5 96.87%);
   gap: $spacing-md;
+
+  @media screen and (max-height: 700px) {
+    // Because the menu is not scrollable (it stays in the same position while
+    // the content behind it scrolls), this makes it take up less space on
+    // screens without a tall viewport, to increase the odds of every item
+    // being visible:
+    padding: $spacing-md;
+  }
 
   .user-avatar {
     border-radius: 50%;

--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -29,6 +29,13 @@ body,
 #overlayProvider {
   height: 100%;
   font-family: $font-stack-base;
+  // In <Layout> all content is wrapped in a `.non-header-wrapper` that has its
+  // own `overflow` applied, to allow the header and mobile menu to remain fixed
+  // in place. However, in Blink- and WebKit-based browsers, this resulted in
+  // empty space at the bottom of the page, below the footer.
+  // Since the user can scroll in `.non-header-wrapper`, everything outside that
+  // that still overflows these elements can safely be hidden:
+  overflow: hidden;
 }
 
 html {


### PR DESCRIPTION
This PR fixes #2047 (and is an alternate approach to / closes #2090). It makes the expanded mobile menu stick to the top of the screen even when scrolling, without [leaving white space at the bottom of short pages](https://github.com/mozilla/fx-private-relay/pull/2090#discussion_r909584056). Of course, there might be other layout effects I didn't think of, so be sure to try everything you can see that might break :)

The trick here is that elements with `position: sticky`

>  "sticks" to its nearest ancestor that has a "scrolling mechanism" (created when overflow is hidden, scroll, auto, or overlay), even if that ancestor isn't the nearest actually scrolling ancestor.

https://developer.mozilla.org/en-US/docs/Web/CSS/position#sticky

Thus, I added a wrapper that contained everything but the things the menu should be positioned below (i.e. the header bar, mock data notification, CSAT survey, notifications) but included the mobile menu, and gave that an `overflow: auto`. Then I could give the mobile menu `position: sticky`, and that appears to have worked.

https://user-images.githubusercontent.com/4251/178084295-c2f702dc-4587-466b-a7e8-1d0137b32ccd.mp4

How to test: on a small screen, expand the mobile menu and scroll down. The menu should remain in view. Also, no other layout things should break if it wasn't broken before - a good stress test won't hurt :)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
