### PR TITLE
Use overlayTrigger instead of menuTrigger

### DIFF
--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -12,9 +12,9 @@ import { event as gaEvent } from "react-ga";
 import {
   FocusScope,
   useButton,
-  useMenuTrigger,
   useOverlay,
   useOverlayPosition,
+  useOverlayTrigger,
 } from "react-aria";
 import { useMenuTriggerState } from "react-stately";
 import { toast } from "react-toastify";
@@ -419,14 +419,14 @@ const StatExplainer = (props: { children: React.ReactNode }) => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const openButtonRef = useRef<HTMLButtonElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
-  const { menuTriggerProps } = useMenuTrigger(
-    {},
+  const { triggerProps } = useOverlayTrigger(
+    { type: "dialog" },
     explainerState,
     openButtonRef
   );
 
   const openButtonProps = useButton(
-    menuTriggerProps,
+    { onPress: () => explainerState.open() },
     openButtonRef
   ).buttonProps;
   const closeButtonProps = useButton(
@@ -451,6 +451,7 @@ const StatExplainer = (props: { children: React.ReactNode }) => {
     >
       <button
         {...openButtonProps}
+        {...triggerProps}
         ref={openButtonRef}
         className={styles["open-button"]}
       >


### PR DESCRIPTION
This turns the "Learn more" button into an overlayTrigger rather than a menuTrigger:

![image](https://user-images.githubusercontent.com/4251/179764523-c0a6c8f0-94cf-4f38-becb-5ee3d1b06291.png)

Since we're not opening a menu, this is more relevant. I'm not sure what behaviour exactly changes, but I expect this to be more accessible; useMenuTrigger might e.g. come with screen reader announcements that are menu-specific.

This mistake was pointed out by a React Aria engineer:
https://twitter.com/devongovett/status/1549139534952087552

How to test: the "Learn more" popover in the profile stats should still work.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
