### PR TITLE
adding flexibility to workflow triggering

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,8 +2,18 @@ name: Relay e2e Tests
 on:
   schedule:
     - cron: '0 8 * * *'
-
+  
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to run the e2e against'
+        required: true
+        default: 'stage'
+        type: choice
+        options:
+          - stage
+          - prod
+          - dev
 
 jobs:
   relaye2e:
@@ -26,9 +36,9 @@ jobs:
           npx playwright install
 
       - name: Run Playwright tests
-        run: npm run test:e2e
+        run: npm run test:${{ inputs.environment }}
         env:
-          E2E_TEST_ENV: stage
+          E2E_TEST_ENV: ${{ inputs.environment }}
           E2E_TEST_ACCOUNT_FREE: ${{ secrets.E2E_TEST_ACCOUNT_FREE }}
           E2E_TEST_ACCOUNT_PASSWORD: ${{ secrets.E2E_TEST_ACCOUNT_PASSWORD }}
           E2E_TEST_ACCOUNT_PREMIUM: ${{ secrets.E2E_TEST_ACCOUNT_PREMIUM }}

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "test:e2e": "playwright test --retries=1",
     "test:local": "E2E_TEST_ENV=local playwright test --retries=1 --headed",
     "test:dev": "E2E_TEST_ENV=dev playwright test --retries=1",
-    "test:stage": "E2E_TEST_ENV=stage playwright test --retries=1 --headed",
-    "test:prod": "E2E_TEST_ENV=prod playwright test --retries=2",
+    "test:stage": "E2E_TEST_ENV=stage playwright test --retries=1",
+    "test:prod": "E2E_TEST_ENV=prod playwright test --retries=1",
     "heroku-prebuild": "printf '{\"commit\":\"%s\", \"commit_link\":\"https://github.com/mozilla/fx-private-relay/commit/%s\"}\n' \"$SOURCE_VERSION\" \"$SOURCE_VERSION\" > version.json",
     "heroku-postbuild": "cd frontend; NODE_ENV=\"development\" npm ci; npm run build"
   },


### PR DESCRIPTION
[#<issue ID>](https://mozilla-hub.atlassian.net/browse/PSP-522)

Adds flexibility to trigger the e2e test workflow for different environments


# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
