### PR TITLE
MPP-2534: Add tests for `/fxa_rp_events/`, log `iat` claim age

### DIFF
--- a/privaterelay/apps.py
+++ b/privaterelay/apps.py
@@ -1,3 +1,4 @@
+from typing import Any
 import requests
 import os
 
@@ -13,10 +14,10 @@ class PrivateRelayConfig(AppConfig):
 
     def __init__(self, app_name, app_module):
         super(PrivateRelayConfig, self).__init__(app_name, app_module)
-        self.fxa_verifying_keys = []
+        self.fxa_verifying_keys: list[dict[str, Any]] = []
 
     def ready(self):
-        import privaterelay.signals
+        import privaterelay.signals  # noqa: F401
 
         resp = requests.get(
             "%s/jwks" % settings.SOCIALACCOUNT_PROVIDERS["fxa"]["OAUTH_ENDPOINT"]

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -330,7 +330,11 @@ def test_fxa_rp_events_password_change(
         response = client.get("/fxa-rp-events", HTTP_AUTHORIZATION=auth_header)
 
     assert mm.get_records() == []
-    assert caplog.record_tuples == [("request.summary", logging.INFO, "")]
+    assert caplog.record_tuples == [
+        ("eventsinfo", logging.INFO, "fxa_rp_event"),
+        ("request.summary", logging.INFO, ""),
+    ]
+    assert 0.0 < caplog.records[0].iat_age_s < 2.0
     assert response.status_code == 200
 
 
@@ -353,6 +357,7 @@ def test_fxa_rp_events_profile_change(
 
     assert mm.get_records() == []
     assert caplog.record_tuples == [
+        ("eventsinfo", logging.INFO, "fxa_rp_event"),
         ("eventsinfo", logging.INFO, "fxa_rp_event"),
         ("request.summary", logging.INFO, ""),
     ]
@@ -384,6 +389,7 @@ def test_fxa_rp_events_subscription_change(
     assert mm.get_records() == []
     assert caplog.record_tuples == [
         ("eventsinfo", logging.INFO, "fxa_rp_event"),
+        ("eventsinfo", logging.INFO, "fxa_rp_event"),
         ("request.summary", logging.INFO, ""),
     ]
     assert response.status_code == 200
@@ -407,6 +413,7 @@ def test_fxa_rp_events_delete_user(
         response = client.get("/fxa-rp-events", HTTP_AUTHORIZATION=auth_header)
     assert mm.get_records() == []
     assert caplog.record_tuples == [
+        ("eventsinfo", logging.INFO, "fxa_rp_event"),
         ("eventsinfo", logging.INFO, "fxa_rp_event"),
         ("request.summary", logging.INFO, ""),
     ]

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -365,6 +365,12 @@ def test_fxa_rp_events_profile_change(
     user = setup_fxa_rp_events.user
     user.refresh_from_db()
     assert user.email == "new-email@example.com"
+    fxa_acct = setup_fxa_rp_events.fxa_acct
+    fxa_acct.refresh_from_db()
+    assert fxa_acct.extra_data == setup_fxa_rp_events.profile_response.data
+    assert fxa_acct.extra_data["email"] == "new-email@example.com"
+    email_record = EmailAddress.objects.get(user=user)
+    assert email_record.email == "new-email@example.com"
 
 
 def test_fxa_rp_events_subscription_change(

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -1,13 +1,27 @@
 import json
+import logging
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Iterator, Literal
+from uuid import uuid4
 from unittest.mock import Mock, patch
 
 from django.contrib.auth.models import User
-from django.test import TestCase
+from django.test import Client, TestCase
+from django.utils import timezone
 
-from allauth.socialaccount.models import SocialAccount
+from allauth.socialaccount.models import SocialAccount, SocialApp, SocialToken
 from allauth.account.models import EmailAddress
+from cryptography.hazmat.primitives.asymmetric.rsa import (
+    RSAPrivateKey,
+    generate_private_key,
+)
+from markus.testing import MetricsMock
 from model_bakery import baker
+import jwt
 import pytest
+import responses
 
 from ..apps import PrivateRelayConfig
 from ..views import _update_all_data, NoSocialToken, fxa_verifying_keys
@@ -135,3 +149,266 @@ def test_fxa_verifying_keys(reload: bool) -> None:
         mock_app.ready.assert_called_once_with()
     else:
         mock_app.ready.assert_not_called()
+
+
+@pytest.fixture(scope="session")
+def mock_fxa_signing_key() -> RSAPrivateKey:
+    """Return a mock FxA signing key for testing."""
+    return generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@dataclass
+class FxaProfileResponse:
+    """Components of a mock FxA profile response."""
+
+    status_code: int
+    headers: dict[str, str]
+    data: dict[str, Any]
+
+
+@dataclass
+class FxaRpEventsSetupData:
+    """Test data and mocks yielded by setup_fxa_rp_events."""
+
+    app: SocialApp
+    key: RSAPrivateKey
+    user: User
+    fxa_acct: SocialAccount
+    fxa_token: SocialToken
+    mock_fxa_verifying_keys: Mock
+    mock_responses: responses.RequestsMock
+    profile_response: FxaProfileResponse
+
+
+@pytest.fixture
+def setup_fxa_rp_events(
+    db, settings, mock_fxa_signing_key
+) -> Iterator[FxaRpEventsSetupData]:
+    """Setup data for testing /fxa_rp_events."""
+
+    # Adjust settings for tests
+    settings.DEBUG = False
+    settings.STATSD_ENABLED = True
+    settings.SUBSCRIPTIONS_WITH_UNLIMITED = "test-unlimited"
+    settings.SUBSCRIPTIONS_WITH_PHONE = "test-phone"
+
+    # Create user subscribed to emails and phones
+    user = baker.make(User, email="test@example.com")
+    user.profile.server_storage = True
+    user.profile.date_subscribed = timezone.now()
+    user.profile.save()
+
+    # Create FxA app, account, token, etc.
+    fxa_app: SocialApp = baker.make(SocialApp, provider="fxa")
+    fxa_profile_data = {
+        "email": user.email,
+        "locale": "en-US,en;q=0.5",
+        "amrValues": ["pwd", "email"],
+        "twoFactorAuthentication": False,
+        "metricsEnabled": True,
+        "uid": str(uuid4()),
+        "avatar": "https://profile.stage.mozaws.net/v1/avatar/t",
+        "avatarDefault": False,
+        "subscriptions": ["test-unlimited", "test-phone"],
+    }
+    fxa_acct: SocialAccount = baker.make(
+        SocialAccount,
+        user=user,
+        provider="fxa",
+        uid=fxa_profile_data["uid"],
+        extra_data=fxa_profile_data,
+    )
+    fxa_token: SocialToken = baker.make(
+        SocialToken,
+        account=fxa_acct,
+        app=fxa_app,
+        expires_at=timezone.now() + timedelta(days=2),
+    )
+    baker.make(EmailAddress, user=user, email=user.email)
+
+    # Setup mock fxa_verifying_key
+    fxa_public_key = mock_fxa_signing_key.public_key()
+    fxa_public_jwk = jwt.algorithms.RSAAlgorithm.to_jwk(fxa_public_key)
+    key_data = json.loads(fxa_public_jwk)
+    fxa_verifying_key = {
+        "kty": key_data["kty"],
+        "alg": "RS256",
+        "kid": "20221108-d3adb33f",
+        "fxa-createdAt": int((timezone.now() - timedelta(days=10)).timestamp()),
+        "use": "sig",
+        "n": key_data["n"],
+        "e": key_data["e"],
+    }
+
+    # Setup FxA profile response that does not change the user
+    # Tests can change this if they want to simulate a changed profile
+    profile_response = FxaProfileResponse(
+        status_code=200,
+        headers={"content_type": "application/json"},
+        data=deepcopy(fxa_profile_data),
+    )
+
+    def request_callback(request) -> tuple[int, dict[str, str], str]:
+        """Mock an FxA profile response, using data the test may have changed."""
+        return (
+            profile_response.status_code,
+            profile_response.headers,
+            json.dumps(profile_response.data),
+        )
+
+    with responses.RequestsMock() as mock_responses, patch(
+        "privaterelay.views.fxa_verifying_keys", return_value=[fxa_verifying_key]
+    ) as mock_fxa_verifying_keys:
+        mock_responses.add_callback(
+            responses.GET,
+            f"{settings.SOCIALACCOUNT_PROVIDERS['fxa']['PROFILE_ENDPOINT']}/profile",
+            callback=request_callback,
+            content_type="application/json",
+        )
+        yield FxaRpEventsSetupData(
+            app=fxa_app,
+            key=mock_fxa_signing_key,
+            user=user,
+            fxa_acct=fxa_acct,
+            fxa_token=fxa_token,
+            mock_fxa_verifying_keys=mock_fxa_verifying_keys,
+            mock_responses=mock_responses,
+            profile_response=profile_response,
+        )
+
+
+FxaEventType = Literal[
+    "password-change", "profile-change", "subscription-state-change", "delete-user"
+]
+
+
+def get_fxa_event_jwt(
+    event_type: FxaEventType,
+    fxa_id: str,
+    client_id: str,
+    signing_key: RSAPrivateKey,
+    event_data: dict[str, Any],
+) -> str:
+    """
+    Return valid Firefox Accounts relying party event JWT
+
+    See https://github.com/mozilla/fxa/tree/main/packages/fxa-event-broker
+    """
+    event_key = f"https://schemas.accounts.firefox.com/event/{event_type}"
+    payload = {
+        "iss": "https://accounts.firefox.com/",
+        "sub": fxa_id,
+        "aud": client_id,
+        "iat": int(datetime.utcnow().timestamp()),
+        "jti": str(uuid4()),
+        "events": {event_key: event_data},
+    }
+    return jwt.encode(
+        payload,
+        # expects str, but RSAPublicKey allowed
+        # https://github.com/jpadilla/pyjwt/issues/660
+        signing_key,  # type: ignore
+        algorithm="RS256",
+    )
+
+
+def test_fxa_rp_events_password_change(
+    client: Client, setup_fxa_rp_events: FxaRpEventsSetupData, caplog
+) -> None:
+    """A password-change event is discarded."""
+    setup_fxa_rp_events.mock_responses.reset()  # No profile fetch for password-change
+    event_jwt = get_fxa_event_jwt(
+        "password-change",
+        fxa_id=setup_fxa_rp_events.fxa_acct.uid,
+        client_id=setup_fxa_rp_events.app.client_id,
+        signing_key=setup_fxa_rp_events.key,
+        event_data={"changeTime": int(datetime.utcnow().timestamp()) - 100},
+    )
+    auth_header = f"Bearer {event_jwt}"
+
+    with MetricsMock() as mm:
+        response = client.get("/fxa-rp-events", HTTP_AUTHORIZATION=auth_header)
+
+    assert mm.get_records() == []
+    assert caplog.record_tuples == [("request.summary", logging.INFO, "")]
+    assert response.status_code == 200
+
+
+def test_fxa_rp_events_profile_change(
+    client: Client, setup_fxa_rp_events: FxaRpEventsSetupData, caplog
+) -> None:
+    """The profile is re-fetched for a profile-change event."""
+    setup_fxa_rp_events.profile_response.data["email"] = "new-email@example.com"
+    event_jwt = get_fxa_event_jwt(
+        "profile-change",
+        fxa_id=setup_fxa_rp_events.fxa_acct.uid,
+        client_id=setup_fxa_rp_events.app.client_id,
+        signing_key=setup_fxa_rp_events.key,
+        event_data={"email": "new-email@example.com"},
+    )
+    auth_header = f"Bearer {event_jwt}"
+
+    with MetricsMock() as mm:
+        response = client.get("/fxa-rp-events", HTTP_AUTHORIZATION=auth_header)
+
+    assert mm.get_records() == []
+    assert caplog.record_tuples == [
+        ("eventsinfo", logging.INFO, "fxa_rp_event"),
+        ("request.summary", logging.INFO, ""),
+    ]
+    assert response.status_code == 200
+    user = setup_fxa_rp_events.user
+    user.refresh_from_db()
+    assert user.email == "new-email@example.com"
+
+
+def test_fxa_rp_events_subscription_change(
+    client: Client, setup_fxa_rp_events: FxaRpEventsSetupData, caplog
+) -> None:
+    """A subscription-state-change for an unrelated sub does not change the profile."""
+    event_jwt = get_fxa_event_jwt(
+        "subscription-state-change",
+        fxa_id=setup_fxa_rp_events.fxa_acct.uid,
+        client_id=setup_fxa_rp_events.app.client_id,
+        signing_key=setup_fxa_rp_events.key,
+        event_data={
+            "capabilities": ["new_capability"],
+            "isActive": True,
+            "changeTime": int(datetime.utcnow().timestamp()) - 100,
+        },
+    )
+    auth_header = f"Bearer {event_jwt}"
+
+    with MetricsMock() as mm:
+        response = client.get("/fxa-rp-events", HTTP_AUTHORIZATION=auth_header)
+    assert mm.get_records() == []
+    assert caplog.record_tuples == [
+        ("eventsinfo", logging.INFO, "fxa_rp_event"),
+        ("request.summary", logging.INFO, ""),
+    ]
+    assert response.status_code == 200
+
+
+def test_fxa_rp_events_delete_user(
+    client: Client, setup_fxa_rp_events: FxaRpEventsSetupData, caplog
+) -> None:
+    """A delete-user event deletes the user."""
+    setup_fxa_rp_events.mock_responses.reset()  # No profile fetch for delete-user
+    event_jwt = get_fxa_event_jwt(
+        "delete-user",
+        fxa_id=setup_fxa_rp_events.fxa_acct.uid,
+        client_id=setup_fxa_rp_events.app.client_id,
+        signing_key=setup_fxa_rp_events.key,
+        event_data={},
+    )
+    auth_header = f"Bearer {event_jwt}"
+
+    with MetricsMock() as mm:
+        response = client.get("/fxa-rp-events", HTTP_AUTHORIZATION=auth_header)
+    assert mm.get_records() == []
+    assert caplog.record_tuples == [
+        ("eventsinfo", logging.INFO, "fxa_rp_event"),
+        ("request.summary", logging.INFO, ""),
+    ]
+    assert response.status_code == 200
+    assert not User.objects.filter(id=setup_fxa_rp_events.user.id).exists()

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -155,6 +155,11 @@ def metrics_event(request):
 def fxa_rp_events(request: HttpRequest) -> HttpResponse:
     req_jwt = _parse_jwt_from_request(request)
     authentic_jwt = _authenticate_fxa_jwt(req_jwt)
+
+    # Issue 2738: log age of iat (issued at) claim, negative if in future
+    iat_age = datetime.now(tz=timezone.utc).timestamp() - authentic_jwt["iat"]
+    info_logger.info("fxa_rp_event", extra={"iat_age_s": round(iat_age, 3)})
+
     event_keys = _get_event_keys_from_jwt(authentic_jwt)
     try:
         social_account = _get_account_from_jwt(authentic_jwt)

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -114,7 +114,7 @@ def version(request):
 
 def heartbeat(request):
     db_conn = connections["default"]
-    c = db_conn.cursor()
+    assert db_conn.cursor()
     return HttpResponse("200 OK", status=200)
 
 
@@ -131,8 +131,8 @@ def metrics_event(request):
         return JsonResponse({"msg": "Could not decode JSON"}, status=415)
     if "ga_uuid" not in request_data:
         return JsonResponse({"msg": "No GA uuid found"}, status=404)
-    # "dimension5" is a Google Analytics-specific variable to track a custom dimension.
-    # This dimension is used to determine which browser vendor the add-on is using: Firefox or Chrome
+    # "dimension5" is a Google Analytics-specific variable to track a custom dimension,
+    # used to determine which browser vendor the add-on is using: Firefox or Chrome
     event_data = event(
         request_data.get("category", None),
         request_data.get("action", None),


### PR DESCRIPTION
As tracked in issue #2738 / MPP-2534, and starting in PyJWT 2.6.0, an `iat` that is in the future will cause the claim to be denied. Many of the claims `POST`ed to `/fxa_rp_events/` were in the future on the Heroku dev server, and were auto-rejected. We can disable the `iat` check, or add a `leeway` parameter to account for the FxA clocks being out of sync with our clocks. 

For this first step, log the age of the `iat` ("issued at") claim, similar to the way PyJWT computes it. We can then process the ages and see if a reasonable `leeway` will cover the variation.

There are additional changes to the view code:

* Add a `FxAEvent` `TypedDict` to describe the security event token (SET) sent to `/fxa_rp_events/`.
* Add `fxa_verifying_keys` to access the FxA verifying keys, and give me a place to change them for tests
* Add typing annotations for the functions used by `/fxa_rp_events/`
* Other `flake8` fixes like removing unused imports

The `/fxa_rp_events/` view had no tests, and required quite a bit of setup to test:

* Set Django settings to desired test values
* Create a premium user subscribed to emails and phones
* Simulate an FxA account with profile data for that user
* Create an RSA public / private key pair for JWT signing, and mock our app to use the public key
* Mock calling the FxA profile endpoint

I've added some "happy path" tests for the four [FxA event types](https://github.com/mozilla/fxa/tree/main/packages/fxa-event-broker):

* `password-change`: unhandled
* `profile-change`: profile re-fetched
* `subscription-state-change`: profile re-fetched
* `delete-user`: user deleted

## Test Process
I do not think these changes can be tested in the local development environment, so review is mostly a code review of the changes and the new tests. This branch can be pushed to Heroku, and the logs (or exceptions) viewed there.