### PR TITLE
change _validate_number to accept CA numbers

### DIFF
--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -343,7 +343,7 @@ def _validate_number(request):
             f"Could not get number details for {e164_number}"
         )
 
-    if number_details.country_code != "US":
+    if number_details.country_code not in ["US", "CA"]:
         raise exceptions.ValidationError(
             "Relay Phone is currently only available in the US. "
             "Your phone number country code is: "


### PR DESCRIPTION
This PR fixes an issue where Canadian numbers were not accepted.

How to test:
1. Spin up your local relay app
2. Go to http://127.0.0.1:8000/phone/
3. Try to register a Candian number (Maybe ask a Canadian colleague if you can use theirs?)
   * [ ] The number should receive the 6-digit confirmation code and allow you to register

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).