### PR TITLE
Update Tracker Removal release date in News

### DIFF
--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -312,8 +312,8 @@ export const WhatsNewMenu = (props: Props) => {
     ),
     announcementDate: {
       year: 2022,
-      month: 6,
-      day: 23,
+      month: 8,
+      day: 3,
     },
   };
   // Only show its announcement if tracker removal is live:


### PR DESCRIPTION
We'd initially planned this to be released earlier, but since it's now more than 30 days later than that original date, the announcement is automatically moved to the History menu.

How to test: with tracker removal enabled, visit the dashboard. If you've never clicked the news announcement in the history tab, it should now show up under the new items. (If you _have_ clicked it before, delete the cookie `whatsnew-feature_tracker-removal-<profile_id>_dismissed` first.)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
