### PR TITLE
Recruit new interview participants

### DIFF
--- a/frontend/src/components/layout/topmessage/InterviewRecruitment.tsx
+++ b/frontend/src/components/layout/topmessage/InterviewRecruitment.tsx
@@ -1,51 +1,29 @@
 import { useLocalization } from "@fluent/react";
 import { event as gaEvent } from "react-ga";
 import styles from "./InterviewRecruitment.module.scss";
-import { ProfileData } from "../../../hooks/api/profile";
 import { CloseIcon } from "../../Icons";
 import { useLocalDismissal } from "../../../hooks/localDismissal";
-import { useRuntimeData } from "../../../hooks/api/runtimeData";
 import { useGaViewPing } from "../../../hooks/gaViewPing";
-import { getLocale } from "../../../functions/getLocale";
-import { useRouter } from "next/router";
-
-export type Props = {
-  profile?: ProfileData;
-};
 
 /**
  * Ask people whether they're be interested in discussing their experience in using Relay.
  */
-export const InterviewRecruitment = (props: Props) => {
-  const router = useRouter();
+export const InterviewRecruitment = () => {
   const recruitmentLink =
-    "https://survey.alchemer-ca.com/s3/50148495/Mozilla-User-Research-2022-05";
+    "https://survey.alchemer.com/s3/6963482/Firefox-Relay-Research-Study-h2-2022";
+  // Only shown to English speakers, so unlocalised:
   const recruitmentLabel =
-    "We want to learn more about your experience with Firefox Relay. Research participants receive a $100 Amazon giftcard. Learn more.";
+    "Want to help improve Firefox Relay? We'd love to hear what you think. Research participants receive a $50 gift card.";
 
   const { l10n } = useLocalization();
-  const dismissal = useLocalDismissal("interview-recruitment-2022-05");
-  const runtimeData = useRuntimeData();
+  const dismissal = useLocalDismissal("interview-recruitment-2022-08");
   const linkRef = useGaViewPing({
     category: "Recruitment",
     label: recruitmentLabel,
   });
 
-  // Only show if...
-  if (
-    // ...the user is currently looking at the dashboard,
-    router.pathname !== "/accounts/profile" ||
-    // ...the user hasn't closed the recruitment banner before,
-    dismissal.isDismissed ||
-    // ...the user is logged in,
-    !props.profile ||
-    // ...the user is located in the Canada, Germany, France, the UK, or the US, and
-    !["ca", "de", "fr", "gb", "us"].includes(
-      runtimeData.data?.PREMIUM_PLANS.country_code ?? "not the user's country"
-    ) ||
-    // ...the user speaks English.
-    getLocale(l10n).split("-")[0] !== "en"
-  ) {
+  // Only show if the user hasn't closed the recruitment banner before:
+  if (dismissal.isDismissed) {
     return null;
   }
 
@@ -64,7 +42,6 @@ export const InterviewRecruitment = (props: Props) => {
         target="_blank"
         rel="noopener noreferrer"
       >
-        {/* Only shown to English speakers, so unlocalised: */}
         {recruitmentLabel}
       </a>
       <button

--- a/frontend/src/components/layout/topmessage/TopMessage.tsx
+++ b/frontend/src/components/layout/topmessage/TopMessage.tsx
@@ -1,9 +1,11 @@
+import { useLocalization } from "@fluent/react";
+import { useRouter } from "next/router";
 import { ProfileData } from "../../../hooks/api/profile";
 import { InterviewRecruitment } from "./InterviewRecruitment";
 import { CsatSurvey } from "./CsatSurvey";
-import { NpsSurvey } from "./NpsSurvey";
 import { RuntimeData } from "../../../hooks/api/runtimeData";
 import { isFlagActive } from "../../../functions/waffle";
+import { getLocale } from "../../../functions/getLocale";
 
 export type Props = {
   profile?: ProfileData;
@@ -11,13 +13,28 @@ export type Props = {
 };
 
 export const TopMessage = (props: Props) => {
-  if (isFlagActive(props.runtimeData, "interview_recruitment")) {
-    return <InterviewRecruitment profile={props.profile} />;
+  const { l10n } = useLocalization();
+  const router = useRouter();
+  if (
+    // Only show the Interview Recruitment banner if it's enabled,
+    isFlagActive(props.runtimeData, "interview_recruitment") &&
+    // ...the user is currently looking at the dashboard,
+    router.pathname === "/accounts/profile" &&
+    // ...the user is logged in,
+    props.profile &&
+    // ...the user is from the US, and...
+    ["us"].includes(
+      props.runtimeData?.PREMIUM_PLANS.country_code ?? "not the user's country"
+    ) &&
+    // ...the user speaks English:
+    getLocale(l10n).split("-")[0] === "en"
+  ) {
+    return <InterviewRecruitment />;
   }
 
   if (props.profile) {
     return <CsatSurvey profile={props.profile} />;
   }
 
-  return <NpsSurvey />;
+  return null;
 };


### PR DESCRIPTION
# New feature description

Note that I moved most of the logic to determine whether the
interview recruitment banner should be shown to people into
`<TopMessage>`; the advantage is that if it is not relevant to a
user, we can show the CSAT survey. (But we won't show the CSAT
survey if the user was shown the recruitment banner first;
that'd be a bit much.)

I also removed the NPS survey, since we never want to show that
any more.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/181739299-ac235162-0824-463d-b304-13888da6920d.png)

# How to test

With your browser language set to `en_US` and the `interview_recruitment` flag enabled, visit the dashboard. Note that this won't work on the mock site, since the mock data says that you're from the Netherlands :)

# Checklist

- [x] l10n changes have been submitted to the l10n repository, if any. - N/A, only shown to English speakers.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
