### PR TITLE
Add end-of-intro-pricing countdown to the landing page and interstitial

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -237,6 +237,11 @@ banner-offer-end-headline = Our intro pricing offer ends soon!
 banner-offer-end-copy = Get { -brand-name-relay-premium } before { $end_date } and enjoy unlimited masking at our intro month-to-month price.
 banner-offer-end-cta = Upgrade now
 
+landing-offer-end-hero-heading = Our intro pricing offer is ending soon!
+# Variables:
+#   $end_date (string) - The localised date the introductory pricing offer ends, e.g. "September 27"
+landing-offer-end-hero-content = Get { -brand-name-relay-premium } before { $end_date } and enjoy premium email protection at our intro month-to-month price.
+
 # Time remaining until Relay Premium's introductory pricing is no longer available.
 # This will not be shown anymore once the time runs out.
 # Variables:

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -238,6 +238,7 @@ banner-offer-end-copy = Get { -brand-name-relay-premium } before { $end_date } a
 banner-offer-end-cta = Upgrade now
 
 landing-offer-end-hero-heading = Our intro pricing offer is ending soon!
+landing-offer-end-hero-cta = Upgrade now
 # Variables:
 #   $end_date (string) - The localised date the introductory pricing offer ends, e.g. "September 27 2022"
 landing-offer-end-hero-content = Get { -brand-name-relay-premium } before { $end_date } and enjoy premium email protection at our intro month-to-month price.
