### PR TITLE
Delete data from twilio immediately after sending

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -63,6 +63,7 @@ if settings.PHONES_ENABLED:
         inbound_call,
         inbound_sms,
         vCard,
+        sms_status,
         voice_status,
         resend_welcome_sms,
     )
@@ -74,6 +75,7 @@ if settings.PHONES_ENABLED:
         path("v1/inbound_sms", inbound_sms, name="inbound_sms"),
         path("v1/inbound_call", inbound_call, name="inbound_call"),
         path("v1/voice_status", voice_status, name="voice_status"),
+        path("v1/sms_status", sms_status, name="sms_status"),
         path("v1/vCard/<lookup_key>", vCard, name="vCard"),
         path(
             "v1/realphone/resend_welcome_sms",

--- a/docs/end-to-end-local-phone-dev.md
+++ b/docs/end-to-end-local-phone-dev.md
@@ -127,8 +127,12 @@ local app URL to its call and text webhooks, and set its app ID to your
    - Friendly name: "your-host Relay"
    - Voice request URL: https://your-host.ngrok.io/api/v1/inbound_call HTTP
      POST
+   - "Show optional settings"
+   - Voice status callback URL: https://your-host.ngrok.io/api/v1/voice_status
    - Messaging request URL: https://your-host.ngrok.io/api/v1/inbound_sms HTTP
      POST
+   - "Show optional settings"
+   - Messaging status callback URL: https://your-host.ngrok.io/api/v1/sms_status
 3. Click "Save"
 4. Click the newly-created app
 5. Copy the `SID` value into your `.env` `TWILIO_SMS_APPLICATION_SID`

--- a/phones/apps.py
+++ b/phones/apps.py
@@ -19,6 +19,11 @@ class PhonesConfig(AppConfig):
             self._twilio_client = Client(
                 settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN
             )
+            # Create TwiML app to access its sms_status_callback
+            # Note:
+            self.twiml_app = self._twilio_client.applications(
+                settings.TWILIO_SMS_APPLICATION_SID
+            ).fetch()
             self._twilio_validator = RequestValidator(settings.TWILIO_AUTH_TOKEN)
         except Exception:
             logger.exception("exception creating Twilio client and/or validator")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = privaterelay.settings
 python_files = tests.py test_*.py *_tests.py
-norecursedirs = .git .local extension
+norecursedirs = .git .local extension frontend node_modules


### PR DESCRIPTION
This PR fixes #MPP-2390.

How to test:
If your local Relay phone config is using a `TWILIO_SMS_APPLICATION_SID` that is in the Mozilla account, ping @groovecoder to pair and watch the Twilio console in real time while performing this test

1. Check out this branch
2. Open the twilio console -> monitor -> logs -> messaging screen
3. Send a text message to your local relay number
   * [x] It should work as expected (either forward or block depending on what your number is doing)
   * [ ] The twilio console message log should NOT have an "Outgoing API" record for the message
4. Open the twilio console -> monitor -> logs -> calls screen
5. Make a call to your local relay number
   * [x] It should work as expected (either forward or block depending on what your number is doing)
   * [ ] The twilio console call log should NOT have an "Outgoing Dial" record for the message

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).