### PR TITLE
No negative numbers in the countdown timer

### DIFF
--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -411,6 +411,9 @@ export const WhatsNewMenu = (props: Props) => {
       day: 13,
     },
   };
+  // Make sure to move the end-of-intro-pricing news entry is in the History
+  // tab if the countdown has finished:
+  introPricingCountdown.dismissal.isDismissed ||= remainingTimeInMs <= 0;
   if (
     // If the remaining time isn't far enough in the future that the user's
     // computer's clock is likely to be wrong,

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -393,7 +393,9 @@ export const WhatsNewMenu = (props: Props) => {
         heading={l10n.getString("whatsnew-feature-offer-countdown-heading")}
         hero={
           <div className={styles["countdown-timer"]}>
-            <CountdownTimer remainingTimeInMs={remainingTimeInMs} />
+            <CountdownTimer
+              remainingTimeInMs={Math.max(remainingTimeInMs, 0)}
+            />
           </div>
         }
         cta={offerCountdownCta}


### PR DESCRIPTION
This PR fixes MPP-2336.

It ensures that when the deadline is in the past, the countdown timer in the news entry does not display negative numbers. (It's the only instance that doesn't just get hidden on that date.) Instead, it just shows 0s.

![image](https://user-images.githubusercontent.com/4251/188156991-8239145d-b8f7-43fc-a17d-c12d606cbbc6.png)

Additionally, I realised another improvement: when the deadline is in the past, even if the user hasn't seen the announcement yet, it's not really relevant anymore. Therefore, it will then also automatically be dismissed and moved into the History tab.

How to test: set your computer clock to beyond 27 September. The countdown timer in the news should show 0s, and only be listed in the History tab.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - Mocking system time is a hassle, so I skipped this, but happy to add a test if you'd prefer.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
