### PR TITLE
Make the Forward/Block toggle look like a toggle

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -23,7 +23,7 @@ fx-desktop-2 = { -brand-name-firefox } for Desktop
 fx-mobile-2 = { -brand-name-firefox } for Mobile
 fx-containers = { -brand-name-firefox } Containers
 
-## Phone Masking FAQ 
+## Phone Masking FAQ
 
 phone-masking-faq-question-what-is = What is a phone number mask?
 phone-masking-faq-answer-what-is = Similar to an email mask, a phone number mask is a phone number that can forward texts and calls to your true phone number without revealing what your true number is to the person calling or texting you.
@@ -82,7 +82,7 @@ phone-masking-faq-answer-how-i-save-card = Once you upgrade to { -brand-name-rel
 phone-masking-faq-question-install-app = Do I need to install an app to use { -brand-name-relay } phone masking?
 phone-masking-faq-answer-install-app = No, { -brand-name-relay } phone masking works using your device’s standard text messaging and calling apps.
 #   $url (url) - link to Firefox Relay's Privacy Policy, i.e. https://www.mozilla.org/privacy/firefox-relay/
-#   $attrs (string) - specific attributes added to external links 
+#   $attrs (string) - specific attributes added to external links
 phone-masking-faq-question-data = What kinds of data does { -brand-name-relay } phone masking store?
 phone-masking-faq-answer-data = Please see the <a href="{ $url }" { $attrs }>{ -brand-name-firefox-relay } Privacy Policy</a>.
 
@@ -184,8 +184,10 @@ phone-statistics-calls-texts-blocked = Calls and texts blocked
 phone-dashboard-metadata-forwarded-to = Forwarded to:
 phone-dashboard-metadata-date-created = Date Created:
 phone-dashboard-number-copied = Copied!
-phone-dashboard-forwarding-toggle-enabled = Forwarding enabled
-phone-dashboard-forwarding-toggle-disabled = Forwarding disabled
+phone-dashboard-forwarding-toggle-enable-label = Forwarding
+phone-dashboard-forwarding-toggle-enable-tooltip = Forward calls and texts to your true phone number
+phone-dashboard-forwarding-toggle-disable-label = Blocking
+phone-dashboard-forwarding-toggle-disable-tooltip = Block calls and texts to your phone mask
 phone-dashboard-forwarding-enabled = { -brand-name-relay } is currently forwarding all phone calls and text messages to your true phone number.
 phone-dashboard-forwarding-blocked = { -brand-name-relay } is blocking all phone calls and text messages—you will not receive anything from your phone number mask.
 phone-dashboard-senders-header = Callers and text senders

--- a/frontend/src/components/phones/dashboard/Dashboard.tsx
+++ b/frontend/src/components/phones/dashboard/Dashboard.tsx
@@ -44,7 +44,7 @@ export const PhoneDashboard = () => {
     dateStyle: "medium",
   });
 
