### PR TITLE
Remove extra $ sign from pricing matrix header

### DIFF
--- a/frontend/src/components/landing/PlanMatrix.tsx
+++ b/frontend/src/components/landing/PlanMatrix.tsx
@@ -524,7 +524,7 @@ export const PlanMatrix = (props: Props) => {
       {isFlagActive(props.runtimeData, "bundle") &&
         isBundleAvailableInCountry(props.runtimeData) && (
           <h2 className={styles["bundle-offer-heading"]}>
-            {l10n.getString("plan-matrix-bundle-offer-heading", {
+            {l10n.getString("plan-matrix-bundle-offer-heading-2", {
               monthly_price: getBundlePrice(props.runtimeData, l10n),
             })}
           </h2>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->
This removes the extra '$' sign from the headline of the pricing matrix.
<img width="852" alt="image" src="https://user-images.githubusercontent.com/13066134/199099029-047a6747-01f6-42a0-93d1-0f8b5640c82d.png">

Related to https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/110/files

How to test:

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
