### PR TITLE
MPP-2325 + MPP-2326

### DIFF
--- a/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
+++ b/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
@@ -199,7 +199,10 @@ const RealPhoneVerification = (props: RealPhoneVerificationProps) => {
     useState<boolean>();
 
   const onChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    setVerificationCode(event.currentTarget.value);
+    // prevent user from entering non-numeric characters
+    if (event.currentTarget.value.match(/^[0-9]*$/)) {
+      setVerificationCode(event.currentTarget.value);
+    }
   };
 
   const onInvalid: FormEventHandler<HTMLInputElement> = (event) => {
@@ -324,7 +327,9 @@ const RealPhoneVerification = (props: RealPhoneVerificationProps) => {
         <Button
           className={styles.button}
           type="submit"
-          disabled={verificationCode.length === 0 || verificationCode === " "}
+          disabled={
+            verificationCode.length === 0 || verificationCode.length < 6
+          }
         >
           {l10n.getString("phone-onboarding-step3-button-cta")}
         </Button>


### PR DESCRIPTION
…umbers allowed in verification input

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-2325 and MPP-2326 

# New feature description

User's can no longer type in letters in the “Verify your true phone number” screen’s input field. MPP-2325

The “Confirm my phone number” button should become active only when the user has introduced 6 digits in the input field. MPP-2326

# Screenshot (if applicable)

https://user-images.githubusercontent.com/3924990/187383749-29b822cd-ca22-4d8f-8bfa-ac41325688a3.mp4

 

# How to test

MPP-2325: 

1. In the input field type in the phone number form the prerequisites;
2. Click on the “Send code” button;
3. On the next screen, the confirmation screen, type any letters in the input field;

MPP-2326

1. In the input field type in the phone number form the prerequisites;
2. Click on the “Send code” button;
3. On the next screen, the confirmation screen, type 5 digits and observe the “Confirm my phone number” button;
4. Type the 6th digit and observe the “Confirm my phone number” button again; 

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
