### PR TITLE
MPP-2451: Add error_code, error_context to address creation errors

### DIFF
--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from rest_framework import status
 from rest_framework.exceptions import APIException
 
@@ -8,9 +10,12 @@ class ConflictError(APIException):
     default_code = "conflict_error"
 
 
+ErrorContextType = dict[str, Union[int, str]]
+
+
 class RelayAPIException(APIException):
     """Base class for exceptions that may be returned through API"""
 
-    def error_context(self) -> dict[str, str]:
+    def error_context(self) -> ErrorContextType:
         """Return context variables for client-side translation."""
         return {}

--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -6,3 +6,11 @@ class ConflictError(APIException):
     status_code = status.HTTP_409_CONFLICT
     default_detail = "Request conflicts with current state of the target resource."
     default_code = "conflict_error"
+
+
+class RelayAPIException(APIException):
+    """Base class for exceptions that may be returned through API"""
+
+    def error_context(self) -> dict[str, str]:
+        """Return context variables for client-side translation."""
+        return {}

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -8,16 +8,16 @@ from emails.models import DomainAddress, Profile, RelayAddress
 class PremiumValidatorsMixin:
     # the user must be premium to set block_list_emails=True
     def validate_block_list_emails(self, value):
-        if (
+        if value and not (
             self.context["request"]
             .user.profile_set.prefetch_related("user__socialaccount_set")
             .first()
             .has_premium
         ):
-            return value
-        raise exceptions.AuthenticationFailed(
-            "Must be premium to set block_list_emails"
-        )
+            raise exceptions.AuthenticationFailed(
+                "Must be premium to set block_list_emails."
+            )
+        return value
 
 
 class RelayAddressSerializer(PremiumValidatorsMixin, serializers.ModelSerializer):

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -1,16 +1,8 @@
-from typing import Mapping
-
 from django.contrib.auth.models import User
 
 from rest_framework import serializers, exceptions
 
-from emails.models import (
-    CannotMakeAddressException,
-    DomainAddress,
-    Profile,
-    RelayAddress,
-    check_user_can_make_another_address,
-)
+from emails.models import DomainAddress, Profile, RelayAddress
 
 
 class PremiumValidatorsMixin:
@@ -69,18 +61,6 @@ class RelayAddressSerializer(PremiumValidatorsMixin, serializers.ModelSerializer
             "num_replied",
             "num_spam",
         ]
-
-    def validate(self, data: Mapping) -> Mapping:
-        """Check if a free user is at their RelayAddress limit."""
-        if self.context["request"].method == "POST":
-            user = self.context["request"].user
-            profile = user.profile_set.get()
-            try:
-                check_user_can_make_another_address(profile)
-            except CannotMakeAddressException as exception:
-                raise exceptions.ValidationError(str(exception)) from exception
-
-        return data
 
 
 class DomainAddressSerializer(PremiumValidatorsMixin, serializers.ModelSerializer):

--- a/api/tests/serializers_tests.py
+++ b/api/tests/serializers_tests.py
@@ -23,6 +23,21 @@ class PremiumValidatorsTest(APITestCase):
         assert response.status_code == 403
         assert free_alias.block_list_emails == False
 
+    def test_non_premium_can_clear_block_list_emails(self):
+        free_user = make_free_test_user()
+        free_alias = baker.make(RelayAddress, user=free_user)
+        assert free_alias.block_list_emails == False
+
+        url = reverse("relayaddress-detail", args=[free_alias.id])
+        data = {"block_list_emails": False}
+        free_token = Token.objects.get(user=free_user)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + free_token.key)
+        response = self.client.patch(url, data, format="json")
+
+        assert response.status_code == 200
+        free_alias.refresh_from_db()
+        assert free_alias.block_list_emails == False
+
     def test_premium_can_set_block_list_emails(self):
         premium_user = make_premium_test_user()
         premium_alias = baker.make(RelayAddress, user=premium_user)

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -85,7 +85,7 @@ def test_post_domainaddress_no_subdomain_error(prem_api_client) -> None:
         format="json",
     )
 
