### PR TITLE
MPP-2310 Remove ability to resubmit existing number for verification

### DIFF
--- a/frontend/src/components/phones/onboarding/PhoneOnboarding.tsx
+++ b/frontend/src/components/phones/onboarding/PhoneOnboarding.tsx
@@ -23,7 +23,7 @@ export const PhoneOnboarding = (props: Props) => {
 
   // Make sure profile and runtime data are available
   if (profiles.data?.[0] === undefined || !runtimeData.data) {
-    return null;
+    return <>TODO: Profile Loading/Error</>;
   }
 
   // Show Upgrade Prompt - User has not yet purchased phone
@@ -33,7 +33,7 @@ export const PhoneOnboarding = (props: Props) => {
 
   // Make sure realPhoneData data is available
   if (realPhoneData.data === undefined) {
-    return null;
+    return <>TODO: realPhoneData Loading/Error</>;
   }
 
   const verifiedPhones = realPhoneData.data.filter(isVerified);

--- a/frontend/src/components/phones/onboarding/PhoneOnboarding.tsx
+++ b/frontend/src/components/phones/onboarding/PhoneOnboarding.tsx
@@ -23,7 +23,7 @@ export const PhoneOnboarding = (props: Props) => {
 
   // Make sure profile and runtime data are available
   if (profiles.data?.[0] === undefined || !runtimeData.data) {
-    return <>TODO: Profile Loading/Error</>;
+    return null;
   }
 
   // Show Upgrade Prompt - User has not yet purchased phone
@@ -33,7 +33,7 @@ export const PhoneOnboarding = (props: Props) => {
 
   // Make sure realPhoneData data is available
   if (realPhoneData.data === undefined) {
-    return <>TODO: realPhoneData Loading/Error</>;
+    return null;
   }
 
   const verifiedPhones = realPhoneData.data.filter(isVerified);

--- a/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
+++ b/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
@@ -94,6 +94,9 @@ const RealPhoneForm = (props: RealPhoneFormProps) => {
       return;
     }
 
+    // reset error state
+    setPhoneNumberError(false);
+
     // check if phone data is available, check if current number matches number being passed in.
     // Only request removal if numbers don't match.
     if (

--- a/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
+++ b/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
@@ -21,10 +21,7 @@ import {
   useState,
 } from "react";
 import { parseDate } from "../../../functions/parseDate";
-import PhoneInput, {
-  isPossiblePhoneNumber,
-  parsePhoneNumber,
-} from "react-phone-number-input";
+import PhoneInput, { isPossiblePhoneNumber } from "react-phone-number-input";
 import { E164Number } from "libphonenumber-js/min";
 import { formatPhone } from "../../../functions/formatPhone";
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-2310


# New feature description

A user was able to enter an already used phone number on the “Verify your true phone number” screen

# Screenshot (if applicable)

<img width="622" alt="image" src="https://user-images.githubusercontent.com/3924990/186826840-955b0ced-0a58-48c6-a8bf-3dbb63d119ec.png">

# How to test

- Go to the Relay dashboard;- 
- Click on the “Phone Number” button from the site header;
- Click on the “Upgrade Now” button;
- Go through the purchase flow;
- Return to the “Phone Number” tab;
- Enter the already used phone number from the first account from the prerequisites and proceed;
- Observe the results;

#### Prerequisites:

Have a Premium Relay account that has a Phone Number Mask set;

Have a Premium Relay account that does NOT have the Phone Number subscription purchased;

Be signed in to the second Relay account;

#### Expected result:

The user is displayed an error message 

#### Actual result:

The user is sent the verification code and redirected to the “Verify your true phone number” screen;

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
