### PR TITLE
Reduce overall mask creation modal size on mobile breakpoint

### DIFF
--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.module.scss
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.module.scss
@@ -28,20 +28,35 @@
       text-align: center;
       border-radius: $border-radius-md;
       background-color: $color-light-gray-10;
-      padding: $spacing-lg $spacing-md;
+      padding: $spacing-md $spacing-sm;
+
+      @media screen and #{$mq-sm} {
+        padding: $spacing-lg $spacing-md;
+      }
     }
 
     .warning {
       display: flex;
       align-items: center;
       gap: $spacing-lg;
-      padding: $spacing-lg $spacing-sm;
+      padding: $spacing-md $spacing-sm;
       border-bottom: 1px solid $color-light-gray-20;
       word-break: break-word;
 
+      @media screen and #{$mq-sm} {
+        padding: $spacing-lg $spacing-sm;
+      }
+
       .warning-icon {
+        // There is limited space on the mask creation modal on mobile.
+        // Hiding this icon until larger screens increases the available space for copy.
+        display: none;
         color: $color-pink-30;
         padding: $spacing-sm;
+
+        @media screen and #{$mq-sm} {
+          display: block;
+        }
 
         svg {
           max-width: unset;
@@ -54,7 +69,11 @@
 
       .form-heading {
         color: $color-dark-gray-70;
-        padding: $spacing-lg 0;
+        padding: $spacing-md 0;
+
+        @media screen and #{$mq-sm} {
+          padding: $spacing-lg 0;
+        }
       }
 
       .prefix {
@@ -89,9 +108,13 @@
       align-items: center;
       justify-content: center;
       gap: $spacing-sm;
-      padding: $spacing-lg $spacing-sm 0;
+      padding: $spacing-md $spacing-sm 0;
       font-family: $font-stack-firefox;
       accent-color: $color-blue-50;
+
+      @media screen and #{$mq-sm} {
+        padding: $spacing-lg $spacing-sm 0;
+      }
 
       .promotionals-blocking-description {
         a {
@@ -110,7 +133,11 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding-top: $spacing-xl;
+      padding-top: $spacing-lg;
+
+      @media screen and #{$mq-sm} {
+        padding-top: $spacing-xl;
+      }
 
       .cancel-button {
         border-style: none;


### PR DESCRIPTION
This PR fixes [MPP-2479](https://mozilla-hub.atlassian.net/browse/MPP-2479)

How to test:
- Test on mobile device or set browser screen size to mobile
- Log in with premium account and subdomain registered
- Click "Generate New Mask" and use custom mask
- **Expected:** The mobile menu should fit better on the screen, and not have clipping/inaccessible areas (compared to what is on prod) 

## Checklist
- [ ] ~l10n changes have been submitted to the l10n repository, if any.~
- [ ] ~I've added a unit test to test for potential regressions of this bug.~
- [ ] ~I've added or updated relevant docs in the docs/ directory.~
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

# Screenshot (if applicable)

![Screen Shot 2022-10-26 at 13 11 12](https://user-images.githubusercontent.com/2692333/198106352-b889e572-6a44-441d-9972-7ebb9af91fa2.png)
