### PR TITLE
Add clearer tracker removal breakage warnings

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -47,7 +47,7 @@ multi-part-onboarding-premium-chrome-extension-get-description-2 = The { -brand-
 setting-tracker-removal-heading = Remove Email Trackers
 setting-tracker-removal-description = Remove email trackers in all forwarded emails.
 setting-tracker-removal-note = { -brand-name-firefox-relay } can now remove common trackers from emails forwarded through your masks.
-setting-tracker-removal-warning = Important: Sometimes removing trackers may cause your email to look broken, because the trackers are often contained within images.
+setting-tracker-removal-warning-2 = Important: Removing trackers may cause your email to look broken, because trackers are often contained in images and links. Any emails you receive like this cannot be fixed or recovered.
 setting-api-key-copied = Copied!
 
 profile-promo-email-blocking-option-promotionals-premiumonly-marker = ({ -brand-name-premium } only)
@@ -203,11 +203,11 @@ profile-stat-learn-more-close = Close
 # This is displayed in small under a number in a large font indicating the number of trackers that have been removed from all emails sent to all of a user's masks
 profile-stat-label-trackers-removed = Trackers removed
 profile-stat-label-trackers-learn-more-part1 = Enabling tracker removal will remove common email trackers from your forwarded emails.
-profile-stat-label-trackers-learn-more-part2 = Important: Sometimes removing trackers may cause your email to look broken, because the trackers are often contained within images.
+profile-stat-label-trackers-learn-more-part2-2 = Important: Removing trackers may cause your email to look broken, because the trackers are often contained within images and links.
 # This is displayed in small under a number in a large font indicating the number of trackers that have been removed from all emails sent to a particular mask
 profile-label-trackers-removed = Trackers removed
 profile-trackers-removed-tooltip-part1 = With tracker removal enabled, common email trackers will be removed from your forwarded emails.
-profile-trackers-removed-tooltip-part2 = Important: Sometimes removing trackers may cause your email to look broken, because the trackers are often contained within images.
+profile-trackers-removed-tooltip-part2-2 = <b>Important:</b> Removing trackers may cause your email to look broken, because the trackers are often contained within images and links.
 # This is a button that, when clicked, will open a tooltip with profile-indicator-tracker-removal-tooltip ("Currently removing email trackers").
 profile-indicator-tracker-removal-alt = Tracker removal
 profile-indicator-tracker-removal-tooltip = Currently removing email trackers
@@ -242,7 +242,7 @@ trackerreport-removal-explainer-content = { -brand-name-firefox-relay } can now 
 trackerreport-trackers-explainer-heading = About email trackers
 trackerreport-trackers-explainer-content-part1 = Email tracking is a common surveillance and advertising tool that has taken over many inboxes. These trackers can be used to understand more about your online behavior, your interests, and your email activity.
 trackerreport-trackers-explainer-content-part2 = A company or organization will embed a tracker in emails sent to you, usually hidden within an image or a link. When the email is opened, code within the tracker sends data back to the company.
-trackerreport-breakage-warning = Important: Sometimes removing trackers may cause your email to look broken, because the trackers are often contained within images, which will not load if they contain a tracker.
+trackerreport-breakage-warning-2 = Important: Removing trackers may cause your email to look broken, because trackers are often contained in images and links. Any emails you receive like this cannot be fixed or recovered.
 trackerreport-faq-heading = Top questions about email trackers
 trackerreport-faq-cta = See more FAQs about { -brand-name-firefox-relay }
 trackerreport-loading = Loading your tracker removal report…
@@ -253,4 +253,4 @@ faq-question-disable-trackerremoval-answer = Yes. If you’re having trouble wit
 faq-question-bulk-trackerremoval-question = Can I remove trackers only on some of my email masks?
 faq-question-bulk-trackerremoval-answer = You can only turn tracker removal on at an account level—it either removes trackers from all of your emails, or none of them.
 faq-question-trackerremoval-breakage-question = Why do my emails look broken?
-faq-question-trackerremoval-breakage-answer = Sometimes removing trackers may cause your email to look broken, because the trackers are often contained within images. When the tracker is removed, the email looks like it’s been formatted wrong because images are missing. This can’t be fixed for emails you’ve already received. If this is preventing you from reading your emails properly, turn off tracker removal.
+faq-question-trackerremoval-breakage-answer-2 = Sometimes removing trackers may cause your email to look broken, because the trackers are often contained within images and links. When the tracker is removed, the email looks like it’s been formatted wrong because images are missing. This can’t be fixed for emails you’ve already received. If this is preventing you from reading your emails properly, turn off tracker removal.

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -196,7 +196,7 @@ whatsnew-feature-tracker-removal-heading = Introducing email tracker removal
 # When translating, please make sure the resulting string is of roughly similar
 # length as the English version.
 whatsnew-feature-tracker-removal-snippet = Now { -brand-name-relay } can remove common email trackers from emails forwarded…
-whatsnew-feature-tracker-removal-description = Now { -brand-name-relay } can remove common email trackers from emails forwarded to you, helping you stay invisible to advertisers.
+whatsnew-feature-tracker-removal-description-2 = Now { -brand-name-relay } can remove common email trackers from emails forwarded to you, helping you stay invisible to advertisers. Turn it on in “Settings.”
 
 profile-stat-learn-more = Learn more
 profile-stat-learn-more-close = Close

--- a/frontend/src/components/dashboard/aliases/Alias.tsx
+++ b/frontend/src/components/dashboard/aliases/Alias.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, ReactNode } from "react";
-import { useLocalization } from "@fluent/react";
+import { Localized, useLocalization } from "@fluent/react";
 import { useToggleState, useTooltipTriggerState } from "react-stately";
 import {
   mergeProps,
@@ -394,7 +394,14 @@ const TrackersRemovedTooltip = (props: TooltipProps) => {
           className={styles.tooltip}
         >
           <p>{l10n.getString("profile-trackers-removed-tooltip-part1")}</p>
-          <p>{l10n.getString("profile-trackers-removed-tooltip-part2")}</p>
+          <Localized
+            id="profile-trackers-removed-tooltip-part2-2"
+            elems={{
+              b: <b />,
+            }}
+          >
+            <p />
+          </Localized>
         </div>
       )}
     </div>

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -313,7 +313,7 @@ export const WhatsNewMenu = (props: Props) => {
     announcementDate: {
       year: 2022,
       month: 8,
-      day: 3,
+      day: 9,
     },
   };
   // Only show its announcement if tracker removal is live:

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -313,7 +313,7 @@ export const WhatsNewMenu = (props: Props) => {
     announcementDate: {
       year: 2022,
       month: 8,
-      day: 9,
+      day: 16,
     },
   };
   // Only show its announcement if tracker removal is live:

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -299,7 +299,7 @@ export const WhatsNewMenu = (props: Props) => {
     content: (
       <WhatsNewContent
         description={l10n.getString(
-          "whatsnew-feature-tracker-removal-description"
+          "whatsnew-feature-tracker-removal-description-2"
         )}
         heading={l10n.getString("whatsnew-feature-tracker-removal-heading")}
         image={TrackerRemovalHero.src}

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -307,7 +307,7 @@ const Profile: NextPage = () => {
                     </p>
                     <p>
                       {l10n.getString(
-                        "profile-stat-label-trackers-learn-more-part2"
+                        "profile-stat-label-trackers-learn-more-part2-2"
                       )}
                     </p>
                   </StatExplainer>

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -180,7 +180,7 @@ const Settings: NextPage = () => {
           </div>
           <div className={styles["field-warning"]}>
             <InfoTriangleIcon alt="" />
-            <p>{l10n.getString("setting-tracker-removal-warning")}</p>
+            <p>{l10n.getString("setting-tracker-removal-warning-2")}</p>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -36,7 +36,7 @@ const Faq: NextPage = () => {
           "faq-question-trackerremoval-breakage-question"
         )}
       >
-        <p>{l10n.getString("faq-question-trackerremoval-breakage-answer")}</p>
+        <p>{l10n.getString("faq-question-trackerremoval-breakage-answer-2")}</p>
       </QAndA>
     </>
   ) : null;

--- a/frontend/src/pages/tracker-report.page.tsx
+++ b/frontend/src/pages/tracker-report.page.tsx
@@ -162,7 +162,7 @@ const TrackerReport: NextPage = () => {
               </p>
               <div className={styles["breakage-warning"]}>
                 <InfoTriangleIcon alt="" />
-                {l10n.getString("trackerreport-breakage-warning")}
+                {l10n.getString("trackerreport-breakage-warning-2")}
               </div>
             </div>
           </div>
@@ -205,7 +205,7 @@ const TrackerReport: NextPage = () => {
                       "faq-question-trackerremoval-breakage-question"
                     ),
                     a: l10n.getString(
-                      "faq-question-trackerremoval-breakage-answer"
+                      "faq-question-trackerremoval-breakage-answer-2"
                     ),
                   },
                 ]}


### PR DESCRIPTION
This PR fixes MPP-2248. The news announcement ~~will also need an update, but I haven't received that string yet~~ has been updated as well.

How to test: look at the locations I screenshotted in [the l10n PR](https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/99#pullrequestreview-1061755644) - the text should be updated to mention trackers in images and links, and about how broken emails can't be recovered.

- [x] l10n changes have been submitted to the l10n repository, if any. - https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/99#pullrequestreview-1061755644
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
