### PR TITLE
Test `PHONES_ENABLED=0`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -484,6 +484,14 @@ workflows:
             tags:
               only: /.*/
 
+      - python_job:
+          name: python test phones disabled
+          command: PHONES_ENABLED=0 pytest --junit-xml=job-results/pytest-phones-disabled.xml .
+          has_results: true
+          filters:
+            tags:
+              only: /.*/
+
       - test_frontend:
           requires:
             - build_frontend

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -10,10 +10,9 @@ from django.contrib.auth.models import User
 from model_bakery import baker
 from rest_framework.test import APIClient
 
-from phones.models import InboundContact
 
 if settings.PHONES_ENABLED:
-    from phones.models import RealPhone, RelayNumber
+    from phones.models import InboundContact, RealPhone, RelayNumber
     from phones.tests.models_tests import make_phone_test_user
 
 

--- a/phones/tests/models_tests.py
+++ b/phones/tests/models_tests.py
@@ -12,10 +12,10 @@ from allauth.socialaccount.models import SocialAccount, SocialToken
 from model_bakery import baker
 
 from emails.models import Profile
-from phones.models import InboundContact
 
 if settings.PHONES_ENABLED:
     from ..models import (
+        InboundContact,
         RealPhone,
         RelayNumber,
         area_code_numbers,


### PR DESCRIPTION
* Fix the test imports when `PHONES_ENABLED=0`
* Add a CircleCI job to run tests with `PHONES_ENABLED=0`

How to test:
* [x] On `main` branch, run `PHONES_ENABLED=0 pytest .`. You should get `ERROR collecting api/tests/phones_views_tests.py` and `... phones/tests/models_tests.py`.
* [x] Checkout this branch, run `PHONES_ENABLED=0 pytest .` Tests should pass, with 63 skipped (all of `api/tests/phones_views_tests.py`, `phones/tests/models_tests.py`, and `api/tests/phones_views_tests.py`)
* [x] Look at CircleCI job ["python test phones disabled"](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/7129/workflows/9ce4f77f-9f38-49ce-88aa-1a6d75990cee/jobs/24975/steps) for this PR. The step `PHONES_ENABLED=0 pytest --junit-xml=job-results/pytest-phones-disabled.xml .` shows `329 passed, 63 skipped, 16 warnings`.