### PR TITLE
Fix menu overlap, adjust z-indexes

### DIFF
--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.module.scss
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.module.scss
@@ -9,7 +9,6 @@
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 10;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/dashboard/aliases/AliasDeletionButton.module.scss
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButton.module.scss
@@ -31,7 +31,6 @@
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 10;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/dashboard/subdomain/ConfirmationModal.module.scss
+++ b/frontend/src/components/dashboard/subdomain/ConfirmationModal.module.scss
@@ -8,7 +8,6 @@
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 10;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/dashboard/tips/Tips.module.scss
+++ b/frontend/src/components/dashboard/tips/Tips.module.scss
@@ -52,8 +52,6 @@
   background-color: $color-white;
   width: $content-sm;
   max-width: calc(100% - $spacing-xl);
-  // Prevent the BlockLevelSlider thumb, which is also absolutely positioned
-  z-index: 1;
 
   .header {
     display: flex;

--- a/frontend/src/components/layout/Layout.module.scss
+++ b/frontend/src/components/layout/Layout.module.scss
@@ -263,6 +263,9 @@ $toastify-toast-close-button: var(--toast-close-button);
   flex-grow: 2;
   display: flex;
   flex-direction: column;
+  // Create a new stacking context for the content, so we can use z-indexes in
+  // the content without preventing the header/mobile menu from overlapping it.
+  isolation: isolate;
 
   @media screen and (min-width: $screen-md) {
     background-color: $color-light-gray-10;

--- a/frontend/src/components/layout/Layout.module.scss
+++ b/frontend/src/components/layout/Layout.module.scss
@@ -151,7 +151,7 @@ $toastify-toast-close-button: var(--toast-close-button);
   // overlap the AppPicker drawer).
   // Thus, upping the z-index stack the header, and menus
   // expanding from it, on top again:
-  z-index: 2;
+  z-index: 1;
   display: grid;
   grid-template-columns: 1fr;
   grid-template-areas:
@@ -325,7 +325,4 @@ $toastify-toast-close-button: var(--toast-close-button);
   padding: $spacing-md $spacing-lg;
   text-align: center;
   position: relative;
-  // We set the index to '2' to overlap mobile menu
-  // Mimicking the behavior of the header
-  z-index: 2;
 }

--- a/frontend/src/components/phones/onboarding/RelayNumberConfirmationModal.module.scss
+++ b/frontend/src/components/phones/onboarding/RelayNumberConfirmationModal.module.scss
@@ -9,7 +9,6 @@
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 10;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/pages/accounts/profile.module.scss
+++ b/frontend/src/pages/accounts/profile.module.scss
@@ -190,6 +190,9 @@
   align-items: baseline;
   gap: $spacing-md;
   padding-bottom: $spacing-xl;
+  // Ensure that the <Tips> card can always overlap elements in the profile,
+  // even if they have z-indexes to overlap each other:
+  isolation: isolate;
 }
 
 .main-wrapper,


### PR DESCRIPTION
This PR fixes MPPUX-754, aka the "Blocking" (or "Forwarding") label overlapping the mobile menu.

![image](https://user-images.githubusercontent.com/4251/200531187-7916ea6f-9675-4987-8825-52f9dbb88fea.png)

I fixed it by giving the content its own [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context), which should ensure that the mobile menu and header will now always overlap the content, even if there are z-indexes used internally in the content. And after having done that, I evaluated the rest of the z-indexes, lowered them where possible, did the same for the Help & Tips area to overlap the content, and removed a bunch of unneeded and undocumented z-indexes on underlays that were just copy-pasted (I'm using the passive voice, but I did that :stuck_out_tongue:) from the react-aria docs. I grouped each change in its own commit.

How to test: open the phone dashboard, and ensure your viewport is small. Open the mobile menu; the "Forwarding" and "Blocking" labels should disappear behind it when you scroll.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