-    assert response.status_code == 403
+    assert response.status_code == 400
     ret_data = response.json()
     assert ret_data == {
         "detail": (
@@ -123,7 +123,7 @@ def test_post_domainaddress_bad_address_error(prem_api_client) -> None:
         format="json",
     )
 
-    assert response.status_code == 403
+    assert response.status_code == 400
     ret_data = response.json()
     assert ret_data == {
         "detail": 'Domain address "myNewAlias" could not be created, try using a different value.',
@@ -167,7 +167,7 @@ def test_post_relayaddress_free_mask_email_limit_error(
 
     response = free_api_client.post(reverse("relayaddress-list"), {}, format="json")
 
-    assert response.status_code == 400
+    assert response.status_code == 403
     ret_data = response.json()
     assert ret_data == {
         "detail": (
@@ -187,7 +187,7 @@ def test_post_relayaddress_flagged_error(free_api_client) -> None:
 
     response = free_api_client.post(reverse("relayaddress-list"), {}, format="json")
 
-    assert response.status_code == 400
+    assert response.status_code == 403
     ret_data = response.json()
     assert ret_data == {
         "detail": "Your account is on pause.",

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -127,7 +127,7 @@ def test_post_domainaddress_bad_address_error(prem_api_client) -> None:
     ret_data = response.json()
     assert ret_data == {
         "errorReason": "addressUnavailable",
-        "detail": "Domain address myNewAlias could not be created, try using a different value.",
+        "detail": 'Domain address "myNewAlias" could not be created, try using a different value.',
     }
 
 

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -1,28 +1,41 @@
 import pytest
 from model_bakery import baker
 
+from django.contrib.auth.models import User
 from django.utils import timezone
 from django.urls import reverse
 from rest_framework.test import APIClient
 
-from emails.models import (
-    CannotMakeAddressException,
-    RelayAddress,
-    check_user_can_make_another_address,
-)
-from emails.tests.models_tests import make_free_test_user
+from emails.models import RelayAddress
+from emails.tests.models_tests import make_free_test_user, make_premium_test_user
 
 
 @pytest.fixture
 def free_api_client(db) -> APIClient:
+    """Return an APIClient for a newly created free user."""
     free_user = make_free_test_user()
     client = APIClient()
     client.force_authenticate(user=free_user)
     return client
 
 
-def get_user(client: APIClient):
-    return client.handler._force_user
+@pytest.fixture
+def prem_api_client(db) -> APIClient:
+    """Return an APIClient for a newly created premium user."""
+    premium_user = make_premium_test_user()
+    premium_profile = premium_user.profile_set.get()
+    premium_profile.subdomain = "premium"
+    premium_profile.save()
+    client = APIClient()
+    client.force_authenticate(user=premium_user)
+    return client
+
+
+def get_user(client: APIClient) -> User:
+    """Get user from APIClient.force_authenticate()"""
+    user = client.handler._force_user
+    assert isinstance(user, User)
+    return user
 
 
 @pytest.mark.parametrize("format", ("yaml", "json"))
@@ -47,22 +60,94 @@ def test_runtime_data(client):
     assert response.status_code == 200
 
 
-def test_post_relayaddress_success(settings, free_api_client) -> None:
-    """A free user is able to create an address."""
-    origin = "https://login.example.com"
-    data = {
-        "enabled": True,
-        "description": origin,
-        "generated_for": origin,
-        "used_on": origin,
+def test_post_domainaddress_success(prem_api_client) -> None:
+    """A premium user can create a domain address."""
+    response = prem_api_client.post(
+        reverse("domainaddress-list"),
+        data={"address": "my-new-mask"},
+        format="json",
+    )
+    assert response.status_code == 201
+    ret_data = response.json()
+    assert ret_data["enabled"]
+    assert ret_data["full_address"].startswith("my-new-mask@premium.")
+
+
+def test_post_domainaddress_no_subdomain_error(prem_api_client) -> None:
+    """A premium user needs to select a subdomain before creating a domain address."""
+    premium_profile = get_user(prem_api_client).profile_set.get()
+    premium_profile.subdomain = ""
+    premium_profile.save()
+
+    response = prem_api_client.post(
+        reverse("domainaddress-list"),
+        data={"address": "my-new-mask"},
+        format="json",
+    )
+
+    assert response.status_code == 403
+    ret_data = response.json()
+    assert ret_data == {
+        "detail": (
+            "You must select a subdomain before creating email address with subdomain."
+        ),
     }
 
-    response = free_api_client.post(reverse("relayaddress-list"), data, format="json")
+
+def test_post_domainaddress_user_flagged_error(prem_api_client) -> None:
+    """A premium user needs to select a subdomain before creating a domain address."""
+    premium_profile = get_user(prem_api_client).profile_set.get()
+    premium_profile.last_account_flagged = timezone.now()
+    premium_profile.save()
+
+    response = prem_api_client.post(
+        reverse("domainaddress-list"),
+        data={"address": "my-new-mask"},
+        format="json",
+    )
+
+    assert response.status_code == 403
+    ret_data = response.json()
+    assert ret_data == {"detail": "Your account is on pause."}
+
+
+def test_post_domainaddress_bad_address_error(prem_api_client) -> None:
+    """A premium user needs to select a subdomain before creating a domain address."""
+    response = prem_api_client.post(
+        reverse("domainaddress-list"),
+        data={"address": "myNewAlias"},
+        format="json",
+    )
+
+    assert response.status_code == 403
+    ret_data = response.json()
+    assert ret_data == {
+        "detail": "Domain address myNewAlias could not be created, try using a different value."
+    }
+
+
+def test_post_domainaddress_free_user_error(free_api_client):
+    """A free user is not allowed to create a domain address."""
+    response = free_api_client.post(
+        reverse("domainaddress-list"), data={"address": "my-new-alias"}, format="json"
+    )
+
+    assert response.status_code == 403
+    ret_data = response.json()
+    assert ret_data == {
+        "detail": "You must be a premium subscriber to create subdomain aliases.",
+    }
+
+
+def test_post_relayaddress_success(settings, free_api_client) -> None:
+    """A free user is able to create an address."""
+    response = free_api_client.post(
+        reverse("relayaddress-list"), data={}, format="json"
+    )
 
     assert response.status_code == 201
     ret_data = response.json()
     assert ret_data["enabled"]
-    assert ret_data["description"] == origin
 
 
 def test_post_relayaddress_free_mask_email_limit_error(
@@ -70,23 +155,10 @@ def test_post_relayaddress_free_mask_email_limit_error(
 ) -> None:
     """A JSON error is returned when a free user hits the mask limit"""
     free_user = get_user(free_api_client)
-    free_profile = free_user.profile_set.get()
     for _ in range(settings.MAX_NUM_FREE_ALIASES):
-        assert check_user_can_make_another_address(free_profile) is None
         baker.make(RelayAddress, user=free_user)
-        del free_profile.relay_addresses  # Invalidate cached_property
-    with pytest.raises(CannotMakeAddressException):
-        check_user_can_make_another_address(free_profile)
 
-    origin = "https://login.example.com"
-    data = {
-        "enabled": True,
-        "description": origin,
-        "generated_for": origin,
-        "used_on": origin,
-    }
-
-    response = free_api_client.post(reverse("relayaddress-list"), data, format="json")
+    response = free_api_client.post(reverse("relayaddress-list"), {}, format="json")
 
     assert response.status_code == 400
     ret_data = response.json()
@@ -104,18 +176,8 @@ def test_post_relayaddress_flagged_error(free_api_client) -> None:
     free_profile = get_user(free_api_client).profile_set.get()
     free_profile.last_account_flagged = timezone.now()
     free_profile.save()
-    with pytest.raises(CannotMakeAddressException):
-        check_user_can_make_another_address(free_profile)
 
-    origin = "https://login.example.com"
-    data = {
-        "enabled": True,
-        "description": origin,
-        "generated_for": origin,
-        "used_on": origin,
-    }
-
-    response = free_api_client.post(reverse("relayaddress-list"), data, format="json")
+    response = free_api_client.post(reverse("relayaddress-list"), {}, format="json")
 
     assert response.status_code == 400
     ret_data = response.json()

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -96,7 +96,7 @@ def test_post_domainaddress_no_subdomain_error(prem_api_client) -> None:
 
 
 def test_post_domainaddress_user_flagged_error(prem_api_client) -> None:
-    """A premium user needs to select a subdomain before creating a domain address."""
+    """A flagged user cannot create a new domain address."""
     premium_profile = get_user(prem_api_client).profile_set.get()
     premium_profile.last_account_flagged = timezone.now()
     premium_profile.save()
@@ -116,7 +116,7 @@ def test_post_domainaddress_user_flagged_error(prem_api_client) -> None:
 
 
 def test_post_domainaddress_bad_address_error(prem_api_client) -> None:
-    """A premium user needs to select a subdomain before creating a domain address."""
+    """A domain address can be rejected due to the address format or content."""
     response = prem_api_client.post(
         reverse("domainaddress-list"),
         data={"address": "myNewAlias"},
@@ -147,7 +147,7 @@ def test_post_domainaddress_free_user_error(free_api_client):
 
 
 def test_post_relayaddress_success(settings, free_api_client) -> None:
-    """A free user is able to create an address."""
+    """A free user is able to create a random address."""
     response = free_api_client.post(
         reverse("relayaddress-list"), data={}, format="json"
     )
@@ -160,7 +160,7 @@ def test_post_relayaddress_success(settings, free_api_client) -> None:
 def test_post_relayaddress_free_mask_email_limit_error(
     settings, free_api_client
 ) -> None:
-    """A JSON error is returned when a free user hits the mask limit"""
+    """A free user is unable to exceed the mask limit."""
     free_user = get_user(free_api_client)
     for _ in range(settings.MAX_NUM_FREE_ALIASES):
         baker.make(RelayAddress, user=free_user)
@@ -180,7 +180,7 @@ def test_post_relayaddress_free_mask_email_limit_error(
 
 
 def test_post_relayaddress_flagged_error(free_api_client) -> None:
-    """A JSON error is returned when a free user hits the mask limit"""
+    """A flagged user is unable to create a random mask."""
     free_profile = get_user(free_api_client).profile_set.get()
     free_profile.last_account_flagged = timezone.now()
     free_profile.save()

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -88,10 +88,10 @@ def test_post_domainaddress_no_subdomain_error(prem_api_client) -> None:
     assert response.status_code == 403
     ret_data = response.json()
     assert ret_data == {
-        "errorReason": "needSubdomain",
         "detail": (
             "You must select a subdomain before creating email address with subdomain."
         ),
+        "error_code": "need_subdomain",
     }
 
 
@@ -110,8 +110,8 @@ def test_post_domainaddress_user_flagged_error(prem_api_client) -> None:
     assert response.status_code == 403
     ret_data = response.json()
     assert ret_data == {
-        "errorReason": "accountIsPaused",
         "detail": "Your account is on pause.",
+        "error_code": "account_is_paused",
     }
 
 
@@ -126,8 +126,9 @@ def test_post_domainaddress_bad_address_error(prem_api_client) -> None:
     assert response.status_code == 403
     ret_data = response.json()
     assert ret_data == {
-        "errorReason": "addressUnavailable",
         "detail": 'Domain address "myNewAlias" could not be created, try using a different value.',
+        "error_code": "address_unavailable",
+        "error_context": {"unavailable_address": "myNewAlias"},
     }
 
 
@@ -140,8 +141,8 @@ def test_post_domainaddress_free_user_error(free_api_client):
     assert response.status_code == 403
     ret_data = response.json()
     assert ret_data == {
-        "errorReason": "freeTierNoDomainAddress",
         "detail": "You must be a premium subscriber to create subdomain aliases.",
+        "error_code": "free_tier_no_subdomain_alias",
     }
 
 
@@ -169,11 +170,12 @@ def test_post_relayaddress_free_mask_email_limit_error(
     assert response.status_code == 400
     ret_data = response.json()
     assert ret_data == {
-        "errorReason": "freeTierLimit",
         "detail": (
             "You must be a premium subscriber to make more than"
             f" {settings.MAX_NUM_FREE_ALIASES} aliases."
         ),
+        "error_code": "free_tier_limit",
+        "error_context": {"free_tier_limit": 5},
     }
 
 
@@ -188,6 +190,6 @@ def test_post_relayaddress_flagged_error(free_api_client) -> None:
     assert response.status_code == 400
     ret_data = response.json()
     assert ret_data == {
-        "errorReason": "accountIsPaused",
         "detail": "Your account is on pause.",
+        "error_code": "account_is_paused",
     }

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -88,6 +88,7 @@ def test_post_domainaddress_no_subdomain_error(prem_api_client) -> None:
     assert response.status_code == 403
     ret_data = response.json()
     assert ret_data == {
+        "errorReason": "needSubdomain",
         "detail": (
             "You must select a subdomain before creating email address with subdomain."
         ),
@@ -108,7 +109,10 @@ def test_post_domainaddress_user_flagged_error(prem_api_client) -> None:
 
     assert response.status_code == 403
     ret_data = response.json()
-    assert ret_data == {"detail": "Your account is on pause."}
+    assert ret_data == {
+        "errorReason": "accountIsPaused",
+        "detail": "Your account is on pause.",
+    }
 
 
 def test_post_domainaddress_bad_address_error(prem_api_client) -> None:
@@ -122,7 +126,8 @@ def test_post_domainaddress_bad_address_error(prem_api_client) -> None:
     assert response.status_code == 403
     ret_data = response.json()
     assert ret_data == {
-        "detail": "Domain address myNewAlias could not be created, try using a different value."
+        "errorReason": "addressUnavailable",
+        "detail": "Domain address myNewAlias could not be created, try using a different value.",
     }
 
 
@@ -135,6 +140,7 @@ def test_post_domainaddress_free_user_error(free_api_client):
     assert response.status_code == 403
     ret_data = response.json()
     assert ret_data == {
+        "errorReason": "freeTierNoDomainAddress",
         "detail": "You must be a premium subscriber to create subdomain aliases.",
     }
 

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -142,7 +142,7 @@ def test_post_domainaddress_free_user_error(free_api_client):
     ret_data = response.json()
     assert ret_data == {
         "detail": "You must be a premium subscriber to create subdomain aliases.",
-        "error_code": "free_tier_no_subdomain_alias",
+        "error_code": "free_tier_no_subdomain_masks",
     }
 
 

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -133,7 +133,8 @@ class DomainAddressViewSet(SaveToRequestUser, viewsets.ModelViewSet):
         try:
             serializer.save(user=self.request.user)
         except CannotMakeAddressException as e:
-            raise exceptions.PermissionDenied(e.message)
+            e.status_code = 403
+            raise e
         except IntegrityError as e:
             domain_address = DomainAddress.objects.filter(
                 user=self.request.user, address=serializer.validated_data.get("address")
@@ -227,7 +228,7 @@ def relay_exception_handler(exc: Exception, context: Mapping) -> Optional[Respon
     # Handle CannotMakeAddressException
     if isinstance(exc, CannotMakeAddressException):
         data = {"errorReason": exc.errorReason, "detail": exc.message}
-        return Response(data, status=400)
+        return Response(data, status=exc.status_code)
 
     # Use DRF's default handler
     return exception_handler(exc, context)

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -133,9 +133,6 @@ class DomainAddressViewSet(SaveToRequestUser, viewsets.ModelViewSet):
     def perform_create(self, serializer):
         try:
             serializer.save(user=self.request.user)
-        except CannotMakeAddressException as e:
-            e.status_code = 403
-            raise e
         except IntegrityError as e:
             domain_address = DomainAddress.objects.filter(
                 user=self.request.user, address=serializer.validated_data.get("address")

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -225,10 +225,15 @@ def report_webcompat_issue(request):
 def relay_exception_handler(exc: Exception, context: Mapping) -> Optional[Response]:
     """Tune error responses for Relay."""
 
+    # Try DRF's exception_handler
+    response = exception_handler(exc, context)
+    if response:
+        return response
+
     # Handle CannotMakeAddressException
     if isinstance(exc, CannotMakeAddressException):
         data = {"errorReason": exc.error_reason, "detail": exc.message}
         return Response(data, status=exc.status_code)
 
-    # Use DRF's default handler
-    return exception_handler(exc, context)
+    # Exception is unhandled
+    return None

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -230,7 +230,6 @@ def relay_exception_handler(exc: Exception, context: Mapping) -> Optional[Respon
     When the error is a RelayAPIException, these additional fields may be present:
 
     error_code - A string identifying the error, for client-side translation
-    error_codes - A list or object identifying the error
     error_context - Additional data needed for client-side translation
     """
 
@@ -239,9 +238,6 @@ def relay_exception_handler(exc: Exception, context: Mapping) -> Optional[Respon
         error_codes = exc.get_codes()
         if isinstance(error_codes, str):
             response.data["error_code"] = error_codes
-        else:
-            response.data["error_codes"] = error_codes
-
         error_context = exc.error_context()
         if error_context:
             response.data["error_context"] = error_context

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -227,7 +227,7 @@ def relay_exception_handler(exc: Exception, context: Mapping) -> Optional[Respon
 
     # Handle CannotMakeAddressException
     if isinstance(exc, CannotMakeAddressException):
-        data = {"errorReason": exc.errorReason, "detail": exc.message}
+        data = {"errorReason": exc.error_reason, "detail": exc.message}
         return Response(data, status=exc.status_code)
 
     # Use DRF's default handler

--- a/emails/models.py
+++ b/emails/models.py
@@ -544,7 +544,11 @@ class CannotMakeAddressException(RelayAPIException):
 
 
 class CannotMakeRelayAddrException(CannotMakeAddressException):
-    """RelayAddress creation failure."""
+    """
+    RelayAddress creation failure.
+
+    Previously implemented as a BadRequest exception, so it uses status code 400
+    """
 
     status_code = 400
 
@@ -573,7 +577,11 @@ class RelayAddrFreeTierLimitException(CannotMakeRelayAddrException):
 
 
 class CannotMakeDomainAddrException(CannotMakeAddressException):
-    """DomainAddress creation failure."""
+    """
+    DomainAddress creation failure.
+
+    Previously implemented as a PermissionDenied exception, so it uses status code 403
+    """
 
     status_code = 403
 

--- a/emails/models.py
+++ b/emails/models.py
@@ -23,7 +23,7 @@ from django.utils.translation.trans_real import (
 from rest_framework.authtoken.models import Token
 from waffle.models import Flag
 
-from api.exceptions import RelayAPIException
+from api.exceptions import ErrorContextType, RelayAPIException
 
 
 emails_config = apps.get_app_config("emails")
@@ -568,7 +568,7 @@ class RelayAddrFreeTierLimitException(CannotMakeRelayAddrException):
         )
         super().__init__(*args, **kwargs)
 
-    def error_context(self):
+    def error_context(self) -> ErrorContextType:
         return {"free_tier_limit": self.free_tier_limit}
 
 
@@ -609,7 +609,7 @@ class DomainAddrUnavailableException(CannotMakeDomainAddrException):
         )
         super().__init__(*args, **kwargs)
 
-    def error_context(self):
+    def error_context(self) -> ErrorContextType:
         return {"unavailable_address": self.unavailable_address}
 
 

--- a/emails/models.py
+++ b/emails/models.py
@@ -544,26 +544,22 @@ class CannotMakeAddressException(RelayAPIException):
 
 
 class CannotMakeRelayAddrException(CannotMakeAddressException):
-    """
-    RelayAddress creation failure.
-
-    Previously implemented as a BadRequest exception, so it uses status code 400
-    """
-
-    status_code = 400
+    """RelayAddress creation failure."""
 
 
 class RelayAddrAccountIsPausedException(CannotMakeRelayAddrException):
-    default_detail = "Your account is on pause."
     default_code = "account_is_paused"
+    default_detail = "Your account is on pause."
+    status_code = 403
 
 
 class RelayAddrFreeTierLimitException(CannotMakeRelayAddrException):
+    default_code = "free_tier_limit"
     default_detail_template = (
         "You must be a premium subscriber to make more than"
         " {free_tier_limit} aliases."
     )
-    default_code = "free_tier_limit"
+    status_code = 403
 
     def __init__(self, free_tier_limit: Optional[int] = None, *args, **kwargs):
         self.free_tier_limit = free_tier_limit or settings.MAX_NUM_FREE_ALIASES
@@ -577,38 +573,36 @@ class RelayAddrFreeTierLimitException(CannotMakeRelayAddrException):
 
 
 class CannotMakeDomainAddrException(CannotMakeAddressException):
-    """
-    DomainAddress creation failure.
-
-    Previously implemented as a PermissionDenied exception, so it uses status code 403
-    """
-
-    status_code = 403
+    """DomainAddress creation failure."""
 
 
 class DomainAddrAccountIsPausedException(CannotMakeDomainAddrException):
-    default_detail = "Your account is on pause."
     default_code = "account_is_paused"
+    default_detail = "Your account is on pause."
+    status_code = 403
 
 
 class DomainAddrFreeTierException(CannotMakeDomainAddrException):
-    default_detail = "You must be a premium subscriber to create subdomain aliases."
     default_code = "free_tier_no_subdomain_masks"
+    default_detail = "You must be a premium subscriber to create subdomain aliases."
+    status_code = 403
 
 
 class DomainAddrNeedSubdomainException(CannotMakeDomainAddrException):
+    default_code = "need_subdomain"
     default_detail = (
         "You must select a subdomain before creating email address with subdomain."
     )
-    default_code = "need_subdomain"
+    status_code = 400
 
 
 class DomainAddrUnavailableException(CannotMakeDomainAddrException):
+    default_code = "address_unavailable"
     default_detail_template = (
         'Domain address "{unavailable_address}" could not be created,'
         " try using a different value."
     )
-    default_code = "address_unavailable"
+    status_code = 400
 
     def __init__(self, unavailable_address: str, *args, **kwargs):
         self.unavailable_address = unavailable_address

--- a/emails/models.py
+++ b/emails/models.py
@@ -543,17 +543,13 @@ class CannotMakeAddressException(RelayAPIException):
     """Base exception for RelayAddress or DomainAddress creation failure."""
 
 
-class CannotMakeRelayAddrException(CannotMakeAddressException):
-    """RelayAddress creation failure."""
-
-
-class RelayAddrAccountIsPausedException(CannotMakeRelayAddrException):
+class AccountIsPausedException(CannotMakeAddressException):
     default_code = "account_is_paused"
     default_detail = "Your account is on pause."
     status_code = 403
 
 
-class RelayAddrFreeTierLimitException(CannotMakeRelayAddrException):
+class RelayAddrFreeTierLimitException(CannotMakeAddressException):
     default_code = "free_tier_limit"
     default_detail_template = (
         "You must be a premium subscriber to make more than"
@@ -572,23 +568,13 @@ class RelayAddrFreeTierLimitException(CannotMakeRelayAddrException):
         return {"free_tier_limit": self.free_tier_limit}
 
 
-class CannotMakeDomainAddrException(CannotMakeAddressException):
-    """DomainAddress creation failure."""
-
-
-class DomainAddrAccountIsPausedException(CannotMakeDomainAddrException):
-    default_code = "account_is_paused"
-    default_detail = "Your account is on pause."
-    status_code = 403
-
-
-class DomainAddrFreeTierException(CannotMakeDomainAddrException):
+class DomainAddrFreeTierException(CannotMakeAddressException):
     default_code = "free_tier_no_subdomain_masks"
     default_detail = "You must be a premium subscriber to create subdomain aliases."
     status_code = 403
 
 
-class DomainAddrNeedSubdomainException(CannotMakeDomainAddrException):
+class DomainAddrNeedSubdomainException(CannotMakeAddressException):
     default_code = "need_subdomain"
     default_detail = (
         "You must select a subdomain before creating email address with subdomain."
@@ -596,7 +582,7 @@ class DomainAddrNeedSubdomainException(CannotMakeDomainAddrException):
     status_code = 400
 
 
-class DomainAddrUnavailableException(CannotMakeDomainAddrException):
+class DomainAddrUnavailableException(CannotMakeAddressException):
     default_code = "address_unavailable"
     default_detail_template = (
         'Domain address "{unavailable_address}" could not be created,'
@@ -690,7 +676,7 @@ class RelayAddress(models.Model):
 
 def check_user_can_make_another_address(profile: Profile) -> None:
     if profile.is_flagged:
-        raise RelayAddrAccountIsPausedException()
+        raise AccountIsPausedException()
     if profile.at_max_free_aliases and not profile.has_premium:
         raise RelayAddrFreeTierLimitException()
 
@@ -738,7 +724,7 @@ def check_user_can_make_domain_address(user_profile: Profile) -> None:
         raise DomainAddrNeedSubdomainException()
 
     if user_profile.is_flagged:
-        raise DomainAddrAccountIsPausedException()
+        raise AccountIsPausedException()
 
 
 class DomainAddress(models.Model):

--- a/emails/models.py
+++ b/emails/models.py
@@ -585,7 +585,7 @@ class DomainAddrAccountIsPausedException(CannotMakeDomainAddrException):
 
 class DomainAddrFreeTierException(CannotMakeDomainAddrException):
     default_detail = "You must be a premium subscriber to create subdomain aliases."
-    default_code = "free_tier_no_subdomain_alias"
+    default_code = "free_tier_no_subdomain_masks"
 
 
 class DomainAddrNeedSubdomainException(CannotMakeDomainAddrException):

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -13,13 +13,13 @@ from django.test import (
 )
 
 from allauth.socialaccount.models import SocialAccount
+import pytest
 
 from model_bakery import baker
 
 from ..models import (
     AbuseMetrics,
     address_hash,
-    ACCOUNT_PAUSED_ERR_MSG,
     CannotMakeAddressException,
     CannotMakeSubdomainException,
     DeletedAddress,
@@ -29,11 +29,9 @@ from ..models import (
     has_bad_words,
     hash_subdomain,
     is_blocklisted,
-    NOT_PREMIUM_USER_ERR_MSG,
     Profile,
     RegisteredSubdomain,
     RelayAddress,
-    TRY_DIFFERENT_VALUE_ERR_MSG,
     valid_available_subdomain,
     valid_address,
     valid_address_pattern,
@@ -181,18 +179,16 @@ class RelayAddressTest(TestCase):
         assert relay_address.user == self.user_profile.user
 
     @override_settings(MAX_NUM_FREE_ALIASES=5, MAX_ADDRESS_CREATION_PER_DAY=10)
-    def test_create_has_limit(self):
-        try:
-            for i in range(100):
-                RelayAddress.objects.create(user=self.premium_user_profile.user)
-        except CannotMakeAddressException as e:
-            relay_address_count = RelayAddress.objects.filter(
-                user=self.premium_user_profile.user
-            ).count()
-            assert e.message == ACCOUNT_PAUSED_ERR_MSG
-            assert relay_address_count == 10
-            return
-        self.fail("Should have raised CannotMakeAddressException")
+    def test_create_has_limit(self) -> None:
+        for _ in range(10):
+            RelayAddress.objects.create(user=self.premium_user_profile.user)
+        with pytest.raises(CannotMakeAddressException) as exc_info:
+            RelayAddress.objects.create(user=self.premium_user_profile.user)
+        assert exc_info.value.error_reason == "accountIsPaused"
+        relay_address_count = RelayAddress.objects.filter(
+            user=self.premium_user_profile.user
+        ).count()
+        assert relay_address_count == 10
 
     def test_create_premium_user_can_exceed_free_limit(self):
         for i in range(settings.MAX_NUM_FREE_ALIASES + 1):
@@ -202,20 +198,16 @@ class RelayAddressTest(TestCase):
         ).values_list("address", flat=True)
         assert len(relay_addresses) == settings.MAX_NUM_FREE_ALIASES + 1
 
-    def test_create_non_premium_user_cannot_pass_free_limit(self):
-        try:
-            for i in range(settings.MAX_NUM_FREE_ALIASES + 1):
-                RelayAddress.objects.create(user=self.user_profile.user)
-        except CannotMakeAddressException as e:
-            assert e.message == NOT_PREMIUM_USER_ERR_MSG.format(
-                f"make more than {settings.MAX_NUM_FREE_ALIASES} aliases"
-            )
-            relay_addresses = RelayAddress.objects.filter(
-                user=self.user_profile.user
-            ).values_list("address", flat=True)
-            assert len(relay_addresses) == settings.MAX_NUM_FREE_ALIASES
-            return
-        self.fail("Should have raised CannotMakeSubdomainException")
+    def test_create_non_premium_user_cannot_pass_free_limit(self) -> None:
+        for _ in range(settings.MAX_NUM_FREE_ALIASES):
+            RelayAddress.objects.create(user=self.user_profile.user)
+        with pytest.raises(CannotMakeAddressException) as exc_info:
+            RelayAddress.objects.create(user=self.user_profile.user)
+        assert exc_info.value.error_reason == "freeTierLimit"
+        relay_addresses = RelayAddress.objects.filter(
+            user=self.user_profile.user
+        ).values_list("address", flat=True)
+        assert len(relay_addresses) == settings.MAX_NUM_FREE_ALIASES
 
     @skip(reason="ignore test for code path that we don't actually use")
     def test_create_with_specified_domain(self):
@@ -1046,18 +1038,16 @@ class DomainAddressTest(TestCase):
         assert domain_address.first_emailed_at is None
 
     @override_settings(MAX_ADDRESS_CREATION_PER_DAY=10)
-    def test_make_domain_address_has_limit(self):
-        try:
-            for i in range(100):
-                DomainAddress.make_domain_address(self.user_profile, "foobar" + str(i))
-        except CannotMakeAddressException as e:
-            domain_address_count = DomainAddress.objects.filter(
-                user=self.user_profile.user
-            ).count()
-            assert e.message == ACCOUNT_PAUSED_ERR_MSG
-            assert domain_address_count == 10
-            return
-        self.fail("Should have raised CannotMakeAddressException")
+    def test_make_domain_address_has_limit(self) -> None:
+        for i in range(10):
+            DomainAddress.make_domain_address(self.user_profile, "foobar" + str(i))
+        with pytest.raises(CannotMakeAddressException) as exc_info:
+            DomainAddress.make_domain_address(self.user_profile, "one-too-many")
+        assert exc_info.value.error_reason == "accountIsPaused"
+        domain_address_count = DomainAddress.objects.filter(
+            user=self.user_profile.user
+        ).count()
+        assert domain_address_count == 10
 
     def test_make_domain_address_makes_requested_address_via_email(self):
         domain_address = DomainAddress.make_domain_address(
@@ -1066,24 +1056,19 @@ class DomainAddressTest(TestCase):
         assert domain_address.address == "foobar"
         assert domain_address.first_emailed_at is not None
 
-    def test_make_domain_address_non_premium_user(self):
-        non_preimum_user_profile = baker.make(Profile)
-        try:
+    def test_make_domain_address_non_premium_user(self) -> None:
+        non_premium_user_profile = baker.make(Profile)
+        with pytest.raises(CannotMakeAddressException) as exc_info:
             DomainAddress.make_domain_address(
-                non_preimum_user_profile, "test-non-premium"
+                non_premium_user_profile, "test-non-premium"
             )
-        except CannotMakeAddressException as e:
-            assert e.message == NOT_PREMIUM_USER_ERR_MSG.format(
-                "create subdomain aliases"
-            )
-            return
-        self.fail("Should have raise CannotMakeAddressException")
+        assert exc_info.value.error_reason == "freeTierNoDomainAddress"
 
     def test_make_domain_address_can_make_blocklisted_address(self):
         domain_address = DomainAddress.make_domain_address(self.user_profile, "testing")
         assert domain_address.address == "testing"
 
-    def test_make_domain_address_valid_premium_user_with_no_subdomain(self):
+    def test_make_domain_address_valid_premium_user_with_no_subdomain(self) -> None:
         user = baker.make(User)
         random_sub = random.choice(settings.SUBSCRIPTIONS_WITH_UNLIMITED.split(","))
         baker.make(
@@ -1093,13 +1078,9 @@ class DomainAddressTest(TestCase):
             extra_data={"subscriptions": [random_sub]},
         )
         user_profile = Profile.objects.get(user=user)
-        try:
+        with pytest.raises(CannotMakeAddressException) as exc_info:
             DomainAddress.make_domain_address(user_profile, "test-nosubdomain")
-        except CannotMakeAddressException as e:
-            excpected_err_msg = "You must select a subdomain before creating email address with subdomain."
-            assert e.message == excpected_err_msg
-            return
-        self.fail("Should have raise CannotMakeAddressException")
+        assert exc_info.value.error_reason == "needSubdomain"
 
     @patch.multiple("string", ascii_lowercase="a", digits="")
     def test_make_domain_address_makes_dupe_of_deleted(self):
@@ -1120,14 +1101,9 @@ class DomainAddressTest(TestCase):
         self, address_default_mocked
     ):
         address_default_mocked.return_value = "angry0123"
-        try:
+        with pytest.raises(CannotMakeAddressException) as exc_info:
             DomainAddress.make_domain_address(self.user_profile)
-        except CannotMakeAddressException as e:
-            assert e.message == TRY_DIFFERENT_VALUE_ERR_MSG.format(
-                "Domain address angry0123"
-            )
-            return
-        self.fail("Should have raise CannotMakeAddressException")
+        assert exc_info.value.error_reason == "addressUnavailable"
 
     def test_delete_adds_deleted_address_object(self):
         domain_address = baker.make(DomainAddress, address="lower-case", user=self.user)

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -1062,7 +1062,7 @@ class DomainAddressTest(TestCase):
             DomainAddress.make_domain_address(
                 non_premium_user_profile, "test-non-premium"
             )
-        assert exc_info.value.get_codes() == "free_tier_no_subdomain_alias"
+        assert exc_info.value.get_codes() == "free_tier_no_subdomain_masks"
 
     def test_make_domain_address_can_make_blocklisted_address(self):
         domain_address = DomainAddress.make_domain_address(self.user_profile, "testing")

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -954,6 +954,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
     "DEFAULT_RENDERER_CLASSES": DRF_RENDERERS,
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
+    "EXCEPTION_HANDLER": "api.views.relay_exception_handler",
 }
 
 PHONE_RATE_LIMIT = "5/minute"


### PR DESCRIPTION
This addresses MPP-2451, and reverts a lot of PR #2671:

* Remove `RelayAddressSerializer.validate`. Validation remains in `RelayAddress.save()`
* Add `api.exceptions.RelayAPIException` as base class for Relay exceptions that will include an `error_code`
* Add a custom DRF error handler `api.views.relay_error_handler` that looks for `RelayAPIException` and adds more information:
    - `error_code` - An error code that identifies the error, and can be used as an index into client-side error handling or translation
    - `error_context` - Optional extra data needed for client-side error handling and translation. For example, the `"error_code": "free_tier_limit"` includes `"error_context": "{"free_tier_limit": 5}"
* Convert exceptions raised from creating `RelayAddress` and `DomainAddress` to raise one of a hierarchy of exceptions derived from `RelayAPIException`. These exceptions have the details of the status code, messages, `error_code`, etc., and are no longer passed at exception creation.
* Change `DomainAddressViewSet.perform_create` to no longer handle `CannotMakeAddressException`, since `relay_error_handler` now does the needed work.

The exception hierarchy:

* `APIException` - provided by Django REST Framework
    * `RelayAPIException` - includes `error_context()`, gets special error handling
        * `CannotMakeAddressException` - expected by lots of test code
            * `AccountIsPausedException` - `error_code` = `account_is_paused`, 403
            * `RelayAddrFreeTierLimitException` - `error_code` = `free_tier_limit`, 403
            * `DomainAddrFreeTierException` - `error_code` = `free_tier_no_subdomain_masks`, 403
            * `DomainAddrNeedSubdomainException` - `error_code` = `need_subdomain`, 400
            * `DomainAddrUnavailableException` - `error_code` = `address_unavailable`, 400

The exceptions for failing to set a subdomain and other runtime errors can be added into this hierarchy.

Some additional changes:
* Free users can pass `"block_list_emails": false` to `RelayAddressSerializer`. Previously, they had to omit the key entirely.
* `DomainAddress.make_domain_address` is now properly decorated as a `@staticmethod`
* Added type annotations to changed methods in `emails.models`
* Added type annotations to tests
* Refactored existing tests to use `with pytest.raises(CannotMakeAddressException)` instead of explicit `try`/`catch`/`return`/`fail`
* Tested models via the new `CannotMakeAddressException.get_codes()` rather than the sentence `.message`, which may change or get translated.

I'm going to tackle error translation (which we might not implement) in a future PR. However, I think this design would be compatible with translations, by generating a Fluent string ID from the error code (`account_is_paused` → `relay-api-error-account-is-paused`) and / or specifying a string ID on the exception.

## Test process

Suggested tests:

* Test website for flagged users
    * [x] Create or select a premium user  
    * [x] In the Django admin, add a `Last Account Flagged` of Today / Now for the test user. You may have to temporarily clear the Subdomain
    * [x] In the application, attempt to create a random mask. You get the message "This mask could not be created. Please try again"
    * [x] In the application, select a subdomain if needed, and attempt to create a subdomain mask. You get the message "This mask could not me created. Please try again."
    * [x] Go to http://127.0.0.1:8000/api/v1/docs/. Attempt to create a subdomain mask via `POST /domainaddresses`. You get the error JSON:
      ```json
      {
        "detail": "Your account is on pause.",
        "error_code": "account_is_paused"
      }
      ```
    * [x] Still in API docs, attempt to create a random mask via `POST /relayaddresses`. You get the error JSON:
      ```json
      {
        "detail": "Your account is on pause.",
        "error_code": "account_is_paused"
      }
      ```
    * [x] In the Django Admin, clear the Last Account Flagged and reset the subdomain.

Similar tests may be needed to check the add-on