@@ -246,6 +247,7 @@ landing-offer-end-hero-content = Get { -brand-name-relay-premium } before { $end
 #   $monthly_price (string) - the monthly cost (including currency symbol) for Relay Premium. Examples: $0.99, 0,99 €
 landing-pricing-offer-end-headline = Introductory price: Unlimited masks for { $monthly_price } per month
 landing-pricing-offer-end-warning = This promo is expiring soon
+landing-pricing-offer-end-cta = Upgrade now
 # Variables:
 #   $end_date (string) - The localised date the introductory pricing offer ends, e.g. "September 27 2022"
 landing-pricing-offer-end-body = Get { -brand-name-relay-premium } before { $end_date } and enjoy premium email protection at our intro month-to-month price.

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -250,6 +250,25 @@ landing-pricing-offer-end-warning = This promo is expiring soon
 #   $end_date (string) - The localised date the introductory pricing offer ends, e.g. "September 27 2022"
 landing-pricing-offer-end-body = Get { -brand-name-relay-premium } before { $end_date } and enjoy premium email protection at our intro month-to-month price.
 
+premium-promo-offer-end-hero-heading = Our intro pricing offer is ending soon!
+# Variables:
+#   $end_date (string) - The localised date the introductory pricing offer ends, e.g. "September 27 2022"
+premium-promo-offer-end-hero-content = Get { -brand-name-relay-premium } before { $end_date } and enjoy premium email protection at our intro month-to-month price.
+premium-promo-offer-end-hero-cta = Upgrade now
+
+# Variables:
+#   $monthly_price (string) - the monthly cost (including currency symbol) for Relay Premium. Examples: $0.99, 0,99 €
+premium-promo-pricing-offer-end-headline = Introductory price: Unlimited masks for { $monthly_price } per month
+premium-promo-pricing-offer-end-warning = This promo is expiring soon
+premium-promo-pricing-offer-end-cta = Upgrade now
+# Variables:
+#   $end_date (string) - The localised date the introductory pricing offer ends, e.g. "September 27 2022"
+premium-promo-pricing-offer-end-body = Get { -brand-name-relay-premium } before { $end_date } and enjoy premium email protection at our intro month-to-month price.
+
+# Variables:
+#   $monthly_price (string) - the monthly cost (including currency symbol) for Relay Premium. Examples: $0.99, 0,99 €
+premium-promo-hero-body-3 = With { -brand-name-firefox-relay-premium }, you get unlimited custom email masks that forward only the emails you want to your true email address.
+
 # Time remaining until Relay Premium's introductory pricing is no longer available.
 # This will not be shown anymore once the time runs out.
 # Variables:

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -233,14 +233,22 @@ banner-upgrade-loyalist-copy-2 = Protect your privacy while joining our mission 
 
 banner-offer-end-headline = Our intro pricing offer ends soon!
 # Variables:
-#   $end_date (string) - The localised date the introductory pricing offer ends, e.g. "September 27"
+#   $end_date (string) - The localised date the introductory pricing offer ends, e.g. "September 27 2022"
 banner-offer-end-copy = Get { -brand-name-relay-premium } before { $end_date } and enjoy unlimited masking at our intro month-to-month price.
 banner-offer-end-cta = Upgrade now
 
 landing-offer-end-hero-heading = Our intro pricing offer is ending soon!
 # Variables:
-#   $end_date (string) - The localised date the introductory pricing offer ends, e.g. "September 27"
+#   $end_date (string) - The localised date the introductory pricing offer ends, e.g. "September 27 2022"
 landing-offer-end-hero-content = Get { -brand-name-relay-premium } before { $end_date } and enjoy premium email protection at our intro month-to-month price.
+
+# Variables:
+#   $monthly_price (string) - the monthly cost (including currency symbol) for Relay Premium. Examples: $0.99, 0,99 €
+landing-pricing-offer-end-headline = Introductory price: Unlimited masks for { $monthly_price } per month
+landing-pricing-offer-end-warning = This promo is expiring soon
+# Variables:
+#   $end_date (string) - The localised date the introductory pricing offer ends, e.g. "September 27 2022"
+landing-pricing-offer-end-body = Get { -brand-name-relay-premium } before { $end_date } and enjoy premium email protection at our intro month-to-month price.
 
 # Time remaining until Relay Premium's introductory pricing is no longer available.
 # This will not be shown anymore once the time runs out.

--- a/frontend/src/pages/index.module.scss
+++ b/frontend/src/pages/index.module.scss
@@ -162,14 +162,22 @@
   }
 
   .callout {
+    display: flex;
+    flex-direction: column;
     text-align: center;
     max-width: $content-md;
+    gap: $spacing-lg;
 
     h2 {
       @include text-title-sm;
       font-family: $font-stack-firefox;
       font-weight: 500;
-      padding: $spacing-lg 0;
+    }
+
+    .end-of-intro-pricing-countdown-and-warning {
+      display: flex;
+      flex-direction: column;
+      gap: $spacing-sm;
     }
   }
 

--- a/frontend/src/pages/index.module.scss
+++ b/frontend/src/pages/index.module.scss
@@ -164,6 +164,7 @@
   .callout {
     display: flex;
     flex-direction: column;
+    align-items: start;
     text-align: center;
     max-width: $content-md;
     gap: $spacing-lg;

--- a/frontend/src/pages/index.module.scss
+++ b/frontend/src/pages/index.module.scss
@@ -43,6 +43,16 @@
       width: auto;
     }
   }
+
+  .end-of-intro-pricing-hero {
+    display: flex;
+    gap: $spacing-lg;
+    flex-wrap: wrap;
+
+    & > div {
+      flex: 1 1 $content-xs;
+    }
+  }
 }
 
 .how-it-works-wrapper {

--- a/frontend/src/pages/index.page.tsx
+++ b/frontend/src/pages/index.page.tsx
@@ -52,6 +52,14 @@ const Home: NextPage = () => {
     category: "Sign In",
     label: "home-hero-cta",
   });
+  const heroCountdownRef = useGaViewPing({
+    category: "Countdown timer",
+    label: "Landing Page: Top Banner",
+  });
+  const plansCountdownRef = useGaViewPing({
+    category: "Countdown timer",
+    label: "Landing Page: Bottom Banner",
+  });
 
   const [now, setNow] = useState(Date.now());
   const endDateFormatter = new Intl.DateTimeFormat(getLocale(l10n), {
@@ -100,6 +108,7 @@ const Home: NextPage = () => {
               })}
             </h2>
             <div
