### PR TITLE
Add Caller and SMS Log to Settings Page

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -254,3 +254,7 @@ faq-question-bulk-trackerremoval-question = Can I remove trackers only on some o
 faq-question-bulk-trackerremoval-answer = You can only turn tracker removal on at an account level—it either removes trackers from all of your emails, or none of them.
 faq-question-trackerremoval-breakage-question = Why do my emails look broken?
 faq-question-trackerremoval-breakage-answer = Sometimes removing trackers may cause your email to look broken, because the trackers are often contained within images. When the tracker is removed, the email looks like it’s been formatted wrong because images are missing. This can’t be fixed for emails you’ve already received. If this is preventing you from reading your emails properly, turn off tracker removal.
+
+phone-settings-caller-sms-log = Caller and SMS log
+phone-settings-caller-sms-log-description = Allow { -brand-name-firefox-relay } to keep a log of your callers and text senders.
+phone-settings-caller-sms-log-warning = If you decide to opt out from this preference, you will lose the ability to block senders or callers.

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -162,6 +162,7 @@ phone-onboarding-step3-code-success-subhead-body = Choose your phone number mask
 phone-onboarding-step3-code-success-cta = Search for phone number masks
 phone-onboarding-step3-loading = Based on your true phone number, { -brand-name-relay } is looking for similar number combinations available to you.
 
+## Phone Masking
 phone-onboarding-step4-country-us = United States
 phone-onboarding-step4-body = These available phone number masks are similar to your true phone number. Once you register a phone number mask, you cannot change it. 
 phone-onboarding-step4-smiliar-phone = Similar to { $phone_number }
@@ -180,6 +181,9 @@ phone-onboarding-step4-code-success-subhead-body-p1 = { -brand-name-relay } sent
 phone-onboarding-step4-code-success-subhead-body-p2 = Please save the contact so you can identify your forwarded messages and calls.
 phone-onboarding-step4-code-success-cta = Continue
 
+phone-settings-caller-sms-log = Caller and SMS log
+phone-settings-caller-sms-log-description = Allow { -brand-name-firefox-relay } to keep a log of your callers and text senders.
+phone-settings-caller-sms-log-warning = If you decide to opt out from this preference, you will lose the ability to block senders or callers.
 
 ## Replies
 profile-label-replies = Replies
@@ -253,8 +257,4 @@ faq-question-disable-trackerremoval-answer = Yes. If you’re having trouble wit
 faq-question-bulk-trackerremoval-question = Can I remove trackers only on some of my email masks?
 faq-question-bulk-trackerremoval-answer = You can only turn tracker removal on at an account level—it either removes trackers from all of your emails, or none of them.
 faq-question-trackerremoval-breakage-question = Why do my emails look broken?
-faq-question-trackerremoval-breakage-answer = Sometimes removing trackers may cause your email to look broken, because the trackers are often contained within images. When the tracker is removed, the email looks like it’s been formatted wrong because images are missing. This can’t be fixed for emails you’ve already received. If this is preventing you from reading your emails properly, turn off tracker removal.
-
-phone-settings-caller-sms-log = Caller and SMS log
-phone-settings-caller-sms-log-description = Allow { -brand-name-firefox-relay } to keep a log of your callers and text senders.
-phone-settings-caller-sms-log-warning = If you decide to opt out from this preference, you will lose the ability to block senders or callers.
+faq-question-trackerremoval-breakage-answer-2 = Sometimes removing trackers may cause your email to look broken, because the trackers are often contained within images and links. When the tracker is removed, the email looks like it’s been formatted wrong because images are missing. This can’t be fixed for emails you’ve already received. If this is preventing you from reading your emails properly, turn off tracker removal.

