### PR TITLE
Add caching and compression for static files

### DIFF
--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -127,6 +127,16 @@ class StoreFirstVisit:
 
 
 class RelayStaticFilesMiddleware(WhiteNoiseMiddleware):
+    """Customize WhiteNoiseMiddleware for Relay.
+
+    The WhiteNoiseMiddleware serves static files and sets headers. In
+    production, the files are read from staticfiles/staticfiles.json,
+    and files with hashes in the name are treated as immutable with
+    10-year cache timeouts.
+
+    This class also treats Next.js output files (already hashed) as immutable.
+    """
+
     def immutable_file_test(self, path, url):
         """
         Determine whether given URL represents an immutable file (i.e. a

--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -10,6 +10,7 @@ from django.shortcuts import redirect
 
 from allauth.socialaccount.models import SocialToken
 from allauth.socialaccount.providers.fxa.views import FirefoxAccountsOAuth2Adapter
+from whitenoise.middleware import WhiteNoiseMiddleware
 
 from .views import _get_oauth2_session, update_social_token, NoSocialToken
 
@@ -123,3 +124,21 @@ class StoreFirstVisit:
         if first_visit is None and not request.user.is_anonymous:
             response.set_cookie("first_visit", datetime.now(timezone.utc))
         return response
+
+
+class RelayStaticFilesMiddleware(WhiteNoiseMiddleware):
+    def immutable_file_test(self, path, url):
+        """
+        Determine whether given URL represents an immutable file (i.e. a
+        file with a hash of its contents as part of its name) which can
+        therefore be cached forever.
+
+        All files outputed by next.js are hashed and immutable
+        """
+        if not url.startswith(self.static_prefix):
+            return False
+        name = url[len(self.static_prefix) :]
+        if name.startswith("_next/static/"):
+            return True
+        else:
+            return super().immutable_file_test(path, url)

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -271,7 +271,7 @@ MIDDLEWARE += [
     "django.middleware.security.SecurityMiddleware",
     "csp.middleware.CSPMiddleware",
     "privaterelay.middleware.RedirectRootIfLoggedIn",
-    "whitenoise.middleware.WhiteNoiseMiddleware",
+    "privaterelay.middleware.RelayStaticFilesMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -837,6 +837,7 @@ if settings.DEBUG:
     # all files spewed out by `npm run watch` in /frontend/out,
     # and we're fine with the performance impact of that.
     WHITENOISE_ROOT = os.path.join(BASE_DIR, "frontend/out")
+STATICFILES_STORAGE = "privaterelay.storage.RelayStaticFilesStorage"
 
 # Relay does not support user-uploaded files
 MEDIA_ROOT = None

--- a/privaterelay/storage.py
+++ b/privaterelay/storage.py
@@ -18,7 +18,7 @@ class RelayStaticFilesStorage(CompressedManifestStaticFilesStorage):
     The Whitenoise CompressedManifestStaticFilesStorage [2] builds on this by
     pre-compressing files as well, so that the gzipped versions can be served.
 
-    This class skips renaming files from next.js, which already include hashes
+    This class skips renaming files from Next.js, which already include hashes
     in the filenames.
 
     [1] https://docs.djangoproject.com/en/3.2/ref/contrib/staticfiles/#manifeststaticfilesstorage
@@ -26,7 +26,7 @@ class RelayStaticFilesStorage(CompressedManifestStaticFilesStorage):
     """
 
     def hashed_name(self, name, content=None, filename=None):
-        """Skip hashing files output by next.js"""
+        """Skip hashing files output by Next.js"""
         if name.startswith("_next/static/"):
             return name
         else:

