### PR TITLE
Downgrade PyJWT from 2.6.0 to 2.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,8 @@ jwcrypto==1.4.2
 markus[datadog]==4.0.1
 pem==21.2.0
 psycopg2==2.9.5
-PyJWT==2.6.0
+# NOTE: update to 2.6.0 blocked by #2738
+PyJWT==2.5.0
 python-decouple==3.6
 pyOpenSSL==22.1.0
 requests==2.28.1


### PR DESCRIPTION
PyJWT adds a checks that the RSA256 JWT iat claim (Issued At) is not in the future. This is failing for FxA updates (issue #2738).