### PR TITLE
Also prevent phone dashboard from overlapping Tips

### DIFF
--- a/frontend/src/components/phones/dashboard/PhoneDashboard.module.scss
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.module.scss
@@ -16,6 +16,9 @@
     gap: $spacing-lg;
     display: flex;
     flex-direction: column;
+    // Ensure that the <Tips> card can always overlap elements in the profile,
+    // even if they have z-indexes to overlap each other:
+    isolation: isolate;
   }
 
   .nav-icon {


### PR DESCRIPTION
This PR fixes MPP-2560. This is basically the same fix as in https://github.com/mozilla/fx-private-relay/pull/2773, but then on the phone dashboard (which didn't have tips back then, that was added in https://github.com/mozilla/fx-private-relay/pull/2780.

How to test: open the phone dashboard. Ensure that the "Forwarding" and "Blocking" labels do not overlap the tips like they do in this screenshot:

![image](https://user-images.githubusercontent.com/4251/202498574-79779fef-2ed8-45f2-99d3-71a897a07730.png)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
