### PR TITLE
MPP-2451: Return JSON Validation error when a free user is at the email mask limit

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -1,8 +1,16 @@
+from typing import Mapping
+
 from django.contrib.auth.models import User
 
 from rest_framework import serializers, exceptions
 
-from emails.models import Profile, DomainAddress, RelayAddress
+from emails.models import (
+    CannotMakeAddressException,
+    DomainAddress,
+    Profile,
+    RelayAddress,
+    check_user_can_make_another_address,
+)
 
 
 class PremiumValidatorsMixin:
@@ -61,6 +69,18 @@ class RelayAddressSerializer(PremiumValidatorsMixin, serializers.ModelSerializer
             "num_replied",
             "num_spam",
         ]
+
+    def validate(self, data: Mapping) -> Mapping:
+        """Check if a free user is at their RelayAddress limit."""
+        if self.context["request"].method == "POST":
+            user = self.context["request"].user
+            profile = user.profile_set.get()
+            try:
+                check_user_can_make_another_address(profile)
+            except CannotMakeAddressException as exception:
+                raise exceptions.ValidationError(str(exception)) from exception
+
+        return data
 
 
 class DomainAddressSerializer(PremiumValidatorsMixin, serializers.ModelSerializer):

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -59,8 +59,9 @@ def test_free_mask_email_limit_error(settings) -> None:
     response = client.post(reverse("relayaddress-list"), data, format="json")
     assert response.status_code == 400
 
-    # MPP-2451: This should return JSON
-    with pytest.raises(ValueError) as exc_info:
-        ret_data = response.json()  # type: ignore[attr-defined]
-    err_msg = 'Content-Type header is "text/html", not "application/json"'
-    assert str(exc_info.value) == err_msg
+    ret_data = response.json()  # type: ignore[attr-defined]
+    expected_msg = (
+        "You must be a premium subscriber to make more than"
+        f" {settings.MAX_NUM_FREE_ALIASES} aliases."
+    )
+    assert ret_data == {"non_field_errors": [expected_msg]}


### PR DESCRIPTION
For MPP-2451, add a call to `check_user_can_make_another_address` for validating `POST /api/v1/relayaddress`, so that it is a validation error returning JSON rather than a server error.

To test:

1. Create a free test user
2. Create 5 aliases
3. Attempt to create a new alias in the UI
    * [ ] Button changes from "+ Generate New Mask" to "Get Unlimited Email Masks"
4. Go to the browsable API at /api/v1/docs, attempt to create the new alias with this data (removing `block_list_emails` member):

    ```json
    {
      "enabled": true,
      "description": "description",
      "generated_for": "generated_for",
      "used_on": "used_on"
    }
    ```
    * [ ] Error is JSON:
    
        ```json
        {
          "non_field_errors": [
            "You must be a premium subscriber to make more than 5 aliases."
          ]
        }
        ```
            

    
    