### PR TITLE
Enable only one alias to be expanded at a time; auto-expand only the newest alias 

### DIFF
--- a/frontend/src/components/dashboard/aliases/Alias.tsx
+++ b/frontend/src/components/dashboard/aliases/Alias.tsx
@@ -33,7 +33,8 @@ export type Props = {
   profile: ProfileData;
   onUpdate: (updatedFields: Partial<AliasData>) => void;
   onDelete: () => void;
-  defaultOpen?: boolean;
+  isOpen: boolean;
+  onChangeOpen: (isOpen: boolean) => void;
   showLabelEditor?: boolean;
   runtimeData?: RuntimeData;
 };
@@ -47,7 +48,8 @@ export const Alias = (props: Props) => {
 
   const expandButtonRef = useRef<HTMLButtonElement>(null);
   const expandButtonState = useToggleState({
-    defaultSelected: props.defaultOpen === true,
+    isSelected: props.isOpen === true,
+    onChange: props.onChangeOpen,
   });
   const expandButtonProps = useToggleButton(
     {},

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -42,7 +42,7 @@ export const AliasList = (props: Props) => {
   );
 
   useEffect(() => {
-    if (props.aliases.length == 0) {
+    if (props.aliases.length === 0) {
       setOpenAlias(undefined);
     } else {
       const existingAliasIds = existingAliases.map((alias) => alias.id);

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -49,7 +49,7 @@ export const AliasList = (props: Props) => {
       const newAliases = props.aliases.filter(
         (alias) => existingAliasIds.indexOf(alias.id) === -1
       );
-      if (newAliases.length != 0) {
+      if (newAliases.length !== 0) {
         setOpenAlias(newAliases[0]);
       }
     }

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -36,9 +36,6 @@ export const AliasList = (props: Props) => {
   const [stringFilterVisible, setStringFilterVisible] = useState(false);
   const [categoryFilters, setCategoryFilters] = useState<SelectedFilters>({});
   const [localLabels, storeLocalLabel] = useLocalLabels();
-  // Whenever a new alias is created, this value tracks the aliases that existed
-  // before that. That allows us to expand newly-created aliases by default.
-  const [existingAliases, setExistingAliases] = useState(props.aliases);
 
   if (props.aliases.length === 0) {
     return null;
@@ -69,7 +66,7 @@ export const AliasList = (props: Props) => {
     })
   );
 
-  const aliasCards = aliases.map((alias) => {
+  const aliasCards = aliases.map((alias, index) => {
     const onUpdate = (updatedFields: Partial<AliasData>) => {
       if (
         localLabels !== null &&
@@ -82,10 +79,6 @@ export const AliasList = (props: Props) => {
       return props.onUpdate(alias, updatedFields);
     };
 
-    const isExistingAlias = existingAliases.some(
-      (existingAlias) => existingAlias.id === alias.id
-    );
-
     return (
       <li
         className={styles["alias-card-wrapper"]}
@@ -97,7 +90,7 @@ export const AliasList = (props: Props) => {
           profile={props.profile}
           onUpdate={onUpdate}
           onDelete={() => props.onDelete(alias)}
-          defaultOpen={!isExistingAlias}
+          defaultOpen={index === 0}
           showLabelEditor={props.profile.server_storage || localLabels !== null}
           runtimeData={props.runtimeData}
         />
@@ -135,12 +128,6 @@ export const AliasList = (props: Props) => {
         <p className={styles["empty-state-message"]} />
       </Localized>
     ) : null;
-
-  const onCreate: typeof props.onCreate = (options) => {
-    setExistingAliases(props.aliases);
-
-    return props.onCreate(options);
-  };
 
   return (
     <section>
@@ -184,7 +171,7 @@ export const AliasList = (props: Props) => {
             aliases={props.aliases}
             profile={props.profile}
             runtimeData={props.runtimeData}
-            onCreate={onCreate}
+            onCreate={props.onCreate}
           />
         </div>
       </div>


### PR DESCRIPTION
This PR fixes #1743.

This PR fixes the issue as per the proposal in the comments of #1743 by @Vinnl.

# Checklist

- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
