### PR TITLE
fix MPP-2285: Lock profile to prevent race condition against free limit

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -558,7 +558,7 @@ class RelayAddress(models.Model):
                 locked_profile = Profile.objects.select_for_update().get(
                     user=self.user
                 )
-                check_user_can_make_another_address(self.user)
+                check_user_can_make_another_address(locked_profile)
                 while True:
                     if valid_address(self.address, self.domain):
                         break
@@ -580,11 +580,10 @@ class RelayAddress(models.Model):
         return "%s@%s" % (self.address, self.domain_value)
 
 
-def check_user_can_make_another_address(user):
-    user_profile = user.profile_set.first()
-    if user_profile.is_flagged:
+def check_user_can_make_another_address(profile):
+    if profile.is_flagged:
         raise CannotMakeAddressException(ACCOUNT_PAUSED_ERR_MSG)
-    if user_profile.at_max_free_aliases and not user_profile.has_premium:
+    if profile.at_max_free_aliases and not profile.has_premium:
         hit_limit = f"make more than {settings.MAX_NUM_FREE_ALIASES} aliases"
         raise CannotMakeAddressException(NOT_PREMIUM_USER_ERR_MSG.format(hit_limit))
 

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -279,7 +279,8 @@ class RelayAddressTest(TestCase):
 
 class ProfileTest(TestCase):
     def setUp(self):
-        self.profile = baker.make(Profile)
+        user = baker.make(User)
+        self.profile = user.profile_set.first()
         self.profile.server_storage = True
         self.profile.save()
 
@@ -712,7 +713,10 @@ class ProfileTest(TestCase):
             _quantity=4,
         )
 
-        server_stored_data_profile = baker.make(Profile, server_storage=True)
+        server_stored_data_user = baker.make(User)
+        server_stored_data_profile = server_stored_data_user.profile_set.first()
+        server_stored_data_profile.server_storage = True
+        server_stored_data_profile.save()
         baker.make(
             RelayAddress,
             user=server_stored_data_profile.user,


### PR DESCRIPTION
This PR fixes MPP-2285 where there is a race condition against free alias limit.

How to test:

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

#
Related to #715