### PR TITLE
Ensure the phone FAQs are only shown if available

### DIFF
--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -6,154 +6,163 @@ import { Layout } from "../components/layout/Layout";
 import { getRuntimeConfig } from "../config";
 import { useRuntimeData } from "../hooks/api/runtimeData";
 import { isFlagActive } from "../functions/waffle";
+import { isPhonesAvailableInCountry } from "../functions/getPlan";
 
 const Faq: NextPage = () => {
   const { l10n } = useLocalization();
   const runtimeData = useRuntimeData();
 
-  const phoneMaskingFaqs = isFlagActive(runtimeData.data, "phones") ? (
-    <>
-      <QAndA
-        id={"phone-masking-faq-question-what-is"}
-        question={l10n.getString("phone-masking-faq-question-what-is")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-what-is")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-where-is"}
-        question={l10n.getString("phone-masking-faq-question-where-is")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-where-is")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-how-many"}
-        question={l10n.getString("phone-masking-faq-question-how-many")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-how-many")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-change-phone-mask"}
-        question={l10n.getString(
-          "phone-masking-faq-question-change-phone-mask"
-        )}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-change-phone-mask")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-can-reply"}
-        question={l10n.getString("phone-masking-faq-question-can-reply")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-can-reply")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-forwarded-texts"}
-        question={l10n.getString("phone-masking-faq-question-forwarded-texts")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-forwarded-texts")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-pictures"}
-        question={l10n.getString("phone-masking-faq-question-pictures")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-pictures")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-historical"}
-        question={l10n.getString("phone-masking-faq-question-historical")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-historical")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-can-i-send"}
-        question={l10n.getString("phone-masking-faq-question-can-i-send")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-can-i-send")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-limit"}
-        question={l10n.getString("phone-masking-faq-question-limit")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-limit")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-call-length"}
-        question={l10n.getString("phone-masking-faq-question-call-length")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-call-length")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-can-i-call"}
-        question={l10n.getString("phone-masking-faq-question-can-i-call")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-can-i-call")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-can-i-see"}
-        question={l10n.getString("phone-masking-faq-question-can-i-see")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-can-i-see")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-can-i-block"}
-        question={l10n.getString("phone-masking-faq-question-can-i-block")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-can-i-block")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-spam"}
-        question={l10n.getString("phone-masking-faq-question-spam")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-spam")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-disable-logging"}
-        question={l10n.getString("phone-masking-faq-question-disable-logging")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-disable-logging")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-can-i-share"}
-        question={l10n.getString("phone-masking-faq-question-can-i-share")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-can-i-share")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-how-i-save-card"}
-        question={l10n.getString("phone-masking-faq-question-how-i-save-card")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-how-i-save-card")}</p>
-      </QAndA>
-      <QAndA
-        id={"phone-masking-faq-question-install-app"}
-        question={l10n.getString("phone-masking-faq-question-install-app")}
-      >
-        <p>{l10n.getString("phone-masking-faq-answer-install-app")}</p>
-      </QAndA>
-      <QAndA
-        id="phone-masking-faq-question-data"
-        question={l10n.getString("phone-masking-faq-question-data")}
-      >
-        <Localized
-          id="phone-masking-faq-answer-data"
-          vars={{
-            url: "https://www.mozilla.org/privacy/firefox-relay/",
-            attrs: "",
-          }}
-          elems={{
-            a: (
-              <a
-                href="https://www.mozilla.org/privacy/firefox-relay/"
-                target="_blank"
-                rel="noopener noreferrer"
-              />
-            ),
-          }}
+  const phoneMaskingFaqs =
+    isPhonesAvailableInCountry(runtimeData.data) &&
+    isFlagActive(runtimeData.data, "phones") ? (
+      <>
+        <QAndA
+          id={"phone-masking-faq-question-what-is"}
+          question={l10n.getString("phone-masking-faq-question-what-is")}
         >
-          <p />
-        </Localized>
-      </QAndA>
-    </>
-  ) : null;
+          <p>{l10n.getString("phone-masking-faq-answer-what-is")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-where-is"}
+          question={l10n.getString("phone-masking-faq-question-where-is")}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-where-is")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-how-many"}
+          question={l10n.getString("phone-masking-faq-question-how-many")}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-how-many")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-change-phone-mask"}
+          question={l10n.getString(
+            "phone-masking-faq-question-change-phone-mask"
+          )}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-change-phone-mask")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-can-reply"}
+          question={l10n.getString("phone-masking-faq-question-can-reply")}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-can-reply")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-forwarded-texts"}
+          question={l10n.getString(
+            "phone-masking-faq-question-forwarded-texts"
+          )}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-forwarded-texts")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-pictures"}
+          question={l10n.getString("phone-masking-faq-question-pictures")}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-pictures")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-historical"}
+          question={l10n.getString("phone-masking-faq-question-historical")}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-historical")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-can-i-send"}
+          question={l10n.getString("phone-masking-faq-question-can-i-send")}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-can-i-send")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-limit"}
+          question={l10n.getString("phone-masking-faq-question-limit")}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-limit")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-call-length"}
+          question={l10n.getString("phone-masking-faq-question-call-length")}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-call-length")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-can-i-call"}
+          question={l10n.getString("phone-masking-faq-question-can-i-call")}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-can-i-call")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-can-i-see"}
+          question={l10n.getString("phone-masking-faq-question-can-i-see")}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-can-i-see")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-can-i-block"}
+          question={l10n.getString("phone-masking-faq-question-can-i-block")}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-can-i-block")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-spam"}
+          question={l10n.getString("phone-masking-faq-question-spam")}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-spam")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-disable-logging"}
+          question={l10n.getString(
+            "phone-masking-faq-question-disable-logging"
+          )}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-disable-logging")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-can-i-share"}
+          question={l10n.getString("phone-masking-faq-question-can-i-share")}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-can-i-share")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-how-i-save-card"}
+          question={l10n.getString(
+            "phone-masking-faq-question-how-i-save-card"
+          )}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-how-i-save-card")}</p>
+        </QAndA>
+        <QAndA
+          id={"phone-masking-faq-question-install-app"}
+          question={l10n.getString("phone-masking-faq-question-install-app")}
+        >
+          <p>{l10n.getString("phone-masking-faq-answer-install-app")}</p>
+        </QAndA>
+        <QAndA
+          id="phone-masking-faq-question-data"
+          question={l10n.getString("phone-masking-faq-question-data")}
+        >
+          <Localized
+            id="phone-masking-faq-answer-data"
+            vars={{
+              url: "https://www.mozilla.org/privacy/firefox-relay/",
+              attrs: "",
+            }}
+            elems={{
+              a: (
+                <a
+                  href="https://www.mozilla.org/privacy/firefox-relay/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              ),
+            }}
+          >
+            <p />
+          </Localized>
+        </QAndA>
+      </>
+    ) : null;
 
   const trackerBlockingFaqs = isFlagActive(
     runtimeData.data,

--- a/frontend/src/pages/faq.test.tsx
+++ b/frontend/src/pages/faq.test.tsx
@@ -1,6 +1,13 @@
-import { act, render } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { mockConfigModule } from "../../__mocks__/configMock";
+import { setMockProfileData } from "../../__mocks__/hooks/api/profile";
+import {
+  getMockRuntimeDataWithoutPremium,
+  getMockRuntimeDataWithPhones,
+  setMockRuntimeData,
+  setMockRuntimeDataOnce,
+} from "../../__mocks__/hooks/api/runtimeData";
 import { mockUseFxaFlowTrackerModule } from "../../__mocks__/hooks/fxaFlowTracker";
 import { mockFluentReact } from "../../__mocks__/modules/fluent__react";
 import { mockNextRouter } from "../../__mocks__/modules/next__router";
@@ -15,6 +22,9 @@ jest.mock("../config.ts", () => mockConfigModule);
 jest.mock("../hooks/gaViewPing.ts");
 jest.mock("../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
 
+setMockRuntimeData();
+setMockProfileData(null);
+
 describe("The page with Frequently Asked Questions", () => {
   describe("under axe accessibility testing", () => {
     it("passes axe accessibility testing", async () => {
@@ -28,4 +38,34 @@ describe("The page with Frequently Asked Questions", () => {
       expect(results).toHaveNoViolations();
     }, 10000); // axe runs a suite of tests that can exceed the default 5s timeout, so we set it to 10s
   });
+});
+
+it("displays phone FAQs if phones is available in the user's country", () => {
+  setMockRuntimeDataOnce({
+    ...getMockRuntimeDataWithPhones(),
+    WAFFLE_FLAGS: [["phones", true]],
+  });
+
+  render(<Faq />);
+
+  const phoneQuestion = screen.getByRole("heading", {
+    name: "l10n string: [phone-masking-faq-question-what-is], with vars: {}",
+  });
+
+  expect(phoneQuestion).toBeInTheDocument();
+});
+
+it("does not display phone FAQs if phones isn't available in the user's country", () => {
+  setMockRuntimeDataOnce({
+    ...getMockRuntimeDataWithoutPremium(),
+    WAFFLE_FLAGS: [["phones", true]],
+  });
+
+  render(<Faq />);
+
+  const phoneQuestion = screen.queryByRole("heading", {
+    name: "l10n string: [phone-masking-faq-question-what-is], with vars: {}",
+  });
+
+  expect(phoneQuestion).not.toBeInTheDocument();
 });


### PR DESCRIPTION
This PR fixes builds on #2599, ensuring that the phone-specific FAQs are only visible in countries where phones is available.

How to test: go to the FAQ page. The phone FAQs should be visible in a locale where it's available, and invisible where they're not.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
