### PR TITLE
Add custom dimension to distinguish add-on telemetry from website traffic

### DIFF
--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -136,12 +136,15 @@ def metrics_event(request):
         return JsonResponse({"msg": "No GA uuid found"}, status=404)
     # "dimension5" is a Google Analytics-specific variable to track a custom dimension,
     # used to determine which browser vendor the add-on is using: Firefox or Chrome
+    # "dimension7" is a Google Analytics-specific variable to track a custom dimension,
+    # used to determine which where the traffic is coming from: website (default), add-on or app
     event_data = event(
         request_data.get("category", None),
         request_data.get("action", None),
         request_data.get("label", None),
         request_data.get("value", None),
         dimension5=request_data.get("dimension5", None),
+        dimension7=request_data.get("dimension7", "website"),
     )
     try:
         report(settings.GOOGLE_ANALYTICS_ID, request_data.get("ga_uuid"), event_data)

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -137,7 +137,7 @@ def metrics_event(request):
     # "dimension5" is a Google Analytics-specific variable to track a custom dimension,
     # used to determine which browser vendor the add-on is using: Firefox or Chrome
     # "dimension7" is a Google Analytics-specific variable to track a custom dimension,
-    # used to determine which where the traffic is coming from: website (default), add-on or app
+    # used to determine where the ping is coming from: website (default), add-on or app
     event_data = event(
         request_data.get("category", None),
         request_data.get("action", None),


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes [MPP-2582](https://mozilla-hub.atlassian.net/browse/MPP-2582)
Companion PR on add-on repo: https://github.com/mozilla/fx-private-relay-add-on/pull/435

There's no direct way to test this PR, except to test the end result in GA. Please flag this if there's a better way to test. 

- [X] ~l10n changes have been submitted to the l10n repository, if any.~
- [X] ~I've added a unit test to test for potential regressions of this bug.~
- [X] ~I've added or updated relevant docs in the docs/ directory.~
- [X] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->
