### PR TITLE
Python dependency updates, October 25, 2022

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ sentry-sdk==1.9.10
 whitenoise==6.2.0
 
 # phones app
-phonenumbers==8.12.56
+phonenumbers==8.12.57
 twilio==7.14.2
 vobject==0.9.6.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.24.89
+boto3==1.25.1
 codetiming==1.3.2
 cryptography==38.0.2
 Django==3.2.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyJWT==2.5.0
 python-decouple==3.6
 pyOpenSSL==22.1.0
 requests==2.28.1
-sentry-sdk==1.9.10
+sentry-sdk==1.10.1
 whitenoise==6.2.0
 
 # phones app

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,6 @@ black==22.10.0
 # type hinting
 mypy==0.982
 types-requests==2.28.11.2
-types-pyOpenSSL==22.1.0.0
+types-pyOpenSSL==22.1.0.1
 django-stubs==1.12.0
 djangorestframework-stubs==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ vobject==0.9.6.1
 
 # tests
 coverage==6.5.0
-model-bakery==1.7.1
+model-bakery==1.9.0
 pytest-cov==4.0.0
 pytest-django==4.5.2
 responses==0.22.0


### PR DESCRIPTION
Update Python dependencies. This covers:

* Bump types-pyopenssl from 22.1.0.0 to 22.1.0.1 (from PR #2653) - updated type definitions
* Bump phonenumbers from 8.12.56 to 8.12.57 (from PR #2654) - updated metadata
* Bump sentry-sdk from 1.9.10 to 1.10.1 (from PR #2681) - Unified naming for span ops, not yet used by our code
* Bump model-bakery from 1.7.1 to 1.9.0 (from PR #2693) - Breaking improvements, our test code is OK
* Bump boto3 from 1.24.89 to 1.25.1 (from PR #2702) - Another week, another set of AWS tweaks