### PR TITLE
MPP-2195 - Bundle banner UI refinements

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -236,7 +236,7 @@ bundle-price-monthly = Monthly: <monthly-price>{ $monthly_price }</monthly-price
 #   $old_price (string) - the outdated monthly cost (including currency symbol) for a given plan. This value has a strikethrough.
 bundle-price-save-amount = Save { $savings } <outdated-price>Normally { $old_price }</outdated-price>
 bundle-banner-alt = { -brand-name-mozilla-vpn } and { -brand-name-relay }
-bundle-banner-cta = Get { -brand-name-mozilla-vpn } + { -brand-name-relay }
+bundle-banner-cta = Get { -brand-name-vpn } + { -brand-name-relay }
 # Variables:
 #   $days_guarantee (string) - the number of days for money-back guarantee. Examples: 30, 90
 bundle-banner-money-back-guarantee = { $days_guarantee }-day money-back guarantee for first-time subscribers

--- a/frontend/src/components/landing/BundleBanner.module.scss
+++ b/frontend/src/components/landing/BundleBanner.module.scss
@@ -161,19 +161,32 @@
 
         .money-back-guarantee {
           @include text-body-sm;
+          text-align: center;
+
+          @media #{$mq-lg} {
+            text-align: start;
+          }
         }
       }
 
       h2 {
-        @include text-title-xs;
+        @include text-title-sm;
         @include font-firefox;
         font-weight: 700;
+
+        @media #{$mq-lg} {
+          @include text-title-xs;
+        }
       }
 
       h3 {
-        @include text-title-2xs;
+        @include text-title-xs;
         @include font-firefox;
         font-weight: 500;
+
+        @media #{$mq-lg} {
+          @include text-title-2xs;
+        }
       }
 
       .pricing-logo-wrapper {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR unblocks MPP-2195, where QA flagged some minor UI inconsistencies. 

1. Change banner CTA to "Get VPN + Relay"
2. Increase the size of the "Security, reliability and speed — on every device, anywhere you go.” subtitle on mobile to contrast it more with the body text.

<img width="378" alt="image" src="https://user-images.githubusercontent.com/13066134/195190689-86c50708-944f-4061-9873-9cbaeaa55cd0.png">


How to test:

With the bundle flag on, check that the Bundle banner on the homepage follows the changes stated above.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
