### PR TITLE
Use correct Plan IDs for Premium in Canada

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -678,7 +678,7 @@ PERIODICAL_PREMIUM_PLAN_COUNTRY_LANG_MAPPING = {
         "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["usd"]["gb"],
     },
     "ca": {
-        "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["usd"]["gb"],
+        "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["usd"]["en"],
     },
     "nz": {
         "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["usd"]["gb"],


### PR DESCRIPTION
It should point to the US plan, but was pointing to the UK ones.

How to test: coming from Canada, try to subscribe. You should be brought to the US plan page in Stripe, rather than the UK one.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
