### PR TITLE
Outsource checking for === to computers

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -17,6 +17,10 @@ module.exports = {
       "warn",
       { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
     ],
+    // Weirdly this rule does not get set by ESLint's recommended ruleset,
+    // but we try to avoid implicitly casting values (see e.g. reviews of
+    // https://github.com/mozilla/fx-private-relay/pull/2315):
+    eqeqeq: ["error", "always"],
   },
   overrides: [
     {


### PR DESCRIPTION
Since we're rightfully calling out the use of == rather than === in
code reviews (e.g. https://github.com/mozilla/fx-private-relay/pull/2315), we might as
well have computers do that for us :)