### PR TITLE
fix MPP-2293: use secrets.randbelow

### DIFF
--- a/phones/models.py
+++ b/phones/models.py
@@ -1,6 +1,4 @@
 from datetime import datetime, timedelta, timezone
-import math
-import random
 import secrets
 import string
 
@@ -29,7 +27,7 @@ def twilio_client():
 
 
 def verification_code_default():
-    return str(math.floor(random.random() * 999999)).zfill(6)
+    return str(secrets.randbelow(1000000)).zfill(6)
 
 
 def verification_sent_date_default():


### PR DESCRIPTION
This PR fixes MPP-2293.

How to test:
1. `pytest` should run with no errors nor failures
2. Real Phone verification flow should work as before

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).