### PR TITLE
Python dependency updates, Oct 11, 2022, part 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ twilio==7.14.2
 vobject==0.9.6.1
 
 # tests
-coverage==6.4.4
+coverage==6.5.0
 model-bakery==1.7.0
 pytest-cov==4.0.0
 pytest-django==4.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,6 @@ black==22.10.0
 # type hinting
 mypy==0.982
 types-requests==2.28.11
-types-pyOpenSSL==22.0.10
+types-pyOpenSSL==22.1.0.0
 django-stubs==1.12.0
 djangorestframework-stubs==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.24.89
-codetiming==1.3.0
+codetiming==1.3.2
 cryptography==38.0.1
 Django==3.2.16
 dj-database-url==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.24.89
 codetiming==1.3.2
-cryptography==38.0.1
+cryptography==38.0.2
 Django==3.2.16
 dj-database-url==1.0.0
 django-allauth==0.51.0


### PR DESCRIPTION
Another set of Python dependencies, all minor:

* Bump coverage from 6.4.4 to 6.5.0 (from PR #2637)
* Bump codetiming from 1.3.0 to 1.3.2 (from PR #2638)
* Bump cryptography from 38.0.1 to 38.0.2 (from PR #2639)
* Bump types-pyopenssl from 22.0.10 to 22.1.0.0 (from PR #2640)