### PR TITLE
Prevent line breaks in stats in Chinese

### DIFF
--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -204,7 +204,8 @@ $trackerRemovalIndicatorWidth: 20px;
 }
 
 .alias-stats {
-  flex-basis: 0;
+  flex: 1 0 $content-xs;
+  text-align: center;
 
   .main-data & {
     display: none;
@@ -302,6 +303,7 @@ $trackerRemovalIndicatorWidth: 20px;
         height: 25px;
         display: flex;
         align-items: center;
+        word-break: keep-all;
       }
 
       // De-emphasise stats for:


### PR DESCRIPTION
Although we want a stat label like "Trackers Removed" to span two lines, we don't want every character in Chinese to be moved to a new line. Although the former was achieved by setting a flex-basis of 0, that caused line breaks between every character in Chinese. By simply setting the flex-basis to a small (i.e. smaller than the width of the word "Trackers") but non-zero (i.e. larger than the width of 追) value, we achieve both goals.

This PR fixes #2575.

How to test: set your browser language to `zh-cn`, and verify that the labels for stats don't have line breaks after every character. Additionally, make sure that in English, the "Trackers Removed" label isn't on a single line.

Before:

![image](https://user-images.githubusercontent.com/4251/196151348-5b11b770-515e-4adb-90c1-c694e5f93c38.png)

After:

![image](https://user-images.githubusercontent.com/4251/196151364-56aee4ea-309c-4a11-afb7-985dafe5721b.png)

and

![image](https://user-images.githubusercontent.com/4251/196151386-fbb32790-a821-4532-a6aa-92ff3c6351e7.png)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
