### PR TITLE
Switch Twilio clients to initialize on first use

### DIFF
--- a/phones/apps.py
+++ b/phones/apps.py
@@ -1,10 +1,12 @@
 import logging
 
+from twilio.base.instance_resource import InstanceResource
 from twilio.request_validator import RequestValidator
 from twilio.rest import Client
 
 from django.apps import AppConfig
 from django.conf import settings
+from django.utils.functional import cached_property
 
 
 logger = logging.getLogger("events")
@@ -13,36 +15,30 @@ logger = logging.getLogger("events")
 class PhonesConfig(AppConfig):
     name = "phones"
 
-    def __init__(self, app_name, app_module):
-        super(PhonesConfig, self).__init__(app_name, app_module)
-        try:
-            self._twilio_client = Client(
-                settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN
+    @cached_property
+    def twilio_client(self) -> Client:
+        if not all((settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)):
+            raise Exception("Must define TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN")
+        return Client(settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)
+
+    @cached_property
+    def twiml_app(self) -> InstanceResource:
+        if not settings.TWILIO_SMS_APPLICATION_SID:
+            raise Exception("Must define TWILIO_SMS_APPLICATION_SID")
+        return self.twilio_client.applications(
+            settings.TWILIO_SMS_APPLICATION_SID
+        ).fetch()
+
+    @cached_property
+    def twilio_test_client(self) -> Client:
+        if not all((settings.TWILIO_TEST_ACCOUNT_SID, settings.TWILIO_TEST_AUTH_TOKEN)):
+            raise Exception(
+                "Must define TWILIO_TEST_ACCOUNT_SID, TWILIO_TEST_AUTH_TOKEN"
             )
-            # Create TwiML app to access its sms_status_callback
-            # Note:
-            self.twiml_app = self._twilio_client.applications(
-                settings.TWILIO_SMS_APPLICATION_SID
-            ).fetch()
-            self._twilio_validator = RequestValidator(settings.TWILIO_AUTH_TOKEN)
-        except Exception:
-            logger.exception("exception creating Twilio client and/or validator")
-        if settings.TWILIO_TEST_ACCOUNT_SID:
-            try:
-                self._twilio_test_client = Client(
-                    settings.TWILIO_TEST_ACCOUNT_SID, settings.TWILIO_TEST_AUTH_TOKEN
-                )
-            except Exception:
-                logger.exception("exception creating Twilio test client")
+        return Client(settings.TWILIO_TEST_ACCOUNT_SID, settings.TWILIO_TEST_AUTH_TOKEN)
 
-    @property
-    def twilio_client(self):
-        return self._twilio_client
-
-    @property
-    def twilio_test_client(self):
-        return self._twilio_test_client
-
-    @property
-    def twilio_validator(self):
-        return self._twilio_validator
+    @cached_property
+    def twilio_validator(self) -> RequestValidator:
+        if not settings.TWILIO_AUTH_TOKEN:
+            raise Exception("Must define TWILIO_AUTH_TOKEN")
+        return RequestValidator(settings.TWILIO_AUTH_TOKEN)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ module = [
     "markus.utils",
     "oauthlib.oauth2.rfc6749.errors",
     "requests_oauthlib",
+    "twilio.base.instance_resource",
     "twilio.base.exceptions",
     "twilio.rest",
     "twilio.request_validator",


### PR DESCRIPTION
Instead of initializing Twilio clients on application startup, initialize them on first use. This benefits applications that do not use phones, such as `./manage.py migrate` and some of the CircleCI tests. They startup faster, and do not need Twilio account settings in the environment.

How to test:
* See CircleCI tests. For example, the `mypy` test shows a startup error without this change, and does not with it applied. The other tests continue to pass.
* Try phone forwarding, if configured in the local environment. Phone code continues to work.