### PR TITLE
Dashboard banner to announce the end of introductory pricing

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,6 +44,7 @@
         "eslint-config-next": "^12.2.5",
         "eslint-plugin-jest-dom": "^4.0.2",
         "eslint-plugin-testing-library": "^5.6.0",
+        "fast-check": "^3.1.2",
         "husky": "^8.0.1",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^28.1.3",
@@ -6765,6 +6766,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/fast-check": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.1.2.tgz",
+      "integrity": "sha512-OZRPFXhZHpIhtG46XtAMzVW1jtuR7Clw13wOcfw1v//tNnPCvVuLLlT1bEqywCQXNXR4qGT3tk7z0MUMSTit3Q==",
+      "dev": true,
+      "dependencies": {
+        "pure-rand": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/fast-check"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -12256,6 +12273,16 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-5.0.1.tgz",
+      "integrity": "sha512-ksWccjmXOHU2gJBnH0cK1lSYdvSZ0zLoCMSz/nTGh6hDvCSgcRxDyIcOBD6KNxFz3xhMPm/T267Tbe2JRymKEQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/fast-check"
       }
     },
     "node_modules/queue-microtask": {
@@ -19613,6 +19640,15 @@
         "tmp": "^0.0.33"
       }
     },
+    "fast-check": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.1.2.tgz",
+      "integrity": "sha512-OZRPFXhZHpIhtG46XtAMzVW1jtuR7Clw13wOcfw1v//tNnPCvVuLLlT1bEqywCQXNXR4qGT3tk7z0MUMSTit3Q==",
+      "dev": true,
+      "requires": {
+        "pure-rand": "^5.0.1"
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -23620,6 +23656,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "pure-rand": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-5.0.1.tgz",
+      "integrity": "sha512-ksWccjmXOHU2gJBnH0cK1lSYdvSZ0zLoCMSz/nTGh6hDvCSgcRxDyIcOBD6KNxFz3xhMPm/T267Tbe2JRymKEQ==",
       "dev": true
     },
     "queue-microtask": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,7 @@
     "eslint-config-next": "^12.2.5",
     "eslint-plugin-jest-dom": "^4.0.2",
     "eslint-plugin-testing-library": "^5.6.0",
+    "fast-check": "^3.1.2",
     "husky": "^8.0.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^28.1.3",

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -229,6 +229,49 @@ banner-upgrade-loyalist-headline-2 = Protect your privacy, save the internet
 #   $monthly_price (string) - the monthly cost (including currency symbol) for Relay Premium. Examples: $0.99, 0,99 €
 banner-upgrade-loyalist-copy-2 = Protect your privacy while joining our mission to build a better internet, all for { $monthly_price }
 
+# End of intro pricing banner
+
+banner-offer-end-headline = Our intro pricing offer ends soon!
+# Variables:
+#   $end_date (string) - The localised date the introductory pricing offer ends, e.g. "September 27"
+banner-offer-end-copy = Get { -brand-name-relay-premium } before { $end_date } and enjoy unlimited masking at our intro month-to-month price.
+banner-offer-end-cta = Upgrade now
+
+# Time remaining until Relay Premium's introductory pricing is no longer available.
+# This will not be shown anymore once the time runs out.
+# Variables:
+#   $remaining_days (number) - The number of days before the countdown stops
+#   $remaining_hours (number) - The number of hours (in addition to $remaining_days) before the countdown stops
+offer-countdown-timer-alt =
+    { $remaining_days ->
+        [0] { $remaining_hours ->
+            [1] 1 hour remaining
+            *[other] { $remaining_hours } hours remaining
+        }
+        [1] { $remaining_hours ->
+            [0] 1 day remaining
+            [1] 1 day and 1 hour remaining
+            *[other] 1 day and { $remaining_hours } hours remaining
+        }
+        *[other] { $remaining_hours ->
+            [0] { $remaining_days } days remaining
+            [1] { $remaining_days } days and 1 hour remaining
+            *[other] { $remaining_days } days and { $remaining_hours } hours remaining
+        }
+    }
+# This is a label displayed on top of a large number representing the number of days that the introductory pricing offer is still valid
+# There's not much room for this, so this might need abbreviating.
+offer-countdown-timer-days = Days
+# This is a label displayed on top of a large number representing the number of hours of the remaining time the introductory pricing offer is still valid
+# There's not much room for this, so this might need abbreviating.
+offer-countdown-timer-hours = Hours
+# This is a label displayed on top of a large number representing the number of minutes of the remaining time the introductory pricing offer is still valid
+# There's not much room for this, hence the abbreviation.
+offer-countdown-timer-minutes = Min.
+# This is a label displayed on top of a large number representing the number of seconds of the remaining time the introductory pricing offer is still valid
+# There's not much room for this, hence the abbreviation.
+offer-countdown-timer-seconds = Sec.
+
 whatsnew-feature-tracker-removal-heading = Introducing email tracker removal
 # A preview of the full content of `whatsnew-feature-tracker-removal-description`.
 # When translating, please make sure the resulting string is of roughly similar

