### PR TITLE
Allow modal close via outside click/pressing Esc

### DIFF
--- a/frontend/src/components/phones/onboarding/RelayNumberConfirmationModal.tsx
+++ b/frontend/src/components/phones/onboarding/RelayNumberConfirmationModal.tsx
@@ -17,6 +17,7 @@ import { formatPhone } from "../../../functions/formatPhone";
 export type Props = {
   onClose: () => void;
   confirm: () => void;
+  isOpen: boolean;
   relayNumber: string;
 };
 
@@ -32,6 +33,7 @@ export const RelayNumberConfirmationModal = (props: Props) => {
       <PickerDialog
         title={`test`}
         onClose={() => props.onClose()}
+        isOpen={props.isOpen}
         isDismissable={true}
       >
         <button
@@ -64,6 +66,7 @@ export const RelayNumberConfirmationModal = (props: Props) => {
 type PickerDialogProps = {
   title: string | ReactElement;
   children: ReactNode;
+  isOpen: boolean;
   onClose?: () => void;
 };
 const PickerDialog = (props: PickerDialogProps & OverlayProps) => {

--- a/frontend/src/components/phones/onboarding/RelayNumberPicker.tsx
+++ b/frontend/src/components/phones/onboarding/RelayNumberPicker.tsx
@@ -5,6 +5,7 @@ import {
   useState,
 } from "react";
 import { useLocalization } from "@fluent/react";
+import { useOverlayTriggerState } from "react-stately";
 import styles from "./RelayNumberPicker.module.scss";
 import EnteryVerifyCodeSuccess from "./images/verify-code-success.svg";
 import { Button } from "../../Button";
@@ -95,7 +96,7 @@ const RelayNumberSelection = (props: RelayNumberSelectionProps) => {
   const [searchValue, setSearchValue] = useState("");
   const [relayNumberIndex, setRelayNumberIndex] = useState(0);
   const [isSearching, setIsSearching] = useState(false);
-  const [confirmationState, setConfirmationState] = useState<boolean>(false);
+  const confirmationModalState = useOverlayTriggerState({});
   const [relayNumberSuggestions, setRelayNumberSuggestions] = useState<
     string[]
   >([]);
@@ -125,7 +126,7 @@ const RelayNumberSelection = (props: RelayNumberSelectionProps) => {
     event.preventDefault();
 
     if (phoneNumber.length !== 0) {
-      setConfirmationState(true);
+      confirmationModalState.open();
     }
   };
 
@@ -246,14 +247,15 @@ const RelayNumberSelection = (props: RelayNumberSelectionProps) => {
 
   return (
     <div className={`${styles.step}`}>
-      {confirmationState && (
+      {confirmationModalState.isOpen && (
         <RelayNumberConfirmationModal
           relayNumber={phoneNumber}
           onClose={() => {
-            setConfirmationState(false);
+            confirmationModalState.close();
           }}
+          isOpen={confirmationModalState.isOpen}
           confirm={() => {
-            setConfirmationState(false);
+            confirmationModalState.close();
             props.registerRelayNumber(phoneNumber);
           }}
         />


### PR DESCRIPTION
This allows the phone number confirmation dialog to be closed by pressing Esc or clicking outside of the modal. Will merge into #2454.