### PR TITLE
MPP-2553 Update premium promo footer copy

### DIFF
--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -322,13 +322,29 @@ const Profile: NextPage = () => {
       <section className={styles["bottom-banner"]}>
         <div className={styles["bottom-banner-wrapper"]}>
           <div className={styles["bottom-banner-content"]}>
-            <Localized
-              id="footer-banner-premium-promo-headine"
-              elems={{ strong: <strong />, i: <i /> }}
-            >
-              <h3 />
-            </Localized>
-            <p>{l10n.getString("footer-banner-premium-promo-body")}</p>
+            {isPhonesAvailableInCountry(runtimeData.data) &&
+            isFlagActive(runtimeData.data, "phones") ? (
+              <>
+                <Localized
+                  id="footer-banner-premium-promo-headine"
+                  elems={{ strong: <strong />, i: <i /> }}
+                >
+                  <h3 />
+                </Localized>
+                <p>{l10n.getString("footer-banner-premium-promo-body")}</p>
+              </>
+            ) : (
+              <>
+                <Localized
+                  id="banner-pack-upgrade-headline-2-html"
+                  elems={{ strong: <strong /> }}
+                >
+                  <h3 />
+                </Localized>
+                <p>{l10n.getString("banner-pack-upgrade-copy-2")}</p>
+              </>
+            )}
+
             <LinkButton
               href="/premium#pricing"
               ref={bottomBannerSubscriptionLinkRef}

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -323,12 +323,12 @@ const Profile: NextPage = () => {
         <div className={styles["bottom-banner-wrapper"]}>
           <div className={styles["bottom-banner-content"]}>
             <Localized
-              id="banner-pack-upgrade-headline-2-html"
-              elems={{ strong: <strong /> }}
+              id="footer-banner-premium-promo-headine"
+              elems={{ strong: <strong />, i: <i /> }}
             >
               <h3 />
             </Localized>
-            <p>{l10n.getString("banner-pack-upgrade-copy-2")}</p>
+            <p>{l10n.getString("footer-banner-premium-promo-body")}</p>
             <LinkButton
               href="/premium#pricing"
               ref={bottomBannerSubscriptionLinkRef}


### PR DESCRIPTION

This PR fixes #MPP-2553

How to test:

With a free account and having your location be or set in US/CAN, check that the promo banner in the footer has been updated to include phone masking callouts. 
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/13066134/200882970-de1b84f1-6717-47fd-acb6-f354a8f751bf.png">, otherwise, revert back to the original banner.


- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
