### PR TITLE
Python dependency updates, September 29, 2022

### DIFF
--- a/.github/workflows/lint-pending-strings.yml
+++ b/.github/workflows/lint-pending-strings.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Set up Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
           cache: 'pip'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.24.77
 codetiming==1.3.0
-cryptography==37.0.4
+cryptography==38.0.1
 Django==3.2.15
 dj-database-url==1.0.0
 django-allauth==0.51.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-filter==22.1
 django-redis==5.2.0
 django-ftl==0.13
 django-referrer-policy==1.0
-djangorestframework==3.13.1
+djangorestframework==3.14.0
 django-waffle==2.7.0
 dockerflow==2022.8.0
 drf-yasg==1.21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ django-referrer-policy==1.0
 djangorestframework==3.14.0
 django-waffle==2.7.0
 dockerflow==2022.8.0
-drf-yasg==1.21.3
+drf-yasg==1.21.4
 google-measurement-protocol==1.1.0
 gunicorn==20.1.0
 jwcrypto==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ black==22.8.0
 
 # type hinting
 mypy==0.971
-types-requests==2.28.10
+types-requests==2.28.11
 types-pyOpenSSL==22.0.10
 django-stubs==1.12.0
 djangorestframework-stubs==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ dj-database-url==1.0.0
 django-allauth==0.51.0
 django-cors-headers==3.13.0
 django-csp==3.7
-django-debug-toolbar==3.6.0
+django-debug-toolbar==3.7.0
 django-filter==22.1
 django-redis==5.2.0
 django-ftl==0.13

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[tool:paul-mclendahand]
+github_user=mozilla
+github_project=fx-private-relay
+main_branch=main


### PR DESCRIPTION
Update dependencies. This covers:

* Bump djangorestframework from 3.13.1 to 3.14.0 (from PR #2560)
* Bump actions/setup-python from 3 to 4 (from PR #2563)
* Bump django-debug-toolbar from 3.6.0 to 3.7.0 (from PR #2561)
* Bump types-requests from 2.28.10 to 2.28.11 (from PR #2559)
* Bump cryptography from 37.0.4 to 38.0.1 (from PR #2481)

There are two follow-on commits:
* Updste drf-yasg to 1.21.4
* Add [pmac](https://github.com/willkg/paul-mclendahand#configure-pmac) config.

This PR was generated using `pmac`:

```
pip install paul-mclendahand
git fetch
git checkout main
git checkout -b dep-updates-sep-29-2022
pmac listprs
pmac add 2481 2559 2561 2563 2560
# Other two commits
git push -u origin dep-updates-sep-29-2022
pmac prmsg
````