### PR TITLE
Simplify base template, fix logout page

### DIFF
--- a/privaterelay/templates/account/logout.html
+++ b/privaterelay/templates/account/logout.html
@@ -5,7 +5,6 @@
 
 {% block head_title %}{% ftlmsg 'nav-profile-sign-out' %}{% endblock %}
 
-
 {% block content %}
 <p>{% ftlmsg 'nav-profile-sign-out-confirm' %}</p>
 <form method="post" action="{% url 'account_logout' %}">

--- a/privaterelay/templates/account/logout.html
+++ b/privaterelay/templates/account/logout.html
@@ -7,23 +7,12 @@
 
 
 {% block content %}
-<main class="container px-4 lg:px-0 py-8 mx-auto max-w-4xl">
-  <div class="bg-white rounded py-8 sm:mt-8 shadow-md  ">
-    <div class="px-8 pb-8">
-      <div class="px-8 mt-8 pb-16">
-        <p class="text-center text-2xl mb-8">{% ftlmsg 'nav-profile-sign-out-confirm' %}</p>
-
-        <form method="post" action="{% url 'account_logout' %}">
-          {% csrf_token %}
-          {% if redirect_field_value %}
-          <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
-          {% endif %}
-          <button class="w-full max-w-xs mx-auto block text-center py-2 px-4 leading-normal rounded border border-solid border-purple-700 text-purple-700 hover:bg-purple-700 hover:text-white" type="submit"> {% ftlmsg 'nav-profile-sign-out' %} </button>
-        </form>
-
-      </div>
-    </div>
-  </div>
-</main>
-
+<p>{% ftlmsg 'nav-profile-sign-out-confirm' %}</p>
+<form method="post" action="{% url 'account_logout' %}">
+  {% csrf_token %}
+  {% if redirect_field_value %}
+    <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
+  {% endif %}
+  <button type="submit">{% ftlmsg 'nav-profile-sign-out' %}</button>
+</form>
 {% endblock %}

--- a/privaterelay/templates/base.html
+++ b/privaterelay/templates/base.html
@@ -1,5 +1,6 @@
 {% load ftl %}
 {% ftlconf bundle='privaterelay.ftl_bundles.main' %}
+
 <!DOCTYPE html>
 <html lang="{{ request.LANGUAGE_CODE }}" dir="ltr">
   <head>

--- a/privaterelay/templates/base.html
+++ b/privaterelay/templates/base.html
@@ -1,14 +1,8 @@
-{% load relay_tags %}
-{% load socialaccount %}
-{% load static %}
 {% load ftl %}
 
-{% if request.user.is_authenticated %}
-    {% get_social_accounts request.user as accounts %}
-{% endif %}
 {% ftlconf bundle='privaterelay.ftl_bundles.main' %}
 
-{% with request.user.profile_set.get() as user_profile %}
+{% with request.user.profile_set.get as user_profile %}
 {% with user_profile.has_premium as user_has_premium %}
 <!DOCTYPE html>
 <html lang="{{ request.LANGUAGE_CODE }}" dir="ltr">
@@ -17,39 +11,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="{% ftlmsg 'meta-description-2' %}" />
     <title>{% block head_title %}{% ftlmsg 'meta-title' %}{% endblock %}</title>
-    <link rel="stylesheet" href="{% static 'css/app.css' %}">
-    <link rel="icon" type="image/svg+xml" href="{% static 'images/logos/relay-logo-dark.svg' %}">
-    <link rel="shortcut icon" href="{%  static 'images/favicon.ico' %}">
-    <link rel="apple-touch-icon" href="{% static 'images/logos/relay-logo-dark-200.png' %}">
-    
-    <!-- Open Graph Tags -->
-    <meta property="og:url" content="{{request.scheme}}://{{request.META.HTTP_HOST}}{{ request.path }}" />
-    <meta property="og:type" content="website" />
-    <meta property="og:title" content="{% ftlmsg 'meta-title' %}" />
-    <meta property="og:description" content="{% ftlmsg 'meta-description-2' %}" />
-    <meta property="og:image" content="{{request.scheme}}://{{request.META.HTTP_HOST}}{% static 'images/share-relay.jpg' %}" />
-    
-    <!-- Twitter Tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@firefox">
-    <meta name="twitter:title" content="{% ftlmsg 'meta-title' %}">
-    <meta name="twitter:description" content="{% ftlmsg 'meta-description-2' %}">
-    <meta name="twitter:image" content="{{request.scheme}}://{{request.META.HTTP_HOST}}{% static 'images/share-relay.jpg' %}">
   </head>
