### PR TITLE
Add @layer to ensure website style overrides

### DIFF
--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -170,6 +170,17 @@ We don't actually do this. Instead, the add-on simply calls
 `browser.tabs.reload` on any open website tab if it needs to reflect updated
 data.
 
+## Show/hide content to/from users with the add-on installed
+
+Apply the class `is-visible-with-addon` to hide an element unless the user is
+visiting with the add-on. Conversely, add `is-hidden-with-addon` to _show_ it
+unless the user is visiting with the add-on. Note that these are plain CSS
+classes, i.e. not CSS modules (in other words, use them as plain strings, rather
+than via `styles["is-visible-with-addon"]`).
+
+They are defined in `/frontend/src/styles/globals.scss` for the website, and in
+`relay-website.css` in the add-on.
+
 ## Work on the tracker removal report
 
 Forwarded emails with blocked trackers contain a link to a report listing the

--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -79,14 +79,19 @@ h6 {
   isolation: isolate;
 }
 
-.is-visible-with-addon {
-  // This class hides an element anything in the regular website;
-  // however, the add-on injects a stylesheet that reveals elements with this class.
-  display: none;
-  visibility: collapse;
-}
+// Styles in the `add-on-overrides` layer (which the add-on injects)
+// should override those in the `add-on-overridable` layer.
+@layer add-on-overridable, add-on-overrides;
+@layer add-on-overridable {
+  .is-visible-with-addon {
+    // This class hides an element anything in the regular website;
+    // however, the add-on injects a stylesheet that reveals elements with this class.
+    display: none;
+    visibility: collapse;
+  }
 
-.is-hidden-with-addon {
-  // This class doesn't do anything in the regular website;
-  // however, the add-on injects a stylesheet that hides elements with this class.
+  .is-hidden-with-addon {
+    // This class doesn't do anything in the regular website;
+    // however, the add-on injects a stylesheet that hides elements with this class.
+  }
 }


### PR DESCRIPTION
Apparently in Chrome, the stylesheet injected by the extension
isn't injected after the website stylesheet, meaning that add-on
styles with the same specificity as website styles do not override
the latter. By moving them into a layer [1], they will. (As long as
the add-on styles are not in a layer, they will override styles
that are, but I've also added a new layer `add-on-overrides` that
the add-on can use to explicitly override the website's
`add-on-overridable` layer.)

[1] https://developer.mozilla.org/en-US/docs/Web/CSS/@layer

This PR fixes [#2189](https://github.com/mozilla/fx-private-relay/issues/2189).

How to test: run Chrome locally with the add-on installed (`npm run web-ext-run:chrome`), then visit a locally running server (127.0.0.1, i.e. using `npm run watch`). Upgrade a free account to Premium, then check the last onboarding step. The "Relay extension added!" text and "Go to Dashboard" button should be visible with this change, whereas it isn't in `main`.

With this fix:

![image](https://user-images.githubusercontent.com/4251/179796637-78bd5469-2cef-4c52-a91f-88cad2959e5c.png)

Without the fix:

![image](https://user-images.githubusercontent.com/4251/179796823-7600d16b-10ed-4542-bd0b-f04dfba2cc08.png)

I also updated the docs to document these classes.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, CSS fixes
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
