### PR TITLE
Add SENTRY_DEBUG config

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -6,6 +6,7 @@ BASKET_ORIGIN="https://basket-dev.allizom.org"
 SECRET_KEY=unsafe-secret-key-for-dev-envs
 ADMIN_ENABLED=
 DEBUG=True
+SENTRY_DEBUG=False
 DJANGO_INTERNAL_IPS=127.0.0.1, localhost
 RELAY_FIREFOX_DOMAIN="relay.firefox.com"
 MOZMAIL_DOMAIN="mozmail.com"

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -691,10 +691,11 @@ elif (
 ):
     sentry_release = f"{CIRCLE_BRANCH}:{CIRCLE_SHA1}"
 
+SENTRY_DEBUG = config("SENTRY_DEBUG", DEBUG, cast=bool)
 sentry_sdk.init(
     dsn=config("SENTRY_DSN", None),
     integrations=[DjangoIntegration()],
-    debug=DEBUG,
+    debug=SENTRY_DEBUG,
     with_locals=DEBUG,
     release=sentry_release,
 )


### PR DESCRIPTION
Add `SENTRY_DEBUG` config that defaults to the same value as `DEBUG`.

Set `SENTRY_DEBUG=False` in your `.env` if you are done watching the Sentry debug output:

```
 [sentry] DEBUG: Setting up integrations (with default = True)
 [sentry] DEBUG: Did not import default integration sentry_sdk.integrations.flask.FlaskIntegration: Flask is not installed
 [sentry] DEBUG: Did not import default integration sentry_sdk.integrations.bottle.BottleIntegration: Bottle not installed
 [sentry] DEBUG: Did not import default integration sentry_sdk.integrations.falcon.FalconIntegration: Falcon not installed
 [sentry] DEBUG: Did not import default integration sentry_sdk.integrations.sanic.SanicIntegration: Sanic not installed
 [sentry] DEBUG: Did not import default integration sentry_sdk.integrations.celery.CeleryIntegration: Celery not installed
 [sentry] DEBUG: Did not import default integration sentry_sdk.integrations.rq.RqIntegration: RQ not installed
 [sentry] DEBUG: Did not import default integration sentry_sdk.integrations.aiohttp.AioHttpIntegration: AIOHTTP not installed
 [sentry] DEBUG: Did not import default integration sentry_sdk.integrations.tornado.TornadoIntegration: Tornado not installed
 [sentry] DEBUG: Did not import default integration sentry_sdk.integrations.sqlalchemy.SqlalchemyIntegration: SQLAlchemy not installed.
 [sentry] DEBUG: Did not import default integration sentry_sdk.integrations.pyramid.PyramidIntegration: Pyramid not installed
 [sentry] DEBUG: Setting up previously not enabled integration django
 [sentry] DEBUG: Setting up previously not enabled integration logging
 [sentry] DEBUG: Setting up previously not enabled integration stdlib
 [sentry] DEBUG: Setting up previously not enabled integration excepthook
 [sentry] DEBUG: Setting up previously not enabled integration dedupe
 [sentry] DEBUG: Setting up previously not enabled integration atexit
 [sentry] DEBUG: Setting up previously not enabled integration modules
 [sentry] DEBUG: Setting up previously not enabled integration argv
 [sentry] DEBUG: Setting up previously not enabled integration threading
 [sentry] DEBUG: Setting up previously not enabled integration redis
 [sentry] DEBUG: Setting up previously not enabled integration boto3
 [sentry] DEBUG: Enabling integration django
 [sentry] DEBUG: Enabling integration logging
 [sentry] DEBUG: Enabling integration stdlib
 [sentry] DEBUG: Enabling integration excepthook
 [sentry] DEBUG: Enabling integration dedupe
 [sentry] DEBUG: Enabling integration atexit
 [sentry] DEBUG: Enabling integration modules
 [sentry] DEBUG: Enabling integration argv
 [sentry] DEBUG: Enabling integration threading
 [sentry] DEBUG: Enabling integration redis
 [sentry] DEBUG: Enabling integration boto3
```