-  const forwardToggleButtonRef = useRef<HTMLSpanElement>(null);
+  const forwardToggleButtonRef = useRef<HTMLButtonElement>(null);
   const forwardToggleState = useToggleState({
     defaultSelected: relayNumberData?.enabled ?? false,
     onChange: (isSelected) => {
@@ -54,7 +54,7 @@ export const PhoneDashboard = () => {
     },
   });
   const forwardToggleButtonProps = useToggleButton(
-    { elementType: "span" },
+    {},
     forwardToggleState,
     forwardToggleButtonRef
   ).buttonProps;
@@ -123,52 +123,35 @@ export const PhoneDashboard = () => {
   const phoneControls = (
     <div className={styles["phone-controls-container"]}>
       <div className={styles["phone-controls"]}>
-        <span
-          // This is a <span> rather than a <button> to allow the use of flexbox,
-          // but React Aria makes sure it's correctly recognised as a button
-          // thanks to `elementType` passed to `useToggleButton`:
+        <button
           {...forwardToggleButtonProps}
           ref={forwardToggleButtonRef}
-          className={`${styles["forwarding-toggle"]} ${
-            forwardToggleState.isSelected
-              ? styles["is-forwarding"]
-              : styles["is-blocking"]
-          }`}
+          className={styles["forwarding-toggle"]}
           title={
             forwardToggleState.isSelected
-              ? l10n.getString("phone-dashboard-forwarding-toggle-enabled")
-              : l10n.getString("phone-dashboard-forwarding-toggle-disabled")
+              ? l10n.getString(
+                  "phone-dashboard-forwarding-toggle-disable-tooltip"
+                )
+              : l10n.getString(
+                  "phone-dashboard-forwarding-toggle-enable-tooltip"
+                )
           }
         >
           <span
             aria-hidden={!forwardToggleState.isSelected}
-            className={`${styles["forwarding-toggle-icon"]} ${styles["forward-icon"]}`}
+            className={`${styles["forwarding-toggle-state"]} ${styles["forward-state"]}`}
           >
-            <ForwardIcon
-              alt={
-                forwardToggleState.isSelected
-                  ? l10n.getString("phone-dashboard-forwarding-toggle-enabled")
-                  : ""
-              }
-              width={15}
-              height={15}
-            />
+            <ForwardIcon alt="" width={15} height={15} />
+            {l10n.getString("phone-dashboard-forwarding-toggle-enable-label")}
           </span>
           <span
             aria-hidden={forwardToggleState.isSelected}
-            className={`${styles["forwarding-toggle-icon"]} ${styles["block-icon"]}`}
+            className={`${styles["forwarding-toggle-state"]} ${styles["block-state"]}`}
           >
-            <BlockIcon
-              alt={
-                forwardToggleState.isSelected
-                  ? ""
-                  : l10n.getString("phone-dashboard-forwarding-toggle-disabled")
-              }
-              width={15}
-              height={15}
-            />
+            <BlockIcon alt="" width={15} height={15} />
+            {l10n.getString("phone-dashboard-forwarding-toggle-disable-label")}
           </span>
-        </span>
+        </button>
       </div>
       <div className={styles["phone-controls-description"]}>
         {relayNumberData?.enabled ? (

--- a/frontend/src/components/phones/dashboard/PhoneDashboard.module.scss
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.module.scss
@@ -403,21 +403,49 @@
       }
 
       .phone-controls {
+        $toggle-border-radius: 40px;
         .forwarding-toggle {
-          border-radius: 40px;
-          border: $border-radius-xs solid $color-light-gray-20;
-          padding: $spacing-sm;
+          width: $content-sm;
+          max-width: 100%;
+          background-color: $color-grey-05;
+          border-radius: $toggle-border-radius;
+          border: 6px solid $color-white;
+          outline: $border-radius-xs solid $color-grey-10;
           display: flex;
           align-items: center;
           justify-content: center;
-          gap: $spacing-md;
+          position: relative;
 
-          .forwarding-toggle-icon {
-            border-radius: $border-radius-lg;
-            background-color: $color-light-gray-30;
+          // This is the background for the selected state; it's a separate
+          // element so we can animate it moving behind the different state
+          // labels ("Forwarding" and "Blocking"):
+          &::before {
+            content: "";
+            position: absolute;
+            background-color: $color-violet-70;
+            border-radius: $toggle-border-radius;
+            width: 50%;
+            height: 100%;
+            transition: transform 200ms ease-out;
+            transform: translateX(-50%);
+
+            @media (prefers-reduced-motion) {
+              transition: none;
+            }
+          }
+          &[aria-pressed="false"]::before {
+            transform: translateX(50%);
+          }
+
+          .forwarding-toggle-state {
+            // Make sure the state indicator is visible above the toggle
+            // background (i.e. the .forwarding-toggle::before), which is
+            // absolutely positioned so it can be animated:
+            z-index: 1;
+            flex: 1 0 auto;
             padding: $spacing-sm $spacing-sm;
             display: flex;
-            width: 100%;
+            gap: $spacing-sm;
             align-items: center;
             justify-content: center;
 
@@ -426,26 +454,26 @@
             }
           }
 
-          &.is-forwarding .forward-icon,
-          &.is-blocking .block-icon {
-            background-color: $color-violet-70;
+          &[aria-pressed="true"] .forward-state,
+          &[aria-pressed="false"] .block-state {
             color: $color-white;
           }
 
+          &[aria-pressed="false"] .forward-state,
+          &[aria-pressed="true"] .block-state {
+            color: $color-grey-30;
+          }
+
           &:hover {
-            &.is-forwarding .block-icon,
-            &.is-blocking .forward-icon {
+            cursor: pointer;
+            background-color: $color-violet-05;
+            &[aria-pressed="true"] .block-state,
+            &[aria-pressed="false"] .forward-state {
               color: $color-blue-50;
             }
           }
-          &:hover,
-          &:focus {
-            cursor: pointer;
-
-            &.is-forwarding .block-icon,
-            &.is-blocking .forward-icon {
-              background-color: $color-purple-05;
-            }
+          &:focus-visible {
+            outline-color: $color-blue-50;
           }
         }
       }


### PR DESCRIPTION
As per design input.

Before:

[Screencast from 14-10-22 11:53:33.webm](https://user-images.githubusercontent.com/4251/195818630-219dd34e-fe60-4617-909b-5a7bef5af195.webm)

After:

[Screencast from 14-10-22 11:54:02.webm](https://user-images.githubusercontent.com/4251/195818825-5c5fee7f-f766-4679-b9e6-c2a3f2bb446a.webm)

# How to test

Open the phone dashboard with a Relay number set up.

# Checklist

- [x] l10n changes have been submitted to the l10n repository, if any. - Yes: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/103/commits/a8b16dec29bccde1596db9b5c8c827f1ae4905fd
- [x] All acceptance criteria are met.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
