### PR TITLE
for MPP-2350: validate voice_status requests

### DIFF
--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -900,6 +900,18 @@ def test_inbound_call_valid_twilio_signature_disabled_number(
     mocked_twilio_client.messages.create.assert_not_called()
 
 
+@pytest.mark.django_db
+def test_voice_status_invalid_twilio_signature(mocked_twilio_validator):
+    mocked_twilio_validator.validate = Mock(return_value=False)
+
+    client = APIClient()
+    path = "/api/v1/voice_status"
+    response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="invalid")
+
+    assert response.status_code == 400
+    assert "Invalid Signature" in response.data[0].title()
+
+
 def test_voice_status_missing_required_params_error():
     client = APIClient()
     path = "/api/v1/voice_status"

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -487,6 +487,7 @@ def inbound_call(request):
 @decorators.api_view(["POST"])
 @decorators.permission_classes([permissions.AllowAny])
 def voice_status(request):
+    _validate_twilio_request(request)
     called = request.data.get("Called", None)
     call_status = request.data.get("CallStatus", None)
     if called is None or call_status is None:


### PR DESCRIPTION
This PR improves MPP-2350.

How to test:
Same steps as https://github.com/mozilla/fx-private-relay/pull/2549#issue-1381360109.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).