### PR TITLE
Fix link to Firefox for mobile

### DIFF
--- a/frontend/src/components/layout/navigation/AppPicker.tsx
+++ b/frontend/src/components/layout/navigation/AppPicker.tsx
@@ -63,7 +63,7 @@ const getProducts = (referringSiteUrl: string) => ({
   },
   fxMobile: {
     id: "fxMobile",
-    url: `https://www.mozilla.org/firefox/new/?utm_source=${encodeURIComponent(
+    url: `https://www.mozilla.org/firefox/browsers/mobile/?utm_source=${encodeURIComponent(
       referringSiteUrl
     )}&utm_medium=referral&utm_campaign=bento&utm_content=desktop`,
     gaLabel: "fx-mobile",


### PR DESCRIPTION
This PR fixes #2188.

How to test: click the link to "Firefox for Mobile" in the app menu. You should end up at the Firefox for Mobile page, rather than Firefox desktop.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
