### PR TITLE
add "free_phones" flag to give free phones to fox-fooders

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -20,6 +20,7 @@ from django.utils.translation.trans_real import (
 )
 
 from rest_framework.authtoken.models import Token
+from waffle.models import Flag
 
 
 emails_config = apps.get_app_config("emails")
@@ -291,6 +292,10 @@ class Profile(models.Model):
     def has_phone(self):
         if not self.fxa:
             return False
+        flags = Flag.objects.filter(name="free_phones")
+        for flag in flags:
+            if flag.is_active_for_user(self.user):
+                return True
         user_subscriptions = self.fxa.extra_data.get("subscriptions", [])
         for sub in settings.SUBSCRIPTIONS_WITH_PHONE.split(","):
             if sub in user_subscriptions:


### PR DESCRIPTION
How to test:
1. Create a brand new user
2. Use http://127.0.0.1:8000/admin/waffle/flag/ to add a new flag `free_phones`
3. Give the new flag to the brand new user
4. Check that the user can skip the phone purchase and go straight into all the phone functionality! 

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).