### PR TITLE
Mask focus styles

### DIFF
--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -100,11 +100,21 @@ $trackerRemovalIndicatorWidth: 20px;
     display: flex;
     align-items: center;
     background-color: transparent;
-    border: 0px none transparent;
+    border: 2px solid transparent;
+    border-radius: $border-radius-md;
     cursor: pointer;
     padding: 0 $spacing-sm;
     width: 100%;
     flex-basis: 0;
+
+    &:focus {
+      // For some reason (presumably related to `.copy-button-wrapper`'s
+      // relative positioning), Protocol's default outline isn't visible by
+      // default. Thus, we add a focus style using a border, and then remove the
+      // remnants of the outline that are made visible when there's a border.
+      border-color: $color-blue-50;
+      outline: none;
+    }
 
     .address {
       font-family: $font-stack-firefox;

--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
@@ -76,6 +76,16 @@ $trackLineHeight: 4px;
           width: 100%;
         }
 
+        &:focus-within {
+          .track-line,
+          .track-stop {
+            background-color: $color-violet-05;
+          }
+          .track-stop p {
+            color: $color-violet-90;
+          }
+        }
+
         .thumb-container {
           position: absolute;
           transform: translateX(-50%);


### PR DESCRIPTION
This PR fixes #2213. It adds focus styles for the "copy mask" button (note: I'm not sure why they weren't shown, so any suggestion there is welcome), and styles the entire block-level slider when the thumb is focused, to indicate that it is keyboard-controlled as one.

How to test: open a mask's card, verify that tabbing highlights all its elements.

Focusing the copy button:

![image](https://user-images.githubusercontent.com/4251/179984082-5fc24360-7eac-448e-beb0-1d098b5d69ca.png)

Focusing the block-level slider (actually also shows the copy button focus styles):

https://user-images.githubusercontent.com/4251/179984202-8574148d-45e7-41f2-aa8f-61691e358e3d.mp4

~~Still set to draft so I can verify that the styles I came up with make sense.~~ [Approved.](https://mozilla.slack.com/archives/G01CAHTUJ9L/p1658257706324359?thread_ts=1658152644.038239&amp;cid=G01CAHTUJ9L)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, CSS fixes.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
