### PR TITLE
fix MPP-2257: report issue endpoint

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -147,3 +147,13 @@ class UserSerializer(serializers.ModelSerializer):
         model = User
         fields = ["email"]
         read_only_fields = ["email"]
+
+
+class WebcompatIssueSerializer(serializers.Serializer):
+    issue_on_domain = serializers.URLField(
+        max_length=200, min_length=None, allow_blank=False
+    )
+    email_mask_not_accepted = serializers.BooleanField(required=False, default=False)
+    add_on_visual_issue = serializers.BooleanField(required=False, default=False)
+    email_not_received = serializers.BooleanField(required=False, default=False)
+    other_issue = serializers.CharField(required=False, default="", allow_blank=True)

--- a/api/urls.py
+++ b/api/urls.py
@@ -9,6 +9,7 @@ from .views import (
     ProfileViewSet,
     UserViewSet,
     premium_countries,
+    report_webcompat_issue,
     runtime_data,
     schema_view,
 )
@@ -37,6 +38,11 @@ api_router.register(r"users", UserViewSet, "user")
 urlpatterns = [
     path("v1/premium_countries", premium_countries, name="premium_countries"),
     path("v1/runtime_data", runtime_data, name="runtime_data"),
+    path(
+        "v1/report_webcompat_issue",
+        report_webcompat_issue,
+        name="report_webcompat_issue",
+    ),
     path(
         "v1/swagger<swagger_format:format>",
         schema_view.without_ui(cache_timeout=0),

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -157,9 +157,8 @@ class ProfileViewSet(viewsets.ModelViewSet):
         if serializer.is_valid():
             info_logger.info("webcompat_issue", extra=serializer.data)
             incr_if_enabled(f"webcompat_issue", 1)
-            import ipdb; ipdb.set_trace()
             for k, v in serializer.data.items():
-                if v:
+                if v and k != "issue_on_domain":
                     incr_if_enabled(f"webcompat_issue_{k}", 1)
             return response.Response(status=status.HTTP_201_CREATED)
         return response.Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -202,6 +201,6 @@ def runtime_data(request):
             "WAFFLE_FLAGS": flag_values,
             "WAFFLE_SWITCHES": switch_values,
             "WAFFLE_SAMPLES": sample_values,
-            "MAX_MINUTES_TO_VERIFY_REAL_PHONE": MAX_MINUTES_TO_VERIFY_REAL_PHONE
+            "MAX_MINUTES_TO_VERIFY_REAL_PHONE": MAX_MINUTES_TO_VERIFY_REAL_PHONE,
         }
     )

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -202,7 +202,7 @@ def report_webcompat_issue(request):
     serializer = WebcompatIssueSerializer(data=request.data)
     if serializer.is_valid():
         info_logger.info("webcompat_issue", extra=serializer.data)
-        incr_if_enabled(f"webcompat_issue", 1)
+        incr_if_enabled("webcompat_issue", 1)
         for k, v in serializer.data.items():
             if v and k != "issue_on_domain":
                 incr_if_enabled(f"webcompat_issue_{k}", 1)


### PR DESCRIPTION
# New feature description
New endpoint POST `/profiles/{id}/report_webcompat_issue/` to log reports on webcompat from the add-on accepting the following data:
```
issue_on_domain = serializers.URLField(
        max_length=200, min_length=None, allow_blank=False
    )
    email_mask_not_accepted = serializers.BooleanField(required=False, default=False)
    add_on_visual_issue = serializers.BooleanField(required=False, default=False)
    email_not_received = serializers.BooleanField(required=False, default=False)
    other_issue = serializers.CharField(required=False, default="", allow_blank=True)
```
an example POST data looks like:
```json
{
  "issue_on_domain": "https://sample.com",
  "email_not_received": true,
  "other_issue": "accepted at first but no email received"
}
```

# Screenshot (if applicable)

Not applicable.

# How to test
## POST request to `/profiles/{id}/report_webcompat_issue/` logs on `eventsinfo` and increments markus metrics
1. Login and go to `/api/v1/docs`
2. Go to `/profiles/{id}/report_webcompat_issue/` and click "Try it out"
3. On the data field add: 
```json
{
  "issue_on_domain": "https://sample.com",
  "email_not_received": true,
  "other_issue": "accepted at first but no email received"
}
```
4. In the id field add the profile id of the user you are logged in as. You can find this value also by making a GET request on `/api/v1/profiles/`
5. Submit the POST request by clicking "Execute" button and check that you get a 201 response and on your local instance you see the following log:
```
{"Timestamp": 1661197908238859008, "Type": "eventsinfo", "Logger": "fx-private-relay", "Hostname": "s00000-0dg8wn", "EnvVersion": "2.0", "Severity": 6, "Pid": 25237, "Fields": {"issue_on_domain": "https://sample.com", "email_mask_not_accepted": false, "add_on_visual_issue": false, "email_not_received": true, "other_issue": "accepted at first but no email received", "msg": "webcompat_issue"}}
```

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
