### PR TITLE
Monthly/yearly toggle in phone onboarding

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -128,9 +128,12 @@ phone-onboarding-step1-list-item-2 = Need to confirm a dinner reservation? Share
 phone-onboarding-step1-list-item-3 = With phone number masking, you can receive texts. Replying is not yet available.
 
 phone-onboarding-step1-button-label = Upgrade to get phone number masking
+phone-onboarding-step1-period-toggle-yearly = Yearly
+phone-onboarding-step1-period-toggle-monthly = Monthly
 # Variables:
 #   $monthly_price (string) - the monthly cost (including currency symbol) for Relay Premium. Examples: $0.99, 0,99 €
 phone-onboarding-step1-button-price = { $monthly_price } / month
+phone-onboarding-step1-button-price-note  = (Billing yearly)
 phone-onboarding-step1-button-cta = Upgrade Now
 
 phone-onboarding-step2-headline = Verify your true phone number
@@ -161,7 +164,7 @@ phone-onboarding-step3-error-exipred = Try again—the time limit expired.
 phone-onboarding-step3-error-cta = Send a new code
 phone-onboarding-step3-code-fail-title = Wrong verification code
 phone-onboarding-step3-code-fail-body = Please try again or request a new code
-phone-onboarding-step3-code-success-title = Congratulations! 
+phone-onboarding-step3-code-success-title = Congratulations!
 phone-onboarding-step3-code-success-body = You’re now ready to choose your phone number mask.
 phone-onboarding-step3-code-success-subhead-title = What’s next?
 phone-onboarding-step3-code-success-subhead-body = Choose your phone number mask and start using { -brand-name-firefox-relay } to protect your true phone number.
@@ -180,11 +183,11 @@ phone-onboarding-step4-confirm-message = To confirm your your phone number mask,
 phone-onboarding-step4-confirm-alt-cancel = Cancel
 phone-onboarding-step4-button-register-phone-number = Confirm number
 phone-onboarding-step4-body-confirm-relay-number = Please confirm that this is the phone number mask you want. This can’t be changed later.
-phone-onboarding-step4-button-confirm-relay-number = Confirm 
-phone-onboarding-step4-code-success-title = Congratulations! 
+phone-onboarding-step4-button-confirm-relay-number = Confirm
+phone-onboarding-step4-code-success-title = Congratulations!
 phone-onboarding-step4-code-success-body = You’ve registered your new phone number mask.
 phone-onboarding-step4-code-success-subhead-title = What’s next?
-phone-onboarding-step4-code-success-subhead-body-p1 = { -brand-name-relay } sent you an SMS with a new contact card through which we’ll forward your calls and messages. 
+phone-onboarding-step4-code-success-subhead-body-p1 = { -brand-name-relay } sent you an SMS with a new contact card through which we’ll forward your calls and messages.
 phone-onboarding-step4-code-success-subhead-body-p2 = Please save the contact so you can identify your forwarded messages and calls.
 phone-onboarding-step4-code-success-cta = Continue
 phone-onboarding-step4-results= No results found. Please try again.
@@ -192,12 +195,12 @@ phone-onboarding-step4-results= No results found. Please try again.
 # Phone Settings
 phone-settings-caller-sms-log = Caller and SMS log
 phone-settings-caller-sms-log-description = Allow { -brand-name-firefox-relay } to keep a log of your callers and text senders.
-phone-settings-caller-sms-log-warning = If you decide to opt out from this preference, you will lose the ability to block and reply to senders or callers. If you’ve blocked any, they will become unblocked and your existing caller and SMS sender log will be permanently cleared from your history. 
+phone-settings-caller-sms-log-warning = If you decide to opt out from this preference, you will lose the ability to block and reply to senders or callers. If you’ve blocked any, they will become unblocked and your existing caller and SMS sender log will be permanently cleared from your history.
 
 # Phone Resend SMS Banner
 phone-banner-resend-welcome-sms-cta = Resend welcome SMS
 phone-banner-resend-welcome-sms-title = Quick Tip
-phone-banner-resend-welcome-sms-body =  Remember to save the contact we shared with you by SMS to help you identify messages forwarded by { -brand-name-relay }. Can’t find it?  
+phone-banner-resend-welcome-sms-body =  Remember to save the contact we shared with you by SMS to help you identify messages forwarded by { -brand-name-relay }. Can’t find it?
 
 # Phone What's New
 whatsnew-feature-phone-header = Introducing phone number masking

--- a/frontend/src/components/phones/onboarding/PurchasePhonesPlan.module.scss
+++ b/frontend/src/components/phones/onboarding/PurchasePhonesPlan.module.scss
@@ -11,15 +11,6 @@
   margin: 0 auto;
   padding: $spacing-lg;
 
