### PR TITLE
fix MPP-2261: delete InboundContact records

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,7 @@ jobs:
             --build-arg CIRCLE_BRANCH="$CIRCLE_BRANCH" \
             --build-arg CIRCLE_TAG="$CIRCLE_TAG" \
             --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
+            --build-arg PHONES_ENABLED="$PHONES_ENABLED" \
             .
 
       - run:
@@ -174,8 +175,6 @@ jobs:
               --entrypoint "/bin/bash" \
               --volumes-from workspace-test-results \
               -e PHONES_ENABLED=$PHONES_ENABLED \
-              -e TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID \
-              -e TWILIO_AUTH_TOKEN=$TWILIO_AUTH_TOKEN \
               fx-private-relay \
               -c \
                 'mkdir --parents /tmp/workspace/test-results/pytest && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN ln --symbolic /app/privaterelay/locales/pt-BR/ privaterelay/locales/pt
 RUN ln --symbolic /app/privaterelay/locales/es-ES/ privaterelay/locales/es
 COPY --chown=app .env-dist /app/.env
 
+ARG PHONES_ENABLED
 RUN mkdir -p /app/staticfiles && \
     python manage.py collectstatic --no-input -v 2
 

--- a/phones/tests/models_tests.py
+++ b/phones/tests/models_tests.py
@@ -12,6 +12,7 @@ from allauth.socialaccount.models import SocialAccount, SocialToken
 from model_bakery import baker
 
 from emails.models import Profile
+from phones.models import InboundContact
 
 if settings.PHONES_ENABLED:
     from ..models import (
@@ -45,7 +46,6 @@ def mocked_twilio_client():
 def make_phone_test_user():
     phone_user = baker.make(User)
     phone_user_profile = Profile.objects.get(user=phone_user)
-    phone_user_profile.server_storage = True
     phone_user_profile.date_subscribed = datetime.now(tz=timezone.utc)
     phone_user_profile.save()
     upgrade_test_user_to_phone(phone_user)
@@ -319,3 +319,43 @@ def test_area_code_numbers(mocked_twilio_client):
     available_numbers_calls = mock_twilio_client.available_phone_numbers.call_args_list
     assert available_numbers_calls == [call("US")]
     assert mock_list.call_args_list == [call(area_code="918", limit=10)]
+
+
+def test_save_store_phone_log_no_relay_number_does_nothing():
+    user = make_phone_test_user()
+    profile = Profile.objects.get(user=user)
+    profile.store_phone_log = True
+    profile.save()
+
+    profile.refresh_from_db()
+    assert profile.store_phone_log
+
+    profile.store_phone_log = False
+    profile.save()
+    assert not profile.store_phone_log
+
+
+def test_save_store_phone_log_true_doesnt_delete_data():
+    user = make_phone_test_user()
+    profile = Profile.objects.get(user=user)
+    baker.make(RealPhone, user=user, verified=True)
+    relay_number = baker.make(RelayNumber, user=user)
+    inbound_contact = baker.make(InboundContact, relay_number=relay_number)
+    profile.store_phone_log = True
+    profile.save()
+
+    inbound_contact.refresh_from_db()
+    assert inbound_contact
+
+
+def test_save_store_phone_log_false_deletes_data():
+    user = make_phone_test_user()
+    profile = Profile.objects.get(user=user)
+    baker.make(RealPhone, user=user, verified=True)
+    relay_number = baker.make(RelayNumber, user=user)
+    inbound_contact = baker.make(InboundContact, relay_number=relay_number)
+    profile.store_phone_log = False
+    profile.save()
+
+    with pytest.raises(InboundContact.DoesNotExist):
+        inbound_contact.refresh_from_db()

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -230,7 +230,7 @@ if AWS_SES_CONFIGSET and AWS_SNS_TOPIC:
         "emails.apps.EmailsConfig",
     ]
 
-if PHONES_ENABLED and TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN:
+if PHONES_ENABLED:
     INSTALLED_APPS += [
         "phones.apps.PhonesConfig",
     ]


### PR DESCRIPTION
When Profile.store_phone_log is set to False, delete all the
InboundContact records.

This PR fixes MPP-2261.

How to test:
1. Run `pytest`
   * [x] All tests should pass
2. Send some text messages to your local Relay number
3. Go to http://127.0.0.1:8000/api/v1/docs/
4. Execute the `GET /inboundcontact/` endpoint
   * [x] You should see an inbound contact record for the sender of the text message
5. Go to http://127.0.0.1:8000/accounts/settings/
6. Un-check "Allow ⁨Firefox Relay⁩ to keep a log of your callers and text senders."
7. Click Save
   * [ ] You should see "Your settings have been saved."
8. Go back to http://127.0.0.1:8000/api/v1/docs/
9. Execute the `GET /inboundcontact/` endpoint
   * [x] You should NOT see any inbound contact records

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).