### PR TITLE
Mention submodule updates in docs

### DIFF
--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -30,7 +30,11 @@ We use [SWR](https://swr.vercel.app/). See `src/hooks/api` for examples.
 
 ## Add a new string
 
-Add it to `pendingTranslations.ftl`, then submit a PR to the l10n repo.
+Add it to `pendingTranslations.ftl`, then submit a PR to the l10n repo. Updates
+to that repository (both yours, as well as updated translations from Pontoon)
+are automatically pushed to this repository (see the "Update submodules" commits
+in the commit history) by
+[a scheduled daily job](https://github.com/mozilla-l10n/fx-private-relay-l10n/actions/workflows/update-upstream-relay-repo.yml).
 
 ## Add styling
 


### PR DESCRIPTION
- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
