### PR TITLE
for MPP-2330: adjust rate limit by origin

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -649,7 +649,7 @@ REST_FRAMEWORK = {
 }
 
 PHONE_RATE_LIMIT = "5/minute"
-if IN_PYTEST or DEBUG:
+if IN_PYTEST or RELAY_CHANNEL in ["local", "dev"]:
     PHONE_RATE_LIMIT = "1000/minute"
 
 # Turn on logging out on GET in development.


### PR DESCRIPTION
This PR addresses a bug found while working on MPP-2330. The dev server kept giving errors during the real phone registration because the rate limit for API requests was set to 5/min.

This changes the code to base the rate limit on the `RELAY_CHANNEL` which comes from the origin (e.g., 127.0.0.01 and dev.fxprivaterelay.nonprod.cloudops.mozgcp.net) rather than the `DEBUG` setting.

How to test:
1. Go to http://127.0.0.1:8000/admin/
2. In the django debug toolbar, open "Settings"
3. Find the `PHONE_RATE_LIMIT` value
   * [ ] Make sure it's still set to `'1000/minute'`

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).