### PR TITLE
Python dependency updates, November 21, 2022, part 1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ black==22.10.0
 
 # type hinting
 mypy==0.982
-types-requests==2.28.11.4
+types-requests==2.28.11.5
 types-pyOpenSSL==22.1.0.2
 django-stubs==1.13.0
 djangorestframework-stubs==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ PyJWT==2.5.0
 python-decouple==3.6
 pyOpenSSL==22.1.0
 requests==2.28.1
-sentry-sdk==1.10.1
+sentry-sdk==1.11.0
 whitenoise==6.2.0
 
 # phones app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.9
+boto3==1.26.13
 codetiming==1.4.0
 cryptography==38.0.3
 Django==3.2.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ whitenoise==6.2.0
 
 # phones app
 phonenumbers==8.13.0
-twilio==7.15.2
+twilio==7.15.3
 vobject==0.9.6.1
 
 # tests


### PR DESCRIPTION
Update Python dependencies for November 21, 2022, part 1. This covers:

* Bump sentry-sdk from 1.10.1 to 1.11.0 (from PR #2820) - Includes some optimizations, and then fixes, for Django signal handling in exceptions.
* Bump types-requests from 2.28.11.4 to 2.28.11.5 (from PR #2821) - Types bump
* Bump twilio from 7.15.2 to 7.15.3 (from PR #2823) - SDK bump
* Bump boto3 from 1.26.9 to 1.26.13 (from PR #2824) - SDK bump


