### PR TITLE
Add email trackers removed data to add on

### DIFF
--- a/frontend/src/components/dashboard/AddonData.tsx
+++ b/frontend/src/components/dashboard/AddonData.tsx
@@ -9,6 +9,7 @@ export type Props = {
   aliases: AliasData[];
   totalForwardedEmails: number;
   totalBlockedEmails: number;
+  totalEmailTrackersRemoved: number;
 };
 
 export const AddonData = (props: Props) => {
@@ -29,6 +30,7 @@ export const AddonData = (props: Props) => {
       data-aliases-used-val={props.aliases.length}
       data-emails-forwarded-val={props.totalForwardedEmails}
       data-emails-blocked-val={props.totalBlockedEmails}
+      data-email-trackers-removed-val={props.totalEmailTrackersRemoved}
       data-premium-subdomain-set={
         typeof props.profile.subdomain === "string"
           ? props.profile.subdomain

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -135,6 +135,7 @@ const Profile: NextPage = () => {
           runtimeData={runtimeData.data}
           totalBlockedEmails={profile.emails_blocked}
           totalForwardedEmails={profile.emails_forwarded}
+          totalEmailTrackersRemoved={profile.level_one_trackers_blocked}
         />
         <Layout runtimeData={runtimeData.data}>
           {isFlagActive(runtimeData.data, "phones") ? (
@@ -381,6 +382,7 @@ const Profile: NextPage = () => {
         runtimeData={runtimeData.data}
         totalBlockedEmails={profile.emails_blocked}
         totalForwardedEmails={profile.emails_forwarded}
+        totalEmailTrackersRemoved={profile.level_one_trackers_blocked}
       />
       <Layout runtimeData={runtimeData.data}>
         {isFlagActive(runtimeData.data, "phones") ? (


### PR DESCRIPTION


# New feature description

Passing the trackers removed total data to the add on to render the following view:
<img width="335" alt="image" src="https://user-images.githubusercontent.com/13066134/187534882-926240cb-83da-4d61-b928-d1186083013b.png">

# Checklist


- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
