### PR TITLE
Change vpn download  link

### DIFF
--- a/frontend/src/pages/vpn-relay-welcome.page.tsx
+++ b/frontend/src/pages/vpn-relay-welcome.page.tsx
@@ -79,7 +79,7 @@ const VpnRelayWelcome: NextPage = () => {
 
               <p>{l10n.getString("vpn-relay-go-vpn-body")}</p>
               <LinkButton
-                href={`https://www.mozilla.org/products/vpn/download/?utm_source=${encodeURIComponent(
+                href={`https://vpn.mozilla.org/vpn/download/?utm_source=${encodeURIComponent(
                   referringSiteUrl
                 )}&utm_medium=referral&utm_campaign=vpn-relay-welcome&utm_content=download-button`}
                 target="_blank"


### PR DESCRIPTION
If a VPN client has come from the client to purchase the bundle then if we send the user to vpn.mozilla.org first, guardian can detect this and can redirect the user back into the client flow. If the user has not come from the VPN client, guardian will redirect correctly to the link that this was pointing to before this patch.
