### PR TITLE
Python dependency updates, November 8, 2022

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.26.3
 codetiming==1.3.2
-cryptography==38.0.2
+cryptography==38.0.3
 Django==3.2.16
 dj-database-url==1.0.0
 django-allauth==0.51.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ sentry-sdk==1.10.1
 whitenoise==6.2.0
 
 # phones app
-phonenumbers==8.12.57
+phonenumbers==8.13.0
 twilio==7.15.1
 vobject==0.9.6.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,6 @@ black==22.10.0
 # type hinting
 mypy==0.982
 types-requests==2.28.11.2
-types-pyOpenSSL==22.1.0.1
+types-pyOpenSSL==22.1.0.2
 django-stubs==1.12.0
 djangorestframework-stubs==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.25.5
+boto3==1.26.3
 codetiming==1.3.2
 cryptography==38.0.2
 Django==3.2.16


### PR DESCRIPTION
Update Python dependencies. This covers:

* Bump boto3 from 1.25.5 to 1.26.3 (from PR #2754)
* Bump phonenumbers from 8.12.57 to 8.13.0 (from PR #2755)
* Bump cryptography from 38.0.2 to 38.0.3 (from PR #2757)
* Bump types-pyopenssl from 22.1.0.1 to 22.1.0.2 (from PR #2758)

