### PR TITLE
Change style class of copy button to focus-visible

### DIFF
--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -108,7 +108,7 @@ $trackerRemovalIndicatorWidth: 20px;
     width: 100%;
     flex-basis: 0;
 
-    &:focus {
+    &:focus-visible {
       // For some reason (presumably related to `.copy-button-wrapper`'s
       // relative positioning), Protocol's default outline isn't visible by
       // default. Thus, we add a focus style using a border, and then remove the


### PR DESCRIPTION
This PR fixes #328.
The default outline that should appear when navigating
with a keyboard does not show up when the focus lands on
the copy button. As a workaround, PR #2218 adds a border
that changes color on focus. However, :focus doesn't
follow the same behavior as the default styling; the
former applies styling when the focus is from the keyboard
OR the mouse. This commit changes the styling class to
:focus-visible, which only applies the styles to a button
if focused via keyboard.

- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
