### PR TITLE
MPP-2503: Prepare for profile.user as OneToOneField

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -9,13 +9,15 @@ from emails.models import DomainAddress, Profile, RelayAddress
 class PremiumValidatorsMixin:
     # the user must be premium to set block_list_emails=True
     def validate_block_list_emails(self, value):
-        if value:
-            user = self.context["request"].user
-            prefetch_related_objects([user], "socialaccount_set", "profile_set")
-            if not user.profile_set.get().has_premium:
-                raise exceptions.AuthenticationFailed(
-                    "Must be premium to set block_list_emails."
-                )
+        if not value:
+            return value
+        user = self.context["request"].user
+        prefetch_related_objects([user], "socialaccount_set", "profile_set")
+        if not user.profile_set.get().has_premium:
+            raise exceptions.AuthenticationFailed(
+                "Must be premium to set block_list_emails."
+            )
+        return value
         return value
 
 

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -1162,11 +1162,10 @@ def test_voice_status_completed_reduces_remaining_seconds_to_negative_value(
     assert response.status_code == 200
     relay_number.refresh_from_db()
     assert relay_number.remaining_seconds == -27
-    profile = phone_user.profile_set.first()
     mocked_events_info.assert_called_once_with(
         "phone_limit_exceeded",
         extra={
-            "fxa_uid": profile.fxa.uid,
+            "fxa_uid": phone_user.profile_set.get().fxa.uid,
             "call_duration_in_seconds": 27,
             "relay_number_enabled": True,
             "remaining_seconds": -27,

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -578,11 +578,10 @@ def voice_status(request):
     relay_number.remaining_seconds = relay_number.remaining_seconds - int(call_duration)
     relay_number.save()
     if relay_number.remaining_seconds < 0:
-        profile = relay_number.user.profile_set.first()
         info_logger.info(
             "phone_limit_exceeded",
             extra={
-                "fxa_uid": profile.fxa.uid,
+                "fxa_uid": relay_number.user.profile_set.get().fxa.uid,
                 "call_duration_in_seconds": int(call_duration),
                 "relay_number_enabled": relay_number.enabled,
                 "remaining_seconds": relay_number.remaining_seconds,

--- a/emails/cleaners.py
+++ b/emails/cleaners.py
@@ -218,6 +218,7 @@ class MissingProfileCleaner(CleanerTask):
 
 
 class ManyProfileDetector(DetectorTask):
+    # TODO: #2708 Remove this detector when Profile.user is a OneToOneField
     slug = "many-profiles"
     title = "Counts users with multiple profiles"
     check_description = "Users should not have multiple profiles."

--- a/emails/models.py
+++ b/emails/models.py
@@ -82,6 +82,7 @@ def default_domain_numerical():
 
 
 class Profile(models.Model):
+    # TODO: #2708 Change to OneToOneField
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     api_token = models.UUIDField(default=uuid.uuid4)
     num_address_deleted = models.PositiveIntegerField(default=0)
@@ -658,8 +659,7 @@ class RelayAddress(models.Model):
                         break
                     self.address = address_default()
                 locked_profile.update_abuse_metric(address_created=True)
-        profile = self.user.profile_set.first()
-        if not profile.server_storage:
+        if not self.user.profile_set.get().server_storage:
             self.description = ""
             self.generated_for = ""
             self.used_on = ""
@@ -851,7 +851,7 @@ class Reply(models.Model):
 
     @property
     def profile(self):
-        return self.address.user.profile_set.first()
+        return self.address.user.profile_set.get()
 
     @property
     def owner_has_premium(self):

--- a/emails/signals.py
+++ b/emails/signals.py
@@ -22,7 +22,7 @@ def create_user_profile(sender, instance, created, **kwargs):
 
 
 def check_premium_for_block_list_emails(sender, instance, **kwargs):
-    if not instance.user.profile_set.first().has_premium:
+    if not instance.user.profile_set.get().has_premium:
         try:
             obj = sender.objects.get(pk=instance.pk)
             if obj.block_list_emails != instance.block_list_emails:

--- a/emails/tests/cleaners_tests.py
+++ b/emails/tests/cleaners_tests.py
@@ -293,10 +293,7 @@ def setup_profile_mismatch_test_data(add_problems=False):
         return
 
     r2 = baker.make(User, email="regular2@example.com")
-    p2 = r2.profile_set.get()
-    r3 = baker.make(User, email="regular3@example.com")
-    # Assign user #2's profile to user #3, leaving r2 with none and r3 with 3
-    Profile.objects.filter(id=p2.id).update(user_id=r3.id)
+    r2.profile_set.get().delete()
 
 
 @pytest.mark.django_db
@@ -345,29 +342,29 @@ def test_missing_profile_cleaner_with_problems() -> None:
     task = MissingProfileCleaner()
     assert task.issues() == 1
     assert task.counts == {
-        "summary": {"ok": 5, "needs_cleaning": 1},
-        "users": {"all": 6, "has_profile": 5, "no_profile": 1},
+        "summary": {"ok": 4, "needs_cleaning": 1},
+        "users": {"all": 5, "has_profile": 4, "no_profile": 1},
     }
     report = task.markdown_report()
     expected = """\
 Users:
-  All: 6
-    Has Profile: 5 ( 83.3%)
-    No Profile : 1 ( 16.7%)"""
+  All: 5
+    Has Profile: 4 ( 80.0%)
+    No Profile : 1 ( 20.0%)"""
     assert report == expected
 
     # Clean the data, check updates
     assert task.clean() == 1
     assert task.counts == {
-        "summary": {"ok": 5, "needs_cleaning": 1, "cleaned": 1},
-        "users": {"all": 6, "has_profile": 5, "no_profile": 1, "cleaned": 1},
+        "summary": {"ok": 4, "needs_cleaning": 1, "cleaned": 1},
+        "users": {"all": 5, "has_profile": 4, "no_profile": 1, "cleaned": 1},
     }
     report = task.markdown_report()
     expected = """\
 Users:
-  All: 6
-    Has Profile: 5 ( 83.3%)
-    No Profile : 1 ( 16.7%)
+  All: 5
+    Has Profile: 4 ( 80.0%)
+    No Profile : 1 ( 20.0%)
       Now has Profile: 1 (100.0%)"""
     assert report == expected
 
@@ -411,25 +408,4 @@ Users:
   All: 4
     One or no Profile: 4 (100.0%)
     Many Profiles    : 0 (  0.0%)"""
-    assert report == expected
-
-
-@pytest.mark.django_db
-def test_many_profile_detector_with_problems() -> None:
-    """ManyProfileDetector detects users with multiple profiles."""
-    setup_profile_mismatch_test_data(add_problems=True)
-
-    task = ManyProfileDetector()
-    assert task.issues() == 1
-    assert task.counts == {
-        "summary": {"ok": 5, "needs_cleaning": 1},
-        "users": {"all": 6, "one_or_no_profile": 5, "many_profiles": 1},
-    }
-    assert task.clean() == 0
-    report = task.markdown_report()
-    expected = """\
-Users:
-  All: 6
-    One or no Profile: 5 ( 83.3%)
-    Many Profiles    : 1 ( 16.7%)"""
     assert report == expected

--- a/emails/tests/cleaners_tests.py
+++ b/emails/tests/cleaners_tests.py
@@ -260,9 +260,7 @@ Domain Addresses:
 
     # Check that data is cleaned or remains as desired
     for r_address in RelayAddress.objects.all():
-        profile = r_address.user.profile_set.first()
-        assert profile
-        if profile.server_storage:
+        if r_address.user.profile_set.get().server_storage:
             assert r_address.used_on
             assert r_address.description
             assert r_address.generated_for
@@ -272,9 +270,7 @@ Domain Addresses:
             assert r_address.generated_for == ""
 
     for d_address in DomainAddress.objects.all():
-        profile = d_address.user.profile_set.first()
-        assert profile
-        if profile.server_storage:
+        if d_address.user.profile_set.get().server_storage:
             assert d_address.used_on
             assert d_address.description
         else:
@@ -297,7 +293,7 @@ def setup_profile_mismatch_test_data(add_problems=False):
         return
 
     r2 = baker.make(User, email="regular2@example.com")
-    p2 = r2.profile_set.first()
+    p2 = r2.profile_set.get()
     r3 = baker.make(User, email="regular3@example.com")
     # Assign user #2's profile to user #3, leaving r2 with none and r3 with 3
     Profile.objects.filter(id=p2.id).update(user_id=r3.id)
@@ -377,8 +373,7 @@ Users:
 
     # Check that all users have profiles
     for user in User.objects.all():
-        profile = user.profile_set.first()
-        assert profile
+        assert user.profile_set.get()
 
 
 @pytest.mark.django_db

--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -79,10 +79,9 @@ class FormattingToolsTest(TestCase):
 
     def test_generate_relay_From_with_premium_user(self):
         premium_user = make_premium_test_user()
-        premium_profile = premium_user.profile_set.first()
         original_from_address = '"foo bar" <foo@bar.com>'
         formatted_from_address = generate_relay_From(
-            original_from_address, premium_profile
+            original_from_address, premium_user.profile_set.get()
         )
 
         expected_encoded_display_name = (
@@ -104,7 +103,7 @@ class FormattingToolsTest(TestCase):
         new_from_flag.users.add(free_user)
         original_from_address = '"foo bar" <foo@bar.com>'
         formatted_from_address = generate_relay_From(
-            original_from_address, free_user.profile_set.first()
+            original_from_address, free_user.profile_set.get()
         )
         expected_encoded_display_name = (
             "=?utf-8?b?IiJmb28gYmFyIiA8Zm9vQGJhci5jb20+IFt2aWEgUmVsYXldIg==?="
@@ -126,7 +125,7 @@ class FormattingToolsTest(TestCase):
         Flag.objects.create(name=NEW_FROM_ADDRESS_FLAG_NAME)
         original_from_address = '"foo bar" <foo@bar.com>'
         formatted_from_address = generate_relay_From(
-            original_from_address, free_user.profile_set.first()
+            original_from_address, free_user.profile_set.get()
         )
         expected_encoded_display_name = (
             "=?utf-8?b?IiJmb28gYmFyIiA8Zm9vQGJhci5jb20+IFt2aWEgUmVsYXldIg==?="
@@ -146,7 +145,7 @@ class FormattingToolsTest(TestCase):
         Flag.objects.create(name=NEW_FROM_ADDRESS_FLAG_NAME)
         original_from_address = '"foo bar" <foo@bar.com>'
         formatted_from_address = generate_relay_From(
-            original_from_address, free_user.profile_set.first()
+            original_from_address, free_user.profile_set.get()
         )
         expected_encoded_display_name = (
             "=?utf-8?b?IiJmb28gYmFyIiA8Zm9vQGJhci5jb20+IFt2aWEgUmVsYXldIg==?="

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -86,7 +86,7 @@ class SNSNotificationTest(TestCase):
     def setUp(self):
         # FIXME: this should make an object so that the test passes
         self.user = baker.make(User)
-        self.profile = self.user.profile_set.first()
+        self.profile = self.user.profile_set.get()
         self.sa = baker.make(SocialAccount, user=self.user, provider="fxa")
         self.ra = baker.make(
             RelayAddress, user=self.user, address="ebsbdsan7", domain=2
@@ -210,14 +210,14 @@ class SNSNotificationTest(TestCase):
 
 class BounceHandlingTest(TestCase):
     def setUp(self):
-        self.user = baker.make(User, email="relayuser@test.com", make_m2m=True)
+        self.user = baker.make(User, email="relayuser@test.com")
 
     def test_sns_message_with_hard_bounce(self):
         pre_request_datetime = datetime.now(timezone.utc)
 
         _sns_notification(BOUNCE_SNS_BODIES["hard"])
 
-        profile = self.user.profile_set.first()
+        profile = self.user.profile_set.get()
         assert profile.last_hard_bounce >= pre_request_datetime
 
     def test_sns_message_with_soft_bounce(self):
@@ -225,12 +225,12 @@ class BounceHandlingTest(TestCase):
 
         _sns_notification(BOUNCE_SNS_BODIES["soft"])
 
-        profile = self.user.profile_set.first()
+        profile = self.user.profile_set.get()
         assert profile.last_soft_bounce >= pre_request_datetime
 
     def test_sns_message_with_spam_bounce_sets_auto_block_spam(self):
         _sns_notification(BOUNCE_SNS_BODIES["spam"])
-        profile = self.user.profile_set.first()
+        profile = self.user.profile_set.get()
         assert profile.auto_block_spam == True
 
 
@@ -519,7 +519,7 @@ class SNSNotificationValidUserEmailsInS3Test(TestCase):
         self.bucket = "test-bucket"
         self.key = "/emails/objectkey123"
         self.user = baker.make(User, email="sender@test.com", make_m2m=True)
-        self.profile = self.user.profile_set.first()
+        self.profile = self.user.profile_set.get()
         assert self.profile is not None
         self.address = baker.make(
             RelayAddress, user=self.user, address="sender", domain=2
@@ -672,7 +672,7 @@ class SNSNotificationValidUserEmailsInS3Test(TestCase):
 class SnsMessageTest(TestCase):
     def setUp(self) -> None:
         self.user = baker.make(User)
-        self.profile = self.user.profile_set.first()
+        self.profile = self.user.profile_set.get()
         assert self.profile is not None
         self.sa: SocialAccount = baker.make(
             SocialAccount, user=self.user, provider="fxa"

--- a/privaterelay/context_processors.py
+++ b/privaterelay/context_processors.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from functools import lru_cache
 
 from django.conf import settings
+from django.db.models import prefetch_related_objects
 
 from .templatetags.relay_tags import premium_plan_price
 from .utils import get_premium_countries_info_from_request
@@ -53,9 +54,8 @@ def _get_fxa(request):
 def _get_csat_cookie_and_reason(request):
     if not request.user.is_authenticated:
         return None, None
-    profile = request.user.profile_set.prefetch_related(
-        "user__socialaccount_set"
-    ).first()
+    prefetch_related_objects([request.user], "socialaccount_set", "profile_set")
+    profile = request.user.profile_set.get()
     first_visit = request.COOKIES.get(
         "first_visit", datetime.now(timezone.utc).isoformat()
     )

--- a/privaterelay/management/commands/cleanup_data.py
+++ b/privaterelay/management/commands/cleanup_data.py
@@ -237,11 +237,15 @@ class Command(BaseCommand):
             detail = [f"## {slug}"]
             detail.extend(textwrap.wrap(task["check_description"], width=80))
             detail.append("")
-            detail.append(f"Detected {needs_cleaning} issues in {query_timer} seconds.")
+            detail.append(
+                f"Detected {needs_cleaning} issue{'' if needs_cleaning == 1 else 's'}"
+                f" in {query_timer} seconds."
+            )
             if cleaned:
                 if task["can_clean"]:
                     detail.append(
-                        f"Cleaned {num_cleaned} issues in {clean_timer} seconds."
+                        f"Cleaned {num_cleaned} issue{'' if num_cleaned == 1 else 's'}"
+                        f" in {clean_timer} seconds."
                     )
                 elif needs_cleaning:
                     detail.append("Unable to automatically clean detected items.")

--- a/privaterelay/management/commands/update_phone_remaining_stats.py
+++ b/privaterelay/management/commands/update_phone_remaining_stats.py
@@ -24,7 +24,7 @@ def update_phone_remaining_stats():
         accounts_with_phones.extend(list(social_accounts))
     updated_profiles = []
     for social_account in accounts_with_phones:
-        profile = social_account.user.profile_set.first()
+        profile = social_account.user.profile_set.get()
         # Has it been more than 30 days since we last checked the user's phone
         # subscription?
         if (

--- a/privaterelay/templates/base.html
+++ b/privaterelay/templates/base.html
@@ -8,7 +8,7 @@
 {% endif %}
 {% ftlconf bundle='privaterelay.ftl_bundles.main' %}
 
-{% with request.user.profile_set.first as user_profile %}
+{% with request.user.profile_set.get() as user_profile %}
 {% with user_profile.has_premium as user_has_premium %}
 <!DOCTYPE html>
 <html lang="{{ request.LANGUAGE_CODE }}" dir="ltr">

--- a/privaterelay/tests/mgmt_cleanup_data_tests.py
+++ b/privaterelay/tests/mgmt_cleanup_data_tests.py
@@ -112,14 +112,14 @@ def test_selected_cleaner(caplog) -> None:
 
 
 @pytest.mark.django_db
-def test_issues_found_by_detector() -> None:
-    """When a detector finds an issue, a warning is included in detailed report."""
+def test_issues_cleaned_by_detector() -> None:
+    """When a detector finds an issue, it cleans it."""
     setup_profile_mismatch_test_data(add_problems=True)
     out = StringIO()
     call_command(
-        COMMAND_NAME, "--many-profiles", "--clean", "--verbosity=2", stdout=out
+        COMMAND_NAME, "--missing-profile", "--clean", "--verbosity=2", stdout=out
     )
     output = out.getvalue()
     assert "# Summary\n" in output
     assert "# Details\n" in output
-    assert "Unable to automatically clean detected items.\n" in output
+    assert "Cleaned 1 issue in " in output

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -59,8 +59,7 @@ class UpdateExtraDataAndEmailTest(TestCase):
 
         assert response.status_code == 202
         sa.refresh_from_db()
-        profile = sa.user.profile_set.first()
-        assert profile.date_subscribed
+        assert sa.user.profile_set.get().date_subscribed
         assert sa.extra_data == new_extra_data
         incr_mocked.assert_called_once()
 
@@ -81,8 +80,7 @@ class UpdateExtraDataAndEmailTest(TestCase):
 
         assert response.status_code == 202
         sa.refresh_from_db()
-        profile = sa.user.profile_set.first()
-        assert profile.date_subscribed_phone
+        assert sa.user.profile_set.get().date_subscribed_phone
         assert sa.extra_data == new_extra_data
         incr_mocked.assert_called_once()
 

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -60,7 +60,7 @@ def _get_fxa(request):
 def profile_refresh(request):
     if not request.user or request.user.is_anonymous:
         return redirect(reverse("fxa_login"))
-    profile = request.user.profile_set.first()
+    profile = request.user.profile_set.get()
 
     fxa = _get_fxa(request)
     update_fxa(fxa)
@@ -77,7 +77,7 @@ def profile_refresh(request):
 def profile_subdomain(request):
     if not request.user or request.user.is_anonymous:
         return redirect(reverse("fxa_login"))
-    profile = request.user.profile_set.first()
+    profile = request.user.profile_set.get()
     if not profile.has_premium:
         raise CannotMakeSubdomainException("error-premium-check-subdomain")
     try:
@@ -266,13 +266,13 @@ def update_fxa(social_account, authentic_jwt=None, event_key=None):
 
 def _update_all_data(social_account, extra_data, new_email):
     try:
-        profile = social_account.user.profile_set.first()
+        profile = social_account.user.profile_set.get()
         had_premium = profile.has_premium
         had_phone = profile.has_phone
         with transaction.atomic():
             social_account.extra_data = extra_data
             social_account.save()
-            profile = social_account.user.profile_set.first()
+            profile = social_account.user.profile_set.get()
             now_has_premium = profile.has_premium
             newly_premium = not had_premium and now_has_premium
             no_longer_premium = had_premium and not now_has_premium


### PR DESCRIPTION
This addresses issue #2708 / MPP-2503. It needs to be fixed over two deployments, first to prepare the code and tests, and second to make the migration and final code changes. PR #2711 attempted to do it all at once, and failed the migrations tests.

When `Profile.user` switches from a `ForeignKey` to a [OneToOneField](https://docs.djangoproject.com/en/3.2/topics/db/examples/one_to_one/), access will change from `user.profile_set.get()` to `user.profile`. Prepare the code for this change:
    
* Switch from `user.profile_set.first()` to `.get()`, which errors if there is not exactly one profile. We've confirmed that no users in deployed systems have multiple profiles, and ones with no profile appear to be unused, and could be fixed at runtime.
* Simplify some code if a `profile` variable was used once.
* Use [prefetch_related_objects](https://docs.djangoproject.com/en/3.2/ref/models/querysets/#prefetch-related-objects) on a `User` object instead of `profile_set.prefetch_related`, which will stop working when the `profile_set` queryset is no longer available.
* In tests, use `baker.make(User).profile_set.get()` instead of `baker.make(Profile)`, because of weirdness using the later after the migration.
* Deprecate `./manage.py cleanup_data --many-profiles`, since soon the database will enforce that no user can have multiple profiles. Remove the test code that creates a use with multiple profiles, and the test that detects it.

**Testing**
I believe the integration tests are sufficient to show this code works.