### PR TITLE
MPP-2562: With flag `multi_replies`, choose relay text recipient by prefix

### DIFF
--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -1281,7 +1281,8 @@ def test_inbound_sms_reply_short_prefix_multi_match(
     assert call_kwargs["from_"] == relay_number.number
     assert call_kwargs["body"] == (
         "Message failed to send. There is more than one phone number in this thread"
-        " ending in 0001. To retry, start your message with the complete number."
+        " ending in \u20680001\u2069. To retry, start your message with the complete"
+        " number."
     )
     relay_number.refresh_from_db()
     assert relay_number.texts_forwarded == multi_reply.old_texts_forwarded
@@ -1308,7 +1309,7 @@ def test_inbound_sms_reply_short_prefix_no_match(
     assert call_kwargs["from_"] == relay_number.number
     assert call_kwargs["body"] == (
         "Message failed to send. There is no phone number in this thread ending in"
-        " 0404. Please check the number and try again."
+        " \u20680404\u2069. Please check the number and try again."
     )
     relay_number.refresh_from_db()
     assert relay_number.texts_forwarded == multi_reply.old_texts_forwarded
@@ -1333,7 +1334,7 @@ def test_inbound_sms_reply_full_prefix_no_match(multi_reply: MultiReplyFixture) 
     assert call_kwargs["from_"] == relay_number.number
     assert call_kwargs["body"] == (
         "Message failed to send. There is no previous sender with the phone number"
-        " +14045550404. Please check the number and try again."
+        " \u2068+14045550404\u2069. Please check the number and try again."
     )
     relay_number.refresh_from_db()
     assert relay_number.texts_forwarded == multi_reply.old_texts_forwarded
@@ -1360,7 +1361,7 @@ def test_inbound_sms_reply_short_prefix_no_message(
     assert call_kwargs["from_"] == relay_number.number
     assert call_kwargs["body"] == (
         "Message failed to send. Please include a message after the sender identifier"
-        " 0002."
+        " \u20680002\u2069."
     )
     relay_number.refresh_from_db()
     assert relay_number.texts_forwarded == multi_reply.old_texts_forwarded
@@ -1387,7 +1388,7 @@ def test_inbound_sms_reply_full_prefix_no_message(
     assert call_kwargs["from_"] == relay_number.number
     assert call_kwargs["body"] == (
         "Message failed to send. Please include a message after the phone number"
-        " +13055550002."
+        " \u2068+13055550002\u2069."
     )
     relay_number.refresh_from_db()
     assert relay_number.texts_forwarded == multi_reply.old_texts_forwarded

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -1429,14 +1429,13 @@ _match_by_prefix_candidates = set(
 
 MatchByPrefixParams = tuple[
     str,  # text message
-    Optional[Literal["short", "full"]],  # match_type
+    Literal["short", "full"],  # match_type
     str,  # prefix
-    Optional[str],  # detected number
+    str,  # detected number
     list[str],  # numbers
 ]
 
 _match_by_prefix_tests: dict[str, MatchByPrefixParams] = {
-    "no prefix": ("no prefix", None, "", None, []),
     "4 digits, no message": ("0000 ", "short", "0000 ", "0000", ["+13015550000"]),
     "4 digit multiple matches": (
         "0001 the message",
@@ -1544,9 +1543,6 @@ _match_by_prefix_tests: dict[str, MatchByPrefixParams] = {
         "0000",
         ["+13015550000"],
     ),
-    "3 digits is not a prefix": ("000 the message", None, "", None, []),
-    "digits with spaces is not a prefix": ("00 01 the message", None, "", None, []),
-    "letter + digits is not a prefix": ("x0000 the message", None, "", None, []),
     "e.164, no message": (
         "+13015550000",
         "full",
@@ -1638,7 +1634,6 @@ _match_by_prefix_tests: dict[str, MatchByPrefixParams] = {
         "+13015550000",
         ["+13015550000"],
     ),
-    "e.164 with extra num, no match": ("+130155500007 message", None, "", None, []),
     "Two e.164, first match": (
         "(301) 555-0000 +13045551301",
         "full",
@@ -1656,9 +1651,9 @@ _match_by_prefix_tests: dict[str, MatchByPrefixParams] = {
 )
 def test_match_by_prefix(
     text: str,
-    match_type: Optional[Literal["short", "full"]],
+    match_type: Literal["short", "full"],
     prefix: str,
-    detected: Optional[str],
+    detected: str,
     numbers: list[str],
 ) -> None:
     """_match_by_prefix returns the matching candidates and the detected prefix."""
@@ -1667,6 +1662,25 @@ def test_match_by_prefix(
         match_type=match_type, prefix=prefix, detected=detected, numbers=numbers
     )
     assert match == expected_match
+
+
+_match_by_prefix_no_match_tests: dict[str, str] = {
+    "no prefix": "no prefix",
+    "3 digits is not a prefix": "000 the message",
+    "digits with spaces is not a prefix": "00 01 the message",
+    "letter + digits is not a prefix": "x0000 the message",
+    "e.164 with extra num, no match": "+130155500007 message",
+}
+
+
+@pytest.mark.parametrize(
+    "text",
+    _match_by_prefix_no_match_tests.values(),
+    ids=list(_match_by_prefix_no_match_tests.keys()),
+)
+def test_match_by_prefix_no_match(text: str):
+    match = _match_by_prefix(text, _match_by_prefix_candidates)
+    assert match is None
 
 
 @pytest.mark.django_db

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -1100,8 +1100,8 @@ class MultiReplyFixture:
     """Bundle fixtures for multi_replies tests."""
 
     user: User
-    real_phone: RealPhone
-    relay_number: RelayNumber
+    real_phone: "RealPhone"
+    relay_number: "RelayNumber"
     mocked_twilio_client: Client
 
 

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -1197,7 +1197,7 @@ def test_inbound_sms_reply_full_number_wins(multi_reply: MultiReplyFixture) -> N
     data = {
         "From": multi_reply.real_phone.number,
         "To": relay_number.number,
-        "Body": "1301 5550000 - Isn't +13045551301 a jerk?",
+        "Body": "1301 5550000 Isn't +13045551301 a jerk?",
     }
     response = APIClient().post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -1221,7 +1221,7 @@ def test_inbound_sms_reply_short_prefix_never_text(
     data = {
         "From": multi_reply.real_phone.number,
         "To": relay_number.number,
-        "Body": "0003 - send reply to caller",
+        "Body": "0003: send reply to caller",
     }
     response = APIClient().post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -1511,35 +1511,35 @@ _match_by_prefix_tests: dict[str, MatchByPrefixParams] = {
     "4 digit with dash": (
         "0000 - the message",
         "short",
-        "0000 - ",
+        "0000 ",
         "0000",
         ["+13015550000"],
     ),
     "4 digit with slash": (
         "0000 / the message",
         "short",
-        "0000 / ",
+        "0000 ",
         "0000",
         ["+13015550000"],
     ),
     "4 digit with backslash": (
         r"0000 \ the message",
         "short",
-        r"0000 \ ",
+        r"0000 ",
         "0000",
         ["+13015550000"],
     ),
     "4 digit with right bracket": (
         "0000] the message",
         "short",
-        "0000] ",
+        "0000",
         "0000",
         ["+13015550000"],
     ),
     "4 digit with pipe": (
         "0000 | the message",
         "short",
-        "0000 | ",
+        "0000 ",
         "0000",
         ["+13015550000"],
     ),
@@ -1567,35 +1567,35 @@ _match_by_prefix_tests: dict[str, MatchByPrefixParams] = {
     "e.164, dash": (
         "+13035550001 - the message",
         "full",
-        "+13035550001 - ",
+        "+13035550001 ",
         "+13035550001",
         ["+13035550001"],
     ),
     "e.164, slash": (
         "+13035550001 / the message",
         "full",
-        "+13035550001 / ",
+        "+13035550001 ",
         "+13035550001",
         ["+13035550001"],
     ),
     "e.164, backslash": (
         r"+13035550001 \ the message",
         "full",
-        r"+13035550001 \ ",
+        r"+13035550001 ",
         "+13035550001",
         ["+13035550001"],
     ),
     "e.164, right bracket": (
         "+13045551301]the message",
         "full",
-        "+13045551301]",
+        "+13045551301",
         "+13045551301",
         ["+13045551301"],
     ),
     "e.164, pipe": (
         "+13045551301|the message",
         "full",
-        "+13045551301|",
+        "+13045551301",
         "+13045551301",
         ["+13045551301"],
     ),

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -1500,6 +1500,13 @@ _match_by_prefix_tests: dict[str, MatchByPrefixParams] = {
         "+13025550001",
         ["+13025550001"],
     ),
+    "e.164, double colon": (
+        "+13025550001 :: the message",
+        "full",
+        "+13025550001 :",
+        "+13025550001",
+        ["+13025550001"],
+    ),
     "e.164, dash": (
         "+13035550001 - the message",
         "full",

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -621,12 +621,17 @@ def _get_phone_objects(inbound_to):
     return relay_number, real_phone
 
 
-def _handle_sms_reply(relay_number, real_phone, inbound_body):
+def _handle_sms_reply(
+    relay_number: RelayNumber, real_phone: RealPhone, inbound_body: str
+) -> None:
     incr_if_enabled("phones_handle_sms_reply")
     client = twilio_client()
     if not relay_number.storing_phone_log:
         origin = settings.SITE_ORIGIN
-        error = f"You can only reply if you allow Firefox Relay to keep a log of your callers and text senders. {origin}/accounts/settings/"
+        error = (
+            "You can only reply if you allow Firefox Relay to keep a log of your"
+            f" callers and text senders. {origin}/accounts/settings/"
+        )
         client.messages.create(
             from_=relay_number.number,
             body=error,
@@ -634,7 +639,7 @@ def _handle_sms_reply(relay_number, real_phone, inbound_body):
         )
         raise exceptions.ValidationError(error)
     last_text_sender = get_last_text_sender(relay_number)
-    if last_text_sender == None:
+    if last_text_sender is None:
         error = "Could not find a previous text sender."
         client.messages.create(
             from_=relay_number.number,

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -780,8 +780,6 @@ def _match_by_prefix(
     """
     Look for a prefix in a text message, and return a likely phone number match.
 
-    If no prefix is detected, NoPrefixFound is raised.
-
     Arguments:
     * A SMS text message
     * A set of phone numbers in E.164 format

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -875,12 +875,12 @@ _SMS_SHORT_PREFIX_RE = re.compile(
 \s*             # One or more spaces
 \d{4}           # 4 digits
 \s*             # Optional whitespace
-[-:/\\\]|]?     # At most one separator, sync with SMS_SEPARATORS below
+[:]?     # At most one separator, sync with SMS_SEPARATORS below
 \s*             # Trailing whitespace
 """,
     re.VERBOSE | re.ASCII,
 )
-_SMS_SEPARATORS = set("-:/\\]|")  # Sync with SMS_SHORT_PREFIX_RE above
+_SMS_SEPARATORS = set(":")  # Sync with SMS_SHORT_PREFIX_RE above
 
 
 def _match_by_prefix(text: str, candidate_numbers: set[str]) -> Optional[MatchByPrefix]:

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -666,9 +666,17 @@ def _handle_sms_reply(
                     f" ending in {digits}. Please check the number and try again."
                 )
             else:
+                try:
+                    pn = phonenumbers.parse(prefix, None)
+                    number = phonenumbers.format_number(
+                        pn, phonenumbers.PhoneNumberFormat.E164
+                    )
+                except phonenumbers.phonenumberutil.NumberParseException:
+                    number = digits
+
                 prefix_error = (
                     "Message failed to send. There is no previous sender with the"
-                    f" phone number +{digits}. Please check the number and try again."
+                    f" phone number {number}. Please check the number and try again."
                 )
         else:
             assert prefix

--- a/emails/models.py
+++ b/emails/models.py
@@ -459,10 +459,6 @@ class Profile(models.Model):
         return True
 
 
-def get_storing_phone_log(relay_number):
-    return relay_number.user.profile.store_phone_log
-
-
 @receiver(models.signals.post_save, sender=Profile)
 def copy_auth_token(sender, instance=None, created=False, **kwargs):
     if created:

--- a/phones/models.py
+++ b/phones/models.py
@@ -235,6 +235,10 @@ class RelayNumber(models.Model):
     def calls_and_texts_blocked(self):
         return self.calls_blocked + self.texts_blocked
 
+    @property
+    def storing_phone_log(self) -> bool:
+        return self.user.profile.store_phone_log
+
     def save(self, *args, **kwargs):
         realphone = get_verified_realphone_records(self.user).first()
         if not realphone:

--- a/phones/models.py
+++ b/phones/models.py
@@ -19,8 +19,6 @@ from twilio.rest import Client
 
 from emails.utils import incr_if_enabled
 
-from .apps import PhonesConfig
-
 MAX_MINUTES_TO_VERIFY_REAL_PHONE = 5
 LAST_CONTACT_TYPE_CHOICES = [
     ("call", "call"),
@@ -29,6 +27,8 @@ LAST_CONTACT_TYPE_CHOICES = [
 
 
 def twilio_client() -> Client:
+    from .apps import PhonesConfig
+
     phones_config = apps.get_app_config("phones")
     assert isinstance(phones_config, PhonesConfig)
     return phones_config.twilio_client

--- a/phones/models.py
+++ b/phones/models.py
@@ -15,8 +15,11 @@ from django.dispatch.dispatcher import receiver
 from django.urls import reverse
 
 from twilio.base.exceptions import TwilioRestException
+from twilio.rest import Client
 
 from emails.utils import incr_if_enabled
+
+from .apps import PhonesConfig
 
 MAX_MINUTES_TO_VERIFY_REAL_PHONE = 5
 LAST_CONTACT_TYPE_CHOICES = [
@@ -25,10 +28,10 @@ LAST_CONTACT_TYPE_CHOICES = [
 ]
 
 
-def twilio_client():
+def twilio_client() -> Client:
     phones_config = apps.get_app_config("phones")
-    client = phones_config.twilio_client
-    return client
+    assert isinstance(phones_config, PhonesConfig)
+    return phones_config.twilio_client
 
 
 def verification_code_default():

--- a/privaterelay/ftl_bundles.py
+++ b/privaterelay/ftl_bundles.py
@@ -1,3 +1,25 @@
-from django_ftl.bundles import Bundle
+import os.path
 
-main = Bundle(["app.ftl", "brands.ftl"])
+from django.utils.functional import cached_property
+
+from django_ftl.bundles import Bundle, DjangoMessageFinder
+
+
+class RelayMessageFinder(DjangoMessageFinder):
+    @cached_property
+    def locale_base_dirs(self):
+        base_dirs = super().locale_base_dirs
+
+        from django.apps import apps
+
+        pending_dirs = []
+        for app_config in apps.get_app_configs():
+            if not app_config.path:
+                continue
+            pending_locales_dir = os.path.join(app_config.path, "pending_locales")
+            if os.path.isdir(pending_locales_dir):
+                pending_dirs.append(pending_locales_dir)
+        return base_dirs + pending_dirs
+
+
+main = Bundle(["app.ftl", "brands.ftl", "pending.ftl"], finder=RelayMessageFinder())

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This is the Django equivalent of frontend/pendingTranslations.ftl
+
+## Relay SMS reply errors
+
+relay-sms-error-no-previous-sender = Message failed to send. Could not find a previous text sender.
+# Variables
+#   $account_settings_url (string) - The URL of the Relay account settings, to enable logs
+relay-sms-error-no-phone-log = You can only reply if you allow { -brand-name-firefox-relay } to keep a log of your callers and text senders. See { $account_settings_url }.
+
+# Variables
+#   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number
+relay-sms-error-short-prefix-matches-no-senders = Message failed to send. There is no phone number in this thread ending in { $short_prefix }. Please check the number and try again.
+# Variables
+#   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number
+relay-sms-error-multiple-number-matches = Message failed to send. There is more than one phone number in this thread ending in { $short_prefix }. To retry, start your message with the complete number.
+# Variables
+#   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number
+relay-sms-error-no-body-after-short-prefix = Message failed to send. Please include a message after the sender identifier { $short_prefix }.
+
+# Variables
+#   $full_number (string) - A phone number, such as '+13025551234' or '1 (302) 555-1234'
+relay-sms-error-full-number-matches-no-senders = Message failed to send. There is no previous sender with the phone number { $full_number }. Please check the number and try again.
+# Variables
+#   $full_number (string) - A phone number, such as '+13025551234' or '1 (302) 555-1234'
+relay-sms-error-no-body-after-full-number = Message failed to send. Please include a message after the phone number { $full_number }.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ module = [
     "debug_toolbar",
     "dj_database_url",
     "django_filters",
+    "django_ftl",
     "django_ftl.bundles",
     "drf_yasg",
     "drf_yasg.utils",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ module = [
     "vobject",
     "waffle",
     "waffle.models",
+    "waffle.testutils",
     "whitenoise.middleware",
     "whitenoise.storage",
 ]


### PR DESCRIPTION
For MPP-2562, implement a method for choosing the recipient of a text by the last 4 or full phone of a previous recipient. This requires the new waffle flag `multi_replies` to be enabled for the user:

## How to test

If you have local phone integration working and a few external numbers to try, you can test locally. Otherwise, you may want to push to Heroku and try there.

1. [x] Add the test user to the `multi_replies` waffle flag:
    ```
    ./manage.py waffle_flag --create --user user@example.com multi_replies
    ./manage.py waffle_flag --list
    ```
2. [x] Send a message via short prefix to a previous sender, like: `1234: Here's my Relay reply`. Sender gets the text without the short prefix
3. [x] Send a message via full number to a previous sender, like: `+13025551234: Here's another relay reply`. Sender gets the text without the full number prefix.
4. [x] Send a message via short prefix to an unknown sender, like `6543: Hello!`. Get a response "Message failed to send. There is no phone number in this thread ending in 6543. Please check the number and try again."
5. [x] Send a message with a full number to an unknown sender, like `(918) 555-1234: Hi!`. Get a response "Message failed to send. There is no previous sender with the phone number 9185551234. Please check the number and try again.
6. [x] Send a message with a full number to an unknown sender in E.164 format, like `+19185559876: Hi!`. Get a response "Message failed to send. There is no previous sender with the phone number +19185559876. Please check the number and try again.
7. [x] Send a message via short prefix with no message, like `1234`. Get a response "Message failed to send. Please include a message after the sender identifier 1234`.
8. [x] Send a message via full number with no message, like `+13025551234`. Get a response "Message failed to send. Please include a message after the phone number +13025551234."
9. [x] Unit tests cover most of the new code, and pass in CircleCI

## Details

A multi-reply message with a 4-digit prefix looks like:
```
1234 Send a text message to a relay contact
```

These 4 digits should match the last 4 digits of a previous contact.

and a full number looks like:
```
+13215551234 Send a text message to a relay contact
```

Whitespace before and after the code, and an optional separator `:` is allowed, so these are equivalent:

```
1234A Message
  1234   A Message
1234: A Message
1234 :A Message
```

Earlier versions of this PR supported `-`, `#`, `/`, `\\`, `]` (from our leader `[Relay 📲 +3215551234]`) and `|`, but I removed those.

Additional digits are treated as part of the message, so the message for `123456 A Message` is `56 A Message`.

The [phonenumbers.PhoneNumberMatcher](https://github.com/daviddrysdale/python-phonenumbers) is used for full numbers, so these are equivalent:

```
+13215551234 A message
13215551234 A message 
1 (321) 555-1234: A message 
321 555 1234 - A message
```

## Caveats
* A user can identify a contact that only previously called and send them a text.
* Using a prefix does _not_ set the last contact, so a second message without a prefix may be sent to an unexpected contact.

## Errors
Some of the error messages are on MPPUX-751, others I created and need to check with the content team. Translation is not (yet?) supported

* **Short prefix, no contact matches**: "Message failed to send. There is no phone number in this thread ending in {digits}. Please check the number and try again."
* **Short prefix, multiple contact matches**: "Message failed to send. There is more than one phone number in this thread ending in {digits}. To retry, start your message with the complete number."
* **Short prefix, contact match, but no message**: "Message failed to send. Please include a message after the sender identifier {digits}."
* **Full number, no contact matches**: "Message failed to send. There is no previous sender with the phone number {number}. Please check the number and try again.". `{number}` is the E.164 format or just the digits.
* **Full number, contact match, but no message**: "Message failed to send. Please include a message after the phone number {number}." The `{number}` is in E.164 format.
There is no previous sender with the phone number {number}. Please check the number and try again.". `{number}` is the E.164 format or just the digits.

