### PR TITLE
MPP-2062 Fast follow

### DIFF
--- a/emails/apps.py
+++ b/emails/apps.py
@@ -25,7 +25,6 @@ def get_trackers(category="Email"):
         for _, resources in entity.items():
             for _, domains in resources.items():
                 trackers.extend(domains)
-    # when storing use a tuple so it's not mutable
     return trackers
 
 

--- a/emails/models.py
+++ b/emails/models.py
@@ -315,9 +315,11 @@ class Profile(models.Model):
     @property
     def level_one_trackers_blocked(self):
         return (
-            sum(ra.num_level_one_trackers_blocked for ra in self.relay_addresses)
-            + sum(da.num_level_one_trackers_blocked for da in self.domain_addresses)
-            + self.num_level_one_trackers_blocked_in_deleted_address
+            sum(ra.num_level_one_trackers_blocked or 0 for ra in self.relay_addresses)
+            + sum(
+                da.num_level_one_trackers_blocked or 0 for da in self.domain_addresses
+            )
+            + (self.num_level_one_trackers_blocked_in_deleted_address or 0)
         )
 
     @property
@@ -529,9 +531,9 @@ class RelayAddress(models.Model):
         profile.num_address_deleted += 1
         profile.num_email_forwarded_in_deleted_address += self.num_forwarded
         profile.num_email_blocked_in_deleted_address += self.num_blocked
-        profile.num_level_one_trackers_blocked_in_deleted_address += (
-            self.num_level_one_trackers_blocked
-        )
+        profile.num_level_one_trackers_blocked_in_deleted_address = (
+            profile.num_level_one_trackers_blocked_in_deleted_address or 0
+        ) + (self.num_level_one_trackers_blocked or 0)
         profile.num_email_replied_in_deleted_address += self.num_replied
         profile.num_email_spam_in_deleted_address += self.num_spam
         profile.save()
@@ -707,9 +709,9 @@ class DomainAddress(models.Model):
         profile.num_address_deleted += 1
         profile.num_email_forwarded_in_deleted_address += self.num_forwarded
         profile.num_email_blocked_in_deleted_address += self.num_blocked
-        profile.num_level_one_trackers_blocked_in_deleted_address += (
-            self.num_level_one_trackers_blocked
-        )
+        profile.num_level_one_trackers_blocked_in_deleted_address = (
+            profile.num_level_one_trackers_blocked_in_deleted_address or 0
+        ) + (self.num_level_one_trackers_blocked or 0)
         profile.num_email_replied_in_deleted_address += self.num_replied
         profile.num_email_spam_in_deleted_address += self.num_spam
         profile.save()

--- a/emails/views.py
+++ b/emails/views.py
@@ -595,7 +595,9 @@ def _sns_message(message_json):
                 f"{settings.SITE_ORIGIN}/tracker-report/#"
                 + json.dumps(tracker_report_details)
             )
-            address.num_level_one_trackers_blocked += removed_count
+            address.num_level_one_trackers_blocked = (
+                address.num_level_one_trackers_blocked or 0
+            ) + removed_count
             address.save()
 
         wrapped_html = wrap_html_email(


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR is a fast follow for #2232 to ensure that DB migration does not cause error when the email tracker fields return a null-able value. 

How to test:

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
