### PR TITLE
fix MPP-2227: set voice_application_sid for relay number

### DIFF
--- a/phones/models.py
+++ b/phones/models.py
@@ -175,6 +175,7 @@ class RelayNumber(models.Model):
         incoming_number = client.incoming_phone_numbers.create(
             phone_number=self.number,
             sms_application_sid=settings.TWILIO_SMS_APPLICATION_SID,
+            voice_application_sid=settings.TWILIO_SMS_APPLICATION_SID
         )
         return super().save(*args, **kwargs)
 

--- a/phones/tests/models_tests.py
+++ b/phones/tests/models_tests.py
@@ -197,6 +197,7 @@ def test_create_relaynumber_when_user_already_has_one_raises_error(
     call_kwargs = mock_number_create.call_args.kwargs
     assert call_kwargs["phone_number"] == relay_number
     assert call_kwargs["sms_application_sid"] == settings.TWILIO_SMS_APPLICATION_SID
+    assert call_kwargs["voice_application_sid"] == settings.TWILIO_SMS_APPLICATION_SID
 
     mock_messages_create.assert_called_once()
     call_kwargs = mock_messages_create.call_args.kwargs
@@ -234,6 +235,7 @@ def test_create_relaynumber_creates_twilio_incoming_number_and_sends_welcome(
     call_kwargs = mock_number_create.call_args.kwargs
     assert call_kwargs["phone_number"] == relay_number
     assert call_kwargs["sms_application_sid"] == settings.TWILIO_SMS_APPLICATION_SID
+    assert call_kwargs["voice_application_sid"] == settings.TWILIO_SMS_APPLICATION_SID
 
     mock_messages_create.assert_called_once()
     call_kwargs = mock_messages_create.call_args.kwargs


### PR DESCRIPTION
This PR fixes #MPP-2227.

How to test:

Since testing requires buying a relay number, probably best to test this on the dev server, where Mozilla is paying for the numbers. ;)

1. Buy a Relay Number
2. Make a call to the relay number
   * [x] The call should forward to the real phone

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).