### PR TITLE
List tracker blocking if Premium's unavailable

### DIFF
--- a/frontend/src/components/landing/Plans.tsx
+++ b/frontend/src/components/landing/Plans.tsx
@@ -8,15 +8,15 @@ import {
   getPlan,
   getPremiumSubscribeLink,
   isPremiumAvailableInCountry,
-  RuntimeDataWithPremiumAvailable,
 } from "../../functions/getPlan";
 import { trackPurchaseStart } from "../../functions/trackPurchase";
 import { getRuntimeConfig } from "../../config";
 import Link from "next/link";
 import { isFlagActive } from "../../functions/waffle";
+import { RuntimeData } from "../../hooks/api/runtimeData";
 
 export type Props = {
-  premiumCountriesData?: RuntimeDataWithPremiumAvailable;
+  runtimeData?: RuntimeData;
 };
 
 /**
@@ -35,7 +35,7 @@ export const Plans = (props: Props) => {
 
   /** List of premium features **/
   const trackerBlockingFeatureListingPremium = isFlagActive(
-    props.premiumCountriesData,
+    props.runtimeData,
     "tracker_removal"
   ) ? (
     <li>{l10n.getString("landing-pricing-premium-feature-6")}</li>
@@ -53,7 +53,7 @@ export const Plans = (props: Props) => {
 
   /** List of free features **/
   const trackerBlockingFeatureListingFree = isFlagActive(
-    props.premiumCountriesData,
+    props.runtimeData,
     "tracker_removal"
   ) ? (
     <li>{l10n.getString("landing-pricing-free-feature-3")}</li>
@@ -122,9 +122,7 @@ export const Plans = (props: Props) => {
     </a>
   );
 
-  const freePlanCard = isPremiumAvailableInCountry(
-    props.premiumCountriesData
-  ) ? (
+  const freePlanCard = isPremiumAvailableInCountry(props.runtimeData) ? (
     <a
       href={getRuntimeConfig().fxaLoginUrl}
       className={`${styles.plan} ${styles["free-plan"]}`}
@@ -152,19 +150,15 @@ export const Plans = (props: Props) => {
   ) : (
     unavailablePremiumPanel
   );
-  const topPremiumDetail = isPremiumAvailableInCountry(
-    props.premiumCountriesData
-  ) ? (
+  const topPremiumDetail = isPremiumAvailableInCountry(props.runtimeData) ? (
     <span className={styles.callout}>
       {l10n.getString("landing-pricing-premium-price-highlight")}
     </span>
   ) : null;
 
-  const premiumPlanCard = isPremiumAvailableInCountry(
-    props.premiumCountriesData
-  ) ? (
+  const premiumPlanCard = isPremiumAvailableInCountry(props.runtimeData) ? (
     <a
-      href={getPremiumSubscribeLink(props.premiumCountriesData)}
+      href={getPremiumSubscribeLink(props.runtimeData)}
       onClick={() => trackPurchaseStart()}
       className={`${styles.plan} ${styles["premium-plan"]}`}
     >
@@ -175,7 +169,7 @@ export const Plans = (props: Props) => {
       />
       <b className={styles.price}>
         {l10n.getString("landing-pricing-premium-price", {
-          monthly_price: getPlan(props.premiumCountriesData).price,
+          monthly_price: getPlan(props.runtimeData).price,
         })}
       </b>
       {premiumFeatures}
@@ -190,7 +184,7 @@ export const Plans = (props: Props) => {
   return (
     <div
       className={
-        isPremiumAvailableInCountry(props.premiumCountriesData)
+        isPremiumAvailableInCountry(props.runtimeData)
           ? styles["comparison"]
           : styles["comparison-waitlist"]
       }

--- a/frontend/src/pages/index.page.tsx
+++ b/frontend/src/pages/index.page.tsx
@@ -62,7 +62,7 @@ const Home: NextPage = () => {
     <section id="pricing" className={styles["plans-wrapper"]}>
       <div className={styles.plans}>
         <div className={styles["plan-comparison"]}>
-          <Plans premiumCountriesData={runtimeData.data} />
+          <Plans runtimeData={runtimeData.data} />
         </div>
         <div className={styles.callout}>
           <h2>
@@ -78,7 +78,7 @@ const Home: NextPage = () => {
     /* Show waitlist prompt if user is a non-premium country */
     <section id="pricing" className={styles["plans-wrapper"]}>
       <div className={`${styles.plans} ${styles["non-premium-country"]}`}>
-        <Plans />
+        <Plans runtimeData={runtimeData.data} />
       </div>
     </section>
   );

--- a/frontend/src/pages/premium.page.tsx
+++ b/frontend/src/pages/premium.page.tsx
@@ -77,7 +77,7 @@ const PremiumPromo: NextPage = () => {
     <section id="pricing" className={styles["plans-wrapper"]}>
       <div className={styles.plans}>
         <div className={styles["plan-comparison"]}>
-          <Plans premiumCountriesData={runtimeData.data} />
+          <Plans runtimeData={runtimeData.data} />
         </div>
         <div className={styles.callout}>
           <h2>
@@ -93,7 +93,7 @@ const PremiumPromo: NextPage = () => {
     /* Show waitlist prompt if user is a non-premium country */
     <section id="pricing" className={styles["plans-wrapper"]}>
       <div className={`${styles.plans} ${styles["non-premium-country"]}`}>
-        <Plans />
+        <Plans runtimeData={runtimeData.data} />
       </div>
     </section>
   );


### PR DESCRIPTION
In countries were Relay Premium is not available, tracker blocking
would not be listed under the plans as an available feature. The
reason for this is that if Premium was not available, we weren't
even passing `runtimeData` to the `<Plans>` component (assuming
that it wouldn't be necessary if there were no plans to select).
However, that data is also needed to determine whether the flag is
active already.

This PR fixes #2332.

How to test: open the landing page and `/premium` with your browser language set to that of a country where Premium is unavailable (or, on stage, use a VPN). Tracker removal should be listed as a feature in the pricing plans cards:

![image](https://user-images.githubusercontent.com/4251/186682796-47658478-2d61-4c6c-8cee-171c77636134.png)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - Not sure if that makes sense here?
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
