### PR TITLE
Add News entry for the intro pricing end

### DIFF
--- a/frontend/__mocks__/hooks/api/runtimeData.ts
+++ b/frontend/__mocks__/hooks/api/runtimeData.ts
@@ -16,6 +16,7 @@ export function getMockRuntimeDataWithPremium(): RuntimeData {
     FXA_ORIGIN: "https://fxa-mock.com",
     BASKET_ORIGIN: "https://basket-mock.com",
     GOOGLE_ANALYTICS_ID: "UA-123456789-0",
+    INTRO_PRICING_END: "2022-09-27T16:00:00.000Z",
     PREMIUM_PRODUCT_ID: "prod_123456789",
     PHONE_PRODUCT_ID: "prod_123456789",
     PREMIUM_PLANS: {
@@ -39,6 +40,7 @@ export function getMockRuntimeDataWithoutPremium(): RuntimeData {
     FXA_ORIGIN: "https://fxa-mock.com",
     BASKET_ORIGIN: "https://basket-mock.com",
     GOOGLE_ANALYTICS_ID: "UA-123456789-0",
+    INTRO_PRICING_END: "2022-09-27T16:00:00.000Z",
     PREMIUM_PRODUCT_ID: "prod_123456789",
     PHONE_PRODUCT_ID: "prod_123456789",
     PREMIUM_PLANS: {

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -306,6 +306,18 @@ offer-countdown-timer-minutes = Min.
 # There's not much room for this, hence the abbreviation.
 offer-countdown-timer-seconds = Sec.
 
+whatsnew-feature-offer-countdown-heading = Our intro pricing offer ends soon!
+# A preview of the full content of `whatsnew-feature-offer-countdown-description`.
+# When translating, please make sure the resulting string is of roughly similar
+# length as the English version.
+# Variables:
+#   $end_date (string) - The localised date the introductory pricing offer ends, e.g. "September 27 2022"
+whatsnew-feature-offer-countdown-snippet = Get { -brand-name-relay-premium } before { $end_date } and enjoy unlimited masking at our…
+# Variables:
+#   $end_date (string) - The localised date the introductory pricing offer ends, e.g. "September 27 2022"
+whatsnew-feature-offer-countdown-description = Get { -brand-name-relay-premium } before { $end_date } and enjoy unlimited masking at our intro month-to-month price.
+whatsnew-feature-offer-countdown-cta = Upgrade now
+
 # Variables:
 #   $premium_link (string) - This is a link to relay.firefox.com/premium. Example: <a href="https://relay.firefox.com/premium" ...>Relay Premium</a>
 forwarded-email-header-offer-countdown-banner = Our intro monthly pricing offer is expiring. Upgrade to { $premium_link }.

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewContent.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewContent.tsx
@@ -59,3 +59,27 @@ const Hero = (props: Pick<Props, "image" | "videos">) => {
     </>
   );
 };
+
+export type WhatsNewComponentContentProps = {
+  heading: string;
+  description: string;
+  hero: JSX.Element;
+  cta?: JSX.Element | null;
+};
+/**
+ * Content of a "What's New" entry with a component as the hero
+ */
+export const WhatsNewComponentContent = (
+  props: WhatsNewComponentContentProps
+) => {
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles["hero-wrapper"]}>{props.hero}</div>
+      <div className={styles.content}>
+        <h2>{props.heading}</h2>
+        <p>{props.description}</p>
+        {props.cta && <div className={styles.cta}>{props.cta}</div>}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.test.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.test.tsx
@@ -27,7 +27,6 @@ function getMockEntry(
     },
     content: `New feature ${id} content`,
     snippet: `New feature ${id} con...`,
-    hero: "https://example.com/new-feature-hero.svg",
     icon: "https://example.com/new-feature-icon.svg",
     dismissal: {
       dismiss: jest.fn(),

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.module.scss
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.module.scss
@@ -68,3 +68,9 @@ button.trigger {
     color: $color-blue-80;
   }
 }
+
+.countdown-timer {
+  display: flex;
+  justify-content: center;
+  padding: $spacing-2xl 0;
+}

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -52,14 +52,18 @@ import { RuntimeData } from "../../../../hooks/api/runtimeData";
 import { isFlagActive } from "../../../../functions/waffle";
 import {
   getPhoneSubscribeLink,
+  getPremiumSubscribeLink,
   isPremiumAvailableInCountry,
 } from "../../../../functions/getPlan";
+import { parseDate } from "../../../../functions/parseDate";
+import { useGaViewPing } from "../../../../hooks/gaViewPing";
+import { CountdownTimer } from "../../../CountdownTimer";
+import { useInterval } from "../../../../hooks/interval";
 
 export type WhatsNewEntry = {
   title: string;
   snippet: string;
   content: ReactNode;
-  hero: string;
   icon: string;
   dismissal: DismissalData;
   /**
@@ -140,7 +144,6 @@ export const WhatsNewMenu = (props: Props) => {
           }}
         />
       ),
-      hero: SizeLimitHero.src,
       icon: SizeLimitIcon.src,
       dismissal: useLocalDismissal(
         `whatsnew-feature_size-limit_${props.profile.id}`
@@ -164,7 +167,6 @@ export const WhatsNewMenu = (props: Props) => {
         image={ForwardSomeHero.src}
       />
     ),
-    hero: ForwardSomeHero.src,
     icon: ForwardSomeIcon.src,
     dismissal: useLocalDismissal(
       `whatsnew-feature_sign-back-in_${props.profile.id}`
@@ -191,7 +193,6 @@ export const WhatsNewMenu = (props: Props) => {
         image={SignBackInHero.src}
       />
     ),
-    hero: SignBackInHero.src,
     icon: SignBackInIcon.src,
     dismissal: useLocalDismissal(
       `whatsnew-feature_sign-back-in_${props.profile.id}`
@@ -218,7 +219,6 @@ export const WhatsNewMenu = (props: Props) => {
         image={aliasToMaskHero.src}
       />
     ),
-    hero: aliasToMaskHero.src,
     icon: aliasToMaskIcon.src,
     dismissal: useLocalDismissal(
       `whatsnew-feature_alias-to-mask_${props.profile.id}`
@@ -267,7 +267,6 @@ export const WhatsNewMenu = (props: Props) => {
         image={PremiumSwedenHero.src}
       />
     ),
-    hero: PremiumSwedenHero.src,
     icon: PremiumSwedenIcon.src,
     dismissal: useLocalDismissal(
       `whatsnew-feature_premium-expansion-sweden_${props.profile.id}`
@@ -299,7 +298,6 @@ export const WhatsNewMenu = (props: Props) => {
         image={PremiumFinlandHero.src}
       />
     ),
-    hero: PremiumFinlandHero.src,
     icon: PremiumFinlandIcon.src,
     dismissal: useLocalDismissal(
       `whatsnew-feature_premium-expansion-finland_${props.profile.id}`
@@ -329,7 +327,6 @@ export const WhatsNewMenu = (props: Props) => {
         image={TrackerRemovalHero.src}
       />
     ),
-    hero: TrackerRemovalHero.src,
     icon: TrackerRemovalIcon.src,
     dismissal: useLocalDismissal(
       `whatsnew-feature_tracker-removal_${props.profile.id}`
@@ -365,7 +362,6 @@ export const WhatsNewMenu = (props: Props) => {
       />
     ),
 
-    hero: PhoneMaskingHero.src,
     icon: PhoneMaskingIcon.src,
     dismissal: useLocalDismissal(`whatsnew-feature_phone_${props.profile.id}`),
     announcementDate: {

--- a/frontend/src/components/layout/navigation/whatsnew/images/offer-countdown-icon.svg
+++ b/frontend/src/components/layout/navigation/whatsnew/images/offer-countdown-icon.svg
@@ -1,0 +1,13 @@
+<svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_217_431" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="50" height="50">
+<rect width="50" height="50" rx="4" fill="white"/>
+</mask>
+<g mask="url(#mask0_217_431)">
+<rect x="-2" y="-3" width="54" height="55" fill="white"/>
+<rect x="6" y="7" width="38" height="37" rx="4" fill="#321C64"/>
+<path d="M6 11C6 8.79086 7.79086 7 10 7H40C42.2091 7 44 8.79086 44 11V15H6V11Z" fill="#DABDFF"/>
+<rect x="15" y="3" width="3" height="6" rx="1.5" fill="#DABDFF"/>
+<rect x="32" y="3" width="3" height="6" rx="1.5" fill="#DABDFF"/>
+<rect x="29" y="21" width="8" height="8" rx="2" fill="#DABDFF"/>
+</g>
+</svg>

--- a/frontend/src/hooks/interval.ts
+++ b/frontend/src/hooks/interval.ts
@@ -1,8 +1,13 @@
 import { useEffect, useRef } from "react";
 
 export type IntervalFunction = () => unknown | void;
-// See https://overreacted.io/making-setinterval-declarative-with-react-hooks/
-export function useInterval(callback: IntervalFunction, delay: number) {
+/**
+ * See https://overreacted.io/making-setinterval-declarative-with-react-hooks/
+ *
+ * @param callback Function to execute at most every `delay` milliseconds
+ * @param delay Milliseconds between calls to `callback`. `null` to disable the interval.
+ */
+export function useInterval(callback: IntervalFunction, delay: number | null) {
   const savedCallback = useRef<IntervalFunction | null>(null);
 
   // Remember the latest callback.


### PR DESCRIPTION
# New feature description

This adds an announcement of the end of the intro pricing to the News section.

Unfortunately I haven't been able to get the Countdown Timer to
update dynamically yet in the news entry, which I'm guessing might
be the result of some interaction between it and the different
React Aria components? For now, I expect that a static counter is
better than not having it at all.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/187479236-04c5ba74-90a0-4301-8e13-61bf3f726ada.png)

![image](https://user-images.githubusercontent.com/4251/187479280-cdb11822-53ad-4ebd-a0fe-2180e048c4f1.png)

# How to test

With the flag enabeld and a non-Premium user, open the News menu.

# Checklist

- [x] l10n changes have been submitted to the l10n repository, if any. https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/100
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
