### PR TITLE
Fix ServerStorageCleaner report when no issues

### DIFF
--- a/emails/cleaners.py
+++ b/emails/cleaners.py
@@ -127,7 +127,7 @@ class ServerStorageCleaner(CleanerTask):
             )
 
             cleaned = counts.get("cleaned")
-            if cleaned is None:
+            if cleaned is None or has_data == 0:
                 return lines
             lines.append(f"        Cleaned: {self._as_percent(cleaned, has_data)}")
             return lines

--- a/emails/tests/cleaners_tests.py
+++ b/emails/tests/cleaners_tests.py
@@ -187,6 +187,11 @@ Domain Addresses:
       Has Data: 0 (  0.0%)"""
     assert report == expected
 
+    # Clean the data, report is the same
+    assert cleaner.clean() == 0
+    report2 = cleaner.markdown_report()
+    assert report2 == expected
+
 
 @pytest.mark.django_db
 def test_server_storage_cleaner_some_data_to_clear() -> None:


### PR DESCRIPTION
Test and fix an error when ServerStorageCleaner runs in `--clean` mode, but there is nothing to clean, and the verbose report (`-v 2`) is requested. Previously, an exception would be raised to avoid a divide-by-zero error when calculating (rows cleaned / rows needing cleaning), where both were zero.