### PR TITLE
Test branch migrations on production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,10 @@ jobs:
         description: "Allow the command to fail without failing job."
         type: boolean
         default: false
+      production_with_new_migrations:
+        description: "Test if deployed code will work with new migrations."
+        type: boolean
+        default: false
     steps:
       - checkout_with_submodules
       - python/install-packages:
@@ -318,6 +322,19 @@ jobs:
       - run:
           name: Set test defaults
           command: cp .env-dist .env
+      - when:
+          condition: << parameters.production_with_new_migrations >>
+          steps:
+            - run:
+                name: Switch to production tag with branch's migrations
+                command: |
+                  echo 'export PROD_TAG=$(curl --silent https://relay.firefox.com/__version__ | jq -r ".version")' >> $BASH_ENV
+                  source $BASH_ENV
+                  echo "# Production tag is ${PROD_TAG}"
+                  git fetch --force origin tag ${PROD_TAG}
+                  git checkout ${PROD_TAG}
+                  git checkout --theirs "${CIRCLE_BRANCH}" -- '**/migrations/**'
+                  git status
       - unless:
           condition: << parameters.allow_fail >>
           steps:
@@ -351,6 +368,15 @@ jobs:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
+    parameters:
+      production_with_new_migrations:
+        description: "Test if deployed code will work with new migrations."
+        type: boolean
+        default: false
+      test_file_name:
+        description: "Name of the test report"
+        type: string
+        default: "report.xml"
     steps:
       - checkout_with_submodules
       - python/install-packages:
@@ -372,9 +398,22 @@ jobs:
       - run:
           name: Create test-report directory
           command: mkdir test-report
+      - when:
+          condition: << parameters.production_with_new_migrations >>
+          steps:
+            - run:
+                name: Switch to production tag with branch's migrations
+                command: |
+                  echo 'export PROD_TAG=$(curl --silent https://relay.firefox.com/__version__ | jq -r ".version")' >> $BASH_ENV
+                  source $BASH_ENV
+                  echo "# Production tag is ${PROD_TAG}"
+                  git fetch --force origin tag ${PROD_TAG}
+                  git checkout ${PROD_TAG}
+                  git checkout --theirs "${CIRCLE_BRANCH}" -- '**/migrations/**'
+                  git status
       - run:
           name: Run tests
-          command: pytest --junit-xml=test-report/report.xml .
+          command: pytest --junit-xml=test-report/<< parameters.test_file_name >> .
           environment:
             DATABASE_URL: postgresql://postgres:6edef2d746f2274cab951a452d5fc13d@localhost/circle
       - store_test_results:
@@ -423,6 +462,24 @@ workflows:
               only: /.*/
 
       - python_test_postgres:
+          filters:
+            tags:
+              only: /.*/
+
+      - python_job:
+          name: sqlite migrations test
+          command: pytest --maxfail=3 --junit-xml=job-results/pytest-migrations.xml .
+          has_results: true
+          allow_fail: false
+          production_with_new_migrations: true
+          filters:
+            tags:
+              only: /.*/
+
+      - python_test_postgres:
+          name: postgres migrations test
+          production_with_new_migrations: true
+          test_file_name: psql_migrations.xml
           filters:
             tags:
               only: /.*/

--- a/phones/migrations/0020_inboundcontact_last_inbound_type.py
+++ b/phones/migrations/0020_inboundcontact_last_inbound_type.py
@@ -21,7 +21,7 @@ def add_db_default_forward_func(apps, schema_editor):
             ' ("id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,'
             '  "inbound_number" varchar(15) NOT NULL,'
             '  "last_inbound_date" datetime NOT NULL,'
-            '  "last_inbound_type" varchar(4) NOT NULL,'
+            '  "last_inbound_type" varchar(4) NOT NULL DEFAULT \'text\','
             '  "num_calls" integer unsigned NOT NULL CHECK ("num_calls" >= 0),'
             '  "num_calls_blocked" integer unsigned NOT NULL CHECK ("num_calls_blocked" >= 0),'
             '  "num_texts" integer unsigned NOT NULL CHECK ("num_texts" >= 0),'


### PR DESCRIPTION
Test if there will be database errors when the current production code runs against the new migrations during the next deploy. 

This is done with two new CircleCI jobs with an extra step that:
* Parses the production tag from https://relay.firefox.com/__version__
* Fetches that tag from the repository
* Checks out that tag
* Checks out the migrations from the current branch

`pytest` / Django will then run the migrations from the current branch, but run the tests from the production tag. This will simulate what happens during the next deployment, when the old code handles traffic while running against the newly migrated database.

How to test:

- [x] See [failing CircleCI results](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/7076/workflows/7d569dff-8eff-40cd-a225-12e9e2d5df3d/jobs/24481/steps) for running this step with sqlite3 (like developer environment)
- [x] See [passing CircleCI results](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/7077/workflows/e7a531b9-6d25-4d79-a41c-53377c735bd2/jobs/24495) for SQLite3 once a default is added
- [x] See [passing CircleCI results](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/7077/workflows/e7a531b9-6d25-4d79-a41c-53377c735bd2/jobs/24493) for running this step with postgres (like production environment)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).