### PR TITLE
MPP-2407 Relay phone masking upsell page strings don't match spec

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -26,10 +26,11 @@ fx-containers = { -brand-name-firefox } Containers
 ## Phone Onboarding
 
 phone-onboarding-step1-headline = Introducing phone number masking
-phone-onboarding-step1-body = With phone number masking, you can create a phone number mask that helps you  protect your true phone number. Share it, and receive messages privately.
-phone-onboarding-step1-list-item-1 = Share a masked phone number that forwards messages to your true number.
-phone-onboarding-step1-list-item-2 = Need to confirm a dinner reservation? Share your phone number mask instead.
-phone-onboarding-step1-list-item-3 = With phone number masking, you can receive texts. Replying is not yet available.
+phone-onboarding-step1-body = With phone number masking, you can create a phone number mask that helps you protect your true phone number. Share it, and receive messages and calls privately.
+phone-onboarding-step1-list-item-1 = Share a phone number mask that forwards texts and calls to your number.
+phone-onboarding-step1-list-item-2 = Need to get a digital receipt? Share your phone number mask instead.
+phone-onboarding-step1-list-item-3 = With phone number masking, you can reply to the last text you received.
+phone-onboarding-step1-list-item-4 = Currently available in the US and Canada only.
 
 phone-onboarding-step1-button-label = Upgrade to get phone number masking
 phone-onboarding-step1-period-toggle-yearly = Yearly
@@ -37,7 +38,7 @@ phone-onboarding-step1-period-toggle-monthly = Monthly
 # Variables:
 #   $monthly_price (string) - the monthly cost (including currency symbol) for Relay Premium. Examples: $0.99, 0,99 €
 phone-onboarding-step1-button-price = { $monthly_price } / month
-phone-onboarding-step1-button-price-note  = (Billing yearly)
+phone-onboarding-step1-button-price-note  = (Billed annually)
 phone-onboarding-step1-button-cta = Upgrade Now
 
 phone-onboarding-step2-headline = Verify your true phone number

--- a/frontend/src/components/phones/onboarding/PurchasePhonesPlan.module.scss
+++ b/frontend/src/components/phones/onboarding/PurchasePhonesPlan.module.scss
@@ -4,12 +4,11 @@
 .wrapper {
   display: flex;
   flex-direction: column;
-  justify-content: space-evenly;
   gap: $spacing-xl;
   flex: 1 0 auto;
   max-width: $content-lg;
   margin: 0 auto;
-  padding: $spacing-lg;
+  padding: $spacing-2xl $spacing-lg;
 
   h2 {
     @include text-title-xs;
@@ -53,6 +52,10 @@
       gap: $spacing-md;
       margin: 0;
       padding: 0;
+
+      ::marker {
+        color: $color-violet-60;
+      }
     }
   }
 

--- a/frontend/src/components/phones/onboarding/PurchasePhonesPlan.tsx
+++ b/frontend/src/components/phones/onboarding/PurchasePhonesPlan.tsx
@@ -37,6 +37,7 @@ export const PurchasePhonesPlan = (props: Props) => {
           <li>{l10n.getString("phone-onboarding-step1-list-item-1")}</li>
           <li>{l10n.getString("phone-onboarding-step1-list-item-2")}</li>
           <li>{l10n.getString("phone-onboarding-step1-list-item-3")}</li>
+          <li>{l10n.getString("phone-onboarding-step1-list-item-4")}</li>
         </ul>
         <div className={styles.action}>
           <h3>{l10n.getString("phone-onboarding-step1-button-label")}</h3>


### PR DESCRIPTION
 

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-2407 

# New feature description

Strings have been updated to match figma spec: https://www.figma.com/file/g829jRfj82xF2x9dHKbpTk?node-id=394:6398#241151180  

Minor CSS tweak to update spacing (vertical) and color of list markers. 

# Screenshot (if applicable)

<img width="968" alt="image" src="https://user-images.githubusercontent.com/3924990/193676413-6bbf456f-969c-4a53-832f-5e8af95c96f9.png">

# How to test

Go to the /phone page without a subscription to phones. Take a look at strings and compare them to figma spec. 

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
