### PR TITLE
Also load brand strings

### DIFF
--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -1,5 +1,5 @@
 {% comment %}
-  Note that Django only loads strings from `app.ftl`,
+  Note that Django only loads strings from `app.ftl` and `brands.ftl`,
   so make sure all email strings are included in that file.
 {% endcomment %}
 {% load ftl %}

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -1078,6 +1078,7 @@ def test_wrapped_email_test_from_profile(rf):
 @pytest.mark.parametrize("num_level_one_email_trackers_removed", ("1", "0"))
 def test_wrapped_email_test(
     rf,
+    caplog,
     language,
     has_premium,
     in_premium_country,
@@ -1096,6 +1097,13 @@ def test_wrapped_email_test(
     request = rf.get("/emails/wrapped_email_test", data=data)
     response = wrapped_email_test(request)
     assert response.status_code == 200
+
+    # Check that all Fluent IDs were in the English corpus
+    if language == "en":
+        for log_name, log_level, message in caplog.record_tuples:
+            if log_name == "django_ftl.message_errors":
+                pytest.fail(message)
+
     no_space_html = re.sub(r"\s+", "", response.content.decode())
     assert f"<dt>language</dt><dd>{language}</dd>" in no_space_html
     assert f"<dt>has_premium</dt><dd>{has_premium}</dd>" in no_space_html

--- a/privaterelay/ftl_bundles.py
+++ b/privaterelay/ftl_bundles.py
@@ -1,3 +1,3 @@
 from django_ftl.bundles import Bundle
 
-main = Bundle(["app.ftl"])
+main = Bundle(["app.ftl", "brands.ftl"])


### PR DESCRIPTION
This PR fixes #2736.

How to test: I haven't been able to test this - when I load `wrapped_email_test`, it appears as expected. But, I deployed it to dev just now, and verified that the bug disappeared - the forwarded email contained no longer said `-brand-name-relay-premium⁩`, whereas the `main` version did.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, config change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
