### PR TITLE
fix relaynumber display on dashboard

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -158,9 +158,7 @@ export const Layout = (props: Props) => {
             userEmail={usersData?.email}
             userAvatar={profiles.data?.[0].avatar}
           />
-          <div role="main" className={styles.content}>
-            {props.children}
-          </div>
+          <div className={styles.content}>{props.children}</div>
           <footer className={styles.footer}>
             <a
               href="https://www.mozilla.org"

--- a/frontend/src/components/phones/dashboard/Dashboard.tsx
+++ b/frontend/src/components/phones/dashboard/Dashboard.tsx
@@ -143,8 +143,8 @@ export const PhoneDashboard = () => {
     <main className={styles["main-phone-wrapper"]}>
       <div className={styles["dashboard-card"]}>
         <span className={styles["header-phone-number"]}>
-          {realPhoneData?.number
-            ? formatPhoneNumberToUSDisplay(realPhoneData.number)
+          {relayNumberData?.number
+            ? formatPhoneNumberToUSDisplay(relayNumberData.number)
             : ""}
           <span className={styles["copy-controls"]}>
             <span className={styles["copy-button-wrapper"]}>

--- a/frontend/src/components/phones/onboarding/PhoneOnboarding.tsx
+++ b/frontend/src/components/phones/onboarding/PhoneOnboarding.tsx
@@ -54,9 +54,5 @@ export const PhoneOnboarding = (props: Props) => {
     step = <RelayNumberPicker onComplete={props.onComplete} />;
   }
 
-  return (
-    <>
-      <main className={styles.onboarding}>{step}</main>
-    </>
-  );
+  return <main className={styles.onboarding}>{step}</main>;
 };

--- a/frontend/src/components/phones/onboarding/PurchasePhonesPlan.tsx
+++ b/frontend/src/components/phones/onboarding/PurchasePhonesPlan.tsx
@@ -20,7 +20,7 @@ export const PurchasePhonesPlan = () => {
   };
 
   return (
-    <div className={styles.wrapper}>
+    <main className={styles.wrapper}>
       <div className={styles.lead}>
         <img src={WomanPhone.src} alt="" width={200} />
         <h2>{l10n.getString("phone-onboarding-step1-headline")}</h2>
@@ -49,6 +49,6 @@ export const PurchasePhonesPlan = () => {
           </LinkButton>
         </div>
       </div>
-    </div>
+    </main>
   );
 };


### PR DESCRIPTION
This PR fixes a bug where the dashboard is showign the real phone at the top instead of the relay number.

How to test:
1. Go to http://localhost:3000/phone/
2. The big number at the top should be the user's *relay* number - not their real phone

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).