### PR TITLE
Fix frontend test coverage

### DIFF
--- a/frontend/__mocks__/hooks/api/profile.ts
+++ b/frontend/__mocks__/hooks/api/profile.ts
@@ -18,6 +18,8 @@ type MockData = Partial<ProfileData>;
 export function getMockProfileData(profileData?: MockData): ProfileData {
   return {
     has_premium: false,
+    has_phone: false,
+    store_phone_log: true,
     id: 0,
     server_storage: true,
     remove_level_one_email_trackers: false,

--- a/frontend/src/apiMocks/handlers.ts
+++ b/frontend/src/apiMocks/handlers.ts
@@ -397,6 +397,7 @@ export function getHandlers(
       number: body.number,
       location: "Unhošť",
       enabled: true,
+      id: mockedRelaynumbers[mockId].length,
     };
     mockedRelaynumbers[mockId].push(newRelaynumber);
     return res(ctx.status(201), ctx.json(newRelaynumber));

--- a/frontend/src/apiMocks/mockData.ts
+++ b/frontend/src/apiMocks/mockData.ts
@@ -280,6 +280,7 @@ export const mockedRelaynumbers: Record<
   onboarding: [],
   some: [
     {
+      id: 0,
       number: "+18089251571",
       location: "Hilo",
       enabled: true,
@@ -287,6 +288,7 @@ export const mockedRelaynumbers: Record<
   ],
   full: [
     {
+      id: 0,
       number: "+18089251571",
       location: "Hilo",
       enabled: true,

--- a/frontend/src/components/phones/dashboard/Dashboard.tsx
+++ b/frontend/src/components/phones/dashboard/Dashboard.tsx
@@ -217,7 +217,7 @@ export const PhoneDashboard = () => {
   }
 
   return (
-    <main className={styles["main-phone-wrapper"]}>
+    <div className={styles["main-phone-wrapper"]}>
       {showingPrimaryDashboard && inboundContactData !== undefined ? (
         // Primary Panel
         <>{primaryPanel}</>
@@ -228,6 +228,6 @@ export const PhoneDashboard = () => {
           back_btn={toggleSendersPanel}
         />
       )}
-    </main>
+    </div>
   );
 };

--- a/frontend/src/components/phones/dashboard/Dashboard.tsx
+++ b/frontend/src/components/phones/dashboard/Dashboard.tsx
@@ -146,9 +146,7 @@ export const PhoneDashboard = () => {
           <dd>{formattedPhoneNumber}</dd>
         </div>
         <div className={`${styles["date-created"]} ${styles.metadata}`}>
-          <dt>
-            <dt>{l10n.getString("phone-dashboard-metadata-date-created")}</dt>
-          </dt>
+          <dt>{l10n.getString("phone-dashboard-metadata-date-created")}</dt>
           <dd>
             <Moment format="D MMM YYYY">{dateToFormat}</Moment>
           </dd>

--- a/frontend/src/hooks/api/relayNumber.ts
+++ b/frontend/src/hooks/api/relayNumber.ts
@@ -2,9 +2,9 @@ import { SWRResponse } from "swr";
 import { apiFetch, useApiV1 } from "./api";
 
 export type RelayNumber = {
+  id: number;
   number: string;
   location?: string;
-  id?: number;
   enabled: boolean;
 };
 

--- a/frontend/src/pages/phone.page.tsx
+++ b/frontend/src/pages/phone.page.tsx
@@ -63,7 +63,7 @@ const Phone: NextPage = () => {
 
   return (
     <Layout>
-      <div className={styles["main-wrapper"]}>
+      <main className={styles["main-wrapper"]}>
         <div className={styles["banner-wrapper"]}>
           <Banner
             title={l10n.getString("phone-banner-resend-welcome-sms-title")}
@@ -85,7 +85,7 @@ const Phone: NextPage = () => {
           </Banner>
         </div>
         <PhoneDashboard />
-      </div>
+      </main>
     </Layout>
   );
 };

--- a/frontend/src/pages/phone.test.tsx
+++ b/frontend/src/pages/phone.test.tsx
@@ -51,6 +51,7 @@ describe("The Phone dashboard", () => {
     beforeEach(() => {
       setMockRelayNumberData([getMockRelayNumber()]);
       setMockRealPhonesData([getMockVerifiedRealPhone()]);
+      setMockProfileData({ has_phone: true });
     });
 
     describe("under axe accessibility testing", () => {


### PR DESCRIPTION
This doesn't add unit tests to test the correct behaviour of the phone UI, but it does ensure that axe's suite of accessibility tests actually run on the phone dashboard for people who went through the onboarding. It didn't before, because the dashboard didn't load in the unit tests because the mock profile didn't have `has_phone` set to `true`. And it uncovered two a11y issues, so this PR fixes those too, in separate commits.

And finally, it marks `id` of the RelayNumber API as required, as per https://github.com/mozilla/fx-private-relay/pull/2327#discussion_r944020997.

How to test: CI succeeds again :)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
