### PR TITLE
Authenticate the l10n repository sync

### DIFF
--- a/.github/workflows/l10n-sync.yml
+++ b/.github/workflows/l10n-sync.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
+          token: ${{ secrets.L10N_UPDATE_TOKEN }}
 
       - name: Pull & update submodules recursively
         run: |


### PR DESCRIPTION
The user `mozilla-pontoon` has permission to bypass our branch protection rules and push directly to `main`; an access token to act on its behalf is present in the L10N_UPDATE_TOKEN secret.