### PR TITLE
MPP-2449 Check remaining seconds not minutes

### DIFF
--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -1149,7 +1149,7 @@ def test_voice_status_completed_reduces_remaining_seconds_to_negative_value(
         "phone_limit_exceeded",
         extra={
             "fxa_uid": profile.fxa.uid,
-            "call_duration": 27,
+            "call_duration_in_seconds": 27,
             "relay_number_enabled": True,
             "remaining_seconds": -27,
             "remaining_minutes": 0,

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -1149,6 +1149,7 @@ def test_voice_status_completed_reduces_remaining_seconds_to_negative_value(
         "phone_limit_exceeded",
         extra={
             "fxa_uid": profile.fxa.uid,
+            "call_duration": 27,
             "relay_number_enabled": True,
             "remaining_seconds": -27,
             "remaining_minutes": 0,

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -1098,6 +1098,11 @@ def test_voice_status_completed_no_duration_error(phone_user):
 
 
 def test_voice_status_completed_reduces_remaining_seconds(phone_user):
+    # TODO: This test should fail since the Relay Number is disabled and
+    # the POST to our /api/v1/voice_status should ignore the the reduced remaining seconds.
+    # This is currently passing because the voice_status() is not checking
+    # if the user's Relay Number has hit the limit or is disabled (bug logged in MPP-2452).
+    # Keeping this test so we can correct it once MPP-2452 is completed.
     _make_real_phone(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user, enabled=False)
     pre_request_remaining_seconds = relay_number.remaining_seconds

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -52,6 +52,7 @@ from ..serializers.phones import (
 
 
 logger = logging.getLogger("events")
+info_logger = logging.getLogger("eventsinfo")
 
 
 def twilio_validator():
@@ -509,6 +510,17 @@ def voice_status(request):
     relay_number, _ = _get_phone_objects(called)
     relay_number.remaining_seconds = relay_number.remaining_seconds - int(call_duration)
     relay_number.save()
+    if relay_number.remaining_seconds < 0:
+        profile = relay_number.user.profile_set.first()
+        info_logger.info(
+            "phone_limit_exceeded",
+            extra={
+                "fxa_uid": profile.fxa.uid,
+                "relay_number_enabled": relay_number.enabled,
+                "remaining_seconds": relay_number.remaining_seconds,
+                "remaining_minutes": relay_number.remaining_minutes,
+            },
+        )
     return response.Response(status=200)
 
 

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -516,6 +516,7 @@ def voice_status(request):
             "phone_limit_exceeded",
             extra={
                 "fxa_uid": profile.fxa.uid,
+                "call_duration": call_duration,
                 "relay_number_enabled": relay_number.enabled,
                 "remaining_seconds": relay_number.remaining_seconds,
                 "remaining_minutes": relay_number.remaining_minutes,

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -478,7 +478,7 @@ def inbound_call(request):
     relay_number, real_phone = _get_phone_objects(inbound_to)
 
     _check_disabled(relay_number, "calls")
-    _check_remaining(relay_number, "minutes")
+    _check_remaining(relay_number, "seconds")
     inbound_contact = _get_inbound_contact(relay_number, inbound_from)
     if inbound_contact:
         _check_and_update_contact(inbound_contact, "calls", relay_number)

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -516,7 +516,7 @@ def voice_status(request):
             "phone_limit_exceeded",
             extra={
                 "fxa_uid": profile.fxa.uid,
-                "call_duration": call_duration,
+                "call_duration_in_seconds": int(call_duration),
                 "relay_number_enabled": relay_number.enabled,
                 "remaining_seconds": relay_number.remaining_seconds,
                 "remaining_minutes": relay_number.remaining_minutes,

--- a/phones/models.py
+++ b/phones/models.py
@@ -194,7 +194,8 @@ class RelayNumber(models.Model):
 
     @property
     def remaining_minutes(self):
-        return floor(self.remaining_seconds / 60)
+        minutes_called = floor(self.remaining_seconds / 60)
+        return minutes_called if minutes_called > 0 else 0
 
     @property
     def calls_and_texts_forwarded(self):

--- a/phones/models.py
+++ b/phones/models.py
@@ -194,8 +194,8 @@ class RelayNumber(models.Model):
 
     @property
     def remaining_minutes(self):
-        minutes_called = floor(self.remaining_seconds / 60)
-        return minutes_called if minutes_called > 0 else 0
+        # return a 0 or positive int for remaining minutes
+        return floor(max(self.remaining_seconds, 0) / 60)
 
     @property
     def calls_and_texts_forwarded(self):


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes [MPP-2449](https://mozilla-hub.atlassian.net/browse/MPP-2449).

How to test:
Check that the phone calls limits are enforced
1. From the second phone number, call the Relay Phone Mask
2. Keep up the call for at least 51 minutes, preferably even more
3. Close the call
4. Observe the Remaining call minutes counter

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).