### PR TITLE
MPP-2498: Localize API error messages

### DIFF
--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -88,9 +88,7 @@ def test_post_domainaddress_no_subdomain_error(prem_api_client) -> None:
     assert response.status_code == 400
     ret_data = response.json()
     assert ret_data == {
-        "detail": (
-            "You must select a subdomain before creating email address with subdomain."
-        ),
+        "detail": ("Please select a subdomain before creating a custom email address."),
         "error_code": "need_subdomain",
     }
 
@@ -125,8 +123,10 @@ def test_post_domainaddress_bad_address_error(prem_api_client) -> None:
 
     assert response.status_code == 400
     ret_data = response.json()
+    # Add unicode characters to get around Fluent.js using unicode isolation.
+    # See https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation for more info
     assert ret_data == {
-        "detail": 'Domain address "myNewAlias" could not be created, try using a different value.',
+        "detail": "“\u2068myNewAlias\u2069” could not be created. Please try again with a different mask name.",
         "error_code": "address_unavailable",
         "error_context": {"unavailable_address": "myNewAlias"},
     }
@@ -140,8 +140,10 @@ def test_post_domainaddress_free_user_error(free_api_client):
 
     assert response.status_code == 403
     ret_data = response.json()
+    # Add unicode characters to get around Fluent.js using unicode isolation.
+    # See https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation for more info
     assert ret_data == {
-        "detail": "You must be a premium subscriber to create subdomain aliases.",
+        "detail": "Your free account does not include custom subdomains for masks. To create custom masks, upgrade to \u2068Relay Premium\u2069.",
         "error_code": "free_tier_no_subdomain_masks",
     }
 
@@ -169,10 +171,13 @@ def test_post_relayaddress_free_mask_email_limit_error(
 
     assert response.status_code == 403
     ret_data = response.json()
+    # Add unicode characters to get around Fluent.js using unicode isolation.
+    # See https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation for more info
+
     assert ret_data == {
         "detail": (
-            "You must be a premium subscriber to make more than"
-            f" {settings.MAX_NUM_FREE_ALIASES} aliases."
+            "You’ve used all"
+            f" \u2068{settings.MAX_NUM_FREE_ALIASES}\u2069 email masks included with your free account. You can reuse an existing mask, but using a unique mask for each account is the most secure option."
         ),
         "error_code": "free_tier_limit",
         "error_context": {"free_tier_limit": 5},

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -242,6 +242,4 @@ def relay_exception_handler(exc: Exception, context: Mapping) -> Optional[Respon
 
         response.data["error_code"] = error_codes
 
-    print(response)
-
     return response

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -215,7 +215,7 @@ def relay_exception_handler(exc: Exception, context: Mapping) -> Optional[Respon
     Add error information to response data.
 
     When the error is a RelayAPIException, these additional fields may be present and
-    the information will be translated if a accept-language header is added to the request:
+    the information will be translated if an Accept-Language header is added to the request:
 
     error_code - A string identifying the error, for client-side translation
     error_context - Additional data needed for client-side translation

--- a/emails/models.py
+++ b/emails/models.py
@@ -552,8 +552,8 @@ class AccountIsPausedException(CannotMakeAddressException):
 class RelayAddrFreeTierLimitException(CannotMakeAddressException):
     default_code = "free_tier_limit"
     default_detail_template = (
-        "You must be a premium subscriber to make more than"
-        " {free_tier_limit} aliases."
+        "You’ve used all {free_tier_limit} email masks included with your free account."
+        "You can reuse an existing mask, but using a unique mask for each account is the most secure option."
     )
     status_code = 403
 
@@ -570,24 +570,19 @@ class RelayAddrFreeTierLimitException(CannotMakeAddressException):
 
 class DomainAddrFreeTierException(CannotMakeAddressException):
     default_code = "free_tier_no_subdomain_masks"
-    default_detail = "You must be a premium subscriber to create subdomain aliases."
+    default_detail = "Your free account does not include custom subdomains for masks. To create custom masks, upgrade to Relay Premium."
     status_code = 403
 
 
 class DomainAddrNeedSubdomainException(CannotMakeAddressException):
     default_code = "need_subdomain"
-    default_detail = (
-        "You must select a subdomain before creating email address with subdomain."
-    )
+    default_detail = "Please select a subdomain before creating a custom email address."
     status_code = 400
 
 
 class DomainAddrUnavailableException(CannotMakeAddressException):
     default_code = "address_unavailable"
-    default_detail_template = (
-        'Domain address "{unavailable_address}" could not be created,'
-        " try using a different value."
-    )
+    default_detail_template = "“{unavailable_address}” could not be created. Please try again with a different mask name."
     status_code = 400
 
     def __init__(self, unavailable_address: str, *args, **kwargs):


### PR DESCRIPTION
This PR fixes [MPP-2498](https://mozilla-hub.atlassian.net/browse/MPP-2498)

~The following PR needs to land before this is merged in (Legacy L10N System Requirements): 
https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/111~

How to test:

- Be sure to check out the latest translations
- Set browser language to DE _(Note that as time of writing testing steps, DE worked)_ 
- Log in with free-tier account and create the maximum allowed email masks (5) 
- Go to API page: http://127.0.0.1:8000/api/v1/docs/
- Go to `relayaddresses` POST entry
- Try it out
   - Be sure to change `block_list_emails` value to FALSE
- **Expected:** The response should FAIL and the message should be in the German language. 


### Screenshot

<img width="915" alt="image" src="https://user-images.githubusercontent.com/2692333/201756076-f5711551-f252-4bfb-9d9c-2b6e965f026b.png">



TBD

- [X] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
