### PR TITLE
Remove unneeded arrow on block level description

### DIFF
--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.module.scss
@@ -274,6 +274,10 @@ $trackLineHeight: 4px;
       // would cause a lot of jumping around:
       min-height: 150px;
 
+      &::after {
+        display: none;
+      }
+
       img {
         display: inline-block;
       }


### PR DESCRIPTION
When the description of the current block level is displayed underneath the slider (i.e. on small screens), an arrow connects it to the slider. On larger screens, however, it is to the side and is connected through positioning, so the arrow should not be visible (and, in fact, displayed as a floating rhombus).

I think this has been there from the start, but QA just has a very sharp eye and possibly a screen with better contrast :P 

![image](https://user-images.githubusercontent.com/4251/197573711-3743d83b-0ddf-4db3-a739-b69ffd5e62b3.png)

(The other demonstrated issue was fixed in https://github.com/mozilla/fx-private-relay/pull/2672.)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
