### PR TITLE
for MPP-2276: pull maxMinutesToVerify from runtime_data endpoint

### DIFF
--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -21,6 +21,7 @@ from privaterelay.settings import (
     GOOGLE_ANALYTICS_ID,
     PREMIUM_PROD_ID,
     PHONE_PROD_ID,
+    MAX_MINUTES_TO_VERIFY_REAL_PHONE,
 )
 from privaterelay.utils import get_premium_countries_info_from_request
 
@@ -183,5 +184,6 @@ def runtime_data(request):
             "WAFFLE_FLAGS": flag_values,
             "WAFFLE_SWITCHES": switch_values,
             "WAFFLE_SAMPLES": sample_values,
+            "MAX_MINUTES_TO_VERIFY_REAL_PHONE": MAX_MINUTES_TO_VERIFY_REAL_PHONE
         }
     )

--- a/frontend/src/apiMocks/mockData.ts
+++ b/frontend/src/apiMocks/mockData.ts
@@ -32,6 +32,7 @@ export const mockedRuntimeData: RuntimeData = {
     ["tracker_removal", true],
     ["phones", true],
   ],
+  MAX_MINUTES_TO_VERIFY_REAL_PHONE: 5,
 };
 
 export const mockedUsers: Record<typeof mockIds[number], UserData> = {

--- a/frontend/src/components/phones/onboarding/PhoneOnboarding.tsx
+++ b/frontend/src/components/phones/onboarding/PhoneOnboarding.tsx
@@ -5,6 +5,7 @@ import {
   isVerified,
   isNotVerified,
 } from "../../../hooks/api/realPhone";
+import { useRuntimeData } from "../../../hooks/api/runtimeData";
 import { PurchasePhonesPlan } from "./PurchasePhonesPlan";
 import { RealPhoneSetup } from "./RealPhoneSetup";
 import { RelayNumberPicker } from "./RelayNumberPicker";
@@ -16,11 +17,12 @@ export type Props = {
 export const PhoneOnboarding = (props: Props) => {
   const profiles = useProfiles();
   const realPhoneData = useRealPhonesData();
+  const runtimeData = useRuntimeData();
 
   let step = null;
 
-  // Make sure profile data is available
-  if (profiles.data?.[0] === undefined) {
+  // Make sure profile and runtime data are available
+  if (profiles.data?.[0] === undefined || !runtimeData.data) {
     return <>TODO: Profile Loading/Error</>;
   }
 
@@ -46,6 +48,7 @@ export const PhoneOnboarding = (props: Props) => {
           await realPhoneData.requestPhoneVerification(number)
         }
         onSubmitVerification={realPhoneData.submitPhoneVerification}
+        runtimeData={runtimeData.data}
       />
     );
   }

--- a/frontend/src/hooks/api/runtimeData.ts
+++ b/frontend/src/hooks/api/runtimeData.ts
@@ -21,6 +21,7 @@ export type RuntimeData = {
   PREMIUM_PLANS: PremiumPlans;
   BASKET_ORIGIN: string;
   WAFFLE_FLAGS: WaffleFlag[];
+  MAX_MINUTES_TO_VERIFY_REAL_PHONE: number;
 };
 
 /**

--- a/phones/models.py
+++ b/phones/models.py
@@ -15,9 +15,6 @@ from django.dispatch.dispatcher import receiver
 from django.urls import reverse
 
 
-MAX_MINUTES_TO_VERIFY_REAL_PHONE = 5
-
-
 def twilio_client():
     phones_config = apps.get_app_config("phones")
     client = phones_config.twilio_client
@@ -38,7 +35,7 @@ def get_expired_unverified_realphone_records(number):
         verified=False,
         verification_sent_date__lt=(
             datetime.now(timezone.utc)
-            - timedelta(0, 60 * MAX_MINUTES_TO_VERIFY_REAL_PHONE)
+            - timedelta(0, 60 * settings.MAX_MINUTES_TO_VERIFY_REAL_PHONE)
         ),
     )
 
@@ -49,7 +46,7 @@ def get_pending_unverified_realphone_records(number):
         verified=False,
         verification_sent_date__gt=(
             datetime.now(timezone.utc)
-            - timedelta(0, 60 * MAX_MINUTES_TO_VERIFY_REAL_PHONE)
+            - timedelta(0, 60 * settings.MAX_MINUTES_TO_VERIFY_REAL_PHONE)
         ),
     )
 
@@ -65,7 +62,7 @@ def get_valid_realphone_verification_record(user, number, verification_code):
         verification_code=verification_code,
         verification_sent_date__gt=(
             datetime.now(timezone.utc)
-            - timedelta(0, 60 * MAX_MINUTES_TO_VERIFY_REAL_PHONE)
+            - timedelta(0, 60 * settings.MAX_MINUTES_TO_VERIFY_REAL_PHONE)
         ),
     ).first()
 

--- a/phones/tests/models_tests.py
+++ b/phones/tests/models_tests.py
@@ -16,7 +16,6 @@ from phones.models import InboundContact
 
 if settings.PHONES_ENABLED:
     from ..models import (
-        MAX_MINUTES_TO_VERIFY_REAL_PHONE,
         RealPhone,
         RelayNumber,
         area_code_numbers,
@@ -94,7 +93,7 @@ def test_get_valid_realphone_verification_record_returns_none(phone_user):
         number=number,
         verification_sent_date=(
             datetime.now(timezone.utc)
-            - timedelta(0, 60 * MAX_MINUTES_TO_VERIFY_REAL_PHONE + 1)
+            - timedelta(0, 60 * settings.MAX_MINUTES_TO_VERIFY_REAL_PHONE + 1)
         ),
     )
     record = get_valid_realphone_verification_record(
@@ -139,7 +138,7 @@ def test_create_realphone_deletes_expired_unverified_records(
         verified=False,
         verification_sent_date=(
             datetime.now(timezone.utc)
-            - timedelta(0, 60 * MAX_MINUTES_TO_VERIFY_REAL_PHONE + 1)
+            - timedelta(0, 60 * settings.MAX_MINUTES_TO_VERIFY_REAL_PHONE + 1)
         ),
     )
     expired_verification_records = get_expired_unverified_realphone_records(number)

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -180,6 +180,7 @@ TWILIO_MAIN_NUMBER = config("TWILIO_MAIN_NUMBER", None)
 TWILIO_SMS_APPLICATION_SID = config("TWILIO_SMS_APPLICATION_SID", None)
 TWILIO_TEST_ACCOUNT_SID = config("TWILIO_TEST_ACCOUNT_SID", None)
 TWILIO_TEST_AUTH_TOKEN = config("TWILIO_TEST_AUTH_TOKEN", None)
+MAX_MINUTES_TO_VERIFY_REAL_PHONE = config("MAX_MINUTES_TO_VERIFY_REAL_PHONE", 5)
 
 STATSD_ENABLED = config("DJANGO_STATSD_ENABLED", False, cast=bool)
 STATSD_HOST = config("DJANGO_STATSD_HOST", "127.0.0.1")
@@ -649,13 +650,17 @@ if IN_PYTEST or DEBUG:
 # an auth token:
 ACCOUNT_LOGOUT_ON_GET = DEBUG
 
+CORS_URLS_REGEX = r"^/api/"
 CORS_ALLOWED_ORIGINS = [
     "https://vault.bitwarden.com",
 ]
-if RELAY_CHANNEL in ["local", "dev", "stage"]:
+if RELAY_CHANNEL in ["dev", "stage"]:
     CORS_ALLOWED_ORIGINS += ["https://vault.qa.bitwarden.pw"]
+if RELAY_CHANNEL == "local":
+    # In local dev, next runs on localhost and makes requests to /accounts/
+    CORS_ALLOWED_ORIGINS += ["http://localhost:3000"]
+    CORS_URLS_REGEX = r"^/(api|accounts)/"
 
-CORS_URLS_REGEX = r"^/api/"
 CSRF_TRUSTED_ORIGINS = []
 if RELAY_CHANNEL == "local":
     # In local development, the React UI can be served up from a different server


### PR DESCRIPTION
# New feature description
This adds a new `MAX_MINUTES_TO_VERIFY_REAL_PHONE` field to the `runtime_data` endpoint to help keep the back-end and front-end code in sync.

# Screenshot (if applicable)
![image](https://user-images.githubusercontent.com/71928/185194883-1fdd7cf1-582e-4d47-969e-3bea072fa8dd.png)

# How to test
1. Go to http://127.0.0.1:8000/api/v1/runtime_data
   * [ ] You should see a new `MAX_MINUTES_TO_VERIFY_REAL_PHONE` field default to `5`
3. Go thru the "Verify your real phone" flow
   * [ ] The remaining time timer should work for 5 minutes
4. Change the `MAX_MINUTES_TO_VERIFY_REAL_PHONE` value
   * Either change the value directly in `privaterelay/settings.py`, or
   * Set a `MAX_MINUTES_TO_VERIFY_REAL_PHONE` env var to a new value and restart the `runserver`
3. Go thru the "Verify your real phone" flow
   * [ ] The remaining time timer should work for the number of minutes you set `MAX_MINUTES_TO_VERIFY_REAL_PHONE`

# Checklist

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
