### PR TITLE
MPP-79: Add .flake8 configuration, fix a few issues

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+
+# Recommend matching the black line length (default 88),
+# rather than using the flake8 default of 79:
+max-line-length = 88
+extend-ignore =
+    # See https://github.com/PyCQA/pycodestyle/issues/373
+    E203,
+exclude =
+    .git,
+    __pycache__,
+    env

--- a/emails/apps.py
+++ b/emails/apps.py
@@ -15,7 +15,8 @@ logger = logging.getLogger("events")
 def get_trackers(category="Email"):
     # email tracker lists from shavar-prod-list as per agreed use under license:
     resp = requests.get(
-        "https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json"
+        "https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists"
+        "/master/disconnect-blacklist.json"
     )
     json_resp = resp.json()
     formatted_trackers = json_resp["categories"][category]
@@ -37,7 +38,8 @@ class EmailsConfig(AppConfig):
             s3_config = Config(
                 region_name=settings.AWS_REGION,
                 retries={
-                    "max_attempts": 1,  # this includes the initial attempt to get the email
+                    # this includes the initial attempt to get the email
+                    "max_attempts": 1,
                     "mode": "standard",
                 },
             )

--- a/emails/apps.py
+++ b/emails/apps.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import requests
@@ -72,4 +71,4 @@ class EmailsConfig(AppConfig):
         return terms
 
     def ready(self):
-        import emails.signals
+        import emails.signals  # NOQA

--- a/emails/models.py
+++ b/emails/models.py
@@ -684,7 +684,6 @@ class DomainAddress(models.Model):
     def make_domain_address(user_profile, address=None, made_via_email=False):
         check_user_can_make_domain_address(user_profile)
 
-        address_contains_badword = False
         if not address:
             # FIXME: if the alias is randomly generated and has bad words
             # we should retry like make_relay_address does

--- a/emails/models.py
+++ b/emails/models.py
@@ -71,7 +71,8 @@ def valid_available_subdomain(subdomain, *args, **kwargs):
     return True
 
 
-# This historical function is referenced in migration 0029_profile_add_deleted_metric_and_changeserver_storage_default
+# This historical function is referenced in migration
+# 0029_profile_add_deleted_metric_and_changeserver_storage_default
 def default_server_storage():
     return True
 
@@ -355,7 +356,9 @@ class Profile(models.Model):
         return subdomain
 
     def update_abuse_metric(self, address_created=False, replied=False):
-        #  TODO: this should be wrapped in atomic to ensure race conditions are properly handled
+        # TODO: this should be wrapped in atomic to ensure race conditions are
+        # properly handled.
+
         # look for abuse metrics created on the same UTC date, regardless of time.
         midnight_utc_today = datetime.combine(
             datetime.now(timezone.utc).date(), datetime.min.time()

--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -240,10 +240,17 @@ class RemoveTrackers(TestCase):
             general_count == general_removed
         )  # count uses the same regex pattern as removing trackers
 
-    def test_general_tracker_embedded_in_another_tracker_replaced_only_once_with_relay_content(
+    def test_embedded_general_tracker_replaced_only_once_with_relay_content(
         self,
     ):
-        content = "<a href='https://foo.open.tracker.com/foo/bar.html?src=trckr.com'>A link</a>"
+        """
+        A general tracker imbedded in the URL of another general tracker is
+        replaced only once.
+        """
+        content = (
+            "<a href='https://foo.open.tracker.com/foo/bar.html?src=trckr.com'>"
+            "A link</a>"
+        )
         changed_content, tracker_details = remove_trackers(content)
         general_removed = tracker_details["tracker_removed"]
         general_count = tracker_details["level_one"]["count"]
@@ -252,10 +259,15 @@ class RemoveTrackers(TestCase):
         assert general_removed == 1
         assert general_count == 1
 
-    def test_general_tracker_also_in_text_tracker_replaced_only_once_with_relay_content(
-        self,
-    ):
-        content = "<a href='https://foo.open.tracker.com/foo/bar.html?src=trckr.com'>trckr.com</a>"
+    def test_embedded_general_tracker_also_in_text_replaced_only_once(self):
+        """
+        A general tracker imbedded in the URL of another general tracker is
+        replaced only once. The same tracker in the text of a link is _not_ replaced.
+        """
+        content = (
+            "<a href='https://foo.open.tracker.com/foo/bar.html?src=trckr.com'>"
+            "trckr.com</a>"
+        )
         changed_content, tracker_details = remove_trackers(content)
         general_removed = tracker_details["tracker_removed"]
         general_count = tracker_details["level_one"]["count"]

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -369,7 +369,9 @@ class SNSNotificationRemoveEmailsInS3Test(TestCase):
     def test_no_header_reply_email_in_s3_deleted(
         self, mocked_get_keys, mocked_message_removed
     ):
-        """If replies@... email has no "In-Reply-To" header, delete email, return 400."""
+        """
+        If replies@... email has no "In-Reply-To" header, delete email, return 400.
+        """
         mocked_get_keys.side_effect = InReplyToNotFound()
 
         with MetricsMock() as mm:
@@ -466,7 +468,9 @@ class SNSNotificationInvalidMessageTest(TestCase):
                 "complaintFeedbackType": "abuse",
                 "arrivalDate": "2009-12-03T04:24:21.000-05:00",
                 "timestamp": "2012-05-25T14:59:38.623Z",
-                "feedbackId": "000001378603177f-18c07c78-fa81-4a58-9dd1-fedc3cb8f49a-000000",
+                "feedbackId": (
+                    "000001378603177f-18c07c78-fa81-4a58-9dd1-fedc3cb8f49a-000000"
+                ),
             },
         }
         json_body = {"Message": json.dumps(complaint)}
