### PR TITLE
MPP-2435 - Disable register phone number mask button if no relay number is chosen

### DIFF
--- a/frontend/src/components/phones/onboarding/RelayNumberPicker.tsx
+++ b/frontend/src/components/phones/onboarding/RelayNumberPicker.tsx
@@ -250,7 +250,10 @@ const RelayNumberSelection = (props: RelayNumberSelectionProps) => {
         <Button
           className={styles.button}
           type="submit"
-          disabled={phoneNumber.length === 0}
+          disabled={
+            phoneNumber.length === 0 ||
+            (relayNumberSuggestions && relayNumberSuggestions.length === 0)
+          }
         >
           {l10n.getString(
             "phone-onboarding-step4-button-register-phone-number"

--- a/frontend/src/components/phones/onboarding/RelayNumberPicker.tsx
+++ b/frontend/src/components/phones/onboarding/RelayNumberPicker.tsx
@@ -166,6 +166,9 @@ const RelayNumberSelection = (props: RelayNumberSelectionProps) => {
   const getRelayNumberOptions: MouseEventHandler<HTMLButtonElement> = () => {
     const newRelayNumberIndex = relayNumberIndex + 3;
 
+    // deselect current relay number that might be set
+    setPhoneNumber("");
+
     // if we have reached the end of the list, reset to the beginning
     if (relayNumberSuggestions) {
       setRelayNumberIndex(
@@ -244,7 +247,11 @@ const RelayNumberSelection = (props: RelayNumberSelectionProps) => {
         </p>
 
         {/* TODO: Add error class to input field */}
-        <Button className={styles.button} type="submit">
+        <Button
+          className={styles.button}
+          type="submit"
+          disabled={phoneNumber.length === 0}
+        >
           {l10n.getString(
             "phone-onboarding-step4-button-register-phone-number"
           )}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-2435
 
<!-- When adding a new feature: -->

# New feature description

Disable register phone number mask button if no relay number is chosen. I also made it so that when you click on 'show me other options' we clear the currently selected relay number. 

# Screenshot (if applicable)

<img width="474" alt="image" src="https://user-images.githubusercontent.com/3924990/195937605-f03a5f74-8863-4642-ae04-e70cc2c65291.png">

# How to test

After verifying number and you get to the choosing a relay number, observe the state of the button "register phone number mask". 

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
