### PR TITLE
Phone refinements

### DIFF
--- a/frontend/__mocks__/hooks/api/realPhone.ts
+++ b/frontend/__mocks__/hooks/api/realPhone.ts
@@ -1,6 +1,5 @@
 import {
   VerifiedPhone,
-  VerificationPendingPhone,
   UnverifiedPhone,
   RealPhone,
   useRealPhonesData,
@@ -31,13 +30,13 @@ export function getMockVerifiedRealPhone(
 }
 
 export function getMockVerificationPendingRealPhone(
-  realPhone?: Partial<VerificationPendingPhone>
-): VerificationPendingPhone {
+  realPhone?: Partial<UnverifiedPhone>
+): UnverifiedPhone {
   return {
     id: 0,
     number: "+14155552671",
     verification_code: "123456",
-    verification_sent_date: "2022-07-27T10:17:29.775Z",
+    verification_sent_date: new Date().toISOString(),
     verified: false,
     verified_date: null,
     ...realPhone,
@@ -51,7 +50,7 @@ export function getMockUnverifiedRealPhone(
     id: 0,
     number: "+14155552671",
     verification_code: "123456",
-    verification_sent_date: null,
+    verification_sent_date: "2022-07-27T10:17:29.775Z",
     verified: false,
     verified_date: null,
     ...realPhone,

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -134,7 +134,19 @@ phone-onboarding-step2-button-cta = Send code
 phone-onboarding-step2-invalid-number = { $phone_number } is not a valid number. Please review and provide a real phone number.
 
 phone-onboarding-step3-headline = Verify your true phone number
-phone-onboarding-step3-body = Please enter the verification code that was sent to <span>{ $phone_number } </span> within <strong>{ $remaining_time } minutes</strong>.
+# Variables:
+#   $phone_number (string) - The phone number to which a verification code was sent, e.g. +1 (415) 555-2671
+#   $remaining_minutes (number) - The number of minutes (to be added to $remaining_seconds) left before the verification code expires
+#   $remaining_seconds (number) - The number of seconds (to be added to $remaining_minutes) left before the verification code expires
+phone-onboarding-step3-body =
+    { $remaining_minutes ->
+        [0] {$remaining_seconds ->
+            [1] Please enter the verification code that was sent to <span>{ $phone_number } </span> within <strong>{ $remaining_seconds } second</strong>.
+            *[other] Please enter the verification code that was sent to <span>{ $phone_number } </span> within <strong>{ $remaining_seconds } seconds</strong>.
+        }
+        *[other] Please enter the verification code that was sent to <span>{ $phone_number } </span> within <strong>{ $remaining_minutes }:{ NUMBER($remaining_seconds, minimumIntegerDigits: 2) } minutes</strong>.
+    }
+
 phone-onboarding-step3-input-placeholder = Enter 6-digit code
 phone-onboarding-step3-button-cta = Confirm my phone number
 phone-onboarding-step3-button-edit = Edit true phone number

--- a/frontend/src/apiMocks/handlers.ts
+++ b/frontend/src/apiMocks/handlers.ts
@@ -1,10 +1,6 @@
 import { rest, RestHandler, RestRequest } from "msw";
 import { CustomAliasData, RandomAliasData } from "../hooks/api/aliases";
-import {
-  UnverifiedPhone,
-  VerificationPendingPhone,
-  VerifiedPhone,
-} from "../hooks/api/realPhone";
+import { UnverifiedPhone, VerifiedPhone } from "../hooks/api/realPhone";
 import { RelayNumber } from "../hooks/api/relayNumber";
 import { ProfileData } from "../hooks/api/profile";
 import {
@@ -334,7 +330,7 @@ export function getHandlers(
       // Pretend the verification was sent 4:40m ago,
       // so expiry can easily be tested:
       const sentDate = Date.now() - 5 * 60 * 1000 + 20 * 1000;
-      const newVerificationPendingPhone: VerificationPendingPhone = {
+      const newVerificationPendingPhone: UnverifiedPhone = {
         id: mockedRealphones[mockId].length,
         number: body.number,
         verification_code: "123456",

--- a/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
+++ b/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
@@ -7,7 +7,6 @@ import { Button } from "../../Button";
 import {
   hasPendingVerification,
   UnverifiedPhone,
-  VerificationPendingPhone,
   PhoneNumberSubmitVerificationFn,
 } from "../../../hooks/api/realPhone";
 import {
@@ -20,7 +19,7 @@ import {
 import { parseDate } from "../../../functions/parseDate";
 
 type RealPhoneSetupProps = {
-  unverifiedRealPhones: Array<UnverifiedPhone | VerificationPendingPhone>;
+  unverifiedRealPhones: Array<UnverifiedPhone>;
   onRequestVerification: (numberToVerify: string) => void;
   onSubmitVerification: PhoneNumberSubmitVerificationFn;
 };
@@ -114,7 +113,7 @@ const RealPhoneForm = (props: RealPhoneFormProps) => {
 // If code is wrong, add is-error classes and update image/title
 // If code is correct, show successWhatsNext and  update image/title
 type RealPhoneVerificationProps = {
-  phonesPendingVerification: VerificationPendingPhone[];
+  phonesPendingVerification: UnverifiedPhone[];
   submitPhoneVerification: PhoneNumberSubmitVerificationFn;
   onGoBack: () => void;
 };
@@ -304,7 +303,7 @@ function formatPhone(phoneNumber: string) {
 }
 
 function getPhoneWithMostRecentlySentVerificationCode(
-  phones: VerificationPendingPhone[]
+  phones: UnverifiedPhone[]
 ) {
   const mostRecentVerifiedPhone = [...phones].sort((a, b) => {
     const sendDateA = parseDate(a.verification_sent_date).getTime();

--- a/frontend/src/hooks/api/realPhone.ts
+++ b/frontend/src/hooks/api/realPhone.ts
@@ -11,7 +11,7 @@ export type VerifiedPhone = {
   verified_date: DateString;
 };
 
-export type VerificationPendingPhone = {
+export type UnverifiedPhone = {
   id: number;
   number: string;
   verification_code: string;
@@ -20,19 +20,7 @@ export type VerificationPendingPhone = {
   verified_date: null;
 };
 
-export type UnverifiedPhone = {
-  id: number;
-  number: string;
-  verification_code: string;
-  verification_sent_date: null;
-  verified: false | undefined;
-  verified_date: null;
-};
-
-export type RealPhone =
-  | VerifiedPhone
-  | VerificationPendingPhone
-  | UnverifiedPhone;
+export type RealPhone = VerifiedPhone | UnverifiedPhone;
 
 export type RealPhoneData = Array<RealPhone>;
 
@@ -43,15 +31,13 @@ export function isVerified(phone: RealPhone): phone is VerifiedPhone {
   return phone.verified;
 }
 
-export function isNotVerified(
-  phone: RealPhone
-): phone is UnverifiedPhone | VerificationPendingPhone {
+export function isNotVerified(phone: RealPhone): phone is UnverifiedPhone {
   return !isVerified(phone);
 }
 
 export function hasPendingVerification(
   phone: RealPhone
-): phone is VerificationPendingPhone {
+): phone is UnverifiedPhone {
   // Short circuit logic if there's no verification sent yet,
   // or if the phone number has already been verified:
   if (


### PR DESCRIPTION
# New feature description

This adds a couple of unrelated refinements of the phone UI code, split up into separate commits:

- 0a1f1b055632265e10196b42a37ef3785fd82d8b: updating the "time remaining" string to allow localisers to localise the exact display of that, rather than formatting it ourselves regardless of locale.
- 3a932fa2cecf80a977e98e276e136c922fc68746: there were some uses of `useRef` that React [recommends against](https://reactjs.org/docs/refs-and-the-dom.html#dont-overuse-refs); this update makes it derive the desired classes from the application state.
- 58a2802a39fa1be2be12837ed996d8f660efcb50: removed the `VerificationPendingPhone` type (or actually, removing the `UnverifiedPhone` type and renaming `VerificationPendingPhone` to `UnverifiedPhone`), because it didn't properly represent back-end behaviour.

# Screenshot (if applicable)

Not applicable.

# How to test

Everything should work as it used to.

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any. - No, like the rest of the phone strings.
- [ ] All acceptance criteria are met. - N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
