### PR TITLE
fix MPP-2303: add /api/v1/realphone/resend_welcome_sms

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -57,6 +57,7 @@ if settings.PHONES_ENABLED:
         inbound_call,
         inbound_sms,
         vCard,
+        resend_welcome_sms,
     )
 
     api_router.register(r"realphone", RealPhoneViewSet, "real_phone")
@@ -66,6 +67,11 @@ if settings.PHONES_ENABLED:
         path("v1/inbound_sms", inbound_sms, name="inbound_sms"),
         path("v1/inbound_call", inbound_call, name="inbound_call"),
         path("v1/vCard/<lookup_key>", vCard, name="vCard"),
+        path(
+            "v1/realphone/resend_welcome_sms",
+            resend_welcome_sms,
+            name="resend_welcome_sms",
+        ),
     ]
 
 urlpatterns += [

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -27,6 +27,7 @@ from phones.models import (
     RelayNumber,
     get_pending_unverified_realphone_records,
     get_valid_realphone_verification_record,
+    send_welcome_message,
     suggested_numbers,
     location_numbers,
     area_code_numbers,
@@ -374,6 +375,24 @@ def vCard(request, lookup_key):
 
     resp = response.Response({"number": number})
     resp["Content-Disposition"] = f"attachment; filename={number}.vcf"
+    return resp
+
+
+@decorators.api_view(["POST"])
+@decorators.permission_classes([permissions.IsAuthenticated, HasPhoneService])
+def resend_welcome_sms(request):
+    """
+    Resend the "Welcome" SMS, including vCard.
+
+    Requires the user to be signed in and to have phone service.
+    """
+    try:
+        relay_number = RelayNumber.objects.get(user=request.user)
+    except RelayNumber.DoesNotExist:
+        raise exceptions.NotFound()
+    send_welcome_message(request.user, relay_number)
+
+    resp = response.Response(status=201, data={"msg": "sent"})
     return resp
 
 

--- a/phones/models.py
+++ b/phones/models.py
@@ -190,18 +190,22 @@ def relaynumber_post_save(sender, instance, created, **kwargs):
         return
 
     if created:
-        real_phone = RealPhone.objects.get(user=instance.user)
         # only send welcome vCard when creating new record
-        media_url = settings.SITE_ORIGIN + reverse(
-            "vCard", kwargs={"lookup_key": instance.vcard_lookup_key}
-        )
-        client = twilio_client()
-        client.messages.create(
-            body="Welcome to Relay Phoanz! 🎉 Please add your number to your contacts. This will help you identify your Relay messages and calls.",
-            from_=settings.TWILIO_MAIN_NUMBER,
-            to=real_phone.number,
-            media_url=[media_url],
-        )
+        send_welcome_message(instance.user, instance)
+
+
+def send_welcome_message(user, relay_number):
+    real_phone = RealPhone.objects.get(user=user)
+    media_url = settings.SITE_ORIGIN + reverse(
+        "vCard", kwargs={"lookup_key": relay_number.vcard_lookup_key}
+    )
+    client = twilio_client()
+    client.messages.create(
+        body="Welcome to Relay Phoanz! 🎉 Please add your number to your contacts. This will help you identify your Relay messages and calls.",
+        from_=settings.TWILIO_MAIN_NUMBER,
+        to=real_phone.number,
+        media_url=[media_url],
+    )
 
 
 def last_inbound_date_default():


### PR DESCRIPTION
This PR fixes MPP-2303.

![image](https://user-images.githubusercontent.com/71928/185245572-7a5b8027-ba52-44c7-b7ef-1c68a64e6a23.png)


How to test:
1. Sign into http://127.0.0.1:8000/ as a phone user with a relay number
2. Go to http://127.0.0.1:8000/api/v1/docs/
3. Scroll down to `POST /realphone/resend_welcome_sms` endpoint
4. Click "Try it out"
5. Click "Execute"
   * [ ] You should get a `201` response
   * [ ] Your real phone should receive the "Welcome" message


- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).