### PR TITLE
Allow up to 10 JS Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
-
+    open-pull-requests-limit: 10
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
If one library with a bunch of packages (e.g. ESLint) releases
updates to several packages at once, our update queue can get
congested. The dependency update tasks on Monday morning isn't
too much work to handle, so I think it's OK for it to be larger
to avoid this problem.

(As an example of how this can be annoying, #2404 might be unblocked by a react-aria upgrade, and though we're actually behind on that, there's no PR to upgrade it this week.)

Note that this only ups the limit for JS upgrades. If we need the same for Python packages or GitHub Actions, we'll have to add the same line to their configs.