+              ref={plansCountdownRef}
               className={styles["end-of-intro-pricing-countdown-and-warning"]}
             >
               <b>{l10n.getString("landing-pricing-offer-end-warning")}</b>
@@ -152,7 +161,10 @@ const Home: NextPage = () => {
     isPremiumAvailableInCountry(runtimeData.data) &&
     // …the relevant feature flag is enabled:
     isFlagActive(runtimeData.data, "intro_pricing_countdown") ? (
-      <div className={styles["end-of-intro-pricing-hero"]}>
+      <div
+        ref={heroCountdownRef}
+        className={styles["end-of-intro-pricing-hero"]}
+      >
         <CountdownTimer remainingTimeInMs={remainingTimeInMs} />
         <div>
           <h3>{l10n.getString("landing-offer-end-hero-heading")}</h3>

--- a/frontend/src/pages/index.page.tsx
+++ b/frontend/src/pages/index.page.tsx
@@ -77,30 +77,69 @@ const Home: NextPage = () => {
     setCookie("user-sign-in", "true", { maxAgeInSeconds: 60 * 60 });
   };
 
-  const plansSection = isPremiumAvailableInCountry(runtimeData.data) ? (
-    <section id="pricing" className={styles["plans-wrapper"]}>
-      <div className={styles.plans}>
-        <div className={styles["plan-comparison"]}>
+  const plansSection =
+    // Show the countdown timer to the end of our introductory pricing offer if…
+    // …the offer hasn't expired yet,
+    remainingTimeInMs > 0 &&
+    // …the remaining time isn't far enough in the future that the user's
+    // computer's clock is likely to be wrong,
+    remainingTimeInMs <= 32 * 24 * 60 * 60 * 1000 &&
+    // …the user is able to purchase Premium at the introductory offer price, and
+    isPremiumAvailableInCountry(runtimeData.data) &&
+    // …the relevant feature flag is enabled:
+    isFlagActive(runtimeData.data, "intro_pricing_countdown") ? (
+      <section id="pricing" className={styles["plans-wrapper"]}>
+        <div className={styles.plans}>
+          <div className={styles["plan-comparison"]}>
+            <Plans runtimeData={runtimeData.data} />
+          </div>
+          <div className={styles.callout}>
+            <h2>
+              {l10n.getString("landing-pricing-offer-end-headline", {
+                monthly_price: getPlan(runtimeData.data).price,
+              })}
+            </h2>
+            <div
+              className={styles["end-of-intro-pricing-countdown-and-warning"]}
+            >
+              <b>{l10n.getString("landing-pricing-offer-end-warning")}</b>
+              <CountdownTimer remainingTimeInMs={remainingTimeInMs} />
+            </div>
+            <p>
+              {l10n.getString("landing-pricing-offer-end-body", {
+                end_date: endDateFormatter.format(introPricingOfferEndDate),
+              })}
+            </p>
+          </div>
+        </div>
+      </section>
+    ) : // Otherwise, if Premium is available in the user's country,
+    // allow them to purchase it:
+    isPremiumAvailableInCountry(runtimeData.data) ? (
+      <section id="pricing" className={styles["plans-wrapper"]}>
+        <div className={styles.plans}>
+          <div className={styles["plan-comparison"]}>
+            <Plans runtimeData={runtimeData.data} />
+          </div>
+          <div className={styles.callout}>
+            <h2>
+              {l10n.getString("landing-pricing-headline-2", {
+                monthly_price: getPlan(runtimeData.data).price,
+              })}
+            </h2>
+            <p>{l10n.getString("landing-pricing-body-2")}</p>
+          </div>
+        </div>
+      </section>
+    ) : (
+      // Or finally, if Premium is not available in the country,
+      // prompt them to join the waitlist:
+      <section id="pricing" className={styles["plans-wrapper"]}>
+        <div className={`${styles.plans} ${styles["non-premium-country"]}`}>
           <Plans runtimeData={runtimeData.data} />
         </div>
-        <div className={styles.callout}>
-          <h2>
-            {l10n.getString("landing-pricing-headline-2", {
-              monthly_price: getPlan(runtimeData.data).price,
-            })}
-          </h2>
-          <p>{l10n.getString("landing-pricing-body-2")}</p>
-        </div>
-      </div>
-    </section>
-  ) : (
-    /* Show waitlist prompt if user is a non-premium country */
-    <section id="pricing" className={styles["plans-wrapper"]}>
-      <div className={`${styles.plans} ${styles["non-premium-country"]}`}>
-        <Plans runtimeData={runtimeData.data} />
-      </div>
-    </section>
-  );
+      </section>
+    );
 
   // Only show the countdown timer to the end of our introductory pricing offer if…
   const introPricingEndBanner =

--- a/frontend/src/pages/premium.module.scss
+++ b/frontend/src/pages/premium.module.scss
@@ -43,6 +43,16 @@
       width: auto;
     }
   }