-  .button {
-    width: 100%;
-
-    // TODO: This is not working
-    &.is-secondary {
-      font-weight: 400;
-    }
-  }
-
   h2 {
     @include text-title-xs;
     font-family: $font-stack-firefox;
@@ -86,11 +77,57 @@
       font-weight: 400;
     }
 
-    span {
-      @include text-title-2xs;
-      padding-top: $spacing-sm;
-      display: block;
-      font-weight: 700;
+    .pricing {
+      display: flex;
+      flex-direction: column;
+      gap: $spacing-sm;
+
+      .pricing-toggle {
+        display: flex;
+        background-color: $color-grey-10;
+        padding: $spacing-xs;
+        border-radius: $border-radius-lg;
+
+        > div {
+          @include text-body-sm;
+          width: 50%;
+          padding: $spacing-xs $spacing-sm;
+          text-align: center;
+          color: $color-grey-40;
+          font-weight: 500;
+          cursor: pointer;
+
+          &.is-selected {
+            background-color: $color-white;
+            border-radius: $border-radius-lg;
+            color: $color-blue-50;
+          }
+        }
+      }
+
+      [role="tabpanel"] {
+        display: flex;
+        flex-direction: column;
+        gap: $spacing-md;
+
+        .price {
+          @include text-title-2xs;
+          padding-top: $spacing-sm;
+          display: block;
+          font-weight: 700;
+          width: $content-xs;
+
+          > span {
+            @include text-body-sm;
+            font-weight: 400;
+            vertical-align: middle;
+          }
+        }
+
+        .pick-button {
+          width: 100%;
+        }
+      }
     }
   }
 }

--- a/frontend/src/components/phones/onboarding/PurchasePhonesPlan.tsx
+++ b/frontend/src/components/phones/onboarding/PurchasePhonesPlan.tsx
@@ -1,4 +1,3 @@
-import { event as gaEvent } from "react-ga";
 import { useLocalization } from "@fluent/react";
 import styles from "./PurchasePhonesPlan.module.scss";
 import WomanPhone from "./images/woman-phone.svg";
@@ -10,6 +9,14 @@ import {
   RuntimeDataWithPhonesAvailable,
 } from "../../../functions/getPlan";
 import { trackPlanPurchaseStart } from "../../../functions/trackPurchase";
