### PR TITLE
Pull in l10n updates daily

### DIFF
--- a/.github/workflows/l10n-sync.yml
+++ b/.github/workflows/l10n-sync.yml
@@ -1,0 +1,27 @@
+name: Fetch latest strings from the l10n repo
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: Pull & update submodules recursively
+        run: |
+          git submodule update --init --recursive
+          git submodule update --recursive --remote
+      - name: Commit
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions — l10n sync"
+          git add --all
+          git commit --message="Merge in latest l10n strings" || echo "No changes to commit"
+          git push


### PR DESCRIPTION
This GitHub Actions script pulls the latest commits from the l10n repository, and can thus replace [the script in that repository](https://github.com/mozilla-l10n/fx-private-relay-l10n/blob/main/.github/workflows/update-upstream-relay-repo.yml) that pushes them here (and requires shared tokens).

An alternative would have been to have Dependabot create Pull Requests for submodule updates, but having to approve those every day could become tiring:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem

# How to test

I temporarily modified the workflow script to run on pushes of this branch as well, and saw it successfully adding a new commit to it: https://github.com/mozilla/fx-private-relay/actions/runs/3089613752/jobs/4997426296

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any. - Once this runs successfully I can submit a PR there to remove the old script and update access permissions in this repo.
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