+
+  .end-of-intro-pricing-hero {
+    display: flex;
+    gap: $spacing-lg;
+    flex-wrap: wrap;
+
+    & > div {
+      flex: 1 1 $content-xs;
+    }
+  }
 }
 
 .perks-wrapper {
@@ -159,13 +169,22 @@
   }
 
   .callout {
+    display: flex;
+    flex-direction: column;
+    align-items: start;
     text-align: center;
+    gap: $spacing-lg;
 
     h2 {
       @include text-title-md;
       font-family: $font-stack-firefox;
       font-weight: 500;
-      padding: $spacing-lg 0;
+    }
+
+    .end-of-intro-pricing-countdown-and-warning {
+      display: flex;
+      flex-direction: column;
+      gap: $spacing-sm;
     }
   }
 

--- a/frontend/src/pages/premium.page.tsx
+++ b/frontend/src/pages/premium.page.tsx
@@ -1,4 +1,5 @@
 import { NextPage } from "next";
+import { useState } from "react";
 import { Localized, useLocalization } from "@fluent/react";
 import { event as gaEvent } from "react-ga";
 import styles from "./premium.module.scss";
@@ -34,6 +35,12 @@ import { CarouselContentHero } from "../components/landing/carousel/ContentHero"
 import ShoppingHero from "../components/landing/carousel/images/shopping-hero.svg";
 import { CarouselContentCards } from "../components/landing/carousel/ContentCards";
 import { isFlagActive } from "../functions/waffle";
+import { getLocale } from "../functions/getLocale";
+import { useInterval } from "../hooks/interval";
+import {
+  CountdownTimer,
+  introPricingOfferEndDate,
+} from "../components/CountdownTimer";
 
 const PremiumPromo: NextPage = () => {
   const { l10n } = useLocalization();
@@ -65,46 +72,147 @@ const PremiumPromo: NextPage = () => {
     }),
   };
 
-  const purchase = () => {
-    gaEvent({
-      category: "Purchase Button",
-      action: "Engage",
-      label: "home-hero-cta",
-    });
-  };
+  const heroCountdownCtaRef = useGaViewPing({
+    category: "Purchase Button",
+    label: "Interstitial Page: Top Banner",
+  });
+  const plansCountdownCtaRef = useGaViewPing({
+    category: "Purchase Button",
+    label: "Interstitial Page: Bottom Banner",
+  });
 
