### PR TITLE
MPP-2286 Prevent verified numbers from doing verification process again.

### DIFF
--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -223,6 +223,29 @@ def test_realphone_post_invalid_verification_code(phone_user, mocked_twilio_clie
     mock_fetch.assert_not_called()
 
 
+def test_realphone_post_existing_verified_number(phone_user, mocked_twilio_client):
+    number = "+12223334444"
+    real_phone = RealPhone.objects.create(user=phone_user, number=number, verified=True)
+    client = APIClient()
+    client.force_authenticate(phone_user)
+    path = "/api/v1/realphone/"
+    data = {"number": number}
+
+    mock_fetch = Mock(
+        return_value=Mock(country_code="US", phone_number=number, carrier="verizon")
+    )
+    mocked_twilio_client.lookups.v1.phone_numbers = Mock(
+        return_value=Mock(fetch=mock_fetch)
+    )
+
+    response = client.post(path, data, format="json")
+    assert response.status_code == 409
+    assert "verified record already exists" in response.content.decode()
+    real_phone.refresh_from_db()
+
+    mock_fetch.assert_not_called()
+
+
 def test_realphone_patch_verification_code(phone_user, mocked_twilio_client):
     number = "+12223334444"
     real_phone = RealPhone.objects.create(
@@ -801,7 +824,9 @@ def test_inbound_call_valid_twilio_signature_good_data(
     decoded_content = response.content.decode()
     assert f'callerId="{caller_number}"' in decoded_content
     assert f"<Number>{real_phone_number}</Number>" in decoded_content
-    inbound_contact = InboundContact.objects.get(relay_number=relay_num_obj, inbound_number=caller_number)
+    inbound_contact = InboundContact.objects.get(
+        relay_number=relay_num_obj, inbound_number=caller_number
+    )
     assert inbound_contact.num_calls == 1
     assert inbound_contact.last_inbound_type == "call"
 

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -27,6 +27,7 @@ from phones.models import (
     RelayNumber,
     get_pending_unverified_realphone_records,
     get_valid_realphone_verification_record,
+    get_verified_realphone_record,
     send_welcome_message,
     suggested_numbers,
     location_numbers,
@@ -138,6 +139,12 @@ class RealPhoneViewSet(SaveToRequestUser, viewsets.ModelViewSet):
                 ],
             )
             return response.Response(response_data, status=201, headers=headers)
+
+        # to prevent sending verification codes to verified numbers,
+        # check if the number is already a verified number.
+        is_verified = get_verified_realphone_record(serializer.validated_data["number"])
+        if is_verified:
+            raise ConflictError("A verified record already exists for this number.")
 
         # to prevent abusive sending of verification messages,
         # check if there is an un-expired verification code for the user

--- a/phones/models.py
+++ b/phones/models.py
@@ -61,6 +61,9 @@ def get_pending_unverified_realphone_records(number):
 def get_verified_realphone_records(user):
     return RealPhone.objects.filter(user=user, verified=True)
 
+def get_verified_realphone_record(number):
+    return RealPhone.objects.filter(number=number, verified=True).first()
+
 
 def get_valid_realphone_verification_record(user, number, verification_code):
     return RealPhone.objects.filter(

--- a/phones/models.py
+++ b/phones/models.py
@@ -61,6 +61,7 @@ def get_pending_unverified_realphone_records(number):
 def get_verified_realphone_records(user):
     return RealPhone.objects.filter(user=user, verified=True)
 
+
 def get_verified_realphone_record(number):
     return RealPhone.objects.filter(number=number, verified=True).first()
 


### PR DESCRIPTION
 

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-2286
 

# New feature description

Show error state when a user tries to register a phone number that is already registered for relay phone masking.

This adds an additional check - is the phone number already verified? This helps prevent verification codes from being sent to numbers that are already verified. 

# Screenshot (if applicable)

<img width="1649" alt="image" src="https://user-images.githubusercontent.com/3924990/185684949-b4d88b4b-2ef2-45cb-b385-1c7486f7dff2.png">

# How to test

Have an existing verified phone number. Try using another account to verify the same real phone number. You should get an error. 

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
