### PR TITLE
Python dependency updates, Oct 31 2021

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ jwcrypto==1.4.2
 markus[datadog]==4.0.1
 pem==21.2.0
 psycopg2==2.9.5
-PyJWT==2.5.0
+PyJWT==2.6.0
 python-decouple==3.6
 pyOpenSSL==22.1.0
 requests==2.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ gunicorn==20.1.0
 jwcrypto==1.4.2
 markus[datadog]==4.0.1
 pem==21.2.0
-psycopg2==2.9.4
+psycopg2==2.9.5
 PyJWT==2.5.0
 python-decouple==3.6
 pyOpenSSL==22.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ whitenoise==6.2.0
 
 # phones app
 phonenumbers==8.12.57
-twilio==7.14.2
+twilio==7.15.0
 vobject==0.9.6.1
 
 # tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.25.1
+boto3==1.25.4
 codetiming==1.3.2
 cryptography==38.0.2
 Django==3.2.16


### PR DESCRIPTION
Update weekly Python dependencies. This covers:

* Bump psycopg2 from 2.9.4 to 2.9.5 (from PR #2713)
* Bump twilio from 7.14.2 to 7.15.0 (from PR #2714)
* Bump boto3 from 1.25.1 to 1.25.4 (from PR #2715)
* Bump pyjwt from 2.5.0 to 2.6.0 (from PR #2716)

👻 Spooky! 👻 