### PR TITLE
Allow periods in custom mask addresses

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -558,7 +558,7 @@ def check_user_can_make_another_address(user):
 def valid_address_pattern(address):
     #   can't start or end with a hyphen
     #   must be 1-63 lowercase alphanumeric characters and/or hyphens
-    valid_address_pattern = re.compile("^(?!-)[a-z0-9-]{1,63}(?<!-)$")
+    valid_address_pattern = re.compile("^(?![-.])[a-z0-9-.]{1,63}(?<![-.])$")
     return valid_address_pattern.match(address) is not None
 
 

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -152,6 +152,7 @@ class MiscEmailModelsTest(TestCase):
     def test_valid_address_pattern_is_valid(self):
         assert valid_address_pattern("foo")
         assert valid_address_pattern("foo-bar")
+        assert valid_address_pattern("foo.bar")
         assert valid_address_pattern("f00bar")
         assert valid_address_pattern("123foo")
         assert valid_address_pattern("123")
@@ -160,6 +161,8 @@ class MiscEmailModelsTest(TestCase):
         assert not valid_address_pattern("-")
         assert not valid_address_pattern("-foo")
         assert not valid_address_pattern("foo-")
+        assert not valid_address_pattern(".foo")
+        assert not valid_address_pattern("foo.")
         assert not valid_address_pattern("foo bar")
         assert not valid_address_pattern("Foo")
 

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -105,6 +105,7 @@ fx-containers = { -brand-name-firefox } Containers
 
 modal-custom-alias-picker-form-prefix-spaces-warning = Spaces are not allowed in email masks.
 modal-custom-alias-picker-form-prefix-invalid-warning = Email masks can only contain lowercase letters, numbers, and hyphens, and may not start or end with a hyphen.
+modal-custom-alias-picker-form-prefix-invalid-warning-2 = Email masks can only contain lowercase letters, numbers, periods, and hyphens, and may not start or end with a period or hyphen.
 
 ## Phone Page
 

--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.test.tsx
@@ -4,7 +4,7 @@ describe("getAddressValidationMessage", () => {
   it("returns `null` for valid addresses", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockL10n = { getString: jest.fn() } as any;
-    expect(getAddressValidationMessage("valid-address", mockL10n)).toBeNull();
+    expect(getAddressValidationMessage("a.valid-address", mockL10n)).toBeNull();
   });
 
   it("returns `null` for valid single-character addresses", () => {
@@ -39,7 +39,7 @@ describe("getAddressValidationMessage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     expect(getAddressValidationMessage("π", mockL10n)).toBe(
-      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning"
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2"
     );
   });
 
@@ -49,7 +49,7 @@ describe("getAddressValidationMessage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     expect(getAddressValidationMessage("Invalid-address", mockL10n)).toBe(
-      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning"
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2"
     );
   });
 
@@ -59,7 +59,7 @@ describe("getAddressValidationMessage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     expect(getAddressValidationMessage("-invalid-address", mockL10n)).toBe(
-      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning"
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2"
     );
   });
 
@@ -69,7 +69,27 @@ describe("getAddressValidationMessage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     expect(getAddressValidationMessage("invalid-address-", mockL10n)).toBe(
-      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning"
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2"
+    );
+  });
+
+  it("returns a generic validation message when starting with a period", () => {
+    const mockL10n = {
+      getString: jest.fn((id: string) => `String ID: ${id}`),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    expect(getAddressValidationMessage(".invalid.address", mockL10n)).toBe(
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2"
+    );
+  });
+
+  it("returns a generic validation message when ending in a period", () => {
+    const mockL10n = {
+      getString: jest.fn((id: string) => `String ID: ${id}`),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    expect(getAddressValidationMessage("invalid.address.", mockL10n)).toBe(
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2"
     );
   });
 
@@ -79,7 +99,7 @@ describe("getAddressValidationMessage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     expect(getAddressValidationMessage("-", mockL10n)).toBe(
-      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning"
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2"
     );
   });
 });

--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
@@ -233,7 +233,7 @@ export function getAddressValidationMessage(
   //
   //   (...)?     followed by zero or one of:
   //
-  //              [a-z0-9-]{0,61}  zero up to 61 lowercase letters, numbers, or hyphens, and
+  //              [a-z0-9-.]{0,61} zero up to 61 lowercase letters, numbers, hyphens, or periods, and
   //              [a-z0-9]         a lowercase letter or number (but not a hyphen),
   //
   //   $          and nothing following that.
@@ -241,9 +241,9 @@ export function getAddressValidationMessage(
   // All that combines to 1-63 lowercase characters, numbers, or hyphens,
   // but not starting or ending with a hyphen, aligned with the backend's
   // validation (`valid_address_pattern` in emails/models.py).
-  if (!/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/.test(address)) {
+  if (!/^[a-z0-9]([a-z0-9-.]{0,61}[a-z0-9])?$/.test(address)) {
     return l10n.getString(
-      "modal-custom-alias-picker-form-prefix-invalid-warning"
+      "modal-custom-alias-picker-form-prefix-invalid-warning-2"
     );
   }
   return null;


### PR DESCRIPTION
This PR fixes MPP-1269, and follows up on #2085 and #2086 to also allow for periods in custom mask addresses.

How to test: create a custom mask with a period in the address. You should not get an error. (**Note:** "period" is a blocked word, so don't use that in your mask name :unamused: )

- [x] l10n changes have been submitted to the l10n repository, if any. https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/94
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
