### PR TITLE
Use more widely supported flex- alignment values

### DIFF
--- a/frontend/src/components/landing/carousel/ContentCards.module.scss
+++ b/frontend/src/components/landing/carousel/ContentCards.module.scss
@@ -37,7 +37,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: end;
+    justify-content: flex-end;
     gap: $spacing-md;
 
     .card-heading {

--- a/frontend/src/pages/index.module.scss
+++ b/frontend/src/pages/index.module.scss
@@ -164,7 +164,7 @@
   .callout {
     display: flex;
     flex-direction: column;
-    align-items: start;
+    align-items: flex-start;
     text-align: center;
     max-width: $content-md;
     gap: $spacing-lg;

--- a/frontend/src/pages/premium.module.scss
+++ b/frontend/src/pages/premium.module.scss
@@ -171,7 +171,7 @@
   .callout {
     display: flex;
     flex-direction: column;
-    align-items: start;
+    align-items: flex-start;
     text-align: center;
     gap: $spacing-lg;
 


### PR DESCRIPTION
The regular `start` and `end` values were warned against by autoprefixer during builds:

> autoprefixer: start value has mixed support, consider using flex-start instead

See e.g. this build: https://app.netlify.com/sites/fx-relay-demo/deploys/6319baa2ee17ce0008d0381e

How to test: everything should look the same.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug. - Well, autoprefixer checks it
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
