### PR TITLE
Python dependency updates, Oct 11, 2022, part 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ pytest-django==4.5.2
 responses==0.21.0
 
 # linting
-black==22.8.0
+black==22.10.0
 
 # type hinting
 mypy==0.982

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ gunicorn==20.1.0
 jwcrypto==1.4.2
 markus[datadog]==4.0.1
 pem==21.2.0
-psycopg2==2.9.3
+psycopg2==2.9.4
 PyJWT==2.5.0
 python-decouple==3.6
 pyOpenSSL==22.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ sentry-sdk==1.9.10
 whitenoise==6.2.0
 
 # phones app
-phonenumbers==8.12.55
+phonenumbers==8.12.56
 twilio==7.14.2
 vobject==0.9.6.1
 


### PR DESCRIPTION
Update Python dependencies, part 2:

* Bump psycopg2 from 2.9.3 to 2.9.4 (from PR #2632)
* Bump phonenumbers from 8.12.55 to 8.12.56 (from PR #2633)
* Bump black from 22.8.0 to 22.10.0 (from PR #2634)

I reviewed these individually, they are minor but clean updates.