### PR TITLE
Make the dashboard switcher non-sticky

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -11,8 +11,9 @@ nav-settings = Settings
 nav-support = Help and Support
 nav-sign-out = Sign Out
 nav-contact = Contact Us
-nav-duo-email-mask-alt = Go to Email Masks Dashboard
-nav-duo-phone-mask-alt = Go to Phone Masks Dashboard
+nav-duo-description = Switch dashboards
+nav-duo-email-mask-alt = Email masks
+nav-duo-phone-mask-alt = Phone masks
 
 landing-pricing-free-feature-3 = Email tracker removal
 landing-pricing-premium-feature-6 = Email tracker removal

--- a/frontend/src/components/layout/Layout.module.scss
+++ b/frontend/src/components/layout/Layout.module.scss
@@ -151,7 +151,7 @@ $toastify-toast-close-button: var(--toast-close-button);
   // overlap the AppPicker drawer).
   // Thus, upping the z-index stack the header, and menus
   // expanding from it, on top again:
-  z-index: 3;
+  z-index: 2;
   display: grid;
   grid-template-columns: 1fr;
   grid-template-areas:
@@ -257,18 +257,6 @@ $toastify-toast-close-button: var(--toast-close-button);
   height: 100%;
   display: flex;
   flex-direction: column;
