### PR TITLE
MPP-1928 - Replace CTAs on Interstitial Page to Join Waitlist for non-premium countries

### DIFF
--- a/frontend/src/pages/premium.page.tsx
+++ b/frontend/src/pages/premium.page.tsx
@@ -216,12 +216,12 @@ const PremiumPromo: NextPage = () => {
       )}
     </LinkButton>
   ) : (
-    <Button
-      disabled={true}
+    <LinkButton
+      href="/premium/waitlist"
       title={l10n.getString("premium-promo-availability-warning-2")}
     >
-      {l10n.getString("premium-promo-hero-cta")}
-    </Button>
+      {l10n.getString("waitlist-submit-label")}
+    </LinkButton>
   );
 
   const getPerkCta = (label: keyof typeof perkCtaRefs) => {

--- a/frontend/src/pages/premium.page.tsx
+++ b/frontend/src/pages/premium.page.tsx
@@ -19,7 +19,7 @@ import OnTheGoPhone from "../components/landing/carousel/images/onthego-illustra
 import OnTheGoReceipt from "../components/landing/carousel/images/onthego-illustration-receipts.svg";
 import { Layout } from "../components/layout/Layout";
 import { useGaViewPing } from "../hooks/gaViewPing";
-import { Button, LinkButton } from "../components/Button";
+import { LinkButton } from "../components/Button";
 import { DemoPhone } from "../components/landing/DemoPhone";
 import { useRuntimeData } from "../hooks/api/runtimeData";
 import { Carousel } from "../components/landing/carousel/Carousel";


### PR DESCRIPTION

This PR fixes #MPP-1928

<img width="1647" alt="image" src="https://user-images.githubusercontent.com/13066134/187774192-aa1778e3-8271-445d-8385-d7e9327aa947.png">

This replaces 'Upgrade CTA' to 'Join the Waitlist' on the interstitial page for users in non-premium countries.

How to test:
Set your browser's language to a non-premium language, such as Romana, and the main CTA in the hero of the interstitial page should display 'Join the Waitlist`, which takes you to the premium waitlist sign up page.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
