### PR TITLE
fix MPP-2299: pull TopicArn and Type from JSON body

### DIFF
--- a/emails/management/commands/process_delayed_emails_from_sqs.py
+++ b/emails/management/commands/process_delayed_emails_from_sqs.py
@@ -9,7 +9,7 @@ from botocore.exceptions import ClientError
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from emails.views import _sns_inbound_logic, validate_sns_header, verify_from_sns
+from emails.views import _sns_inbound_logic, validate_sns_arn_and_type, verify_from_sns
 from emails.utils import incr_if_enabled
 
 
@@ -23,7 +23,7 @@ def _verify_and_run_sns_inbound_on_message(message):
     verified_json_body = verify_from_sns(json_body)
     topic_arn = verified_json_body["TopicArn"]
     message_type = verified_json_body["Type"]
-    validate_sns_header(topic_arn, message_type)
+    validate_sns_arn_and_type(topic_arn, message_type)
     try:
         _sns_inbound_logic(topic_arn, message_type, verified_json_body)
         info_logger.info(f"processed sqs message ID: {message.message_id}")

--- a/emails/management/commands/process_emails_from_sqs.py
+++ b/emails/management/commands/process_emails_from_sqs.py
@@ -26,7 +26,7 @@ import OpenSSL
 from django.core.management.base import CommandError
 
 from emails.sns import verify_from_sns
-from emails.views import _sns_inbound_logic, validate_sns_header
+from emails.views import _sns_inbound_logic, validate_sns_arn_and_type
 from emails.utils import incr_if_enabled, gauge_if_enabled
 from emails.management.command_from_django_settings import (
     CommandFromDjangoSettings,
@@ -367,7 +367,7 @@ class Command(CommandFromDjangoSettings):
 
         topic_arn = verified_json_body["TopicArn"]
         message_type = verified_json_body["Type"]
-        error_details = validate_sns_header(topic_arn, message_type)
+        error_details = validate_sns_arn_and_type(topic_arn, message_type)
         if error_details:
             results["success"] = False
             results.update(error_details)

--- a/emails/views.py
+++ b/emails/views.py
@@ -11,6 +11,7 @@ import re
 import shlex
 from tempfile import SpooledTemporaryFile
 from textwrap import dedent
+from typing import Any, Optional
 
 from botocore.exceptions import ClientError
 from decouple import strtobool
@@ -322,7 +323,7 @@ def sns_inbound(request):
     return _sns_inbound_logic(topic_arn, message_type, verified_json_body)
 
 
-def validate_sns_arn_and_type(topic_arn, message_type):
+def validate_sns_arn_and_type(topic_arn: str, message_type: str) -> Optional[dict[str, Any]]:
     """
     Validate Topic ARN and SNS Message Type.
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -307,23 +307,22 @@ def _index_DELETE(request_data, user_profile):
 @csrf_exempt
 def sns_inbound(request):
     incr_if_enabled("sns_inbound", 1)
-    # We can check for some invalid values in headers before processing body
-    # Grabs message information for validation
-    topic_arn = request.headers.get("X-Amz-Sns-Topic-Arn", None)
-    message_type = request.headers.get("X-Amz-Sns-Message-Type", None)
-
-    # Validates header
-    error_details = validate_sns_header(topic_arn, message_type)
-    if error_details:
-        logger.error("validate_sns_header_error", extra=error_details)
-        return HttpResponse(error_details["error"], status=400)
-
+    # First thing we do is verify the signature
     json_body = json.loads(request.body)
     verified_json_body = verify_from_sns(json_body)
+
+    # Validate ARN and message type
+    topic_arn = verified_json_body.get("TopicArn", None)
+    message_type = verified_json_body.get("Type", None)
+    error_details = validate_sns_arn_and_type(topic_arn, message_type)
+    if error_details:
+        logger.error("validate_sns_arn_and_type_error", extra=error_details)
+        return HttpResponse(error_details["error"], status=400)
+
     return _sns_inbound_logic(topic_arn, message_type, verified_json_body)
 
 
-def validate_sns_header(topic_arn, message_type):
+def validate_sns_arn_and_type(topic_arn, message_type):
     """
     Validate Topic ARN and SNS Message Type.
 


### PR DESCRIPTION
This PR fixes MPP-2299 by pulling the `TopicArn` and `Type` values from the verified JSON body rather than the HTTP headers.

How to test:
1. `pytest` should run with no error nor failures
2. Mail processing should work exactly as before.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).