### PR TITLE
for MPP-2276: add `DELETE /api/v1/realphone/{id}/` endpoint

### DIFF
--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -70,9 +70,10 @@ class RealPhoneViewSet(SaveToRequestUser, viewsets.ModelViewSet):
     Client must be authenticated, and these endpoints only return data that is
     "owned" by the authenticated user.
 
+    All endpoints are rate-limited to settings.PHONE_RATE_LIMIT
     """
 
-    http_method_names = ["get", "post", "patch"]
+    http_method_names = ["get", "post", "patch", "delete"]
     permission_classes = [permissions.IsAuthenticated, HasPhoneService]
     serializer_class = RealPhoneSerializer
     # TODO: this doesn't seem to e working?
@@ -203,6 +204,17 @@ class RealPhoneViewSet(SaveToRequestUser, viewsets.ModelViewSet):
         instance.mark_verified()
         return super().partial_update(request, *args, **kwargs)
 
+    def destroy(self, request,*args, **kwargs):
+        """
+        Delete a real phone resource.
+
+        Only **un-verified** real phone resources can be deleted.
+        """
+        instance = self.get_object()
+        if instance.verified:
+            raise exceptions.ValidationError("Only un-verified real phone resources can be deleted.")
+
+        return super().destroy(request, *args, **kwargs)
 
 class RelayNumberViewSet(SaveToRequestUser, viewsets.ModelViewSet):
     http_method_names = ["get", "post", "patch"]

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -620,7 +620,7 @@ LOGGING = {
     },
 }
 
-if DEBUG:
+if DEBUG and not IN_PYTEST:
     DRF_RENDERERS = [
         "rest_framework.renderers.BrowsableAPIRenderer",
         "rest_framework.renderers.JSONRenderer",


### PR DESCRIPTION
# New feature description
Adds a `DELETE /api/v1/realphone/{id}/` endpoint for the "Edit number" button.


# Screenshot (if applicable)
![image](https://user-images.githubusercontent.com/71928/185660520-84d66415-42e1-4437-84ce-314562be713c.png)

# How to test
1. `pytest` should run with no failures nor errors
2. Go to http://127.0.0.1:8000/phone/
3. Enter a real phone number
4. Go to http://127.0.0.1:8000/api/v1/docs/
5. Execute the `GET /realphone/` endpoint to get the `id` value of the real phone record
6. Execute the `DELETE /realphone/{id}` endpoint
   * [ ] It should return a `204`
7. Execute the `GET /realphone/` endpoint to get the `id` value of the real phone record
   * [ ] It should return a `200` with an empty array `[]`
8. Go thru the full real phone verification flow
9. Go to http://127.0.0.1:8000/api/v1/docs/
10. Execute the `GET /realphone/` endpoint to get the `id` value of the verified real phone record
11. Execute the `DELETE /realphone/{id}` endpoint
    * [ ] It should return a `400`

# Checklist
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
