### PR TITLE
Fix small icons

### DIFF
--- a/frontend/src/components/landing/FaqAccordion.module.scss
+++ b/frontend/src/components/landing/FaqAccordion.module.scss
@@ -43,6 +43,7 @@
   }
 
   .plus-icon {
+    flex: 0 0 auto;
     transition: transform 0.2s ease-out;
     color: $color-blue-50;
   }

--- a/frontend/src/pages/accounts/settings.module.scss
+++ b/frontend/src/pages/accounts/settings.module.scss
@@ -130,7 +130,7 @@ $field-gap: $spacing-lg;
 
     svg {
       color: $color-yellow-50;
-      flex: 1 0 1;
+      flex: 1 0 auto;
     }
   }
 }


### PR DESCRIPTION
This PR fixes #2191 and fixes #2202.

How to test: on the homepage/interstitial, the X / + icons should all be the same size, regardless of your screen size. (Before, if the FAQ title took up more space, the icon would get smaller.) Additionally, the warning when unchecking data collection on the settings page should have a regular-sized icon, rather than a really tiny one.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, layout fix
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
