### PR TITLE
Increase timeout for axe tests to reduce flakiness

### DIFF
--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -79,7 +79,7 @@ describe("The dashboard", () => {
       });
 
       expect(results).toHaveNoViolations();
-    });
+    }, 10000); // axe runs a suite of tests that can exceed the default 5s timeout, so we set it to 10s
 
     it("passes axe accessibility testing with the Premium user interface", async () => {
       // The label editor sets a timeout when submitted, which axe doesn't wait for.
@@ -93,7 +93,7 @@ describe("The dashboard", () => {
       });
 
       expect(results).toHaveNoViolations();
-    });
+    }, 10000); // axe runs a suite of tests that can exceed the default 5s timeout, so we set it to 10s
   });
 
   it("shows a count of the user's aliases for Premium users", () => {

--- a/frontend/src/pages/accounts/settings.test.tsx
+++ b/frontend/src/pages/accounts/settings.test.tsx
@@ -36,7 +36,7 @@ describe("The settings screen", () => {
       });
 
       expect(results).toHaveNoViolations();
-    });
+    }, 10000); // axe runs a suite of tests that can exceed the default 5s timeout, so we set it to 10s
   });
 
   it("shows a warning when the user currently has server-side label storage disabled", () => {

--- a/frontend/src/pages/faq.test.tsx
+++ b/frontend/src/pages/faq.test.tsx
@@ -26,6 +26,6 @@ describe("The page with Frequently Asked Questions", () => {
       });
 
       expect(results).toHaveNoViolations();
-    });
+    }, 10000); // axe runs a suite of tests that can exceed the default 5s timeout, so we set it to 10s
   });
 });

--- a/frontend/src/pages/index.test.tsx
+++ b/frontend/src/pages/index.test.tsx
@@ -26,6 +26,6 @@ describe("The landing page", () => {
       });
 
       expect(results).toHaveNoViolations();
-    });
+    }, 10000); // axe runs a suite of tests that can exceed the default 5s timeout, so we set it to 10s
   });
 });

--- a/frontend/src/pages/phone.test.tsx
+++ b/frontend/src/pages/phone.test.tsx
@@ -43,7 +43,7 @@ describe("The Phone dashboard", () => {
         });
 
         expect(results).toHaveNoViolations();
-      });
+      }, 10000); // axe runs a suite of tests that can exceed the default 5s timeout, so we set it to 10s
     });
   });
 
@@ -63,7 +63,7 @@ describe("The Phone dashboard", () => {
         });
 
         expect(results).toHaveNoViolations();
-      });
+      }, 10000); // axe runs a suite of tests that can exceed the default 5s timeout, so we set it to 10s
     });
   });
 });

--- a/frontend/src/pages/premium.test.tsx
+++ b/frontend/src/pages/premium.test.tsx
@@ -26,6 +26,6 @@ describe("The promotional page about Relay Premium", () => {
       });
 
       expect(results).toHaveNoViolations();
-    });
+    }, 10000); // axe runs a suite of tests that can exceed the default 5s timeout, so we set it to 10s
   });
 });

--- a/frontend/src/pages/premium/waitlist.test.tsx
+++ b/frontend/src/pages/premium/waitlist.test.tsx
@@ -65,7 +65,7 @@ describe("The waitlist", () => {
       });
 
       expect(results).toHaveNoViolations();
-    });
+    }, 10000); // axe runs a suite of tests that can exceed the default 5s timeout, so we set it to 10s
   });
 
   // Disabled since the upgrade to Jest 28; for some reason, the waitlist form's


### PR DESCRIPTION
I noticed that a bunch of accessibility tests are a bit flaky because they keep hitting the timeout:

![image](https://user-images.githubusercontent.com/4251/182828489-a0e24d36-86c9-41ca-8dad-4b752543045c.png)

```
FAIL src/pages/index.test.tsx (19.275 s)
  ● The landing page › under axe accessibility testing › passes axe accessibility testing

    thrown: "Exceeded timeout of 5000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."
```

Since the [axe](https://www.deque.com/axe/) accessibility tests run a suite of tests, it makes sense that they can take a bit longer, so I think increasing the timeout for them is fine.

# Checklist

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met. - N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
