### PR TITLE
Remove superfluous whitespace on mobile

### DIFF
--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -204,9 +204,6 @@ $trackerRemovalIndicatorWidth: 20px;
 }
 
 .alias-stats {
-  flex: 1 0 $content-xs;
-  text-align: center;
-
   .main-data & {
     display: none;
   }
@@ -220,6 +217,8 @@ $trackerRemovalIndicatorWidth: 20px;
     // stylelint-disable-next-line no-duplicate-selectors
     .main-data & {
       display: flex;
+      flex: 1 0 $content-xs;
+      text-align: center;
     }
     // I've grouped these together under the media query to emphasise that they
     // switch visibility at the same time:

--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
@@ -164,6 +164,7 @@ $trackLineHeight: 4px;
           // stop:
           top: calc(var(--thumbDiameter) + #{$spacing-xs});
           height: $stopLabelHeight;
+          word-break: keep-all;
         }
 
         &.is-selected {


### PR DESCRIPTION
This is a follow-up to #2666.

I set a small flex-basis on stats to prevent line breaks in Chinese for the stat, which was fine on desktop, but on mobile (where stats are stacked vertically), it resulted in a bunch of whitespace at the bottom.

This also prevents Chinese labels for slider positions (e.g. "Promotionals") from having line breaks.

Before:

![image](https://user-images.githubusercontent.com/4251/196779336-98058d2a-8b48-4942-8178-8fb3e52f124d.png)

and

![image](https://user-images.githubusercontent.com/4251/196779522-fe7aac7b-c1d1-445a-98f3-7f9f3920223b.png)

After:

![image](https://user-images.githubusercontent.com/4251/196779403-8ae0ef84-7ac2-423c-b73f-27147fb04995.png)

and

![image](https://user-images.githubusercontent.com/4251/196779592-7351d907-f16f-424b-a3f8-e54de5f2bbd5.png)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual changes
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
