### PR TITLE
Use consistent size for tracker blocking icon

### DIFF
--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -49,6 +49,7 @@ $trackerRemovalIndicatorWidth: 20px;
     color: $color-grey-30;
     display: flex;
     align-items: center;
+    padding: 0 $spacing-xs;
   }
 
   $arrowWidth: 6px;


### PR DESCRIPTION
Different browsers have different default paddings for buttons,
resulting in the "eye" icon having different sizes in different
browsers.

This PR fixes #2235.

How to test: open the dashboard in Chrome, with tracker removal enabled. The eye icon should be the same size as in Firefox.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. N/A, styling change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
