### PR TITLE
Update Dockerfile weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Enable Dependabot updates for our `Dockerfile` Python 3.9.13 is the current release, so I don't expect any updates for a while.