+import {
+  Item,
+  TabListProps,
+  TabListState,
+  useTabListState,
+} from "react-stately";
+import { Key, ReactNode, useRef } from "react";
+import { useTab, useTabList, useTabPanel } from "react-aria";
 
 export type Props = {
   runtimeData: RuntimeDataWithPhonesAvailable;
@@ -17,19 +24,6 @@ export type Props = {
 
 export const PurchasePhonesPlan = (props: Props) => {
   const { l10n } = useLocalization();
-  const purchaseButtonRef = useGaViewPing({
-    category: "Purchase Button",
-    label: "phone-onboarding-purchase-cta",
-  });
-
-  const purchase = () => {
-    gaEvent({
-      category: "Purchase Premium+phones button",
-      action: "Engage",
-      label: "phone-cta",
-    });
-    trackPlanPurchaseStart({ plan: "phones", billing_period: "monthly" });
-  };
 
   return (
     <main className={styles.wrapper}>
@@ -45,23 +39,138 @@ export const PurchasePhonesPlan = (props: Props) => {
           <li>{l10n.getString("phone-onboarding-step1-list-item-3")}</li>
         </ul>
         <div className={styles.action}>
-          <h3>
-            {l10n.getString("phone-onboarding-step1-button-label")}
-            <span>
-              {l10n.getString("phone-onboarding-step1-button-price", {
-                monthly_price: getPhonesPrice(props.runtimeData, "monthly"),
-              })}
-            </span>
-          </h3>
-          <LinkButton
-            ref={purchaseButtonRef}
-            href={getPhoneSubscribeLink(props.runtimeData, "monthly")}
-            onClick={() => purchase()}
-          >
-            {l10n.getString("phone-onboarding-step1-button-cta")}
-          </LinkButton>
+          <h3>{l10n.getString("phone-onboarding-step1-button-label")}</h3>
+          <PricingToggle runtimeData={props.runtimeData} />
         </div>
       </div>
     </main>
+  );
+};
+
+type PricingToggleProps = {
+  runtimeData: RuntimeDataWithPhonesAvailable;
+};
+const PricingToggle = (props: PricingToggleProps) => {
+  const { l10n } = useLocalization();
+  const yearlyButtonRef = useGaViewPing({
+    category: "Purchase yearly Premium+phones button",
+    label: "phone-onboarding-purchase-yearly-cta",
+  });
+  const monthlyButtonRef = useGaViewPing({
+    category: "Purchase monthly Premium+phones button",
+    label: "phone-onboarding-purchase-monthly-cta",
+  });
+
+  return (
+    <PricingTabs>
+      <Item
+        key="yearly"
+        title={l10n.getString("phone-onboarding-step1-period-toggle-yearly")}
+      >
+        <span className={styles.price}>
+          {l10n.getString("phone-onboarding-step1-button-price", {
+            monthly_price: getPhonesPrice(props.runtimeData, "yearly"),
+          })}
+          <span>
+            {` `}
+            {l10n.getString("phone-onboarding-step1-button-price-note")}
+          </span>
+        </span>
+        <LinkButton
+          ref={yearlyButtonRef}
+          href={getPhoneSubscribeLink(props.runtimeData, "yearly")}
+          onClick={() =>
+            trackPlanPurchaseStart(
+              { plan: "phones", billing_period: "yearly" },
+              {
+                label: "phone-onboarding-purchase-yearly-cta",
+              }
+            )
+          }
+          // tabIndex tells react-aria that this element is focusable
+          tabIndex={0}
+          className={styles["pick-button"]}
+        >
+          {l10n.getString("phone-onboarding-step1-button-cta")}
+        </LinkButton>
+      </Item>
+      <Item
+        key="monthly"
+        title={l10n.getString("phone-onboarding-step1-period-toggle-monthly")}
+      >
+        <span className={styles.price}>
+          {l10n.getString("phone-onboarding-step1-button-price", {
+            monthly_price: getPhonesPrice(props.runtimeData, "monthly"),
+          })}
+        </span>
+        <LinkButton
+          ref={monthlyButtonRef}
+          href={getPhoneSubscribeLink(props.runtimeData, "monthly")}
+          onClick={() =>
+            trackPlanPurchaseStart(
+              { plan: "phones", billing_period: "monthly" },
+              {
+                label: "phone-onboarding-purchase-monthly-cta",
+              }
+            )
+          }
+          // tabIndex tells react-aria that this element is focusable
+          tabIndex={0}
+          className={styles["pick-button"]}
+        >
+          {l10n.getString("phone-onboarding-step1-button-cta")}
+        </LinkButton>
+      </Item>
+    </PricingTabs>
+  );
+};
+
+const PricingTabs = (props: TabListProps<object>) => {
+  const tabListState = useTabListState(props);
+  const tabListRef = useRef(null);
+  const { tabListProps } = useTabList(props, tabListState, tabListRef);
+  const tabPanelRef = useRef(null);
+  const { tabPanelProps } = useTabPanel({}, tabListState, tabPanelRef);
+
+  return (
+    <div className={styles.pricing}>
+      <div className={styles["pricing-toggle-wrapper"]}>
+        <div
+          {...tabListProps}
+          ref={tabListRef}
+          className={styles["pricing-toggle"]}
+        >
+          {Array.from(tabListState.collection).map((item) => (
+            <PricingTab key={item.key} item={item} state={tabListState} />
+          ))}
+        </div>
+      </div>
+      <div
+        {...tabPanelProps}
+        ref={tabPanelRef}
+        className={styles["pricing-overview"]}
+      >
+        {tabListState.selectedItem?.props.children}
+      </div>
+    </div>
+  );
+};
+
+const PricingTab = (props: {
+  state: TabListState<object>;
+  item: { key: Key; rendered: ReactNode };
+}) => {
+  const tabRef = useRef(null);
+  const { tabProps } = useTab({ key: props.item.key }, props.state, tabRef);
+  return (
+    <div
+      {...tabProps}
+      ref={tabRef}
+      className={
+        props.state.selectedKey === props.item.key ? styles["is-selected"] : ""
+      }
+    >
+      {props.item.rendered}
+    </div>
   );
 };


### PR DESCRIPTION
# New feature description

This allows the user to choose whether they want a yearly or monthly plan for phones when upgrading in the onboarding UI:

![image](https://user-images.githubusercontent.com/4251/189333572-9bba5794-199e-4d0e-9083-663ef4899975.png)

(As discussed [here](https://mozilla.slack.com/archives/C013CSYEL5T/p1662565123188379?thread_ts=1662548886.744219&cid=C013CSYEL5T).)

Also, it updates the "Upgrade now" link in the announcement to no longer preselect the monthly plan, but instead point to the plan comparison, as discussed [here](https://mozilla.slack.com/archives/C013CSYEL5T/p1662565686526129?thread_ts=1662548886.744219&cid=C013CSYEL5T).

# How to test

Go to `/phone` with the flag enabled and it being available in the country, with an account that hasn't subscribed to it yet. You should see the new yearly/monthly toggle.

Also, open the news item and verify that it points to `/premium` rather than going straight into SubPlat.

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any. - Not yet, will go in with the batch I think (if we do localisations).
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