@@ -1067,5 +1071,6 @@ def test_wrapped_email_test(
         "Yes" if int(num_level_one_email_trackers_removed) else "No"
     )
     assert (
-        f"<dt>has_num_level_one_email_trackers_removed</dt><dd>{has_num_level_one_email_trackers_removed}</dd>"
+        "<dt>has_num_level_one_email_trackers_removed</dt>"
+        f"<dd>{has_num_level_one_email_trackers_removed}</dd>"
     ) in no_space_html

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -230,7 +230,7 @@ class BounceHandlingTest(TestCase):
     def test_sns_message_with_spam_bounce_sets_auto_block_spam(self):
         _sns_notification(BOUNCE_SNS_BODIES["spam"])
         profile = self.user.profile_set.first()
-        assert profile.auto_block_spam == True
+        assert profile.auto_block_spam
 
 
 class SNSNotificationRemoveEmailsInS3Test(TestCase):

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from email.message import EmailMessage
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 import glob
 import io
 import json

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -319,7 +319,7 @@ def _get_bucket_and_key_from_s3_json(message_json):
         if "S3" in message_json_receipt["action"]["type"]:
             bucket = message_json_receipt["action"]["bucketName"]
             object_key = message_json_receipt["action"]["objectKey"]
-    except (KeyError, TypeError) as e:
+    except (KeyError, TypeError):
         logger.error(
             "sns_inbound_message_receipt_malformed",
             extra={

--- a/emails/views.py
+++ b/emails/views.py
@@ -143,8 +143,9 @@ def wrapped_email_test(request):
         has_tracker_report_link = False
     if has_tracker_report_link:
         tracker_report_link = (
-            '/tracker-report/#{"sender": "sender@example.com", "received_at": 1658434657,'
-            + '"trackers": {"fake-tracker.example.com": 2}}'
+            '/tracker-report/#{"sender": "sender@example.com",'
+            ' "received_at": 1658434657,'
+            ' "trackers": {"fake-tracker.example.com": 2}}'
         )
     else:
         tracker_report_link = ""

--- a/emails/views.py
+++ b/emails/views.py
@@ -25,7 +25,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db import transaction
 from django.http import HttpResponse, JsonResponse
-from django.shortcuts import redirect, render
+from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.utils.html import escape
 from django.views.decorators.csrf import csrf_exempt


### PR DESCRIPTION
As part of MPP-79, add a `.flake8` configuration that is compatible with `black`, and fix a few of the detected issues.

[Flake8](https://flake8.pycqa.org/en/latest/) is a static analyzer used on many Python projects to enforce [PEP8](https://peps.python.org/pep-0008/) and detect unused variables and imports. It comes with some good analyzers by default, and others (like docstring checkers) can be added. I've found it much faster than `pylint` for similar benefits.

I wasn't planning on adding `flake8` itself - we're still getting used to `black` - but I've found it useful in my own development work, and run it on each save in Vim (through [scrooloose/syntastic](https://github.com/vim-syntastic/syntastic)). 

This PR also fixes some issues in the files I'm working on in another PR - mostly long lines, but some unused imports and variables. After these changes, there are 119 issues remaining, which would take about an hour to clean up.

# How to test

* Checkout `main` branch
* Run `pip install flake8`
* Run `flake8 emails/models.py --statistics`
    - [ ] There are over 40 warnings for `E501 line too long`
    - [ ] There is one error `F841 local variable 'address_contains_badword' is assigned to but never used`
* Checkout this branch `start-flake8-mpp-79`
* Run `flake8 emails/models.py --statistics`
    - [ ] There is no output, because there are no remaining issues.
* Run `flake8 . --statistics`
    - [ ] There are 100 - 150 warnings and errors, and about 8 unique issues