--- a/privaterelay/storage.py
+++ b/privaterelay/storage.py
@@ -1,0 +1,33 @@
+"""
+Staticfiles storage implementation for Relay.
+
+This is used when running ./manage.py collectstatic, or rendering Django templates.
+"""
+from whitenoise.storage import CompressedManifestStaticFilesStorage
+
+
+class RelayStaticFilesStorage(CompressedManifestStaticFilesStorage):
+    """
+    Customize Whitenoise storage for Relay
+
+    The Django ManifestStaticFilesStorage [1] creates a copy of each file that
+    includes a hash of its contents, and serves these with a long cache time.
+    It also creates staticfiles/staticfiles.json that lists all the known static
+    files, rather than scanning the folder for files at startup.
+
+    The Whitenoise CompressedManifestStaticFilesStorage [2] builds on this by
+    pre-compressing files as well, so that the gzipped versions can be served.
+
+    This class skips renaming files from next.js, which already include hashes
+    in the filenames.
+
+    [1] https://docs.djangoproject.com/en/3.2/ref/contrib/staticfiles/#manifeststaticfilesstorage
+    [2] http://whitenoise.evans.io/en/stable/django.html#add-compression-and-caching-support
+    """
+
+    def hashed_name(self, name, content=None, filename=None):
+        """Skip hashing files output by next.js"""
+        if name.startswith("_next/static/"):
+            return name
+        else:
+            return super().hashed_name(name, content, filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ module = [
     "vobject",
     "waffle",
     "waffle.models",
+    "whitenoise.middleware",
+    "whitenoise.storage",
 ]
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
This is an alternate for PR #2679 

Use Whitenoise's [CompressedManifestStaticFilesStorage](http://whitenoise.evans.io/en/stable/django.html#add-compression-and-caching-support) for hashed files and gzip-compressed versions, but extend it to skip hashing of Next.js files, which already include hashes in the filename.

Use Whitenoise's middleware, but consider all Next.js files to be immutable, so they get long cache times.

Next.js files are identified by being in the `_next/static` folder.

The behavior does not change with `DEBUG=True`. When logged out and requesting the homepage:

- The homepage has header `Cache-Control: no-cache, public`
- CSS like `_next/static/css/b10b975241d9d9b6.css` have header `Cache-Control: max-age=0, public`
- Images like `_next/static/media/hero-image-nopremium.ca4d2ad8.svg` have header `Cache-Control: max-age=0, public`
- Fonts like `fonts/Inter/Inter-Regular.woff2?v=3.18` have header `Cache-Control: max-age=0, public`

The change is with `DEBUG=False`:

* Stop the server if running
* Set `DEBUG=False` in `.env`
* Build frontend if needed (`cd frontend; npm install; npm run build; cd -`)
* Collect staticfiles with `./manage.py collectstatic -v 2 --clear --noinput`
    - Before this change, files are copied to `staticfiles/`, with an output like `1248 static files copied to 'my-projects/fx-private-relay/staticfiles'`
    - After this change, files are copied to `staticfiles/`, gzipped versions are created, and `staticfiles/staticfiles.json` is written, with output like `1248 static files copied to 'my-projects/fx-private-relay/staticfiles', 1664 post-processed.`
* Run the server with `./manage.py runserver`

Before this change, when logged out and requesting the `DEBUG=False` homepage, the cache times increase to 60 seconds:

- The homepage has header `Cache-Control: no-cache, public`
- CSS like `_next/static/css/b10b975241d9d9b6.css` have header `Cache-Control: max-age=60, public`
- Images like `_next/static/media/hero-image-nopremium.ca4d2ad8.svg` have header `Cache-Control: max-age=60, public`
- Fonts like `fonts/Inter/Inter-Regular.woff2?v=3.18` have header `Cache-Control: max-age=60, public`

After this change, with `DEBUG=False`, cache times increase to 10 years, and some are gzipped:

- The homepage still has header `Cache-Control: no-cache, public`, but also `Content-Encoding: gzip`
- CSS like `_next/static/css/b10b975241d9d9b6.css` have headers `Cache-Control: max-age=315360000, public, immutable`, `Content-Encoding: gzip`
- Images like `_next/static/media/hero-image-nopremium.ca4d2ad8.svg` have header `Cache-Control: max-age=315360000, public, immutable`, `Content-Encoding: gzip`
- Fonts like `fonts/Inter/Inter-Regular.4232a675a077.woff2?v=3.18` have header `Cache-Control: max-age=315360000, public, immutable` (URL has hash in name, but no gzip header)
