### PR TITLE
Add a database default for relaynumber.enabled

### DIFF
--- a/phones/migrations/0017_relaynumber_enabled.py
+++ b/phones/migrations/0017_relaynumber_enabled.py
@@ -3,16 +3,66 @@
 from django.db import migrations, models
 
 
+def add_db_default_forward_func(apps, schema_editor):
+    """
+    Add a database default of TRUE for enabled, for PostgreSQL and SQLite3
+
+    Using `./manage.py sqlmigrate` for the SQL, and the technique from:
+    https://stackoverflow.com/a/45232678/10612
+    """
+    if schema_editor.connection.vendor.startswith("postgres"):
+        schema_editor.execute(
+            'ALTER TABLE "phones_relaynumber"'
+            ' ALTER COLUMN "enabled" SET DEFAULT true;'
+        )
+    elif schema_editor.connection.vendor.startswith("sqlite"):
+        schema_editor.execute(
+            'CREATE TABLE "new__phones_relaynumber"'
+            ' ("id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,'
+            ' "enabled" bool NOT NULL DEFAULT 1,'
+            ' "number" varchar(15) NOT NULL,'
+            ' "location" varchar(255) NOT NULL,'
+            ' "user_id" integer NOT NULL REFERENCES "auth_user" ("id")'
+            " DEFERRABLE INITIALLY DEFERRED,"
+            ' "vcard_lookup_key" varchar(6) NOT NULL UNIQUE);'
+        )
+        schema_editor.execute(
+            'INSERT INTO "new__phones_relaynumber"'
+            ' ("id", "number", "location", "user_id", "vcard_lookup_key", "enabled")'
+            ' SELECT "id", "number", "location", "user_id", "vcard_lookup_key", 1'
+            ' FROM "phones_relaynumber";'
+        )
+        schema_editor.execute('DROP TABLE "phones_relaynumber";')
+        schema_editor.execute(
+            'ALTER TABLE "new__phones_relaynumber" RENAME TO "phones_relaynumber";'
+        )
+        schema_editor.execute(
+            'CREATE INDEX "phones_relaynumber_number_742e5d6b" ON "phones_relaynumber"'
+            ' ("number");'
+        )
+        schema_editor.execute(
+            'CREATE INDEX "phones_relaynumber_user_id_62c65ede" ON "phones_relaynumber"'
+            ' ("user_id");'
+        )
+    else:
+        raise Exception(f'Unknown database vendor "{schema_editor.connection.vendor}"')
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('phones', '0016_alter_relaynumber_number'),
+        ("phones", "0016_alter_relaynumber_number"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='relaynumber',
-            name='enabled',
+            model_name="relaynumber",
+            name="enabled",
             field=models.BooleanField(default=True),
+        ),
+        migrations.RunPython(
+            code=add_db_default_forward_func,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
         ),
     ]


### PR DESCRIPTION
With a database-enabled default value, the existing v3.6.1 code will continue to work during the period when this migration is run and the new release is not fully deployed.

Tested locally with sqlite3 3.37.0 and PostgreSQL 14.4. CircleCI will run tests against both.