--- a/frontend/src/apiMocks/mockData.ts
+++ b/frontend/src/apiMocks/mockData.ts
@@ -32,6 +32,7 @@ export const mockedRuntimeData: RuntimeData = {
     ["new_from_address", true],
     ["tracker_removal", true],
     ["phones", true],
+    ["intro_pricing_countdown", true],
   ],
   MAX_MINUTES_TO_VERIFY_REAL_PHONE: 5,
 };

--- a/frontend/src/components/Banner.module.scss
+++ b/frontend/src/components/Banner.module.scss
@@ -48,8 +48,14 @@
   background-color: $color-white;
   flex-wrap: wrap;
 
+  .title-and-large-cta-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    flex: 1 0 $content-xs;
+  }
+
   .title-text {
-    flex: 1 0 50%;
+    flex: 1 1 auto;
   }
 
   .info-icon {
@@ -158,6 +164,7 @@
   }
 
   a {
+    display: block;
     padding: $spacing-md $spacing-lg;
     font-weight: 700;
     background: $color-blue-50;

--- a/frontend/src/components/Banner.module.scss
+++ b/frontend/src/components/Banner.module.scss
@@ -52,10 +52,15 @@
     display: flex;
     flex-wrap: wrap;
     flex: 1 0 $content-xs;
+
+    @media screen and #{$mq-lg} {
+      flex-wrap: nowrap;
+    }
   }
 
   .title-text {
     flex: 1 1 auto;
+    padding-inline: $spacing-md;
   }
 
   .info-icon {
@@ -154,7 +159,8 @@
 
 // For Loyalist upsell
 .cta-large-button {
-  margin: $spacing-xl 0 $spacing-md $spacing-md;
+  padding: $spacing-md;
+  flex: 0 0 auto;
   align-self: center;
 
   @media screen and #{$mq-md} {

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -90,14 +90,16 @@ export const Banner = (props: BannerProps) => {
         <div className={`${styles["highlight-wrapper"]}`}>
           {illustration}
           {infoIcon}
-          <div className={`${styles["title-text"]}`}>
-            {title}
-            {props.children}
-            {/* A regular-sized button is shown close to the content… */}
-            {props.cta?.size !== "large" ? cta : null}
+          <div className={styles["title-and-large-cta-wrapper"]}>
+            <div className={`${styles["title-text"]}`}>
+              {title}
+              {props.children}
+              {/* A regular-sized button is shown close to the content… */}
+              {props.cta?.size !== "large" ? cta : null}
+            </div>
+            {/* …whereas a large button can stand on its own. */}
+            {props.cta?.size === "large" ? cta : null}
           </div>
-          {/* …whereas a large button can stand on its own. */}
-          {props.cta?.size === "large" ? cta : null}
         </div>
         {dismissButton}
       </div>

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -16,12 +16,7 @@ export type BannerProps = {
     content: string;
     onClick?: () => void;
     gaViewPing?: Parameters<typeof useGaViewPing>[0];
-  };
-  ctaLargeButton?: {
-    target: string;
-    content: string;
-    onClick?: () => void;
-    gaViewPing?: Parameters<typeof useGaViewPing>[0];
+    size?: "medium" | "large";
   };
   btn?: {
     content: string;
@@ -77,7 +72,11 @@ export const Banner = (props: BannerProps) => {
   ) : null;
 
   const cta = props.cta ? (
-    <div className={styles.cta}>
+    <div
+      className={
+        props.cta.size === "large" ? styles["cta-large-button"] : styles.cta
+      }
+    >
       <OutboundLink
         to={props.cta.target}
         eventLabel={props.cta.content}
@@ -86,20 +85,6 @@ export const Banner = (props: BannerProps) => {
         onClick={props.cta.onClick}
       >
         <span ref={ctaRef}>{props.cta.content}</span>
-      </OutboundLink>
-    </div>
-  ) : null;
-
-  const ctaLargeButton = props.ctaLargeButton ? (
-    <div className={styles["cta-large-button"]}>
-      <OutboundLink
-        to={props.ctaLargeButton.target}
-        eventLabel={props.ctaLargeButton.content}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={props.ctaLargeButton.onClick}
-      >
-        <span ref={ctaRef}>{props.ctaLargeButton.content}</span>
       </OutboundLink>
     </div>
   ) : null;
@@ -142,10 +127,10 @@ export const Banner = (props: BannerProps) => {
           <div className={`${styles["title-text"]}`}>
             {title}
             {props.children}
-            {cta}
+            {props.cta?.size !== "large" ? cta : null}
             {btn}
           </div>
-          {ctaLargeButton}
+          {props.cta?.size === "large" ? cta : null}
         </div>
         {dismissButton}
       </div>

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -52,7 +52,9 @@ export const Banner = (props: BannerProps) => {
             {props.title}
           </h2>
         )) ||
-        (type === "info" && <h2 className={styles.title}>{props.title}</h2>)
+        (["info", "promo"].includes(type) && (
+          <h2 className={styles.title}>{props.title}</h2>
+        ))
       : null;
 
   const illustration = props.illustration ? (

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -11,18 +11,7 @@ export type BannerProps = {
   type?: "promo" | "warning" | "info";
   title?: string;
   illustration?: ReactNode;
-  cta?: {
-    target: string;
-    content: string;
-    onClick?: () => void;
-    gaViewPing?: Parameters<typeof useGaViewPing>[0];
-    size?: "medium" | "large";
-  };
-  btn?: {
-    content: string;
-    onClick?: () => void;
-    gaViewPing?: Parameters<typeof useGaViewPing>[0];
-  };
+  cta?: BannerCtaProps;
   /**
    * See {@link useLocalDismissal}; determines whether and for how long the user can dismiss this banner.
    */
@@ -39,7 +28,6 @@ export type BannerProps = {
  * See {@link BannerProps["type"]} for the different types of banner themes supported.
  */
 export const Banner = (props: BannerProps) => {
-  const ctaRef = useGaViewPing(props.cta?.gaViewPing ?? null);
   const dismissal = useLocalDismissal(props.dismissal?.key ?? "unused", {
     duration: props.dismissal?.duration,
   });
@@ -71,31 +59,7 @@ export const Banner = (props: BannerProps) => {
     <div className={styles.illustration}>{props.illustration}</div>
   ) : null;
 
-  const cta = props.cta ? (
-    <div
-      className={
-        props.cta.size === "large" ? styles["cta-large-button"] : styles.cta
-      }
-    >
-      <OutboundLink
-        to={props.cta.target}
-        eventLabel={props.cta.content}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={props.cta.onClick}
-      >
-        <span ref={ctaRef}>{props.cta.content}</span>
-      </OutboundLink>
-    </div>
-  ) : null;
-
-  const btn = props.btn ? (
-    <div className={styles.cta}>
-      <button onClick={props.btn.onClick}>
-        <span ref={ctaRef}>{props.btn.content}</span>
-      </button>
-    </div>
-  ) : null;
+  const cta = props.cta ? <BannerCta {...props.cta} /> : null;
 
   const dismissButton =
     typeof props.dismissal !== "undefined" ? (
@@ -127,9 +91,10 @@ export const Banner = (props: BannerProps) => {
           <div className={`${styles["title-text"]}`}>
             {title}
             {props.children}
+            {/* A regular-sized button is shown close to the content… */}
             {props.cta?.size !== "large" ? cta : null}
-            {btn}
           </div>
+          {/* …whereas a large button can stand on its own. */}
           {props.cta?.size === "large" ? cta : null}
         </div>
         {dismissButton}
@@ -138,4 +103,55 @@ export const Banner = (props: BannerProps) => {
   }
 
   return null;
+};
+
+type BannerCtaProps = {
+  /**
+   * URL for the call-to-action to link to. Optional, but `onClick` is required when left out — the CTA will then be a button rather than a link.
+   */
+  target?: string;
+  content: string;
+  /**
+   * Callback to run when the call-to-action is activated. Optional if `target` is provided.
+   */
+  onClick?: () => void;
+  gaViewPing?: Parameters<typeof useGaViewPing>[0];
+  size?: "medium" | "large";
+} & ({ target: string } | { onClick: () => void }); // At least one of `target` and `onClick` is required:
+export const BannerCta = (props: BannerCtaProps) => {
+  const ctaRef = useGaViewPing(props.gaViewPing ?? null);
+
+  // If no URL to link to is provided (via `target`), render a <button> rather than an <a>:
+  if (typeof props.target !== "string") {
+    return (
+      <div
+        className={
+          props.size === "large" ? styles["cta-large-button"] : styles.cta
+        }
+      >
+        <button onClick={props.onClick}>
+          <span ref={ctaRef}>{props.content}</span>
+        </button>
+      </div>
+    );
+  }
+
+  // When given a URL to link to in `target`, render an <a> (via <OutboundLink>):
+  return (
+    <div
+      className={
+        props.size === "large" ? styles["cta-large-button"] : styles.cta
+      }
+    >
+      <OutboundLink
+        to={props.target}
+        eventLabel={props.content}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={props.onClick}
+      >
+        <span ref={ctaRef}>{props.content}</span>
+      </OutboundLink>
+    </div>
+  );
 };

--- a/frontend/src/components/CountdownTimer.module.scss
+++ b/frontend/src/components/CountdownTimer.module.scss
@@ -1,0 +1,40 @@
+@import "~@mozilla-protocol/core/protocol/css/includes/lib";
+@import "../styles/tokens.scss";
+
+.countdown-timer {
+  dl {
+    display: flex;
+    gap: $spacing-sm;
+
+    > div {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: $spacing-xs;
+      width: $layout-lg;
+      background-color: $color-purple-90;
+      border: 2px solid $color-white;
+      border-radius: $border-radius-md;
+      color: $color-white;
+      box-shadow: $box-shadow-sm;
+      padding: $spacing-sm;
+      font-family: $font-stack-firefox;
+
+      dt {
+        @include text-body-md;
+        font-weight: 600;
+      }
+
+      dd {
+        @include text-title-sm;
+        font-weight: 700;
+      }
+
+      @media (prefers-reduced-motion) {
+        &.remaining-seconds {
+          display: none;
+        }
+      }
+    }
+  }
+}

--- a/frontend/src/components/CountdownTimer.test.tsx
+++ b/frontend/src/components/CountdownTimer.test.tsx
@@ -1,3 +1,4 @@
+import fc from "fast-check";
 import { getRemainingTimeParts } from "./CountdownTimer";
 
 describe("getRemainingTimeParts", () => {
@@ -140,5 +141,140 @@ describe("getRemainingTimeParts", () => {
       remainingMinutes: 3,
       remainingSeconds: 59,
     });
+  });
+
+  it("never returns a negative number of days", () => {
+    const runs = 100;
+    expect.assertions(runs);
+    fc.assert(
+      fc.property(
+        fc.nat({ max: 90 * 24 * 60 * 60 * 1000 }),
+        (timeInMilliseconds) => {
+          const remainingTimeParts = getRemainingTimeParts(timeInMilliseconds);
+          expect(remainingTimeParts.remainingDays).toBeGreaterThanOrEqual(0);
+        }
+      ),
+      { numRuns: runs }
+    );
+  });
+
+  it("never returns more hours than fit in a day", () => {
+    const runs = 100;
+    expect.assertions(runs);
+    fc.assert(
+      fc.property(
+        fc.nat({ max: 90 * 24 * 60 * 60 * 1000 }),
+        (timeInMilliseconds) => {
+          const remainingTimeParts = getRemainingTimeParts(timeInMilliseconds);
+          expect(remainingTimeParts.remainingHours).toBeLessThan(24);
+        }
+      ),
+      { numRuns: runs }
+    );
+  });
+
+  it("never returns a negative number of hours", () => {
+    const runs = 100;
+    expect.assertions(runs);
+    fc.assert(
+      fc.property(
+        fc.nat({ max: 90 * 24 * 60 * 60 * 1000 }),
+        (timeInMilliseconds) => {
+          const remainingTimeParts = getRemainingTimeParts(timeInMilliseconds);
+          expect(remainingTimeParts.remainingHours).toBeGreaterThanOrEqual(0);
+        }
+      ),
+      { numRuns: runs }
+    );
+  });
+
+  it("never returns more minutes than fit in an hour", () => {
+    const runs = 100;
+    expect.assertions(runs);
+    fc.assert(
+      fc.property(
+        fc.nat({ max: 90 * 24 * 60 * 60 * 1000 }),
+        (timeInMilliseconds) => {
+          const remainingTimeParts = getRemainingTimeParts(timeInMilliseconds);
+          expect(remainingTimeParts.remainingMinutes).toBeLessThan(60);
+        }
+      ),
+      { numRuns: runs }
+    );
+  });
+
+  it("never returns a negative number of minutes", () => {
+    const runs = 100;
+    expect.assertions(runs);
+    fc.assert(
+      fc.property(
+        fc.nat({ max: 90 * 24 * 60 * 60 * 1000 }),
+        (timeInMilliseconds) => {
+          const remainingTimeParts = getRemainingTimeParts(timeInMilliseconds);
+          expect(remainingTimeParts.remainingMinutes).toBeGreaterThanOrEqual(0);
+        }
+      ),
+      { numRuns: runs }
+    );
+  });
+
+  it("never returns more seconds than fit in a minute", () => {
+    const runs = 100;
+    expect.assertions(runs);
+    fc.assert(
+      fc.property(
+        fc.nat({ max: 90 * 24 * 60 * 60 * 1000 }),
+        (timeInMilliseconds) => {
+          const remainingTimeParts = getRemainingTimeParts(timeInMilliseconds);
+          expect(remainingTimeParts.remainingSeconds).toBeLessThan(60);
+        }
+      ),
+      { numRuns: runs }
+    );
+  });
+
+  it("never returns a negative number of seconds", () => {
+    const runs = 100;
+    expect.assertions(runs);
+    fc.assert(
+      fc.property(
+        fc.nat({ max: 90 * 24 * 60 * 60 * 1000 }),
+        (timeInMilliseconds) => {
+          const remainingTimeParts = getRemainingTimeParts(timeInMilliseconds);
+          expect(remainingTimeParts.remainingSeconds).toBeGreaterThanOrEqual(0);
+        }
+      ),
+      { numRuns: runs }
+    );
+  });
+
+  it("always properly detects the number of remaining days, hours, minutes and seconds", () => {
+    const runs = 100;
+    expect.assertions(runs * 4);
+    fc.assert(
+      fc.property(
+        fc.tuple(
+          fc.nat({ max: 90 }),
+          fc.nat({ max: 23 }),
+          fc.nat({ max: 59 }),
+          fc.nat({ max: 59 }),
+          fc.nat({ max: 999 })
+        ),
+        ([days, hours, minutes, seconds, milliseconds]) => {
+          const remainingTimeParts = getRemainingTimeParts(
+            days * 24 * 60 * 60 * 1000 +
+              hours * 60 * 60 * 1000 +
+              minutes * 60 * 1000 +
+              seconds * 1000 +
+              milliseconds
+          );
+          expect(remainingTimeParts.remainingDays).toBe(days);
+          expect(remainingTimeParts.remainingHours).toBe(hours);
+          expect(remainingTimeParts.remainingMinutes).toBe(minutes);
+          expect(remainingTimeParts.remainingSeconds).toBe(seconds);
+        }
+      ),
+      { numRuns: runs }
+    );
   });
 });

--- a/frontend/src/components/CountdownTimer.test.tsx
+++ b/frontend/src/components/CountdownTimer.test.tsx
@@ -1,0 +1,144 @@
+import { getRemainingTimeParts } from "./CountdownTimer";
+
+describe("getRemainingTimeParts", () => {
+  it("knows when there's zero of everything", () => {
+    expect(getRemainingTimeParts(0)).toStrictEqual({
+      remainingDays: 0,
+      remainingHours: 0,
+      remainingMinutes: 0,
+      remainingSeconds: 0,
+    });
+  });
+
+  it("knows when there's zero of everything when there's less than half a second left", () => {
+    expect(getRemainingTimeParts(499)).toStrictEqual({
+      remainingDays: 0,
+      remainingHours: 0,
+      remainingMinutes: 0,
+      remainingSeconds: 0,
+    });
+  });
+
+  it("knows when there's zero of everything but seconds", () => {
+    expect(getRemainingTimeParts(1337)).toStrictEqual({
+      remainingDays: 0,
+      remainingHours: 0,
+      remainingMinutes: 0,
+      remainingSeconds: 1,
+    });
+  });
+
+  it("knows when there's zero of everything but minutes and seconds", () => {
+    expect(getRemainingTimeParts(3 * 60 * 1000 + 2 * 1000 + 42)).toStrictEqual({
+      remainingDays: 0,
+      remainingHours: 0,
+      remainingMinutes: 3,
+      remainingSeconds: 2,
+    });
+  });
+
+  it("knows when there are zero days left", () => {
+    expect(
+      getRemainingTimeParts(4 * 60 * 60 * 1000 + 3 * 60 * 1000 + 2 * 1000 + 42)
+    ).toStrictEqual({
+      remainingDays: 0,
+      remainingHours: 4,
+      remainingMinutes: 3,
+      remainingSeconds: 2,
+    });
+  });
+
+  it("knows when are multiple days left", () => {
+    expect(
+      getRemainingTimeParts(
+        5 * 24 * 60 * 60 * 1000 +
+          4 * 60 * 60 * 1000 +
+          3 * 60 * 1000 +
+          2 * 1000 +
+          42
+      )
+    ).toStrictEqual({
+      remainingDays: 5,
+      remainingHours: 4,
+      remainingMinutes: 3,
+      remainingSeconds: 2,
+    });
+  });
+
+  it("can deal with hours reaching zero with multiple days left", () => {
+    expect(
+      getRemainingTimeParts(
+        5 * 24 * 60 * 60 * 1000 + 3 * 60 * 1000 + 2 * 1000 + 42
+      )
+    ).toStrictEqual({
+      remainingDays: 5,
+      remainingHours: 0,
+      remainingMinutes: 3,
+      remainingSeconds: 2,
+    });
+  });
+
+  it("can deal with minutes reaching zero with multiple days left", () => {
+    expect(
+      getRemainingTimeParts(
+        5 * 24 * 60 * 60 * 1000 + 4 * 60 * 60 * 1000 + 2 * 1000 + 42
+      )
+    ).toStrictEqual({
+      remainingDays: 5,
+      remainingHours: 4,
+      remainingMinutes: 0,
+      remainingSeconds: 2,
+    });
+  });
+
+  it("can deal with hours close to 24", () => {
+    expect(
+      getRemainingTimeParts(
+        5 * 24 * 60 * 60 * 1000 +
+          23 * 60 * 60 * 1000 +
+          3 * 60 * 1000 +
+          2 * 1000 +
+          42
+      )
+    ).toStrictEqual({
+      remainingDays: 5,
+      remainingHours: 23,
+      remainingMinutes: 3,
+      remainingSeconds: 2,
+    });
+  });
+
+  it("can deal with minutes close to 60", () => {
+    expect(
+      getRemainingTimeParts(
+        5 * 24 * 60 * 60 * 1000 +
+          4 * 60 * 60 * 1000 +
+          59 * 60 * 1000 +
+          2 * 1000 +
+          42
+      )
+    ).toStrictEqual({
+      remainingDays: 5,
+      remainingHours: 4,
+      remainingMinutes: 59,
+      remainingSeconds: 2,
+    });
+  });
+
+  it("can deal with seconds close to 60", () => {
+    expect(
+      getRemainingTimeParts(
+        5 * 24 * 60 * 60 * 1000 +
+          4 * 60 * 60 * 1000 +
+          3 * 60 * 1000 +
+          59 * 1000 +
+          42
+      )
+    ).toStrictEqual({
+      remainingDays: 5,
+      remainingHours: 4,
+      remainingMinutes: 3,
+      remainingSeconds: 59,
+    });
+  });
+});

--- a/frontend/src/components/CountdownTimer.tsx
+++ b/frontend/src/components/CountdownTimer.tsx
@@ -1,0 +1,84 @@
+import { useLocalization } from "@fluent/react";
+import styles from "./CountdownTimer.module.scss";
+
+/**
+ * A single place to define the day our intro pricing offer ends.
+ *
+ * This might not be the best place to keep this; if the back-end needs this as
+ * well, we'll probalby want to add it to {@link RuntimeData}.
+ *
+ * The deadline is currently September 27th at 9AM PT, so 4PM UTC.
+ */
+export const introPricingOfferEndDate = new Date(Date.UTC(2022, 8, 27, 16));
+
+export type Props = {
+  remainingTimeInMs: number;
+};
+
+export const CountdownTimer = (props: Props) => {
+  const { l10n } = useLocalization();
+
+  const { remainingDays, remainingHours, remainingMinutes, remainingSeconds } =
+    getRemainingTimeParts(props.remainingTimeInMs);
+
+  return (
+    <figure className={styles["countdown-timer"]}>
+      <time
+        dateTime={`P${remainingDays}DT${remainingHours}H`}
+        aria-label={l10n.getString("offer-countdown-timer-alt", {
+          remaining_days: remainingDays,
+          remaining_hours: remainingHours,
+        })}
+      >
+        <dl>
+          <div>
+            <dt>{l10n.getString("offer-countdown-timer-days")}</dt>
+            <dd>{remainingDays}</dd>
+          </div>
+          <div>
+            <dt>{l10n.getString("offer-countdown-timer-hours")}</dt>
+            <dd>{remainingHours}</dd>
+          </div>
+          <div>
+            <dt>{l10n.getString("offer-countdown-timer-minutes")}</dt>
+            <dd>{remainingMinutes}</dd>
+          </div>
+          <div className={styles["remaining-seconds"]}>
+            <dt>{l10n.getString("offer-countdown-timer-seconds")}</dt>
+            <dd>{remainingSeconds}</dd>
+          </div>
+        </dl>
+      </time>
+    </figure>
+  );
+};
+
+export function getRemainingTimeParts(remainingMilliseconds: number) {
+  const remainingDays = Math.floor(
+    remainingMilliseconds / (1000 * 60 * 60 * 24)
+  );
+  const remainingHours = Math.floor(
+    (remainingMilliseconds - remainingDays * (1000 * 60 * 60 * 24)) /
+      (1000 * 60 * 60)
+  );
+  const remainingMinutes = Math.floor(
+    (remainingMilliseconds -
+      remainingDays * (1000 * 60 * 60 * 24) -
+      remainingHours * (1000 * 60 * 60)) /
+      (1000 * 60)
+  );
+  const remainingSeconds = Math.floor(
+    (remainingMilliseconds -
+      remainingDays * (1000 * 60 * 60 * 24) -
+      remainingHours * (1000 * 60 * 60) -
+      remainingMinutes * (1000 * 60)) /
+      1000
+  );
+
+  return {
+    remainingDays,
+    remainingHours,
+    remainingMinutes,
+    remainingSeconds,
+  };
+}

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -308,7 +308,14 @@ const EndOfIntroPricingOfferBanner = (
         size: "large",
         content: l10n.getString("banner-offer-end-cta"),
         target: getPremiumSubscribeLink(props.runtimeData),
-        onClick: () => trackPurchaseStart(),
+        onClick: () =>
+          trackPurchaseStart({
+            label: "Intro-Pricing: Dashboard",
+          }),
+        gaViewPing: {
+          category: "Purchase Button",
+          label: "Intro-Pricing: Dashboard",
+        },
       }}
       dismissal={{
         key: `offer-end-${props.profile.id}`,

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -235,7 +235,8 @@ const LoyalistPremiumBanner = (props: NoPremiumBannerProps) => {
       type="promo"
       title={l10n.getString("banner-upgrade-loyalist-headline-2")}
       illustration={<img src={FirefoxLogo.src} alt="" width={60} height={60} />}
-      ctaLargeButton={{
+      cta={{
+        size: "large",
         target: getPremiumSubscribeLink(props.runtimeData),
         content: l10n.getString("banner-upgrade-loyalist-cta"),
         onClick: () => trackPurchaseStart(),

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -27,6 +27,7 @@ import { AliasData } from "../../hooks/api/aliases";
 import { getLocale } from "../../functions/getLocale";
 import { CountdownTimer, introPricingOfferEndDate } from "../CountdownTimer";
 import { useInterval } from "../../hooks/interval";
+import { isFlagActive } from "../../functions/waffle";
 
 export type Props = {
   profile: ProfileData;
@@ -73,7 +74,8 @@ export const ProfileBanners = (props: Props) => {
 
   if (
     !props.profile.has_premium &&
-    isPremiumAvailableInCountry(props.runtimeData)
+    isPremiumAvailableInCountry(props.runtimeData) &&
+    isFlagActive(props.runtimeData, "intro_pricing_countdown")
   ) {
     banners.push(
       <EndOfIntroPricingOfferBanner

--- a/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
+++ b/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
@@ -1,4 +1,7 @@
+import { ChangeEventHandler, FormEventHandler, useState } from "react";
 import { Localized, useLocalization } from "@fluent/react";
+import PhoneInput, { isPossiblePhoneNumber } from "react-phone-number-input";
+import { E164Number } from "libphonenumber-js/min";
 import styles from "./RealPhoneSetup.module.scss";
 import "react-phone-number-input/style.css";
 import PhoneVerify from "./images/phone-verify.svg";
@@ -13,17 +16,9 @@ import {
   useRealPhonesData,
 } from "../../../hooks/api/realPhone";
 import { RuntimeData } from "../../../hooks/api/runtimeData";
-import {
-  ChangeEventHandler,
-  FormEventHandler,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
 import { parseDate } from "../../../functions/parseDate";
-import PhoneInput, { isPossiblePhoneNumber } from "react-phone-number-input";
-import { E164Number } from "libphonenumber-js/min";
 import { formatPhone } from "../../../functions/formatPhone";
+import { useInterval } from "../../../hooks/interval";
 
 type RealPhoneSetupProps = {
   unverifiedRealPhones: Array<UnverifiedPhone>;
@@ -345,30 +340,6 @@ const RealPhoneVerification = (props: RealPhoneVerificationProps) => {
     </div>
   );
 };
-
-type IntervalFunction = () => unknown | void;
-// See https://overreacted.io/making-setinterval-declarative-with-react-hooks/
-function useInterval(callback: IntervalFunction, delay: number) {
-  const savedCallback = useRef<IntervalFunction | null>(null);
-
-  // Remember the latest callback.
-  useEffect(() => {
-    savedCallback.current = callback;
-  }, [callback]);
-
-  // Set up the interval.
-  useEffect(() => {
-    function tick() {
-      if (savedCallback.current !== null) {
-        savedCallback.current();
-      }
-    }
-    if (delay !== null) {
-      const id = setInterval(tick, delay);
-      return () => clearInterval(id);
-    }
-  }, [delay]);
-}
 
 function getRemainingTime(
   verificationSentTime: Date,

--- a/frontend/src/hooks/interval.ts
+++ b/frontend/src/hooks/interval.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from "react";
+
+export type IntervalFunction = () => unknown | void;
+// See https://overreacted.io/making-setinterval-declarative-with-react-hooks/
+export function useInterval(callback: IntervalFunction, delay: number) {
+  const savedCallback = useRef<IntervalFunction | null>(null);
+
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  useEffect(() => {
+    function tick() {
+      if (savedCallback.current !== null) {
+        savedCallback.current();
+      }
+    }
+    if (delay !== null) {
+      const id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+}

--- a/frontend/src/pages/phone.page.tsx
+++ b/frontend/src/pages/phone.page.tsx
@@ -72,7 +72,7 @@ const Phone: NextPage = () => {
           <Banner
             title={l10n.getString("phone-banner-resend-welcome-sms-title")}
             type="info"
-            btn={{
+            cta={{
               content: l10n.getString("phone-banner-resend-welcome-sms-cta"),
               onClick: () => realPhoneData.resendWelcomeSMS(),
 


### PR DESCRIPTION
# New feature description

This adds a banner to announce the end of the introductory pricing rate

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/187177862-a43d6b48-78c5-4f6e-8ae6-43de766ec649.png)

# How to test

Log in with an account that does not have Premium yet, while Premium is available, and with the `intro_pricing_countdown` flag enabled. You should see a countdown on the email mask dashboard, counting down to September 27th, 9AM PT.

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any. - Not yet, the banner will also appear on a couple of other pages that should be quick to add, so I'll submit the strings after that.
- [ ] All acceptance criteria are met. - The upgrade button is filled, rather than outlined as in the design, and the date is localised by the browser and hence also includes the year (both changes [are approved](https://mozilla.slack.com/archives/C013CSYEL5T/p1661529448639169?thread_ts=1661527618.018519&cid=C013CSYEL5T)).
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
