### PR TITLE
Reverse direction of the phone banner

### DIFF
--- a/frontend/src/components/landing/PhoneBanner.module.scss
+++ b/frontend/src/components/landing/PhoneBanner.module.scss
@@ -5,6 +5,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-direction: row-reverse;
   flex-wrap: wrap-reverse;
   column-gap: $spacing-2xl;
   row-gap: $spacing-lg;
@@ -56,7 +57,10 @@
     margin-inline: -1 * $spacing-2xl;
 
     @media screen and #{$mq-sm} {
-      margin-inline: unset;
+      // On large screens, `.floating-features li`s (and in particular,
+      // `nth-child(1)`) is positioned *outside* `.illustration`, so leave a
+      // marging around it to have room for that:
+      margin-inline: $spacing-2xl;
     }
 
     .floating-features {


### PR DESCRIPTION
This will make it look more balanced as long as the bundle banner isn't visible yet.

This PR fixes MPP-2469.

How to test: open the landing page. The phone banner's illustration should be on the left-hand side on large screens.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
