### PR TITLE
MPP-2332: Handle dupe US A2P 10DLC registration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ module = [
     "markus.utils",
     "oauthlib.oauth2.rfc6749.errors",
     "requests_oauthlib",
+    "twilio.base.exceptions",
     "twilio.rest",
     "twilio.request_validator",
     "vobject",


### PR DESCRIPTION
Ignore error 21710 when a US relay number is already registered with the US A2P 10DLC campaign. At this point, this issue probably only affects developers with access to the Django admin or the database.

How to test:

- Set up [end-to-end local phone dev](https://github.com/mozilla/fx-private-relay/blob/main/docs/end-to-end-local-phone-dev.md)
- Register a real phone and a relay number.
- As an admin use, load the Django admin
- Load the `RealPhone`. Change the user to a different user, such as the admin user, and click "Save"
- Load the `RelayNumber`. Ensure the `country_code` is `US`. Change the user to the different user, and select "Save"

On `main`, an exception is raised:

```
HTTP Error Your request was:

POST /Services/<TWILIO_MESSAGING_SERVICE_SID>/PhoneNumbers

Twilio returned the following information:

Unable to create record: Phone Number or Short Code is already in the Messaging Service.

More information may be available here:

https://www.twilio.com/docs/errors/21710
```

With this PR:

* [ ] The RelayNumber is saved.

After testing, you can use the Django admin to return the `RealNumber` and `RelayNumber` to the original user.