--- a/frontend/src/apiMocks/mockData.ts
+++ b/frontend/src/apiMocks/mockData.ts
@@ -54,6 +54,7 @@ export const mockedProfiles: Record<typeof mockIds[number], ProfileData> = {
     next_email_try: "2020-04-09T00:00:00.000Z",
     onboarding_state: 0,
     server_storage: true,
+    store_phone_log: true,
     subdomain: null,
     emails_blocked: 0,
     emails_forwarded: 0,
@@ -77,6 +78,7 @@ export const mockedProfiles: Record<typeof mockIds[number], ProfileData> = {
     emails_forwarded: 0,
     emails_replied: 0,
     level_one_trackers_blocked: 0,
+    store_phone_log: true,
   },
   some: {
     api_token: "some",
@@ -95,6 +97,7 @@ export const mockedProfiles: Record<typeof mockIds[number], ProfileData> = {
     emails_forwarded: 1337,
     emails_replied: 40,
     level_one_trackers_blocked: 72,
+    store_phone_log: true,
   },
   full: {
     api_token: "full",
@@ -113,6 +116,7 @@ export const mockedProfiles: Record<typeof mockIds[number], ProfileData> = {
     emails_forwarded: 1337,
     emails_replied: 9631,
     level_one_trackers_blocked: 1409,
+    store_phone_log: true,
   },
 };
 export const mockedRelayaddresses: Record<

--- a/frontend/src/hooks/api/profile.ts
+++ b/frontend/src/hooks/api/profile.ts
@@ -19,6 +19,7 @@ export type ProfileData = {
   emails_forwarded: number;
   emails_replied: number;
   level_one_trackers_blocked: number;
+  store_phone_log: boolean;
 };
 
 export type ProfilesData = [ProfileData];

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -171,6 +171,13 @@ const Settings: NextPage = () => {
     </div>
   );
 
+  const copyApiKeyToClipboard: MouseEventHandler<HTMLButtonElement> = () => {
+    navigator.clipboard.writeText(profile.api_token);
+    apiKeyElementRef.current?.select();
+    setJustCopiedApiKey(true);
+    setTimeout(() => setJustCopiedApiKey(false), 1000);
+  };
+
   const apiKeySetting = (
     <div className={styles.field}>
       <h2 className={styles["field-heading"]}>
@@ -223,13 +230,6 @@ const Settings: NextPage = () => {
       </div>
     </div>
   );
-
-  const copyApiKeyToClipboard: MouseEventHandler<HTMLButtonElement> = () => {
-    navigator.clipboard.writeText(profile.api_token);
-    apiKeyElementRef.current?.select();
-    setJustCopiedApiKey(true);
-    setTimeout(() => setJustCopiedApiKey(false), 1000);
-  };
 
   // To allow us to add this UI before the back-end is updated, we only show it
   // when the profiles API actually returns a property `remove_level_one_email_trackers`.

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -277,12 +277,12 @@ const Settings: NextPage = () => {
         <div className={styles["field-control"]}>
           <input
             type="checkbox"
-            name="tracker-removal"
-            id="tracker-removal"
+            name="caller-sms-log"
+            id="caller-sms-log"
             defaultChecked={profile.store_phone_log}
             onChange={(e) => setPhoneCallerSMSLogEnabled(e.target.checked)}
           />
-          <label htmlFor="tracker-removal">
+          <label htmlFor="caller-sms-log">
             <p>{l10n.getString("phone-settings-caller-sms-log-description")}</p>
           </label>
         </div>

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -43,6 +43,9 @@ const Settings: NextPage = () => {
   const [trackerRemovalEnabled, setTrackerRemovalEnabled] = useState(
     profileData.data?.[0].remove_level_one_email_trackers
   );
+  const [phoneCallerSMSLogEnabled, setPhoneCallerSMSLogEnabled] = useState(
+    profileData.data?.[0].store_phone_log
+  );
   const [justCopiedApiKey, setJustCopiedApiKey] = useState(false);
   const apiKeyElementRef = useRef<HTMLInputElement>(null);
 
@@ -94,6 +97,7 @@ const Settings: NextPage = () => {
           typeof profile.remove_level_one_email_trackers === "boolean"
             ? trackerRemovalEnabled
             : undefined,
+        store_phone_log: phoneCallerSMSLogEnabled,
       });
 
       // After having enabled new server-side data storage, upload the locally stored labels:
@@ -144,6 +148,82 @@ const Settings: NextPage = () => {
     </li>
   ) : null;
 
+  const labelCollectionPrivacySetting = (
+    <div className={styles.field}>
+      <h2 className={styles["field-heading"]}>
+        {l10n.getString("setting-label-collection-heading-v2")}
+      </h2>
+      <div className={styles["field-content"]}>
+        <div className={styles["field-control"]}>
+          <input
+            type="checkbox"
+            name="label-collection"
+            id="label-collection"
+            defaultChecked={profile.server_storage}
+            onChange={(e) => setLabelCollectionEnabled(e.target.checked)}
+          />
+          <label htmlFor="label-collection">
+            {l10n.getString("setting-label-collection-description-2")}
+          </label>
+        </div>
+        {labelCollectionWarning}
+      </div>
+    </div>
+  );
+
+  const apiKeySetting = (
+    <div className={styles.field}>
+      <h2 className={styles["field-heading"]}>
+        <label htmlFor="api-key">
+          {l10n.getString("setting-label-api-key")}
+        </label>
+      </h2>
+      <div
+        className={`${styles["copy-api-key-content"]} ${styles["field-content"]}`}
+      >
+        <div className={styles["settings-api-key-wrapper"]}>
+          <input
+            id="api-key"
+            ref={apiKeyElementRef}
+            className={styles["copy-api-key-display"]}
+            value={profile.api_token}
+            size={profile.api_token.length}
+            readOnly={true}
+          />
+          <span className={styles["copy-controls"]}>
+            <span className={styles["copy-button-wrapper"]}>
+              <button
+                type="button"
+                className={styles["copy-button"]}
+                title={l10n.getString("settings-button-copy")}
+                onClick={copyApiKeyToClipboard}
+              >
+                <CopyIcon
+                  alt={l10n.getString("settings-button-copy")}
+                  className={styles["copy-icon"]}
+                  width={24}
+                  height={24}
+                />
+              </button>
+              <span
+                aria-hidden={!justCopiedApiKey}
+                className={`${styles["copied-confirmation"]} ${
+                  justCopiedApiKey ? styles["is-shown"] : ""
+                }`}
+              >
+                {l10n.getString("setting-api-key-copied")}
+              </span>
+            </span>
+          </span>
+        </div>
+        <div className={styles["settings-api-key-copy"]}>
+          {l10n.getString("settings-api-key-description")}{" "}
+          <b>{l10n.getString("settings-api-key-description-bolded")}</b>
+        </div>
+      </div>
+    </div>
+  );
+
   const copyApiKeyToClipboard: MouseEventHandler<HTMLButtonElement> = () => {
     navigator.clipboard.writeText(profile.api_token);
     apiKeyElementRef.current?.select();
@@ -186,6 +266,34 @@ const Settings: NextPage = () => {
       </div>
     ) : null;
 
+  const phoneCallerSMSLogSetting = isFlagActive(runtimeData.data, "phones") ? (
+    <div className={styles.field}>
+      <h2 className={styles["field-heading"]}>
+        <span className={styles["field-heading-icon-wrapper"]}>
+          {l10n.getString("phone-settings-caller-sms-log")}
+        </span>
+      </h2>
+      <div className={styles["field-content"]}>
+        <div className={styles["field-control"]}>
+          <input
+            type="checkbox"
+            name="tracker-removal"
+            id="tracker-removal"
+            defaultChecked={profile.store_phone_log}
+            onChange={(e) => setPhoneCallerSMSLogEnabled(e.target.checked)}
+          />
+          <label htmlFor="tracker-removal">
+            <p>{l10n.getString("phone-settings-caller-sms-log-description")}</p>
+          </label>
+        </div>
+        <div className={styles["field-warning"]}>
+          <InfoTriangleIcon alt="" />
+          <p>{l10n.getString("phone-settings-caller-sms-log-warning")}</p>
+        </div>
+      </div>
+    </div>
+  ) : null;
+
   return (
     <>
       <Layout runtimeData={runtimeData.data}>
@@ -194,83 +302,11 @@ const Settings: NextPage = () => {
             {currentSettingWarning}
             <div className={styles["settings-form-wrapper"]}>
               <form onSubmit={saveSettings} className={styles["settings-form"]}>
-                <div className={styles.field}>
-                  <h2 className={styles["field-heading"]}>
-                    {l10n.getString("setting-label-collection-heading-v2")}
-                  </h2>
-                  <div className={styles["field-content"]}>
-                    <div className={styles["field-control"]}>
-                      <input
-                        type="checkbox"
-                        name="label-collection"
-                        id="label-collection"
-                        defaultChecked={profile.server_storage}
-                        onChange={(e) =>
-                          setLabelCollectionEnabled(e.target.checked)
-                        }
-                      />
-                      <label htmlFor="label-collection">
-                        {l10n.getString(
-                          "setting-label-collection-description-2"
-                        )}
-                      </label>
-                    </div>
-                    {labelCollectionWarning}
-                  </div>
-                </div>
-                <div className={styles.field}>
-                  <h2 className={styles["field-heading"]}>
-                    <label htmlFor="api-key">
-                      {l10n.getString("setting-label-api-key")}
-                    </label>
-                  </h2>
-                  <div
-                    className={`${styles["copy-api-key-content"]} ${styles["field-content"]}`}
-                  >
-                    <div className={styles["settings-api-key-wrapper"]}>
-                      <input
-                        id="api-key"
-                        ref={apiKeyElementRef}
-                        className={styles["copy-api-key-display"]}
-                        value={profile.api_token}
-                        size={profile.api_token.length}
-                        readOnly={true}
-                      />
-                      <span className={styles["copy-controls"]}>
-                        <span className={styles["copy-button-wrapper"]}>
-                          <button
-                            type="button"
-                            className={styles["copy-button"]}
-                            title={l10n.getString("settings-button-copy")}
-                            onClick={copyApiKeyToClipboard}
-                          >
-                            <CopyIcon
-                              alt={l10n.getString("settings-button-copy")}
-                              className={styles["copy-icon"]}
-                              width={24}
-                              height={24}
-                            />
-                          </button>
-                          <span
-                            aria-hidden={!justCopiedApiKey}
-                            className={`${styles["copied-confirmation"]} ${
-                              justCopiedApiKey ? styles["is-shown"] : ""
-                            }`}
-                          >
-                            {l10n.getString("setting-api-key-copied")}
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                    <div className={styles["settings-api-key-copy"]}>
-                      {l10n.getString("settings-api-key-description")}{" "}
-                      <b>
-                        {l10n.getString("settings-api-key-description-bolded")}
-                      </b>
-                    </div>
-                  </div>
-                </div>
+                {labelCollectionPrivacySetting}
+                {apiKeySetting}
                 {trackerRemovalSetting}
+                {phoneCallerSMSLogSetting}
+
                 <div className={styles.controls}>
                   <Button type="submit">
                     {l10n.getString("settings-button-save-label")}


### PR DESCRIPTION

<!-- When adding a new feature: -->

# New feature description

This adds the Caller and SMS log toggle on the settings page.

Endpoint PR: https://github.com/mozilla/fx-private-relay/pull/2303

# Screenshot (if applicable)

Preview:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/13066134/183712289-9763d6f4-2b70-4dcf-b0c2-f9c509fe1747.png">



# Checklist

- [x] l10n changes have been submitted to the l10n repository, if any. **NOTE:** We're keeping the strings in English, so we may not need to localize phone masking strings as of yet.
- [x] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
