### PR TITLE
MPP-2405: add new API_DOCS_ENABLED env var for api docs

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,3 +1,4 @@
+API_DOCS_ENABLED=False
 FXA_OAUTH_ENDPOINT=https://oauth.stage.mozaws.net/v1
 FXA_PROFILE_ENDPOINT=https://profile.stage.mozaws.net/v1
 FXA_BASE_ORIGIN=https://accounts.stage.mozaws.net

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -2,6 +2,7 @@ import pytest
 from model_bakery import baker
 
 from django.contrib.auth.models import User
+from django.test import override_settings
 from django.utils import timezone
 from django.urls import reverse
 from rest_framework.test import APIClient
@@ -39,6 +40,7 @@ def get_user(client: APIClient) -> User:
 
 
 @pytest.mark.parametrize("format", ("yaml", "json"))
+@override_settings(API_DOCS_ENABLED=True)
 def test_swagger_format(client, format):
     path = f"/api/v1/swagger.{format}"
     response = client.get(path)

--- a/api/urls.py
+++ b/api/urls.py
@@ -10,7 +10,6 @@ from .views import (
     UserViewSet,
     report_webcompat_issue,
     runtime_data,
-    schema_view,
 )
 
 
@@ -41,17 +40,23 @@ urlpatterns = [
         report_webcompat_issue,
         name="report_webcompat_issue",
     ),
-    path(
-        "v1/swagger<swagger_format:format>",
-        schema_view.without_ui(cache_timeout=0),
-        name="schema-json",
-    ),
-    path(
-        "v1/docs/",
-        schema_view.with_ui("swagger", cache_timeout=0),
-        name="schema-swagger-ui",
-    ),
 ]
+
+if settings.API_DOCS_ENABLED:
+    from .views import schema_view
+
+    urlpatterns += [
+        path(
+            "v1/swagger<swagger_format:format>",
+            schema_view.without_ui(cache_timeout=0),
+            name="schema-json",
+        ),
+        path(
+            "v1/docs/",
+            schema_view.with_ui("swagger", cache_timeout=0),
+            name="schema-swagger-ui",
+        ),
+    ]
 
 if settings.PHONES_ENABLED:
     from .views.phones import (

--- a/api/urls.py
+++ b/api/urls.py
@@ -3,6 +3,7 @@ from django.urls import include, path, register_converter
 
 from rest_framework import routers
 
+from privaterelay.utils import enable_if_setting
 from .views import (
     DomainAddressViewSet,
     RelayAddressViewSet,
@@ -10,6 +11,7 @@ from .views import (
     UserViewSet,
     report_webcompat_issue,
     runtime_data,
+    schema_view,
 )
 
 
@@ -40,23 +42,19 @@ urlpatterns = [
         report_webcompat_issue,
         name="report_webcompat_issue",
     ),
+    path(
+        "v1/swagger<swagger_format:format>",
+        enable_if_setting("API_DOCS_ENABLED")(schema_view.without_ui(cache_timeout=0)),
+        name="schema-json",
+    ),
+    path(
+        "v1/docs/",
+        enable_if_setting("API_DOCS_ENABLED")(
+            schema_view.with_ui("swagger", cache_timeout=0)
+        ),
+        name="schema-swagger-ui",
+    ),
 ]
-
-if settings.API_DOCS_ENABLED:
-    from .views import schema_view
-
-    urlpatterns += [
-        path(
-            "v1/swagger<swagger_format:format>",
-            schema_view.without_ui(cache_timeout=0),
-            name="schema-json",
-        ),
-        path(
-            "v1/docs/",
-            schema_view.with_ui("swagger", cache_timeout=0),
-            name="schema-swagger-ui",
-        ),
-    ]
 
 if settings.PHONES_ENABLED:
     from .views.phones import (

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -227,11 +227,17 @@ INSTALLED_APPS = [
     "api.apps.ApiConfig",
 ]
 
+API_DOCS_ENABLED = config("API_DOCS_ENABLED", False, cast=bool) or DEBUG
+if API_DOCS_ENABLED:
+    INSTALLED_APPS += [
+        "drf_yasg",
+    ]
+
 if DEBUG:
     INSTALLED_APPS += [
         "debug_toolbar",
-        "drf_yasg",
     ]
+
 if USE_SILK:
     INSTALLED_APPS.append("silk")
 
@@ -810,13 +816,11 @@ LOGGING = {
     },
 }
 
+DRF_RENDERERS = ["rest_framework.renderers.JSONRenderer"]
 if DEBUG and not IN_PYTEST:
-    DRF_RENDERERS = [
+    DRF_RENDERERS += [
         "rest_framework.renderers.BrowsableAPIRenderer",
-        "rest_framework.renderers.JSONRenderer",
     ]
-else:
-    DRF_RENDERERS = ["rest_framework.renderers.JSONRenderer"]
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [


### PR DESCRIPTION
# API_DOCS_ENABLED
We want to show the API docs (especially on the dev server) even when `DEBUG=False`.

## How to test
1. Set env var `DEBUG=0` and remove any `API_DOCS_ENABLED` var value
2. Visit http://127.0.0.1:8000/api/v1/docs/
   * [ ] You should see "Not Found"
1. Set env var `DEBUG=0` and `API_DOCS_ENABLED=1`
2. Visit http://127.0.0.1:8000/api/v1/docs/
   * [ ] You should still see the API docs!
1. Set env var `DEBUG=0` and `API_DOCS_ENABLED=0`
2. Visit http://127.0.0.1:8000/api/v1/docs/
   * [ ] You should see "Not Found"

## Checklist
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
