### PR TITLE
Add `enable_if_setting` decorator

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -3,6 +3,7 @@ from django.urls import include, path, register_converter
 
 from rest_framework import routers
 
+from privaterelay.utils import enable_if_setting
 from .views import (
     DomainAddressViewSet,
     RelayAddressViewSet,
@@ -10,6 +11,7 @@ from .views import (
     UserViewSet,
     report_webcompat_issue,
     runtime_data,
+    schema_view,
 )
 
 
@@ -40,23 +42,19 @@ urlpatterns = [
         report_webcompat_issue,
         name="report_webcompat_issue",
     ),
+    path(
+        "v1/swagger<swagger_format:format>",
+        enable_if_setting("API_DOCS_ENABLED")(schema_view.without_ui(cache_timeout=0)),
+        name="schema-json",
+    ),
+    path(
+        "v1/docs/",
+        enable_if_setting("API_DOCS_ENABLED")(
+            schema_view.with_ui("swagger", cache_timeout=0)
+        ),
+        name="schema-swagger-ui",
+    ),
 ]
-
-if settings.API_DOCS_ENABLED:
-    from .views import schema_view
-
-    urlpatterns += [
-        path(
-            "v1/swagger<swagger_format:format>",
-            schema_view.without_ui(cache_timeout=0),
-            name="schema-json",
-        ),
-        path(
-            "v1/docs/",
-            schema_view.with_ui("swagger", cache_timeout=0),
-            name="schema-swagger-ui",
-        ),
-    ]
 
 if settings.PHONES_ENABLED:
     from .views.phones import (


### PR DESCRIPTION
Add an `enable_if_setting` decorator that allows a view to return 404 based on a setting, computed at access time. This allows testing both the enabled and disabled states with `@override_settings`