### PR TITLE
Use a table for tabular log data

### DIFF
--- a/frontend/src/components/phones/dashboard/PhoneDashboard.module.scss
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.module.scss
@@ -135,6 +135,26 @@
       margin-top: $spacing-2xl;
     }
 
+    thead {
+      // On mobile, the table heading only exists for screen readers.
+      // See https://webaim.org/techniques/css/invisiblecontent/#offscreen.
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      clip-path: circle(0);
+
+      @media screen and #{$mq-md} {
+        position: unset;
+        width: unset;
+        height: unset;
+        overflow: unset;
+        clip: unset;
+        clip-path: unset;
+      }
+    }
+
     tr {
       display: grid;
       grid-template-columns: 2fr 1fr;
@@ -142,14 +162,6 @@
       padding: $spacing-sm 0;
       align-items: center;
       gap: $spacing-sm;
-
-      &:first-child {
-        display: none;
-
-        @media screen and #{$mq-md} {
-          display: grid;
-        }
-      }
 
       @media screen and #{$mq-md} {
         grid-template-columns: 3fr 2fr 1fr;
@@ -178,7 +190,9 @@
       }
 
       .sender-controls {
-        position: absolute;
+        grid-row: 1 / 3;
+        grid-column: 2;
+        align-self: center;
         justify-self: end;
       }
 
@@ -192,7 +206,6 @@
         .sender-controls {
           grid-row: auto;
           grid-column: auto;
-          position: relative;
           justify-self: auto;
         }
       }

--- a/frontend/src/components/phones/dashboard/PhoneDashboard.module.scss
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.module.scss
@@ -127,7 +127,6 @@
   .caller-sms-senders-table {
     display: flex;
     flex-direction: column;
-    gap: $spacing-sm;
     margin-top: $spacing-lg;
     padding: 0 $spacing-lg;
 
@@ -136,11 +135,11 @@
       margin-top: $spacing-2xl;
     }
 
-    li {
+    tr {
       display: grid;
       grid-template-columns: 2fr 1fr;
       border-bottom: 1px solid $color-light-gray-20;
-      padding-bottom: $spacing-sm;
+      padding: $spacing-sm 0;
       align-items: center;
       gap: $spacing-sm;
 
@@ -155,6 +154,11 @@
       @media screen and #{$mq-md} {
         grid-template-columns: 3fr 2fr 1fr;
         grid-gap: $spacing-md;
+      }
+
+      th {
+        text-align: start;
+        font-weight: 400;
       }
 
       .sender-number {

--- a/frontend/src/components/phones/dashboard/SendersPanelView.tsx
+++ b/frontend/src/components/phones/dashboard/SendersPanelView.tsx
@@ -81,14 +81,14 @@ export const SendersPanelView = (props: Props) => {
       )
       .map((data) => {
         return (
-          <li
+          <tr
             key={data.id}
             className={data.blocked ? styles["greyed-contact"] : ""}
           >
-            <span className={styles["sender-number"]}>
+            <td className={styles["sender-number"]}>
               {formatPhone(data.inbound_number ?? "")}
-            </span>
-            <span
+            </td>
+            <td
               className={`${styles["sender-date"]} ${styles["sender-date-wrapper"]}`}
             >
               {data.last_inbound_type === "text" && (
@@ -108,8 +108,8 @@ export const SendersPanelView = (props: Props) => {
                 />
               )}
               {dateTimeFormatter.format(parseDate(data.last_inbound_date))}
-            </span>
-            <span className={styles["sender-controls"]}>
+            </td>
+            <td className={styles["sender-controls"]}>
               <button
                 onClick={() =>
                   inboundContactData.setForwardingState(!data.blocked, data.id)
@@ -118,26 +118,24 @@ export const SendersPanelView = (props: Props) => {
               >
                 {data.blocked ? "Unblock" : "Block"}
               </button>
-            </span>
-          </li>
+            </td>
+          </tr>
         );
       });
 
   const senderLogsPanel = (
-    <ul className={styles["caller-sms-senders-table"]}>
-      <li className={styles["greyed-contact"]}>
-        <span>
-          {l10n.getString("phone-dashboard-sender-table-title-sender")}
-        </span>
-        <span>
-          {l10n.getString("phone-dashboard-sender-table-title-activity")}
-        </span>
-        <span>
-          {l10n.getString("phone-dashboard-sender-table-title-action")}
-        </span>
-      </li>
-      {inboundContactArray}
-    </ul>
+    <table className={styles["caller-sms-senders-table"]}>
+      <thead>
+        <tr className={styles["greyed-contact"]}>
+          <th>{l10n.getString("phone-dashboard-sender-table-title-sender")}</th>
+          <th>
+            {l10n.getString("phone-dashboard-sender-table-title-activity")}
+          </th>
+          <th>{l10n.getString("phone-dashboard-sender-table-title-action")}</th>
+        </tr>
+      </thead>
+      <tbody>{inboundContactArray}</tbody>
+    </table>
   );
 
   return (


### PR DESCRIPTION
Otherwise screen readers will announce the entire &lt;li&gt; as a single
item, disconnected from the headings. (If you're on MacOS, try enabling VoiceOver, and compare how it reads the log data before this change and after this change.)

How to test: the call and SMS log should be roughly the same, but when inspecting it through a screen reader, the separate cells should be read separately, with the associated table headings announced as well.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
