### PR TITLE
Python dependency updates, Oct 11, 2022

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ vobject==0.9.6.1
 # tests
 coverage==6.4.4
 model-bakery==1.7.0
-pytest-cov==3.0.0
+pytest-cov==4.0.0
 pytest-django==4.5.2
 responses==0.21.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyJWT==2.5.0
 python-decouple==3.6
 pyOpenSSL==22.0.0
 requests==2.28.1
-sentry-sdk==1.9.8
+sentry-sdk==1.9.10
 whitenoise==6.2.0
 
 # phones app

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-redis==5.2.0
 django-ftl==0.13
 django-referrer-policy==1.0
 djangorestframework==3.14.0
-django-waffle==2.7.0
+django-waffle==3.0.0
 dockerflow==2022.8.0
 drf-yasg==1.21.4
 google-measurement-protocol==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ responses==0.21.0
 black==22.8.0
 
 # type hinting
-mypy==0.971
+mypy==0.982
 types-requests==2.28.11
 types-pyOpenSSL==22.0.10
 django-stubs==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.24.89
 codetiming==1.3.0
 cryptography==38.0.1
-Django==3.2.15
+Django==3.2.16
 dj-database-url==1.0.0
 django-allauth==0.51.0
 django-cors-headers==3.13.0


### PR DESCRIPTION
Update Python dependencies. This covers:

* Bump django-waffle from 2.7.0 to 3.0.0 (from PR #2441)
* Bump pytest-cov from 3.0.0 to 4.0.0 (from PR #2583)
* Bump sentry-sdk from 1.9.8 to 1.9.10 (from PR #2594)
* Bump mypy from 0.971 to 0.982 (from PR #2628)
* Bump django from 3.2.15 to 3.2.16 (from PR #2629)

I've reviewed these individually. This combined PR makes it easier to keep in sync with `main`.