### PR TITLE
Use BadRequest instead of SuspiciousOperation for 400 errors

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -9,7 +9,7 @@ import uuid
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.exceptions import SuspiciousOperation
+from django.core.exceptions import BadRequest
 from django.core.validators import MinLengthValidator
 from django.db import models, transaction
 from django.dispatch import receiver
@@ -512,9 +512,7 @@ class RegisteredSubdomain(models.Model):
         return self.subdomain_hash
 
 
-# extend from SuspiciousOperation to trigger 400 status code error
-# TODO: in Django 3.2+ change this to BadRequest
-class CannotMakeSubdomainException(SuspiciousOperation):
+class CannotMakeSubdomainException(BadRequest):
     """Exception raised by Profile due to error on subdomain creation.
 
     Attributes:
@@ -525,9 +523,7 @@ class CannotMakeSubdomainException(SuspiciousOperation):
         self.message = message
 
 
-# extend from SuspiciousOperation to trigger 400 status code error
-# TODO: in Django 3.2+ change this to BadRequest
-class CannotMakeAddressException(SuspiciousOperation):
+class CannotMakeAddressException(BadRequest):
     """Exception raised by RelayAddress or DomainAddress due to error on alias creation.
 
     Attributes:

--- a/emails/signals.py
+++ b/emails/signals.py
@@ -3,8 +3,7 @@ import logging
 
 from django.contrib.auth.models import User
 
-# use SuspiciousOperation when we need to raise a 4xx error
-from django.core.exceptions import SuspiciousOperation
+from django.core.exceptions import BadRequest
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
@@ -27,10 +26,10 @@ def check_premium_for_block_list_emails(sender, instance, **kwargs):
         try:
             obj = sender.objects.get(pk=instance.pk)
             if obj.block_list_emails != instance.block_list_emails:
-                raise SuspiciousOperation("Must be premium to set block_list_emails")
+                raise BadRequest("Must be premium to set block_list_emails")
         except sender.DoesNotExist:
             if instance.block_list_emails:
-                raise SuspiciousOperation("Must be premium to set block_list_emails")
+                raise BadRequest("Must be premium to set block_list_emails")
 
 
 @receiver(pre_save, sender=Profile)

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.exceptions import SuspiciousOperation
+from django.core.exceptions import BadRequest
 from django.test import (
     override_settings,
     TestCase,
@@ -249,7 +249,7 @@ class RelayAddressTest(TestCase):
 
     def test_free_user_cant_set_block_list_emails(self):
         relay_address = RelayAddress.objects.create(user=self.user)
-        with self.assertRaises(SuspiciousOperation):
+        with self.assertRaises(BadRequest):
             relay_address.block_list_emails = True
             relay_address.save()
         relay_address.refresh_from_db()

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -719,6 +719,9 @@ ignore_logger("django.security.DisallowedHost")
 # It is more effective to process these from logs using BigQuery than to track
 # as events in Sentry.
 ignore_logger("django_ftl.message_errors")
+# Security scanner attempts on Heroku dev, no action required
+if RELAY_CHANNEL == "dev":
+    ignore_logger("django.security.SuspiciousFileOperation")
 
 markus.configure(
     backends=[


### PR DESCRIPTION
Use [BadRequest](https://docs.djangoproject.com/en/3.2/ref/exceptions/#badrequest), added in Django 3.2, to return a `400 Bad Request` response when the user can not perform the requested action. Previously, a `SuspiciousOperation` was used, which also sent an unneeded exception to Sentry.

Also, ignore `SuspiciousFileOperation` in Heroku, which is triggered by security scanners looking for interesting endpoints.

How to test:

- [ ] All tests run with `pytest .`
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
