### PR TITLE
Use correct country code for Sweden

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -379,7 +379,7 @@ PREMIUM_PLAN_ID_MATRIX = {
             "id": "price_1JmRCQJNcmPzuWtRprMnmtax",
             "price": "0,99 €",
         },
-        "sv": {
+        "se": {
             "id": "price_1KQc1PJNcmPzuWtRsEfb6inB",
             "price": "0,99 €",
         },
@@ -431,7 +431,7 @@ PREMIUM_PLAN_COUNTRY_LANG_MAPPING = {
     },
     # Sweden
     "se": {
-        "sv": PREMIUM_PLAN_ID_MATRIX["euro"]["sv"],
+        "sv": PREMIUM_PLAN_ID_MATRIX["euro"]["se"],
     },
     # Finland
     "fi": {
@@ -569,7 +569,7 @@ PERIODICAL_PREMIUM_PLAN_ID_MATRIX = {
                 "currency": "EUR",
             },
         },
-        "sv": {
+        "se": {
             "monthly": {
                 "id": "price_1LYBblJNcmPzuWtRGRHIoYZ5",
                 "price": 1.99,
@@ -664,7 +664,7 @@ PERIODICAL_PREMIUM_PLAN_COUNTRY_LANG_MAPPING = {
     },
     # Sweden
     "se": {
-        "sv": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["euro"]["sv"],
+        "sv": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["euro"]["se"],
     },
     # Finland
     "fi": {

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -52,7 +52,7 @@ class PremiumPlanIDTest(TestCase):
         assert plan_id == plans["euro"]["at"]["id"]
 
         plan_id = premium_plan_id("sv", "se")
-        assert plan_id == plans["euro"]["sv"]["id"]
+        assert plan_id == plans["euro"]["se"]["id"]
 
         plan_id = premium_plan_id("fi", "fi")
         assert plan_id == plans["euro"]["fi"]["id"]


### PR DESCRIPTION
We accidentally used the language code (sv) rather than the country code (se) for Sweden. This did not cause any problems, because the mapping from country and language to a plan made the same mistake, so it evened out. Still, probably a good idea to use the correct code.

To locally verify that it still works, set your Accept-Language to sv-SE, visit the locally running website, and verify that the upgrade links still point to the correct plan.

Thanks @birdsarah for spotting this!

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