-  z-index: 2; //z-index is a unit higher, so that it sits above the mask/phone duo nav
-}
-
-.mobile-nav-duo-wrapper {
-  z-index: 1; //z-index is a unit lower, so that the mask/phone duo nav slides sits under the expanded mobile menu
-  position: sticky;
-  top: 0;
-  padding-bottom: $layout-xl; // Adds padding to make room for the mask/phone nav on mobile
-
-  @media screen and (min-width: $screen-md) {
-    padding-bottom: 0;
-  }
 }
 
 .content {

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -151,15 +151,13 @@ export const Layout = (props: Props) => {
         />
 
         <div className={styles["non-header-wrapper"]}>
-          <div className={styles["mobile-nav-duo-wrapper"]}>
-            <MobileNavigation
-              mobileMenuExpanded={mobileMenuExpanded}
-              hasPremium={hasPremium}
-              isLoggedIn={isLoggedIn}
-              userEmail={usersData?.email}
-              userAvatar={profiles.data?.[0].avatar}
-            />
-          </div>
+          <MobileNavigation
+            mobileMenuExpanded={mobileMenuExpanded}
+            hasPremium={hasPremium}
+            isLoggedIn={isLoggedIn}
+            userEmail={usersData?.email}
+            userAvatar={profiles.data?.[0].avatar}
+          />
           <div className={styles.content}>{props.children}</div>
           <footer className={styles.footer}>
             <a

--- a/frontend/src/components/layout/navigation/DashboardSwitcher.module.scss
+++ b/frontend/src/components/layout/navigation/DashboardSwitcher.module.scss
@@ -1,0 +1,62 @@
+@import "~@mozilla-protocol/core/protocol/css/includes/lib";
+@import "../../../styles/tokens.scss";
+
+.nav-mask-phone {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  border-bottom: 1px solid $color-light-gray-20;
+  background-color: white;
+
+  > * {
+    flex: 1 1 0;
+    padding: $spacing-lg 0 $spacing-md 0;
+    justify-content: center;
+    display: flex;
+    border-bottom: 5px solid transparent;
+
+    &.is-active {
+      border-bottom: 5px solid $color-purple-40;
+    }
+
+    &:hover {
+      background-color: $color-purple-05;
+    }
+  }
+
+  .nav-mask-phone-icon {
+    color: $color-grey-40;
+    stroke: $color-grey-40;
+    stroke-width: 0.5px;
+
+    p,
+    p.is-active {
+      color: $color-purple-70;
+      text-transform: uppercase;
+    }
+
+    &.is-active {
+      color: $color-purple-40;
+      stroke: $color-purple-40;
+    }
+  }
+
+  .phone-icon-new-wrapper {
+    display: flex;
+    flex-direction: row;
+    align-content: center;
+
+    p {
+      @include text-body-sm;
+      margin: 0;
+      font-weight: 600;
+      align-self: center;
+    }
+  }
+}
+
+.hidden-desktop {
+  @media screen and (min-width: $screen-md) {
+    display: none;
+  }
+}

--- a/frontend/src/components/layout/navigation/DashboardSwitcher.tsx
+++ b/frontend/src/components/layout/navigation/DashboardSwitcher.tsx
@@ -1,0 +1,54 @@
+import { useLocalization } from "@fluent/react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import styles from "./DashboardSwitcher.module.scss";
+import { MaskIcon, PhoneIcon } from "../../Icons";
+
+/** Component that allows the user to switch between the Email and Phone masks dashboards. */
+export const DashboardSwitcher = () => {
+  const router = useRouter();
+  const { l10n } = useLocalization();
+
+  return (
+    /* Email and Phone Duo Header on Mobile */
+    <nav
+      className={`${styles["nav-mask-phone"]} ${styles["hidden-desktop"]}`}
+      aria-label={l10n.getString("nav-duo-description")}
+    >
+      {/* Email Mask Btn */}
+      <Link href="/accounts/profile">
+        <a
+          className={`${styles["nav-mask-phone-icon"]} ${
+            router.pathname === "/accounts/profile" ? styles["is-active"] : null
+          }`}
+          title={l10n.getString("nav-duo-email-mask-alt")}
+        >
+          <MaskIcon
+            width={25}
+            height={25}
+            alt={l10n.getString("nav-duo-phone-mask-alt")}
+          />
+        </a>
+      </Link>
+      {/* Phone Mask Btn */}
+      <Link href="/phone">
+        <a
+          className={`${styles["nav-mask-phone-icon"]} ${
+            router.pathname === "/phone" ? styles["is-active"] : null
+          }`}
+          title={l10n.getString("nav-duo-phone-mask-alt")}
+        >
+          <span className={styles["phone-icon-new-wrapper"]}>
+            <PhoneIcon
+              width={30}
+              height={30}
+              alt={l10n.getString("nav-duo-phone-mask-alt")}
+              viewBox="0 0 20 25"
+            />
+            <p>{l10n.getString("phone-dashboard-header-new")}</p>
+          </span>
+        </a>
+      </Link>
+    </nav>
+  );
+};

--- a/frontend/src/components/layout/navigation/MobileNavigation.module.scss
+++ b/frontend/src/components/layout/navigation/MobileNavigation.module.scss
@@ -17,7 +17,7 @@
   background-color: white;
 
   > * {
-    flex: 1 1 auto;
+    flex: 1 1 0;
     padding: $spacing-lg 0 $spacing-md 0;
     justify-content: center;
     display: flex;
@@ -25,6 +25,10 @@
 
     &.is-active {
       border-bottom: 5px solid $color-purple-40;
+    }
+
+    &:hover {
+      background-color: $color-purple-05;
     }
   }
 

--- a/frontend/src/components/layout/navigation/MobileNavigation.module.scss
+++ b/frontend/src/components/layout/navigation/MobileNavigation.module.scss
@@ -3,64 +3,14 @@
 
 .mobile-menu {
   width: 100%;
+  position: sticky;
+  top: 0;
+  // z-index of 1 (so it overlaps content)
+  // allows menu to slide under main navigation header
+  z-index: 1;
   // `height: 0` prevents the menu from taking up space when it's not expanded:
   height: 0;
   flex-direction: column;
-}
-
-.nav-mask-phone {
-  width: 100%;
-  position: absolute;
-  display: flex;
-  flex-direction: row;
-  border-bottom: 1px solid $color-light-gray-20;
-  background-color: white;
-
-  > * {
-    flex: 1 1 0;
-    padding: $spacing-lg 0 $spacing-md 0;
-    justify-content: center;
-    display: flex;
-    border-bottom: 5px solid transparent;
-
-    &.is-active {
-      border-bottom: 5px solid $color-purple-40;
-    }
-
-    &:hover {
-      background-color: $color-purple-05;
-    }
-  }
-
-  .nav-mask-phone-icon {
-    color: $color-grey-40;
-    stroke: $color-grey-40;
-    stroke-width: 0.5px;
-
-    p,
-    p.is-active {
-      color: $color-purple-70;
-      text-transform: uppercase;
-    }
-
-    &.is-active {
-      color: $color-purple-40;
-      stroke: $color-purple-40;
-    }
-  }
-
-  .phone-icon-new-wrapper {
-    display: flex;
-    flex-direction: row;
-    align-content: center;
-
-    p {
-      @include text-body-sm;
-      margin: 0;
-      font-weight: 600;
-      align-self: center;
-    }
-  }
 }
 
 #mobile-menu {
@@ -213,11 +163,5 @@
     svg {
       color: $color-purple-40;
     }
-  }
-}
-
-.hidden-desktop {
-  @media screen and (min-width: $screen-md) {
-    display: none;
   }
 }

