### PR TITLE
Prevent lockfile getting out-of-date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: npm run build
           working_directory: ./frontend/
       - save_cache:
-          key: v1-frontend-build-{{ .Branch }}-{{ .Revision }}
+          key: v1-frontend-build-{{ .Branch }}-{{ .Revision }}-{{ checksum "frontend/package-lock.json" }}
           paths:
             - ./frontend/out/
 
@@ -134,7 +134,7 @@ jobs:
           version: 20.10.11
           docker_layer_caching: True
       - restore_cache:
-          key: v1-frontend-build-{{ .Branch }}-{{ .Revision }}
+          key: v1-frontend-build-{{ .Branch }}-{{ .Revision }}-{{ checksum "frontend/package-lock.json" }}
       - run:
           name: Copy build artefacts from build_frontend into this folder
           command: mv /home/circleci/project/frontend/out /dockerflow/frontend/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,6 @@
         "react-dom": "17.0.2",
         "react-ga": "^3.3.1",
         "react-intersection-observer": "^9.4.0",
-        "react-phone-number-input": "^3.2.11",
         "react-stately": "^3.17.0",
         "react-toastify": "^9.0.8",
         "swr": "^1.3.0"
@@ -5030,11 +5029,6 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
-    "node_modules/classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
-    },
     "node_modules/cldr-core": {
       "version": "41.0.0",
       "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-41.0.0.tgz",
@@ -5299,11 +5293,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/country-flag-icons": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.5.5.tgz",
-      "integrity": "sha512-k4WXZ/WvWOSiYXRG1n8EYHNr1m/IX0GffKqAidaet5DrJsDOmJ8Q/8JvvONhZNnKYg24s4lvsm+9og1HcuIU/g=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -7342,14 +7331,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
-    },
-    "node_modules/input-format": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/input-format/-/input-format-0.3.8.tgz",
-      "integrity": "sha512-tLR0XRig1xIcG1PtIpMd/uoltvkAI62CN9OIbtj4/tEJAkqTCQLNHUZ9N4M46w0dopny7Rlt/lRH5Xzp7e6F+g==",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      }
     },
     "node_modules/inquirer": {
       "version": "8.2.4",
@@ -10207,11 +10188,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/libphonenumber-js": {
-      "version": "1.10.13",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.13.tgz",
-      "integrity": "sha512-b74iyWmwb4GprAUPjPkJ11GTC7KX4Pd3onpJfKxYyY8y9Rbb4ERY47LvCMEDM09WD3thiLDMXtkfDK/AX+zT7Q=="
-    },
     "node_modules/license-checker": {
       "version": "25.0.1",
       "resolved": "https://registry.npmjs.org/license-checker/-/license-checker-25.0.1.tgz",
@@ -12130,22 +12106,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
-    },
-    "node_modules/react-phone-number-input": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/react-phone-number-input/-/react-phone-number-input-3.2.11.tgz",
-      "integrity": "sha512-fcY6KHCqG9qDzlUhuCj0QdP1/THW6lUu9UwuOEfFQU/eRhPasv52DzBINRRrhVPJ/N2qsbSShKBt3WX0Igu3Lw==",
-      "dependencies": {
-        "classnames": "^2.3.1",
-        "country-flag-icons": "^1.5.4",
-        "input-format": "^0.3.8",
-        "libphonenumber-js": "^1.10.13",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
     },
     "node_modules/react-shallow-renderer": {
       "version": "16.14.1",
@@ -18062,11 +18022,6 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
-    "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
-    },
     "cldr-core": {
       "version": "41.0.0",
       "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-41.0.0.tgz",
@@ -18267,11 +18222,6 @@
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
       }
-    },
-    "country-flag-icons": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.5.5.tgz",
-      "integrity": "sha512-k4WXZ/WvWOSiYXRG1n8EYHNr1m/IX0GffKqAidaet5DrJsDOmJ8Q/8JvvONhZNnKYg24s4lvsm+9og1HcuIU/g=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -19783,14 +19733,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
-    },
-    "input-format": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/input-format/-/input-format-0.3.8.tgz",
-      "integrity": "sha512-tLR0XRig1xIcG1PtIpMd/uoltvkAI62CN9OIbtj4/tEJAkqTCQLNHUZ9N4M46w0dopny7Rlt/lRH5Xzp7e6F+g==",
-      "requires": {
-        "prop-types": "^15.8.1"
-      }
     },
     "inquirer": {
       "version": "8.2.4",
@@ -21906,11 +21848,6 @@
         "type-check": "~0.4.0"
       }
     },
-    "libphonenumber-js": {
-      "version": "1.10.13",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.13.tgz",
-      "integrity": "sha512-b74iyWmwb4GprAUPjPkJ11GTC7KX4Pd3onpJfKxYyY8y9Rbb4ERY47LvCMEDM09WD3thiLDMXtkfDK/AX+zT7Q=="
-    },
     "license-checker": {
       "version": "25.0.1",
       "resolved": "https://registry.npmjs.org/license-checker/-/license-checker-25.0.1.tgz",
@@ -23284,18 +23221,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
-    },
-    "react-phone-number-input": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/react-phone-number-input/-/react-phone-number-input-3.2.11.tgz",
-      "integrity": "sha512-fcY6KHCqG9qDzlUhuCj0QdP1/THW6lUu9UwuOEfFQU/eRhPasv52DzBINRRrhVPJ/N2qsbSShKBt3WX0Igu3Lw==",
-      "requires": {
-        "classnames": "^2.3.1",
-        "country-flag-icons": "^1.5.4",
-        "input-format": "^0.3.8",
-        "libphonenumber-js": "^1.10.13",
-        "prop-types": "^15.8.1"
-      }
     },
     "react-shallow-renderer": {
       "version": "16.14.1",


### PR DESCRIPTION
~~While CircleCI [supposedly](https://circleci.com/developer/orbs/orb/circleci/node#usage-npm_install) uses `npm ci` to install dependencies, which should warn if the lockfile does not match what is specified in package.json, a mismatch did slip in without failing the build. My hypothesis is that this was due to dependencies being cached from a previous run.~~

Well, that did not work. Apparently `npm ci` only cares if necessary dependencies _aren't_ in the lockfile, but if there's too many, it's totally fine with it. Thus, this PR is now just updating the lockfile, and at least ensuring that CircleCI's cache isn't re-used if our lockfile has changed :/

~~Furthermore, the Netlify command did not use `npm ci` at all. It does now.~~ I reverted this, because it's fine if this fails just in CircleCI - having the preview deployment can still be useful then.