### PR TITLE
MPP-2282 - Limit input field length to 6 characters

### DIFF
--- a/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
+++ b/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
@@ -234,6 +234,7 @@ const RealPhoneVerification = (props: RealPhoneVerificationProps) => {
         <input
           placeholder={codeEntryPlaceholder}
           required={true}
+          maxLength={6}
           onChange={onChange}
           className={isVerifiedSuccessfully === false ? styles["is-error"] : ""}
           autoFocus={true}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes # MPP-2282
 
<!-- When adding a new feature: -->

# New feature description

This limits verification code field to 6 characters.

# Screenshot (if applicable)

Not applicable.

# How to test

1. Go to phones page
2. Type a working real phone number 
3. Once you get to the verification screen, try inputting more than 6 characters.

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