--- a/frontend/src/components/layout/navigation/MobileNavigation.tsx
+++ b/frontend/src/components/layout/navigation/MobileNavigation.tsx
@@ -11,14 +11,10 @@ import {
   NewTabIcon,
   SignOutIcon,
   SupportIcon,
-  MaskIcon,
-  PhoneIcon,
 } from "../../Icons";
 import { useRuntimeData } from "../../../hooks/api/runtimeData";
 import { getRuntimeConfig } from "../../../config";
 import { getCsrfToken } from "../../../functions/cookies";
-import { isFlagActive } from "../../../functions/waffle";
-import { useRouter } from "next/router";
 
 export type MenuItem = {
   url: string;
@@ -41,10 +37,6 @@ export const MobileNavigation = (props: Props) => {
   const { l10n } = useLocalization();
   const runtimeData = useRuntimeData();
   const { supportUrl } = getRuntimeConfig();
-  const router = useRouter();
-
-  const homePath = isLoggedIn ? "/accounts/profile" : "/";
-  const phonePath = isLoggedIn ? "/phone" : "/";
 
   const renderMenuItem = (item: MenuItem) => {
     const { isVisible = true } = item;
@@ -71,160 +63,107 @@ export const MobileNavigation = (props: Props) => {
       : styles["not-active"];
 
   return (
-    <>
-      {/* Email and Phone Duo Header on Mobile */}
-      {isLoggedIn && isFlagActive(runtimeData.data, "phones") ? (
-        <nav
-          className={`${styles["nav-mask-phone"]} ${styles["hidden-desktop"]}`}
-        >
-          {/* Email Mask Btn */}
-          <Link href={homePath}>
-            <a
-              className={`${styles["nav-mask-phone-icon"]} ${
-                router.pathname === "/accounts/profile"
-                  ? styles["is-active"]
-                  : null
-              }`}
-              title={l10n.getString("nav-duo-email-mask-alt")}
-            >
-              <MaskIcon
-                width={25}
-                height={25}
-                alt={l10n.getString("nav-duo-phone-mask-alt")}
-              />
-            </a>
-          </Link>
-          {/* Phone Mask Btn */}
-          <Link href={phonePath}>
-            <a
-              className={`${styles["nav-mask-phone-icon"]} ${
-                router.pathname === "/phone" ? styles["is-active"] : null
-              }`}
-              title={l10n.getString("nav-duo-phone-mask-alt")}
-            >
-              <span className={styles["phone-icon-new-wrapper"]}>
-                <PhoneIcon
-                  width={30}
-                  height={30}
-                  alt={l10n.getString("nav-duo-phone-mask-alt")}
-                  viewBox="0 0 20 25"
-                />
-                <p>{l10n.getString("phone-dashboard-header-new")}</p>
-              </span>
-            </a>
-          </Link>
-        </nav>
-      ) : null}
-
-      <nav
-        aria-label={l10n.getString("nav-menu-mobile")}
-        className={`${styles["mobile-menu"]}`}
+    <nav
+      aria-label={l10n.getString("nav-menu-mobile")}
+      className={`${styles["mobile-menu"]}`}
+    >
+      {/* Below we have conditional rendering of menu items  */}
+      <ul
+        id={`${styles["mobile-menu"]}`}
+        className={`${styles["menu-item-list"]} ${toggleMenuStateClass}`}
       >
-        {/* Below we have conditional rendering of menu items  */}
-        <ul
-          id={`${styles["mobile-menu"]}`}
-          className={`${styles["menu-item-list"]} ${toggleMenuStateClass}`}
-        >
-          {isLoggedIn && (
-            <li className={`${styles["menu-item"]} ${styles["user-info"]}`}>
-              <img
-                src={userAvatar ?? ""}
-                alt=""
-                className={styles["user-avatar"]}
-                width={42}
-                height={42}
+        {isLoggedIn && (
+          <li className={`${styles["menu-item"]} ${styles["user-info"]}`}>
+            <img
+              src={userAvatar ?? ""}
+              alt=""
+              className={styles["user-avatar"]}
+              width={42}
+              height={42}
+            />
+            <span>
+              <b className={styles["user-email"]}>{userEmail ?? ""}</b>
+              <a
+                href={`${runtimeData?.data?.FXA_ORIGIN}/settings/`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles["settings-link"]}
+              >
+                {l10n.getString("nav-profile-manage-fxa")}
+                <NewTabIcon width={12} height={18} viewBox="0 0 16 18" alt="" />
+              </a>
+            </span>
+          </li>
+        )}
+
+        {renderMenuItem({
+          url: "/",
+          isVisible: !isLoggedIn,
+          icon: <HomeIcon width={20} height={20} alt="" />,
+          l10n: "nav-home",
+        })}
+
+        {renderMenuItem({
+          url: "/accounts/profile",
+          isVisible: isLoggedIn,
+          icon: <DashboardIcon width={20} height={20} alt="" />,
+          l10n: "nav-dashboard",
+        })}
+
+        {/* omitting condition as this should always be visible */}
+        {renderMenuItem({
+          url: "/faq",
+          icon: <FaqIcon width={20} height={20} alt="" />,
+          l10n: "nav-faq",
+        })}
+
+        {!isLoggedIn && (
+          <li
+            className={`${styles["menu-item"]} ${styles["sign-up-menu-item"]}`}
+          >
+            <SignUpButton className={`${styles["sign-up-button"]}`} />
+          </li>
+        )}
+
+        {renderMenuItem({
+          url: "/accounts/settings",
+          isVisible: isLoggedIn,
+          icon: <Cogwheel width={20} height={20} alt="" />,
+          l10n: "nav-settings",
+        })}
+
+        {renderMenuItem({
+          url: `${runtimeData?.data?.FXA_ORIGIN}/support/?utm_source=${
+            getRuntimeConfig().frontendOrigin
+          }`,
+          isVisible: isLoggedIn && hasPremium,
+          icon: <ContactIcon width={20} height={20} alt="" />,
+          l10n: "nav-contact",
+        })}
+
+        {renderMenuItem({
+          url: `${supportUrl}?utm_source=${getRuntimeConfig().frontendOrigin}`,
+          isVisible: isLoggedIn,
+          icon: <SupportIcon width={20} height={20} alt="" />,
+          l10n: "nav-support",
+        })}
+
+        {isLoggedIn && (
+          <li className={`${styles["menu-item"]}`}>
+            <form method="POST" action={getRuntimeConfig().fxaLogoutUrl}>
+              <input
+                type="hidden"
+                name="csrfmiddlewaretoken"
+                value={getCsrfToken()}
               />
-              <span>
-                <b className={styles["user-email"]}>{userEmail ?? ""}</b>
-                <a
-                  href={`${runtimeData?.data?.FXA_ORIGIN}/settings/`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={styles["settings-link"]}
-                >
-                  {l10n.getString("nav-profile-manage-fxa")}
-                  <NewTabIcon
-                    width={12}
-                    height={18}
-                    viewBox="0 0 16 18"
-                    alt=""
-                  />
-                </a>
-              </span>
-            </li>
-          )}
-
-          {renderMenuItem({
-            url: "/",
-            isVisible: !isLoggedIn,
-            icon: <HomeIcon width={20} height={20} alt="" />,
-            l10n: "nav-home",
-          })}
-
-          {renderMenuItem({
-            url: "/accounts/profile",
-            isVisible: isLoggedIn,
-            icon: <DashboardIcon width={20} height={20} alt="" />,
-            l10n: "nav-dashboard",
-          })}
-
-          {/* omitting condition as this should always be visible */}
-          {renderMenuItem({
-            url: "/faq",
-            icon: <FaqIcon width={20} height={20} alt="" />,
-            l10n: "nav-faq",
-          })}
-
-          {!isLoggedIn && (
-            <li
-              className={`${styles["menu-item"]} ${styles["sign-up-menu-item"]}`}
-            >
-              <SignUpButton className={`${styles["sign-up-button"]}`} />
-            </li>
-          )}
-
-          {renderMenuItem({
-            url: "/accounts/settings",
-            isVisible: isLoggedIn,
-            icon: <Cogwheel width={20} height={20} alt="" />,
-            l10n: "nav-settings",
-          })}
-
-          {renderMenuItem({
-            url: `${runtimeData?.data?.FXA_ORIGIN}/support/?utm_source=${
-              getRuntimeConfig().frontendOrigin
-            }`,
-            isVisible: isLoggedIn && hasPremium,
-            icon: <ContactIcon width={20} height={20} alt="" />,
-            l10n: "nav-contact",
-          })}
-
-          {renderMenuItem({
-            url: `${supportUrl}?utm_source=${
-              getRuntimeConfig().frontendOrigin
-            }`,
-            isVisible: isLoggedIn,
-            icon: <SupportIcon width={20} height={20} alt="" />,
-            l10n: "nav-support",
-          })}
-
-          {isLoggedIn && (
-            <li className={`${styles["menu-item"]}`}>
-              <form method="POST" action={getRuntimeConfig().fxaLogoutUrl}>
-                <input
-                  type="hidden"
-                  name="csrfmiddlewaretoken"
-                  value={getCsrfToken()}
-                />
-                <button className={`${styles.link}`} type="submit">
-                  <SignOutIcon width={20} height={20} alt="" />
-                  {l10n.getString("nav-sign-out")}
-                </button>
-              </form>
-            </li>
-          )}
-        </ul>
-      </nav>
-    </>
+              <button className={`${styles.link}`} type="submit">
+                <SignOutIcon width={20} height={20} alt="" />
+                {l10n.getString("nav-sign-out")}
+              </button>
+            </form>
+          </li>
+        )}
+      </ul>
+    </nav>
   );
 };

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -52,6 +52,7 @@ import { AddonData } from "../../components/dashboard/AddonData";
 import { useAddonData } from "../../hooks/addon";
 import { CloseIcon } from "../../components/Icons";
 import { isFlagActive } from "../../functions/waffle";
+import { DashboardSwitcher } from "../../components/layout/navigation/DashboardSwitcher";
 
 const Profile: NextPage = () => {
   const runtimeData = useRuntimeData();
@@ -136,6 +137,9 @@ const Profile: NextPage = () => {
           totalForwardedEmails={profile.emails_forwarded}
         />
         <Layout runtimeData={runtimeData.data}>
+          {isFlagActive(runtimeData.data, "phones") ? (
+            <DashboardSwitcher />
+          ) : null}
           <PremiumOnboarding
             profile={profile}
             onNextStep={onNextStep}
@@ -379,6 +383,9 @@ const Profile: NextPage = () => {
         totalForwardedEmails={profile.emails_forwarded}
       />
       <Layout runtimeData={runtimeData.data}>
+        {isFlagActive(runtimeData.data, "phones") ? (
+          <DashboardSwitcher />
+        ) : null}
         <main className={styles["profile-wrapper"]}>
           {stats}
           {topBanners}

--- a/frontend/src/pages/phone.page.tsx
+++ b/frontend/src/pages/phone.page.tsx
@@ -12,6 +12,7 @@ import { Banner } from "../components/Banner";
 import styles from "./phone.module.scss";
 import { useLocalization } from "@fluent/react";
 import { useRealPhonesData } from "../hooks/api/realPhone";
+import { DashboardSwitcher } from "../components/layout/navigation/DashboardSwitcher";
 
 const Phone: NextPage = () => {
   const profileData = useProfiles();
@@ -48,6 +49,7 @@ const Phone: NextPage = () => {
   if (profile && user && !profile.has_phone) {
     return (
       <Layout>
+        <DashboardSwitcher />
         <PurchasePhonesPlan />
       </Layout>
     );
@@ -56,6 +58,7 @@ const Phone: NextPage = () => {
   if (isInOnboarding || relayNumberData.data.length === 0) {
     return (
       <Layout>
+        <DashboardSwitcher />
         <PhoneOnboarding onComplete={() => setIsInOnboarding(false)} />
       </Layout>
     );
@@ -63,6 +66,7 @@ const Phone: NextPage = () => {
 
   return (
     <Layout>
+      <DashboardSwitcher />
       <main className={styles["main-wrapper"]}>
         <div className={styles["banner-wrapper"]}>
           <Banner


### PR DESCRIPTION
This PR (that targets #2390) tackles two things at once:

- Ensures the Duo Mobile Nav is not visible on the settings, FAQ and interstitial pages when the user is logged in
- Makes the Duo Mobile Nav non-sticky again, to preserve screen real estate on mobile (discussed with Eduardo)

@codemist This PR will merge into your PR, so up to you if you're OK with this approach, would like to try another one, or even want to push back on whether the changes are necessary in the first place :)