### PR TITLE
add inbound_call API endpoint

### DIFF
--- a/api/renderers.py
+++ b/api/renderers.py
@@ -20,3 +20,21 @@ class vCardRenderer(renderers.BaseRenderer):
         vCard.add("tel")
         vCard.tel.value = data.get("number", "")
         return vCard.serialize().encode()
+
+
+class TwilioCallForwardXMLRenderer(renderers.BaseRenderer):
+    """
+    Twilio POSTS its request with x-www-form-urlencoded but it wants responses
+    in TwiML XML.
+    """
+
+    media_type = "text/xml"
+    format = "xml"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        xml_header = '<?xml version="1.0" encoding="UTF-8"?>'
+        if renderer_context["response"].status_code != 201:
+            error = data[0]
+            title = error.title()
+            return f"{xml_header}<Error><code>{error.code}</code><title>{title}</title></Error>"
+        return f'{xml_header}<Response><Dial callerId="{data["inbound_from"]}"><Number>{data["real_number"]}</Number></Dial></Response>'

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -509,3 +509,59 @@ def test_inbound_sms_valid_twilio_signature_good_data(
     assert call_kwargs["to"] == real_phone_number
     assert call_kwargs["from_"] == relay_number
     assert "[Relay" in call_kwargs["body"]
+
+
+@pytest.mark.django_db
+def test_inbound_call_no_twilio_signature():
+    client = APIClient()
+    path = "/api/v1/inbound_call"
+    response = client.post(path)
+
+    assert response.status_code == 400
+    assert "Missing X-Twilio-Signature" in response.data[0].title()
+
+
+@pytest.mark.django_db
+def test_inbound_call_invalid_twilio_signature(mocked_twilio_validator):
+    mocked_twilio_validator.validate = Mock(return_value=False)
+
+    client = APIClient()
+    path = "/api/v1/inbound_call"
+    response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="invalid")
+
+    assert response.status_code == 400
+    assert "Invalid Signature" in response.data[0].title()
+
+
+@pytest.mark.django_db
+def test_inbound_call_valid_twilio_signature_bad_data(mocked_twilio_validator):
+    mocked_twilio_validator.validate = Mock(return_value=True)
+
+    client = APIClient()
+    path = "/api/v1/inbound_call"
+    response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="valid")
+
+    assert response.status_code == 400
+    assert "Missing Caller Or Called." in response.data[0].title()
+
+
+def test_inbound_call_valid_twilio_signature_good_data(
+    phone_user, mocked_twilio_client, mocked_twilio_validator
+):
+    mocked_twilio_validator.validate = Mock(return_value=True)
+    real_phone_number = "+12223334444"
+    relay_number = "+19998887777"
+    caller_number = "+15556660000"
+    RealPhone.objects.create(user=phone_user, number=real_phone_number, verified=True)
+    RelayNumber.objects.create(user=phone_user, number=relay_number)
+    mocked_twilio_client.reset_mock()
+
+    client = APIClient()
+    path = "/api/v1/inbound_call"
+    data = {"Caller": caller_number, "Called": relay_number}
+    response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
+
+    assert response.status_code == 201
+    decoded_content = response.content.decode()
+    assert f'callerId="{caller_number}"' in decoded_content
+    assert f"<Number>{real_phone_number}</Number>" in decoded_content

--- a/api/urls.py
+++ b/api/urls.py
@@ -50,12 +50,19 @@ urlpatterns = [
 ]
 
 if settings.PHONES_ENABLED:
-    from .views.phones import RealPhoneViewSet, RelayNumberViewSet, inbound_sms, vCard
+    from .views.phones import (
+        RealPhoneViewSet,
+        RelayNumberViewSet,
+        inbound_call,
+        inbound_sms,
+        vCard,
+    )
 
     api_router.register(r"realphone", RealPhoneViewSet, "real_phone")
     api_router.register(r"relaynumber", RelayNumberViewSet, "relay_number")
     urlpatterns += [
         path("v1/inbound_sms", inbound_sms, name="inbound_sms"),
+        path("v1/inbound_call", inbound_call, name="inbound_call"),
         path("v1/vCard/<lookup_key>", vCard, name="vCard"),
     ]
 


### PR DESCRIPTION
# New feature description
This adds a new `/api/v1/inbound_call` endpoint which is used to forward calls made to the relay number. It uses [the `callerId` attribute of the TwiML `Dial` command](https://www.twilio.com/docs/voice/twiml/dial#callerid) to preserve the original caller's ID for the forwarded call.

# Screenshot (if applicable)

# How to test
1. Go thru [the docs to set up your local Relay for end-to-end local phone development](https://github.com/mozilla/fx-private-relay/blob/main/docs/end-to-end-local-phone-dev.md)
   * Make sure you set the "Voice Request URL" at [the appropriate step](https://github.com/mozilla/fx-private-relay/blob/main/docs/end-to-end-local-phone-dev.md#set-up-a-relay-sms-application-in-twilio).
3. Run both `runserver` and `ngrok`
4. Call your local Relay number
   * [ ] Relay should forward the call to your real phone number, preserving the original caller ID !


# Checklist

- [x] I've added or updated relevant docs in the docs/ directory.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).