### PR TITLE
Reverse Phone Masking Promo Banner Image

### DIFF
--- a/frontend/src/components/landing/PhoneBanner.module.scss
+++ b/frontend/src/components/landing/PhoneBanner.module.scss
@@ -5,7 +5,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-direction: row-reverse;
   flex-wrap: wrap-reverse;
   column-gap: $spacing-2xl;
   row-gap: $spacing-lg;


### PR DESCRIPTION
Part of a fast follow - Eduardo's urgent request to switch back the phone masking banner into its original orientation.

![image](https://user-images.githubusercontent.com/13066134/200613354-79b2735c-69a5-4d80-bdb0-dba49625355a.png)

How to test:

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