-  const plansSection = isPremiumAvailableInCountry(runtimeData.data) ? (
-    <section id="pricing" className={styles["plans-wrapper"]}>
-      <div className={styles.plans}>
-        <div className={styles["plan-comparison"]}>
+  const [now, setNow] = useState(Date.now());
+  const endDateFormatter = new Intl.DateTimeFormat(getLocale(l10n), {
+    dateStyle: "long",
+  });
+
+  useInterval(() => {
+    setNow(Date.now());
+  }, 1000);
+
+  const remainingTimeInMs = introPricingOfferEndDate.getTime() - now;
+
+  const plansSection =
+    // Show the countdown timer to the end of our introductory pricing offer if…
+    // …the offer hasn't expired yet,
+    remainingTimeInMs > 0 &&
+    // …the remaining time isn't far enough in the future that the user's
+    // computer's clock is likely to be wrong,
+    remainingTimeInMs <= 32 * 24 * 60 * 60 * 1000 &&
+    // …the user is able to purchase Premium at the introductory offer price, and
+    isPremiumAvailableInCountry(runtimeData.data) &&
+    // …the relevant feature flag is enabled:
+    isFlagActive(runtimeData.data, "intro_pricing_countdown") ? (
+      <section id="pricing" className={styles["plans-wrapper"]}>
+        <div className={styles.plans}>
+          <div className={styles["plan-comparison"]}>
+            <Plans runtimeData={runtimeData.data} />
+          </div>
+          <div className={styles.callout}>
+            <h2>
+              {l10n.getString("premium-promo-pricing-offer-end-headline", {
+                monthly_price: getPlan(runtimeData.data).price,
+              })}
+            </h2>
+            <div
+              className={styles["end-of-intro-pricing-countdown-and-warning"]}
+            >
+              <b>{l10n.getString("premium-promo-pricing-offer-end-warning")}</b>
+              <CountdownTimer remainingTimeInMs={remainingTimeInMs} />
+            </div>
+            <LinkButton
+              ref={plansCountdownCtaRef}
+              href={getPremiumSubscribeLink(runtimeData.data)}
+              onClick={() => {
+                gaEvent({
+                  category: "Purchase Button",
+                  action: "Engage",
+                  label: "Interstitial Page: Bottom Banner",
+                });
+              }}
+            >
+              {l10n.getString("premium-promo-pricing-offer-end-cta")}
+            </LinkButton>
+            <p>
+              {l10n.getString("premium-promo-pricing-offer-end-body", {
+                end_date: endDateFormatter.format(introPricingOfferEndDate),
+              })}
+            </p>
+          </div>
+        </div>
+      </section>
+    ) : // Otherwise, if Premium is available in the user's country,
+    // allow them to purchase it:
+    isPremiumAvailableInCountry(runtimeData.data) ? (
+      <section id="pricing" className={styles["plans-wrapper"]}>
+        <div className={styles.plans}>
+          <div className={styles["plan-comparison"]}>
+            <Plans runtimeData={runtimeData.data} />
+          </div>
+          <div className={styles.callout}>
+            <h2>
+              {l10n.getString("landing-pricing-headline-2", {
+                monthly_price: getPlan(runtimeData.data).price,
+              })}
+            </h2>
+            <p>{l10n.getString("landing-pricing-body-2")}</p>
+          </div>
+        </div>
+      </section>
+    ) : (
+      // Or finally, if Premium is not available in the country,
+      // prompt them to join the waitlist:
+      <section id="pricing" className={styles["plans-wrapper"]}>
+        <div className={`${styles.plans} ${styles["non-premium-country"]}`}>
           <Plans runtimeData={runtimeData.data} />
         </div>
-        <div className={styles.callout}>
-          <h2>
-            {l10n.getString("landing-pricing-headline-2", {
-              monthly_price: getPlan(runtimeData.data).price,
+      </section>
+    );
+
+  // Only show the countdown timer to the end of our introductory pricing offer if…
+  const introPricingEndBanner =
+    // …the offer hasn't expired yet,
+    remainingTimeInMs > 0 &&
+    // …the remaining time isn't far enough in the future that the user's
+    // computer's clock is likely to be wrong,
+    remainingTimeInMs <= 32 * 24 * 60 * 60 * 1000 &&
+    // …the user is able to purchase Premium at the introductory offer price, and
+    isPremiumAvailableInCountry(runtimeData.data) &&
+    // …the relevant feature flag is enabled:
+    isFlagActive(runtimeData.data, "intro_pricing_countdown") ? (
+      <div className={styles["end-of-intro-pricing-hero"]}>
+        <CountdownTimer remainingTimeInMs={remainingTimeInMs} />
+        <div>
+          <h3>{l10n.getString("premium-promo-offer-end-hero-heading")}</h3>
+          <p>
+            {l10n.getString("premium-promo-offer-end-hero-content", {
+              end_date: endDateFormatter.format(introPricingOfferEndDate),
             })}
-          </h2>
-          <p>{l10n.getString("landing-pricing-body-2")}</p>
+          </p>
         </div>
       </div>
-    </section>
-  ) : (
-    /* Show waitlist prompt if user is a non-premium country */
-    <section id="pricing" className={styles["plans-wrapper"]}>
-      <div className={`${styles.plans} ${styles["non-premium-country"]}`}>
-        <Plans runtimeData={runtimeData.data} />
-      </div>
-    </section>
-  );
+    ) : null;
 
   const cta = isPremiumAvailableInCountry(runtimeData.data) ? (
     <LinkButton
-      ref={heroCtaRef}
+      ref={introPricingEndBanner === null ? heroCtaRef : heroCountdownCtaRef}
       href={getPremiumSubscribeLink(runtimeData.data)}
-      onClick={() => purchase()}
+      onClick={() => {
+        gaEvent({
+          category: "Purchase Button",
+          action: "Engage",
+          label:
+            introPricingEndBanner === null
+              ? "home-hero-cta"
+              : "Interstitial Page: Top Banner",
+        });
+      }}
     >
-      {l10n.getString("premium-promo-hero-cta")}
+      {l10n.getString(
+        introPricingEndBanner === null
+          ? "premium-promo-hero-cta"
+          : "premium-promo-offer-end-hero-cta"
+      )}
     </LinkButton>
   ) : (
     <Button
@@ -138,19 +246,17 @@ const PremiumPromo: NextPage = () => {
           <div className={styles.lead}>
             <h2>{l10n.getString("premium-promo-hero-headline")}</h2>
             <Localized
-              id="premium-promo-hero-body-2-html"
+              id="premium-promo-hero-body-3"
               vars={{
                 monthly_price: isPremiumAvailableInCountry(runtimeData.data)
                   ? getPlan(runtimeData.data).price
                   : runtimeData.data?.PREMIUM_PLANS.plan_country_lang_mapping.us
                       .en.price ?? "&hellip;",
               }}
-              elems={{
-                b: <b />,
-              }}
             >
               <p />
             </Localized>
+            {introPricingEndBanner}
             {cta}
             <p>{l10n.getString("premium-promo-availability-warning-2")}</p>
           </div>


### PR DESCRIPTION
# New feature description

This adds countdown banners to the landing page to notify people of the impending end of our introductory pricing.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/187434652-5cd244e6-cdf1-4f16-b19d-6330993696d4.png)

![image](https://user-images.githubusercontent.com/4251/187434684-b78c4e97-7ca6-444d-929c-ac4578551571.png)

![image](https://user-images.githubusercontent.com/4251/187434722-e7bf9a16-7a1c-42ee-9f00-3b00642f3ebd.png)

![image](https://user-images.githubusercontent.com/4251/187434762-36cb12c3-eb22-4da0-b6e0-17df175d0a40.png)

# How to test

Open the landing page and interstitial in a country that can purchase Premium, with the flag `intro_pricing_countdown` enabled.

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any. - Not yet, will do when I've got the other countdown updates done as well.
- [ ] All acceptance criteria are met. - I added the same CTAs to the landing page as were listed for the interstitial. Also, the date formatting is determined by the browser. And finally, it's not necessarily limited to free users (since the user isn't signed in on the landing page).
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
