### PR TITLE
Fix CircleCI job failing when pushing tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,7 +333,7 @@ jobs:
                   echo "# Production tag is ${PROD_TAG}"
                   git fetch --force origin tag ${PROD_TAG}
                   git checkout ${PROD_TAG}
-                  git checkout --theirs "${CIRCLE_BRANCH}" -- '**/migrations/**'
+                  git checkout --theirs "${CIRCLE_SHA1}" -- '**/migrations/**'
                   git status
       - unless:
           condition: << parameters.allow_fail >>


### PR DESCRIPTION
The CircleCI job that tests migrations would try to compare against the branch that CircleCI was running against. However, when pushing a tag, there is no known branch (i.e. $CIRCLE_BRANCH is unset, whereas $CIRCLE_TAG is). To check out the actual relevant commit regardless of whether we're running for a branch of a tag, checking $CIRCLE_SHA1 should work.

The main thing I'm not so sure about is why this didn't happen with last week's stage deploy, since this change made it in before that (https://github.com/mozilla/fx-private-relay/pull/2375). But I'm having trouble navigation CircleCI's UI and finding that pipeline, so maybe it did fail.