### PR TITLE
MPP-2341 Add clearer warning that disabling sender data clears sender log history

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -190,7 +190,7 @@ phone-onboarding-step4-results= No results found. Please try again.
 # Phone Settings
 phone-settings-caller-sms-log = Caller and SMS log
 phone-settings-caller-sms-log-description = Allow { -brand-name-firefox-relay } to keep a log of your callers and text senders.
-phone-settings-caller-sms-log-warning = If you decide to opt-out from this preference, you will lose the ability to view the names/labels of the websites where the aliases have been generated using the add-on. 
+phone-settings-caller-sms-log-warning = If you decide to opt out from this preference, you will lose the ability to block and reply to senders or callers. If you’ve blocked any, they will become unblocked and your existing caller and SMS sender log will be permanently cleared from your history. 
 
 # Phone Resend SMS Banner
 phone-banner-resend-welcome-sms-cta = Resend welcome SMS

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -190,7 +190,7 @@ phone-onboarding-step4-results= No results found. Please try again.
 # Phone Settings
 phone-settings-caller-sms-log = Caller and SMS log
 phone-settings-caller-sms-log-description = Allow { -brand-name-firefox-relay } to keep a log of your callers and text senders.
-phone-settings-caller-sms-log-warning = If you decide to opt out from this preference, you will lose the ability to block senders or callers.
+phone-settings-caller-sms-log-warning = If you decide to opt-out from this preference, you will lose the ability to view the names/labels of the websites where the aliases have been generated using the add-on. 
 
 # Phone Resend SMS Banner
 phone-banner-resend-welcome-sms-cta = Resend welcome SMS

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -46,6 +46,8 @@ const Settings: NextPage = () => {
   const [phoneCallerSMSLogEnabled, setPhoneCallerSMSLogEnabled] = useState(
     profileData.data?.[0].store_phone_log
   );
+  const [phoneCallerSMSLogEnabledLabel, setPhoneCallerSMSLogEnabledLabel] =
+    useState(false);
   const [justCopiedApiKey, setJustCopiedApiKey] = useState(false);
   const apiKeyElementRef = useRef<HTMLInputElement>(null);
 
@@ -280,16 +282,21 @@ const Settings: NextPage = () => {
             name="caller-sms-log"
             id="caller-sms-log"
             defaultChecked={profile.store_phone_log}
-            onChange={(e) => setPhoneCallerSMSLogEnabled(e.target.checked)}
+            onChange={(e) => {
+              setPhoneCallerSMSLogEnabled(e.target.checked);
+              setPhoneCallerSMSLogEnabledLabel(!phoneCallerSMSLogEnabledLabel);
+            }}
           />
           <label htmlFor="caller-sms-log">
             <p>{l10n.getString("phone-settings-caller-sms-log-description")}</p>
           </label>
         </div>
-        <div className={styles["field-warning"]}>
-          <InfoTriangleIcon alt="" />
-          <p>{l10n.getString("phone-settings-caller-sms-log-warning")}</p>
-        </div>
+        {phoneCallerSMSLogEnabledLabel ? (
+          <div className={styles["field-warning"]}>
+            <InfoTriangleIcon alt="" />
+            <p>{l10n.getString("phone-settings-caller-sms-log-warning")}</p>
+          </div>
+        ) : null}
       </div>
     </div>
   ) : null;


### PR DESCRIPTION


<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #MPP-2341

Only show warning component when the user unchecks the Caller and SMS log setting.



https://user-images.githubusercontent.com/13066134/188737166-64239243-b5e5-4580-b597-e4acf0de6a6a.mov




How to test:

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).