-  <body class="{% if user_has_premium %}is-premium{% endif %} {% if request.resolver_match.url_name == "faq" %}is-dark{% endif %}" data-fxa-settings-url="{{ settings.FXA_SETTINGS_URL }}" data-site-origin="{{ settings.SITE_ORIGIN }}" data-google-analytics-id="{{ settings.GOOGLE_ANALYTICS_ID }}" data-debug="{{ settings.DEBUG }}">
-    <div class="c-layout-wrapper">
-      <firefox-private-relay-addon data-user-logged-in="{{ request.user.is_authenticated }}" data-addon-installed="false"></firefox-private-relay-addon>
-      {% block content %}
-      {% endblock %}
-    </div>
-
+  <body>
+    {% block content %}
+    {% endblock %}
     {% block javascript %}
     {% endblock %}
-    
-    <script type="text/javascript" src="{% static 'js/clipboard.min.js' %}" charset="utf-8"></script>
-    <script src="{% static 'js/fx-bento.js' %}"></script>
-    <script src="{% static 'js/app.js' %}"></script>
-    <script src="{% static 'js/analytics.js' %}"></script>
   </body>
 </html>
 

--- a/privaterelay/templates/base.html
+++ b/privaterelay/templates/base.html
@@ -1,9 +1,5 @@
 {% load ftl %}
-
 {% ftlconf bundle='privaterelay.ftl_bundles.main' %}
-
-{% with request.user.profile_set.get as user_profile %}
-{% with user_profile.has_premium as user_has_premium %}
 <!DOCTYPE html>
 <html lang="{{ request.LANGUAGE_CODE }}" dir="ltr">
   <head>
@@ -19,6 +15,3 @@
     {% endblock %}
   </body>
 </html>
-
-{% endwith %}
-{% endwith %}

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -7,7 +7,9 @@ from django.test import TestCase
 from allauth.socialaccount.models import SocialAccount
 from allauth.account.models import EmailAddress
 from model_bakery import baker
+import pytest
 
+from emails.models import Profile
 from ..views import _update_all_data, NoSocialToken
 
 
@@ -110,3 +112,11 @@ class UpdateExtraDataAndEmailTest(TestCase):
         # values should be un-changed because of the dupe error
         assert sa2.extra_data == extra_data
         assert ea2.email == "user2@example.com"
+
+
+@pytest.mark.django_db
+def test_logout_page(client):
+    user = baker.make(User)
+    client.force_login(user)
+    response = client.get("/accounts/logout/")
+    assert response.status_code == 200

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -115,8 +115,9 @@ class UpdateExtraDataAndEmailTest(TestCase):
 
 
 @pytest.mark.django_db
-def test_logout_page(client):
+def test_logout_page(client, settings):
     user = baker.make(User)
     client.force_login(user)
+    settings.ACCOUNT_LOGOUT_ON_GET = False
     response = client.get("/accounts/logout/")
     assert response.status_code == 200


### PR DESCRIPTION
This PR fixes #2742. This page is viewed when a user goes directly to `/accounts/logout/`. Most users bypass this page when selecting "Sign Out", which POSTs to the page, but it is used by some django-allauth error paths.

* ~Fix~ Remove the reference to `request.user.profile_set.get`, which is unused.
* Drop references to static files that have been removed after the move to the frontend. The few views that are left can be mostly unstyled.
* Simplify HTML structure, since no CSS left to style the content
* Add a test that the logout page renders for a logged-in user.