### PR TITLE
Align UI with updated API

### DIFF
--- a/frontend/__mocks__/hooks/api/profile.ts
+++ b/frontend/__mocks__/hooks/api/profile.ts
@@ -31,7 +31,7 @@ export function getMockProfileData(profileData?: MockData): ProfileData {
     emails_blocked: 0,
     emails_forwarded: 0,
     emails_replied: 0,
-    num_level_one_trackers_blocked_in_deleted_address: 0,
+    level_one_trackers_blocked: 0,
     ...profileData,
   };
 }

--- a/frontend/src/apiMocks/mockData.ts
+++ b/frontend/src/apiMocks/mockData.ts
@@ -51,7 +51,7 @@ export const profiles: Record<typeof mockIds[number], ProfileData> = {
     emails_blocked: 0,
     emails_forwarded: 0,
     emails_replied: 0,
-    num_level_one_trackers_blocked_in_deleted_address: 0,
+    level_one_trackers_blocked: 0,
   },
   onboarding: {
     api_token: "onboarding",
@@ -68,7 +68,7 @@ export const profiles: Record<typeof mockIds[number], ProfileData> = {
     emails_blocked: 0,
     emails_forwarded: 0,
     emails_replied: 0,
-    num_level_one_trackers_blocked_in_deleted_address: 0,
+    level_one_trackers_blocked: 0,
   },
   some: {
     api_token: "some",
@@ -85,7 +85,7 @@ export const profiles: Record<typeof mockIds[number], ProfileData> = {
     emails_blocked: 424284,
     emails_forwarded: 1337,
     emails_replied: 40,
-    num_level_one_trackers_blocked_in_deleted_address: 72,
+    level_one_trackers_blocked: 72,
   },
   full: {
     api_token: "full",
@@ -102,7 +102,7 @@ export const profiles: Record<typeof mockIds[number], ProfileData> = {
     emails_blocked: 848526,
     emails_forwarded: 1337,
     emails_replied: 9631,
-    num_level_one_trackers_blocked_in_deleted_address: 1409,
+    level_one_trackers_blocked: 1409,
   },
 };
 export const relayaddresses: Record<typeof mockIds[number], RandomAliasData[]> =

--- a/frontend/src/components/dashboard/aliases/Alias.tsx
+++ b/frontend/src/components/dashboard/aliases/Alias.tsx
@@ -26,6 +26,8 @@ import { getLocale } from "../../../functions/getLocale";
 import { BlockLevel, BlockLevelSlider } from "./BlockLevelSlider";
 import { RuntimeData } from "../../../hooks/api/runtimeData";
 import { HideIcon } from "../../Icons";
+import { isFlagActive } from "../../../functions/waffle";
+import { runtimeData } from "../../../apiMocks/mockData";
 
 export type Props = {
   alias: AliasData;
@@ -232,6 +234,7 @@ export const Alias = (props: Props) => {
 type StatsProps = {
   alias: AliasData;
   profile: ProfileData;
+  runtimeData?: RuntimeData;
 };
 const Stats = (props: StatsProps) => {
   const { l10n } = useLocalization();
@@ -275,16 +278,19 @@ const Stats = (props: StatsProps) => {
         If the back-end does not yet support providing tracker blocking stats,
         hide the blocked trackers count:
        */}
-      {typeof props.alias.num_level_one_trackers_blocked === "number" && (
-        <TrackersRemovedTooltip>
-          <span className={styles.number}>
-            {numberFormatter.format(props.alias.num_level_one_trackers_blocked)}
-          </span>
-          <span className={styles.label}>
-            {l10n.getString("profile-label-trackers-removed")}
-          </span>
-        </TrackersRemovedTooltip>
-      )}
+      {isFlagActive(runtimeData, "tracker_removal") &&
+        typeof props.alias.num_level_one_trackers_blocked === "number" && (
+          <TrackersRemovedTooltip>
+            <span className={styles.number}>
+              {numberFormatter.format(
+                props.alias.num_level_one_trackers_blocked
+              )}
+            </span>
+            <span className={styles.label}>
+              {l10n.getString("profile-label-trackers-removed")}
+            </span>
+          </TrackersRemovedTooltip>
+        )}
     </div>
   );
 };

--- a/frontend/src/hooks/api/profile.ts
+++ b/frontend/src/hooks/api/profile.ts
@@ -17,7 +17,7 @@ export type ProfileData = {
   emails_blocked: number;
   emails_forwarded: number;
   emails_replied: number;
-  num_level_one_trackers_blocked_in_deleted_address: number;
+  level_one_trackers_blocked: number;
 };
 
 export type ProfilesData = [ProfileData];

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -290,16 +290,13 @@ const Profile: NextPage = () => {
           {/*
             Only show tracker blocking stats if the back-end provides them:
           */}
-          {typeof profile.num_level_one_trackers_blocked_in_deleted_address ===
-            "number" && (
+          {typeof profile.level_one_trackers_blocked === "number" && (
             <div className={styles.stat}>
               <dt className={styles.label}>
                 {l10n.getString("profile-stat-label-trackers-removed")}
               </dt>
               <dd className={styles.value}>
-                {numberFormatter.format(
-                  profile.num_level_one_trackers_blocked_in_deleted_address
-                )}
+                {numberFormatter.format(profile.level_one_trackers_blocked)}
                 <StatExplainer>
                   <p>
                     {l10n.getString(

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -51,6 +51,7 @@ import { InfoTooltip } from "../../components/InfoTooltip";
 import { AddonData } from "../../components/dashboard/AddonData";
 import { useAddonData } from "../../hooks/addon";
 import { CloseIcon } from "../../components/Icons";
+import { isFlagActive } from "../../functions/waffle";
 
 const Profile: NextPage = () => {
   const runtimeData = useRuntimeData();
@@ -290,28 +291,29 @@ const Profile: NextPage = () => {
           {/*
             Only show tracker blocking stats if the back-end provides them:
           */}
-          {typeof profile.level_one_trackers_blocked === "number" && (
-            <div className={styles.stat}>
-              <dt className={styles.label}>
-                {l10n.getString("profile-stat-label-trackers-removed")}
-              </dt>
-              <dd className={styles.value}>
-                {numberFormatter.format(profile.level_one_trackers_blocked)}
-                <StatExplainer>
-                  <p>
-                    {l10n.getString(
-                      "profile-stat-label-trackers-learn-more-part1"
-                    )}
-                  </p>
-                  <p>
-                    {l10n.getString(
-                      "profile-stat-label-trackers-learn-more-part2"
-                    )}
-                  </p>
-                </StatExplainer>
-              </dd>
-            </div>
-          )}
+          {isFlagActive(runtimeData.data, "tracker_removal") &&
+            typeof profile.level_one_trackers_blocked === "number" && (
+              <div className={styles.stat}>
+                <dt className={styles.label}>
+                  {l10n.getString("profile-stat-label-trackers-removed")}
+                </dt>
+                <dd className={styles.value}>
+                  {numberFormatter.format(profile.level_one_trackers_blocked)}
+                  <StatExplainer>
+                    <p>
+                      {l10n.getString(
+                        "profile-stat-label-trackers-learn-more-part1"
+                      )}
+                    </p>
+                    <p>
+                      {l10n.getString(
+                        "profile-stat-label-trackers-learn-more-part2"
+                      )}
+                    </p>
+                  </StatExplainer>
+                </dd>
+              </div>
+            )}
         </dl>
       </div>
     </section>


### PR DESCRIPTION
`num_level_one_trackers_blocked_in_deleted_address` will be called
 `level_one_trackers_blocked`. Additionally, the stats are now only shown if that flag is on, to ensure the API can start exposing those properties without actually implementing the counts yet.

@say-yawn Could you test them? I don't have the proper API endpoints available yet locally, so I'm just assuming that the code is OK. (It's pretty simple.)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
