### PR TITLE
MPP-1921: Count and Log complaints

### DIFF
--- a/emails/utils.py
+++ b/emails/utils.py
@@ -298,23 +298,22 @@ def decrypt_reply_metadata(key, jwe):
 
 
 def _get_bucket_and_key_from_s3_json(message_json):
-    bucket = None
-    object_key = None
+    # Only Received notifications have S3-stored data
+    notification_type = message_json.get("notificationType")
+    if notification_type != "Received":
+        return None, None
+
     if "receipt" in message_json and "action" in message_json["receipt"]:
         message_json_receipt = message_json["receipt"]
     else:
-        notification_type = message_json.get("notificationType")
-        event_type = message_json.get("eventType")
-        is_bounce_notification = notification_type == "Bounce" or event_type == "Bounce"
-        if not is_bounce_notification:
-            # TODO: sns inbound notification does not have 'receipt'
-            # we need to look into this more
-            logger.error(
-                "sns_inbound_message_without_receipt",
-                extra={"message_json_keys": message_json.keys()},
-            )
+        logger.error(
+            "sns_inbound_message_without_receipt",
+            extra={"message_json_keys": message_json.keys()},
+        )
         return None, None
 
+    bucket = None
+    object_key = None
     try:
         if "S3" in message_json_receipt["action"]["type"]:
             bucket = message_json_receipt["action"]["bucketName"]
@@ -322,9 +321,7 @@ def _get_bucket_and_key_from_s3_json(message_json):
     except (KeyError, TypeError) as e:
         logger.error(
             "sns_inbound_message_receipt_malformed",
-            extra={
-                "receipt_action": message_json_receipt["action"],
-            },
+            extra={"receipt_action": message_json_receipt["action"]},
         )
     return bucket, object_key
 


### PR DESCRIPTION
When a complaint event or notification is received:
* increment `fx.private.relay.email_complaint` counter
* log "complaint_received", with complainer domains in context
* return a 200 response

This PR addresses #1856 / MPP-1921.

How to test:

* Get [end-to-end local email](https://github.com/mozilla/fx-private-relay/blob/main/docs/end-to-end-local-email-dev.md) working in the dev environment, with back-end processing
* Run `./manage.py runserver`
    - Create or find a Relay address, **take note of the email**
* Run `./manage.py process_emails_from_sqs` in a separate tab
* Create a verified address in AWS for a Relay address
    - Log into the AWS console at https://console.aws.amazon.com
    - Go to SES settings at https://console.aws.amazon.com/ses/home
    - Select "Verified Identities" from the side menu
    - Click "Create Identity"
    - On "Create Identity", select "Email address" and enter the Relay address. Select "Create Identity"
    - Find the confirmation email forwarded by your dev relay instance, with a subject like "Amazon Web Services – Email Address Verification Request in region US East (N. Virginia)."
    - Click the link in the email
    - Return to "Verified Identities" and the new identity, refresh as needed to confirm that it is Verified
 * Enable Complaint notifications for the verified email. While viewing the verified relay email:
    - Select the "Notifications" tab
    - Select "Edit" by "Feedback notifications"
    - For "Bounce feedback" and "Complaint feedback", select your SNS topic and "Include original email headers".
    - Select "Save changes"
 * Send a message to the AWS simulator. Still on the verified relay email:
    - Select "Send Test Email"
         - For "Email format", keep "Formatted"
         - The "From-address" should be your relay address
         - For "Scenario", select "Complaint"
         - Enter a Subject and Body
         - Click "Send Test Email"
    * [x] The `./manage.py process_emails_from_sqs` shows a `"complaint_received"` message

The full set of messages may look like:

```
{"Timestamp": 1660593450742540032, "Type": "eventsinfo", "Logger": "fx-private-relay", "Hostname": "johnwhitlock-4zq05n", "EnvVersion": "2.0", "Severity": 6, "Pid": 38817, "Fields": {"recipient_domains": ["simulator.amazonses.com"], "subtype": null, "feedback": "abuse", "msg": "complaint_received"}}
{"Timestamp": 1660593450794928128, "Type": "eventsinfo.process_emails_from_sqs", "Logger": "fx-private-relay", "Hostname": "johnwhitlock-4zq05n", "EnvVersion": "2.0", "Severity": 6, "Pid": 38817, "Fields": {"success": true, "sqs_message_id": "a4df041b-2b41-48fa-b474-a1a127d2f58b", "message_process_time_s": 0.287, "msg": "Message processed"}}
{"Timestamp": 1660593450795190016, "Type": "eventsinfo.process_emails_from_sqs", "Logger": "fx-private-relay", "Hostname": "johnwhitlock-4zq05n", "EnvVersion": "2.0", "Severity": 6, "Pid": 38817, "Fields": {"message_count": 1, "sqs_poll_s": 4.179, "process_s": 0.287, "message_total": 1, "cycle_s": 4.52, "msg": "Cycle 2: processed 1 message"}}
Not using django_ftl autoreloader because pyinotify is not installed. Set `Bundle.auto_reload` or `AUTO_RELOAD_BUNDLES` to `False` to disable this warning.
{"Timestamp": 1660593452847646976, "Type": "eventsinfo.process_emails_from_sqs", "Logger": "fx-private-relay", "Hostname": "johnwhitlock-4zq05n", "EnvVersion": "2.0", "Severity": 6, "Pid": 38817, "Fields": {"success": true, "sqs_message_id": "91dfa9f9-be65-4db9-baa4-526b006e5f10", "message_process_time_s": 1.167, "msg": "Message processed"}}
{"Timestamp": 1660593452847854080, "Type": "eventsinfo.process_emails_from_sqs", "Logger": "fx-private-relay", "Hostname": "johnwhitlock-4zq05n", "EnvVersion": "2.0", "Severity": 6, "Pid": 38817, "Fields": {"message_count": 1, "sqs_poll_s": 0.733, "process_s": 1.167, "message_total": 2, "cycle_s": 1.958, "msg": "Cycle 3: processed 1 message"}}
{"Timestamp": 1660593453170723072, "Type": "events", "Logger": "fx-private-relay", "Hostname": "johnwhitlock-4zq05n", "EnvVersion": "2.0", "Severity": 3, "Pid": 38817, "Fields": {"Code": "NoSuchKey", "Message": "The specified key does not exist.", "Key": "emails/kqsbcfln0i8aja6goplcsb927bdmaicnl3hn2jo1", "msg": "s3_object_does_not_exist"}}
```

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).