### PR TITLE
First leg of Phone QA feedback incorporation

### DIFF
--- a/frontend/src/components/layout/navigation/Navigation.tsx
+++ b/frontend/src/components/layout/navigation/Navigation.tsx
@@ -38,17 +38,18 @@ export const Navigation = (props: Props) => {
   const homePath = isLoggedIn ? "/accounts/profile" : "/";
   const isPremiumPage = router.pathname === "/premium";
 
-  const phoneLink = isFlagActive(runtimeData.data, "phones") ? (
-    <Link href="/phone">
-      <a
-        className={`${styles.link} ${
-          router.pathname === "/phone" ? styles["is-active"] : null
-        }`}
-      >
-        {l10n.getString("nav-phone")}
-      </a>
-    </Link>
-  ) : null;
+  const phoneLink =
+    isLoggedIn && isFlagActive(runtimeData.data, "phones") ? (
+      <Link href="/phone">
+        <a
+          className={`${styles.link} ${
+            router.pathname === "/phone" ? styles["is-active"] : null
+          }`}
+        >
+          {l10n.getString("nav-phone")}
+        </a>
+      </Link>
+    ) : null;
 
   const ToggleButton = () => (
     <button

--- a/frontend/src/pages/phone.page.tsx
+++ b/frontend/src/pages/phone.page.tsx
@@ -4,7 +4,7 @@ import { useProfiles } from "../hooks/api/profile";
 import { useUsers } from "../hooks/api/user";
 import { PhoneOnboarding } from "../components/phones/onboarding/PhoneOnboarding";
 import { useRelayNumber } from "../hooks/api/relayNumber";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { PhoneDashboard } from "../components/phones/dashboard/Dashboard";
 import { getRuntimeConfig } from "../config";
 
@@ -16,9 +16,17 @@ const Phone: NextPage = () => {
   const user = userData.data?.[0];
 
   const relayNumberData = useRelayNumber();
-  const [isInOnboarding, setIsInOnboarding] = useState(
-    !relayNumberData.data || relayNumberData.data.length === 0
-  );
+  const [isInOnboarding, setIsInOnboarding] = useState<boolean>();
+
+  useEffect(() => {
+    if (
+      typeof isInOnboarding === "undefined" &&
+      Array.isArray(relayNumberData.data) &&
+      relayNumberData.data.length === 0
+    ) {
+      setIsInOnboarding(true);
+    }
+  }, [isInOnboarding, relayNumberData]);
 
   if (!userData.isValidating && userData.error) {
     document.location.assign(getRuntimeConfig().fxaLoginUrl);

--- a/frontend/src/pages/phone.page.tsx
+++ b/frontend/src/pages/phone.page.tsx
@@ -6,6 +6,7 @@ import { PhoneOnboarding } from "../components/phones/onboarding/PhoneOnboarding
 import { useRelayNumber } from "../hooks/api/relayNumber";
 import { useState } from "react";
 import { PhoneDashboard } from "../components/phones/dashboard/Dashboard";
+import { getRuntimeConfig } from "../config";
 
 const Phone: NextPage = () => {
   const profileData = useProfiles();
@@ -18,6 +19,10 @@ const Phone: NextPage = () => {
   const [isInOnboarding, setIsInOnboarding] = useState(
     !relayNumberData.data || relayNumberData.data.length === 0
   );
+
+  if (!userData.isValidating && userData.error) {
+    document.location.assign(getRuntimeConfig().fxaLoginUrl);
+  }
 
   if (!profile || !user || !relayNumberData.data) {
     // TODO: Show a loading spinner?


### PR DESCRIPTION
There's two changes in here:

- The link to the phone dashboard isn't shown when the user is not logged in, and if the user visits the URL while not logged in, they'll go to the login page (just like in `/accounts/profile/`).
- The dashboard is now properly shown when the user is done onboarding.

How to test:

- [ ] l10n changes have been submitted to the l10n repository, if any. - Will all be submitted later
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, I think?
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
