### PR TITLE
Add Resend Welcome SMS Banner to Phone Dashboard

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -57,6 +57,7 @@ if settings.PHONES_ENABLED:
         inbound_call,
         inbound_sms,
         vCard,
+        resend_welcome_sms,
     )
 
     api_router.register(r"realphone", RealPhoneViewSet, "real_phone")
@@ -66,6 +67,11 @@ if settings.PHONES_ENABLED:
         path("v1/inbound_sms", inbound_sms, name="inbound_sms"),
         path("v1/inbound_call", inbound_call, name="inbound_call"),
         path("v1/vCard/<lookup_key>", vCard, name="vCard"),
+        path(
+            "v1/realphone/resend_welcome_sms",
+            resend_welcome_sms,
+            name="resend_welcome_sms",
+        ),
     ]
 
 urlpatterns += [

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -27,6 +27,7 @@ from phones.models import (
     RelayNumber,
     get_pending_unverified_realphone_records,
     get_valid_realphone_verification_record,
+    send_welcome_message,
     suggested_numbers,
     location_numbers,
     area_code_numbers,
@@ -374,6 +375,24 @@ def vCard(request, lookup_key):
 
     resp = response.Response({"number": number})
     resp["Content-Disposition"] = f"attachment; filename={number}.vcf"
+    return resp
+
+
+@decorators.api_view(["POST"])
+@decorators.permission_classes([permissions.IsAuthenticated, HasPhoneService])
+def resend_welcome_sms(request):
+    """
+    Resend the "Welcome" SMS, including vCard.
+
+    Requires the user to be signed in and to have phone service.
+    """
+    try:
+        relay_number = RelayNumber.objects.get(user=request.user)
+    except RelayNumber.DoesNotExist:
+        raise exceptions.NotFound()
+    send_welcome_message(request.user, relay_number)
+
+    resp = response.Response(status=201, data={"msg": "sent"})
     return resp
 
 

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -185,6 +185,11 @@ phone-settings-caller-sms-log = Caller and SMS log
 phone-settings-caller-sms-log-description = Allow { -brand-name-firefox-relay } to keep a log of your callers and text senders.
 phone-settings-caller-sms-log-warning = If you decide to opt out from this preference, you will lose the ability to block senders or callers.
 
+# Phone Resend SMS Banner
+phone-banner-resend-welcome-sms-cta = Resend welcome SMS
+phone-banner-resend-welcome-sms-title = Quick Tip
+phone-banner-resend-welcome-sms-body =  Remember to save the contact we shared with you by SMS to help you identify messages forwarded by { -brand-name-relay }. Can’t find it?  
+
 # Phone Dashboard
 phone-statistics-remaining-call-minutes = Remaining call minutes
 phone-statistics-remaining-texts = Remaining texts
@@ -199,6 +204,7 @@ phone-dashboard-senders-header = Callers and SMS senders
 phone-dashboard-sender-table-title-sender = Sender
 phone-dashboard-sender-table-title-activity = Latest Activity
 phone-dashboard-sender-table-title-action = Action
+
 
 ## Replies
 profile-label-replies = Replies

--- a/frontend/src/components/Banner.module.scss
+++ b/frontend/src/components/Banner.module.scss
@@ -8,6 +8,10 @@
   background-color: $color-white;
   position: relative;
 
+  .banner.info & {
+    padding: $spacing-xs;
+  }
+
   &:not(.promo) {
     box-shadow: $box-shadow-sm;
   }
@@ -48,10 +52,20 @@
     flex: 1 0 50%;
   }
 
-  .banner:not(.promo) & {
+  .info-icon {
+    align-self: center;
+    margin-right: $spacing-lg;
+    color: $color-yellow-50;
+  }
+
+  .banner:not(.promo):not(.info) & {
     padding: $spacing-xs $spacing-lg $spacing-md;
     border-left-width: 4px;
     border-left-style: solid;
+  }
+
+  .banner.info & {
+    padding: 0 $spacing-sm 0 $spacing-md;
   }
 
   .banner.promo & {
@@ -83,10 +97,21 @@
   align-items: center;
   padding: $spacing-md 0;
 
+  .banner.info & {
+    @include text-body-sm;
+    font-family: $font-stack-base;
+    padding: $spacing-xs 0;
+    font-weight: 600;
+  }
+
   .icon {
     margin-right: $spacing-md;
 
     .warning & {
+      color: $color-yellow-50;
+    }
+
+    .info & {
       color: $color-yellow-50;
     }
   }
@@ -98,6 +123,12 @@
     padding: $spacing-md 0;
     font-weight: 700;
     color: $color-blue-50;
+
+    .banner.info & {
+      font-weight: 500;
+      text-decoration: underline;
+      padding: $spacing-sm 0 0 0;
+    }
 
     &:hover {
       color: $color-blue-40;

--- a/frontend/src/components/Banner.module.scss
+++ b/frontend/src/components/Banner.module.scss
@@ -118,11 +118,15 @@
 }
 
 .cta {
-  a {
+  a,
+  button {
     display: inline-block;
     padding: $spacing-md 0;
     font-weight: 700;
     color: $color-blue-50;
+    cursor: pointer;
+    background: none;
+    border: none;
 
     .banner.info & {
       font-weight: 500;

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -50,7 +50,7 @@ export const Banner = (props: BannerProps) => {
     <WarningFilledIcon alt="" className={styles.icon} width={20} height={20} />
   );
   const infoIcon =
-    props.type === "info" ? (
+    type === "info" ? (
       <div className={styles["info-icon"]}>
         <InfoFilledIcon alt="" className={styles.icon} width={20} height={20} />
       </div>
@@ -58,15 +58,13 @@ export const Banner = (props: BannerProps) => {
 
   const title =
     typeof props.title !== "undefined"
-      ? (props.type === "warning" && (
+      ? (type === "warning" && (
           <h2 className={styles.title}>
             {warningIcon}
             {props.title}
           </h2>
         )) ||
-        (props.type === "info" && (
-          <h2 className={styles.title}>{props.title}</h2>
-        ))
+        (type === "info" && <h2 className={styles.title}>{props.title}</h2>)
       : null;
 
   const illustration = props.illustration ? (

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -3,12 +3,12 @@ import { OutboundLink } from "react-ga";
 import { useLocalization } from "@fluent/react";
 import styles from "./Banner.module.scss";
 import { useLocalDismissal } from "../hooks/localDismissal";
-import { CloseIcon, InfoFilledIcon } from "./Icons";
+import { CloseIcon, WarningFilledIcon, InfoFilledIcon } from "./Icons";
 import { useGaViewPing } from "../hooks/gaViewPing";
 
 export type BannerProps = {
   children: ReactNode;
-  type?: "promo" | "warning";
+  type?: "promo" | "warning" | "info";
   title?: string;
   illustration?: ReactNode;
   cta?: {
@@ -45,17 +45,29 @@ export const Banner = (props: BannerProps) => {
   });
   const { l10n } = useLocalization();
   const type = props.type ?? "warning";
-  const icon =
-    props.type === "warning" ? (
-      <InfoFilledIcon alt="" className={styles.icon} width={20} height={20} />
+
+  const warningIcon = (
+    <WarningFilledIcon alt="" className={styles.icon} width={20} height={20} />
+  );
+  const infoIcon =
+    props.type === "info" ? (
+      <div className={styles["info-icon"]}>
+        <InfoFilledIcon alt="" className={styles.icon} width={20} height={20} />
+      </div>
     ) : null;
+
   const title =
-    typeof props.title !== "undefined" ? (
-      <h2 className={styles.title}>
-        {icon}
-        {props.title}
-      </h2>
-    ) : null;
+    typeof props.title !== "undefined"
+      ? (props.type === "warning" && (
+          <h2 className={styles.title}>
+            {warningIcon}
+            {props.title}
+          </h2>
+        )) ||
+        (props.type === "info" && (
+          <h2 className={styles.title}>{props.title}</h2>
+        ))
+      : null;
 
   const illustration = props.illustration ? (
     <div className={styles.illustration}>{props.illustration}</div>
@@ -112,6 +124,7 @@ export const Banner = (props: BannerProps) => {
     >
       <div className={`${styles["highlight-wrapper"]}`}>
         {illustration}
+        {infoIcon}
         <div className={`${styles["title-text"]}`}>
           {title}
           {props.children}

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -12,13 +12,18 @@ export type BannerProps = {
   title?: string;
   illustration?: ReactNode;
   cta?: {
-    target?: string;
+    target: string;
     content: string;
     onClick?: () => void;
     gaViewPing?: Parameters<typeof useGaViewPing>[0];
   };
   ctaLargeButton?: {
     target: string;
+    content: string;
+    onClick?: () => void;
+    gaViewPing?: Parameters<typeof useGaViewPing>[0];
+  };
+  btn?: {
     content: string;
     onClick?: () => void;
     gaViewPing?: Parameters<typeof useGaViewPing>[0];
@@ -99,6 +104,14 @@ export const Banner = (props: BannerProps) => {
     </div>
   ) : null;
 
+  const btn = props.btn ? (
+    <div className={styles.cta}>
+      <button onClick={props.btn.onClick}>
+        <span ref={ctaRef}>{props.btn.content}</span>
+      </button>
+    </div>
+  ) : null;
+
   const dismissButton =
     typeof props.dismissal !== "undefined" ? (
       <button
@@ -127,6 +140,7 @@ export const Banner = (props: BannerProps) => {
           {title}
           {props.children}
           {cta}
+          {btn}
         </div>
         {ctaLargeButton}
       </div>

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -12,7 +12,7 @@ export type BannerProps = {
   title?: string;
   illustration?: ReactNode;
   cta?: {
-    target: string;
+    target?: string;
     content: string;
     onClick?: () => void;
     gaViewPing?: Parameters<typeof useGaViewPing>[0];

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -30,7 +30,7 @@ export const InfoIcon = ({
 };
 
 /** Filled info button that inherits the text color of its container */
-export const InfoFilledIcon = ({
+export const WarningFilledIcon = ({
   alt,
   ...props
 }: SVGProps<SVGSVGElement> & { alt: string }) => {
@@ -48,6 +48,28 @@ export const InfoFilledIcon = ({
     >
       <title>{alt}</title>
       <path d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM11 15H9V13H11V15ZM11 11H9V5H11V11Z" />
+    </svg>
+  );
+};
+
+export const InfoFilledIcon = ({
+  alt,
+  ...props
+}: SVGProps<SVGSVGElement> & { alt: string }) => {
+  return (
+    <svg
+      role="img"
+      aria-label={alt}
+      aria-hidden={alt === ""}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      width={20}
+      height={20}
+      {...props}
+      className={`${props.className ?? ""} ${styles["colorify-fill"]}`}
+    >
+      <title>{alt}</title>
+      <path d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM11 15H9V9H11V15ZM11 7H9V5H11V7Z" />
     </svg>
   );
 };

--- a/frontend/src/components/phones/dashboard/PhoneDashboard.module.scss
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.module.scss
@@ -2,7 +2,6 @@
 @import "../../../styles/tokens.scss";
 
 .main-phone-wrapper {
-
   .nav-icon {
     color: $color-light-gray-80;
     stroke: $color-light-gray-80;

--- a/frontend/src/components/phones/dashboard/PhoneDashboard.module.scss
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.module.scss
@@ -2,10 +2,6 @@
 @import "../../../styles/tokens.scss";
 
 .main-phone-wrapper {
-  max-width: $content-lg;
-  width: 100%;
-  margin: 0 auto;
-  padding: $spacing-md;
 
   .nav-icon {
     color: $color-light-gray-80;

--- a/frontend/src/hooks/api/realPhone.ts
+++ b/frontend/src/hooks/api/realPhone.ts
@@ -62,6 +62,8 @@ export type PhoneNumberRequestVerificationFn = (
   phoneNumber: string
 ) => Promise<Response>;
 
+export type ResendWelcomeSMSFn = () => Promise<Response>;
+
 export type RealPhoneVerification = Pick<
   VerifiedPhone,
   "number" | "verification_code"
@@ -77,6 +79,7 @@ export type PhoneNumberSubmitVerificationFn = (
 export function useRealPhonesData(): SWRResponse<RealPhoneData, unknown> & {
   requestPhoneVerification: PhoneNumberRequestVerificationFn;
   submitPhoneVerification: PhoneNumberSubmitVerificationFn;
+  resendWelcomeSMS: ResendWelcomeSMSFn;
 } {
   const realphone: SWRResponse<RealPhoneData, unknown> =
     useApiV1("/realphone/");
@@ -113,9 +116,17 @@ export function useRealPhonesData(): SWRResponse<RealPhoneData, unknown> & {
     return response;
   };
 
+  const resendWelcomeSMS: ResendWelcomeSMSFn = async () => {
+    const response = await apiFetch("/realphone/resend_welcome_sms/", {
+      method: "POST",
+    });
+    return response;
+  };
+
   return {
     ...realphone,
     requestPhoneVerification: requestPhoneVerification,
     submitPhoneVerification: submitPhoneVerification,
+    resendWelcomeSMS: resendWelcomeSMS,
   };
 }

--- a/frontend/src/hooks/api/realPhone.ts
+++ b/frontend/src/hooks/api/realPhone.ts
@@ -117,7 +117,7 @@ export function useRealPhonesData(): SWRResponse<RealPhoneData, unknown> & {
   };
 
   const resendWelcomeSMS: ResendWelcomeSMSFn = async () => {
-    const response = await apiFetch("/realphone/resend_welcome_sms/", {
+    const response = await apiFetch("/realphone/resend_welcome_sms", {
       method: "POST",
     });
     realphone.mutate();

--- a/frontend/src/hooks/api/realPhone.ts
+++ b/frontend/src/hooks/api/realPhone.ts
@@ -120,6 +120,7 @@ export function useRealPhonesData(): SWRResponse<RealPhoneData, unknown> & {
     const response = await apiFetch("/realphone/resend_welcome_sms/", {
       method: "POST",
     });
+    realphone.mutate();
     return response;
   };
 

--- a/frontend/src/pages/phone.module.scss
+++ b/frontend/src/pages/phone.module.scss
@@ -2,7 +2,7 @@
 @import "../styles/tokens.scss";
 
 .main-wrapper {
-  max-width: $content-lg;
+  max-width: calc($content-lg + $layout-lg);
   width: 100%;
   margin: 0 auto;
   padding: $spacing-md;

--- a/frontend/src/pages/phone.module.scss
+++ b/frontend/src/pages/phone.module.scss
@@ -1,9 +1,14 @@
 @import "~@mozilla-protocol/core/protocol/css/includes/lib";
 @import "../styles/tokens.scss";
 
-.main-phone-wrapper {
+.main-wrapper {
   max-width: $content-lg;
   width: 100%;
   margin: 0 auto;
   padding: $spacing-md;
+}
+
+.banner-wrapper {
+  @include text-body-sm;
+  padding-bottom: $spacing-xl;
 }

--- a/frontend/src/pages/phone.page.tsx
+++ b/frontend/src/pages/phone.page.tsx
@@ -11,6 +11,7 @@ import { PurchasePhonesPlan } from "../components/phones/onboarding/PurchasePhon
 import { Banner } from "../components/Banner";
 import styles from "./phone.module.scss";
 import { useLocalization } from "@fluent/react";
+import { useRealPhonesData } from "../hooks/api/realPhone";
 
 const Phone: NextPage = () => {
   const profileData = useProfiles();
@@ -22,6 +23,7 @@ const Phone: NextPage = () => {
 
   const relayNumberData = useRelayNumber();
   const [isInOnboarding, setIsInOnboarding] = useState<boolean>();
+  const realPhoneData = useRealPhonesData();
 
   useEffect(() => {
     if (
@@ -66,15 +68,18 @@ const Phone: NextPage = () => {
           <Banner
             title={l10n.getString("phone-banner-resend-welcome-sms-title")}
             type="info"
-            // TODO: add resend welcome SMS trigger here
+            // TODO: add resend welcome SMS trigger here *WIP!!!!*
             cta={{
-              target: "/",
+              target: "",
               content: l10n.getString("phone-banner-resend-welcome-sms-cta"),
-              onClick: () => "",
+              onClick: () => realPhoneData.resendWelcomeSMS(),
               gaViewPing: {
                 category: "Resend Welcome SMS",
                 label: "phone-page-banner-resend-welcome",
               },
+            }}
+            dismissal={{
+              key: "resend-sms-banner",
             }}
           >
             {l10n.getString("phone-banner-resend-welcome-sms-body")}

--- a/frontend/src/pages/phone.page.tsx
+++ b/frontend/src/pages/phone.page.tsx
@@ -8,10 +8,14 @@ import { useEffect, useState } from "react";
 import { PhoneDashboard } from "../components/phones/dashboard/Dashboard";
 import { getRuntimeConfig } from "../config";
 import { PurchasePhonesPlan } from "../components/phones/onboarding/PurchasePhonesPlan";
+import { Banner } from "../components/Banner";
+import styles from "./phone.module.scss";
+import { useLocalization } from "@fluent/react";
 
 const Phone: NextPage = () => {
   const profileData = useProfiles();
   const profile = profileData.data?.[0];
+  const { l10n } = useLocalization();
 
   const userData = useUsers();
   const user = userData.data?.[0];
@@ -57,7 +61,27 @@ const Phone: NextPage = () => {
 
   return (
     <Layout>
-      <PhoneDashboard />
+      <div className={styles["main-wrapper"]}>
+        <div className={styles["banner-wrapper"]}>
+          <Banner
+            title={l10n.getString("phone-banner-resend-welcome-sms-title")}
+            type="info"
+            // TODO: add resend welcome SMS trigger here
+            cta={{
+              target: "/",
+              content: l10n.getString("phone-banner-resend-welcome-sms-cta"),
+              onClick: () => "",
+              gaViewPing: {
+                category: "Resend Welcome SMS",
+                label: "phone-page-banner-resend-welcome",
+              },
+            }}
+          >
+            {l10n.getString("phone-banner-resend-welcome-sms-body")}
+          </Banner>
+        </div>
+        <PhoneDashboard />
+      </div>
     </Layout>
   );
 };

--- a/frontend/src/pages/phone.page.tsx
+++ b/frontend/src/pages/phone.page.tsx
@@ -69,8 +69,7 @@ const Phone: NextPage = () => {
             title={l10n.getString("phone-banner-resend-welcome-sms-title")}
             type="info"
             // TODO: add resend welcome SMS trigger here *WIP!!!!*
-            cta={{
-              target: "",
+            btn={{
               content: l10n.getString("phone-banner-resend-welcome-sms-cta"),
               onClick: () => realPhoneData.resendWelcomeSMS(),
               gaViewPing: {

--- a/frontend/src/pages/phone.page.tsx
+++ b/frontend/src/pages/phone.page.tsx
@@ -68,7 +68,6 @@ const Phone: NextPage = () => {
           <Banner
             title={l10n.getString("phone-banner-resend-welcome-sms-title")}
             type="info"
-            // TODO: add resend welcome SMS trigger here *WIP!!!!*
             btn={{
               content: l10n.getString("phone-banner-resend-welcome-sms-cta"),
               onClick: () => realPhoneData.resendWelcomeSMS(),

--- a/frontend/src/pages/tracker-report.page.tsx
+++ b/frontend/src/pages/tracker-report.page.tsx
@@ -7,7 +7,7 @@ import logo from "./images/placeholder-logo.svg";
 import { PageMetadata } from "../components/layout/PageMetadata";
 import {
   HideIcon,
-  InfoFilledIcon,
+  WarningFilledIcon,
   InfoTriangleIcon,
 } from "../components/Icons";
 import Link from "next/link";
@@ -138,7 +138,7 @@ const TrackerReport: NextPage = () => {
               {trackerListing}
             </div>
             <div className={styles["confidentiality-notice"]}>
-              <InfoFilledIcon alt="" />
+              <WarningFilledIcon alt="" />
               {l10n.getString("trackerreport-confidentiality-notice")}
             </div>
             <div className={styles.explainer}>

--- a/phones/models.py
+++ b/phones/models.py
@@ -194,18 +194,22 @@ def relaynumber_post_save(sender, instance, created, **kwargs):
         return
 
     if created:
-        real_phone = RealPhone.objects.get(user=instance.user)
         # only send welcome vCard when creating new record
-        media_url = settings.SITE_ORIGIN + reverse(
-            "vCard", kwargs={"lookup_key": instance.vcard_lookup_key}
-        )
-        client = twilio_client()
-        client.messages.create(
-            body="Welcome to Relay Phoanz! 🎉 Please add your number to your contacts. This will help you identify your Relay messages and calls.",
-            from_=settings.TWILIO_MAIN_NUMBER,
-            to=real_phone.number,
-            media_url=[media_url],
-        )
+        send_welcome_message(instance.user, instance)
+
+
+def send_welcome_message(user, relay_number):
+    real_phone = RealPhone.objects.get(user=user)
+    media_url = settings.SITE_ORIGIN + reverse(
+        "vCard", kwargs={"lookup_key": relay_number.vcard_lookup_key}
+    )
+    client = twilio_client()
+    client.messages.create(
+        body="Welcome to Relay Phoanz! 🎉 Please add your number to your contacts. This will help you identify your Relay messages and calls.",
+        from_=settings.TWILIO_MAIN_NUMBER,
+        to=real_phone.number,
+        media_url=[media_url],
+    )
 
 
 def last_inbound_date_default():


### PR DESCRIPTION
<!-- When adding a new feature: -->

# New feature description

Adds a banner with a prompt to resend welcome verification SMS.

# Screenshot (if applicable)

<img width="985" alt="image" src="https://user-images.githubusercontent.com/13066134/185227525-589763d8-4ece-42e0-a719-bc710888cc67.png">

# How to test

On the phone dashboard page, a resend welcome SMS banner should show at the top. The CTA should trigger another welcome SMS message to the Relay number / return a successful response.

# Remaining To-Do
- [x] Waiting on API endpoint for resending a welcome SMS
- [ ] Trigger a toast event (Opening a new PR for this, still waiting on Chris' approval)

# Checklist

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
