### PR TITLE
MPP-2259: Use a timezone-aware datetime for last_inbound_date

### DIFF
--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 
 import phonenumbers
@@ -457,7 +457,7 @@ def _check_and_update_contact(inbound_contact, contact_type):
         inbound_contact.save()
         raise exceptions.ValidationError(f"Number is not accepting {contact_type}.")
 
-    inbound_contact.last_inbound_date = datetime.now()
+    inbound_contact.last_inbound_date = datetime.now(timezone.utc)
     attr = f"num_{contact_type}"
     setattr(inbound_contact, attr, getattr(inbound_contact, attr) + 1)
     inbound_contact.save()


### PR DESCRIPTION
I saw this warning four times in the `pytest` output:

```
api/tests/phones_views_tests.py::test_inbound_sms_valid_twilio_signature_good_data
  /Users/john/.virtualenvs/fx-private-relay/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1416: RuntimeWarning: DateTimeField InboundContact.last_inbound_date received a naive datetime (2022-08-09 16:22:14.436928) while time zone support is active.
    warnings.warn("DateTimeField %s received a naive datetime (%s)"
```

This PR updates `api.views.phones._check_and_update_contact` to use a time-zone aware ``datetime`` when setting ``InboundContact.last_inbound_date``. 