### PR TITLE
MPP-2289: Error state broken for true phone number verification

### DIFF
--- a/frontend/src/components/phones/onboarding/PhoneOnboarding.tsx
+++ b/frontend/src/components/phones/onboarding/PhoneOnboarding.tsx
@@ -42,8 +42,8 @@ export const PhoneOnboarding = (props: Props) => {
     step = (
       <RealPhoneSetup
         unverifiedRealPhones={unverifiedPhones}
-        onRequestVerification={(number) =>
-          realPhoneData.requestPhoneVerification(number)
+        onRequestVerification={async (number) =>
+          await realPhoneData.requestPhoneVerification(number)
         }
         onSubmitVerification={realPhoneData.submitPhoneVerification}
       />

--- a/frontend/src/components/phones/onboarding/RealPhoneSetup.module.scss
+++ b/frontend/src/components/phones/onboarding/RealPhoneSetup.module.scss
@@ -105,6 +105,14 @@
   padding: $spacing-md;
   text-align: center;
 }
+.step-verify-input .is-error {
+  border: 2px solid $color-red-60;
+  box-shadow: 0 0 4px 4px $color-red-30;
+}
+
+.step-verify-input .is-hidden {
+  display: none;
+}
 
 .form {
   max-width: $content-sm;


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-2289
 
<!-- When adding a new feature: -->

# New feature description

Error state broken for true phone number verification - this makes it so that the error message is hidden by default. Once the user submits a true phone number and the fetch request is made, an error message will be displayed if unsuccessful. The input field also has a visual update for this. 

# Screenshot (if applicable)

Not applicable.

# How to test

1. Go to the phones page 
2. Enter a non-working true phone numbers (letters work)
3. Submit the form
4. Error message should now be rendered and the input field should have a visual update as well. 


# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
