### PR TITLE
MPP-2804: Collect static files for API docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,6 @@ jobs:
             --build-arg CIRCLE_BRANCH="$CIRCLE_BRANCH" \
             --build-arg CIRCLE_TAG="$CIRCLE_TAG" \
             --build-arg CIRCLE_SHA1="$CIRCLE_SHA1" \
-            --build-arg PHONES_ENABLED="$PHONES_ENABLED" \
             .
 
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,10 @@ RUN ln --symbolic /app/privaterelay/locales/pt-BR/ privaterelay/locales/pt
 RUN ln --symbolic /app/privaterelay/locales/es-ES/ privaterelay/locales/es
 COPY --chown=app .env-dist /app/.env
 
-ARG PHONES_ENABLED
-RUN mkdir -p /app/staticfiles && \
+# Collect all staticfiles, including for apps that may be disabled
+RUN PHONES_ENABLED=True \
+    API_DOCS_ENABLED=True \
+    mkdir -p /app/staticfiles && \
     python manage.py collectstatic --no-input -v 2
 
 ENTRYPOINT ["/app/.local/bin/gunicorn"]


### PR DESCRIPTION
When collecting static files in the Docker image, enable phones and API docs so that those are collected as well. They can still be disabled via the environment variables at runtime.

# How to test
In CircleCI for this PR, view the "build_test_backend" job, and find the "Build Docker Image" step. View the raw results. It should show assets like `drf-yasg/swagger-ui-dist/favicon-32x32.png` being collected.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).