### PR TITLE
Python dependency updates, Nov 15, 2022, round 1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ whitenoise==6.2.0
 
 # phones app
 phonenumbers==8.13.0
-twilio==7.15.1
+twilio==7.15.2
 vobject==0.9.6.1
 
 # tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.26.8
-codetiming==1.3.2
+codetiming==1.4.0
 cryptography==38.0.3
 Django==3.2.16
 dj-database-url==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ black==22.10.0
 
 # type hinting
 mypy==0.982
-types-requests==2.28.11.2
+types-requests==2.28.11.4
 types-pyOpenSSL==22.1.0.2
 django-stubs==1.13.0
 djangorestframework-stubs==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ drf-yasg==1.21.4
 google-measurement-protocol==1.1.0
 gunicorn==20.1.0
 jwcrypto==1.4.2
-markus[datadog]==4.0.1
+markus[datadog]==4.1.0
 pem==21.2.0
 psycopg2==2.9.5
 # NOTE: update to 2.6.0 blocked by #2738

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.5
+boto3==1.26.8
 codetiming==1.3.2
 cryptography==38.0.3
 Django==3.2.16


### PR DESCRIPTION
Update Python dependencies for the week. This covers:

* Bump twilio from 7.15.1 to 7.15.2 (from PR #2787) - API updates, including campaign opt-in / opt-out details
* Bump markus[datadog] from 4.0.1 to 4.1.0 (from PR #2788) - Python 3.11 support
* Bump types-requests from 2.28.11.2 to 2.28.11.4 (from PR #2789) - Unknown type tweaks
* Bump boto3 from 1.26.5 to 1.26.8 (from PR #2790) - API changes, including adding API support for [EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/what-is-scheduler.html), which is interesting but we probably won't use it.
* Bump codetiming from 1.3.2 to 1.4.0 (from PR #2791) - Adds parameter to log when the timer starts.

There's at least one more update (`mypy`) and maybe some more once this merges.

