### PR TITLE
Python dependency updates, Oct 31 2022, part 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ whitenoise==6.2.0
 
 # phones app
 phonenumbers==8.12.57
-twilio==7.15.0
+twilio==7.15.1
 vobject==0.9.6.1
 
 # tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.25.4
+boto3==1.25.5
 codetiming==1.3.2
 cryptography==38.0.2
 Django==3.2.16


### PR DESCRIPTION
Update Python dependencies, round 2. This covers:

* Bump twilio from 7.15.0 to 7.15.1 (from PR #2733)
* Bump boto3 from 1.25.4 to 1.25.5 (from PR #2734)

