### PR TITLE
Add API mocks for the /realphone/ API

### DIFF
--- a/frontend/src/apiMocks/mockData.ts
+++ b/frontend/src/apiMocks/mockData.ts
@@ -1,4 +1,5 @@
 import { CustomAliasData, RandomAliasData } from "../hooks/api/aliases";
+import { RealPhoneData } from "../hooks/api/phone";
 import { ProfileData } from "../hooks/api/profile";
 import { RuntimeData } from "../hooks/api/runtimeData";
 import { UserData } from "../hooks/api/user";
@@ -28,6 +29,7 @@ export const mockedRuntimeData: RuntimeData = {
   WAFFLE_FLAGS: [
     ["new_from_address", true],
     ["tracker_removal", true],
+    ["phones", true],
   ],
 };
 
@@ -234,6 +236,31 @@ export const mockedDomainaddresses: Record<
       num_level_one_trackers_blocked: 1337,
       mask_type: "custom",
       used_on: "",
+    },
+  ],
+};
+
+export const mockedRealphones: Record<typeof mockIds[number], RealPhoneData> = {
+  empty: [],
+  onboarding: [],
+  some: [
+    {
+      id: 0,
+      number: "+14155552671",
+      verification_code: "123456",
+      verification_sent_date: "2022-07-27T10:17:29.775Z",
+      verified: true,
+      verified_date: "2022-07-27T10:18:01.801Z",
+    },
+  ],
+  full: [
+    {
+      id: 0,
+      number: "+14155552671",
+      verification_code: "123456",
+      verification_sent_date: "2022-07-27T10:17:29.775Z",
+      verified: true,
+      verified_date: "2022-07-27T10:18:01.801Z",
     },
   ],
 };

--- a/frontend/src/hooks/api/phone.ts
+++ b/frontend/src/hooks/api/phone.ts
@@ -71,7 +71,8 @@ export function useRealPhonesData(): SWRResponse<RealPhoneData, unknown> & {
   requestPhoneVerification: PhoneNumberRequestVerificationFn;
   submitPhoneVerification: PhoneNumberSubmitVerificationFn;
 } {
-  const realphone: SWRResponse<RealPhoneData, unknown> = useApiV1("/realphone");
+  const realphone: SWRResponse<RealPhoneData, unknown> =
+    useApiV1("/realphone/");
 
   /**
    * Submit the one-time password given from the requestPhoneVerification function * to confirm/register a real phone number


### PR DESCRIPTION
# New feature description

To familiarise myself with the phones API, and to make it easier for me to test if I don't manage to set up the full end-to-end phone infra, I thought I'd initialise the phone API mocks.

I've set them up so that the `onboarding` user has just purchased `phones`, but has otherwise not set it up yet. Any verification code will be accepted, and as soon as you submit a real number, it will pretend the verification code has been sent 4:40 m ago (so if you want to test what happens when it expires, you'll only need to wait 20 seconds).

The `some` and `full` users will just have one confirmed real number.

Additionally, I enabled the flag in the mocked `runtimeData`.

# Screenshot (if applicable)

Not applicable.

# How to test

Run `npm run dev:mocked`, and test the phone UI with the `empty` user (should see prompt to upgrade), the `onboarding` user (should be able to go through the in-progress onboarding flow) and the `full` user (should see the TODO for the phone dashboard).

# Checklist

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met. N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
