### PR TITLE
mypy 0.991 update and related changes

### DIFF
--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -12,31 +12,33 @@ from emails.tests.models_tests import make_free_test_user, make_premium_test_use
 
 
 @pytest.fixture
-def free_api_client(db) -> APIClient:
+def free_user(db) -> User:
+    return make_free_test_user()
+
+
+@pytest.fixture
+def free_api_client(free_user: User) -> APIClient:
     """Return an APIClient for a newly created free user."""
-    free_user = make_free_test_user()
     client = APIClient()
     client.force_authenticate(user=free_user)
     return client
 
 
 @pytest.fixture
-def prem_api_client(db) -> APIClient:
-    """Return an APIClient for a newly created premium user."""
+def premium_user(db) -> User:
     premium_user = make_premium_test_user()
     premium_profile = premium_user.profile
     premium_profile.subdomain = "premium"
     premium_profile.save()
+    return premium_user
+
+
+@pytest.fixture
+def prem_api_client(premium_user: User) -> APIClient:
+    """Return an APIClient for a newly created premium user."""
     client = APIClient()
     client.force_authenticate(user=premium_user)
     return client
-
-
-def get_user(client: APIClient) -> User:
-    """Get user from APIClient.force_authenticate()"""
-    user = client.handler._force_user
-    assert isinstance(user, User)
-    return user
 
 
 @pytest.mark.parametrize("format", ("yaml", "json"))
@@ -75,9 +77,9 @@ def test_post_domainaddress_success(prem_api_client) -> None:
     assert ret_data["full_address"].startswith("my-new-mask@premium.")
 
 
-def test_post_domainaddress_no_subdomain_error(prem_api_client) -> None:
+def test_post_domainaddress_no_subdomain_error(premium_user, prem_api_client) -> None:
     """A premium user needs to select a subdomain before creating a domain address."""
-    premium_profile = get_user(prem_api_client).profile
+    premium_profile = premium_user.profile
     premium_profile.subdomain = ""
     premium_profile.save()
 
@@ -95,9 +97,9 @@ def test_post_domainaddress_no_subdomain_error(prem_api_client) -> None:
     }
 
 
-def test_post_domainaddress_user_flagged_error(prem_api_client) -> None:
+def test_post_domainaddress_user_flagged_error(premium_user, prem_api_client) -> None:
     """A flagged user cannot create a new domain address."""
-    premium_profile = get_user(prem_api_client).profile
+    premium_profile = premium_user.profile
     premium_profile.last_account_flagged = timezone.now()
     premium_profile.save()
 
@@ -162,10 +164,9 @@ def test_post_relayaddress_success(settings, free_api_client) -> None:
 
 
 def test_post_relayaddress_free_mask_email_limit_error(
-    settings, free_api_client
+    settings, free_user, free_api_client
 ) -> None:
     """A free user is unable to exceed the mask limit."""
-    free_user = get_user(free_api_client)
     for _ in range(settings.MAX_NUM_FREE_ALIASES):
         baker.make(RelayAddress, user=free_user)
 
@@ -186,9 +187,9 @@ def test_post_relayaddress_free_mask_email_limit_error(
     }
 
 
-def test_post_relayaddress_flagged_error(free_api_client) -> None:
+def test_post_relayaddress_flagged_error(free_user, free_api_client) -> None:
     """A flagged user is unable to create a random mask."""
-    free_profile = get_user(free_api_client).profile
+    free_profile = free_user.profile
     free_profile.last_account_flagged = timezone.now()
     free_profile.save()
 

--- a/emails/tests/cleaners_tests.py
+++ b/emails/tests/cleaners_tests.py
@@ -13,8 +13,9 @@ from .models_tests import make_premium_test_user, make_storageless_test_user
 
 
 def setup_server_storage_test_data(
-    add_user_without_storage=False, add_server_data_for_user_without_storage=False
-):
+    add_user_without_storage: bool = False,
+    add_server_data_for_user_without_storage: bool = False,
+) -> None:
     """Setup users and addresses for testing."""
 
     # Create a user with server storage and addresses

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -38,7 +38,7 @@ from ..models import (
 )
 
 
-def make_free_test_user():
+def make_free_test_user() -> User:
     user = baker.make(User)
     user_profile = Profile.objects.get(user=user)
     user_profile.server_storage = True
@@ -49,7 +49,7 @@ def make_free_test_user():
     return user
 
 
-def make_premium_test_user():
+def make_premium_test_user() -> User:
     # premium user
     premium_user = baker.make(User, email="premium@email.com")
     premium_user_profile = Profile.objects.get(user=premium_user)

--- a/privaterelay/apps.py
+++ b/privaterelay/apps.py
@@ -4,6 +4,7 @@ import os
 
 from django.apps import AppConfig
 from django.conf import settings
+from django.utils.functional import cached_property
 
 
 ROOT_DIR = os.path.abspath(os.curdir)
@@ -12,16 +13,20 @@ ROOT_DIR = os.path.abspath(os.curdir)
 class PrivateRelayConfig(AppConfig):
     name = "privaterelay"
 
-    def __init__(self, app_name, app_module):
-        super(PrivateRelayConfig, self).__init__(app_name, app_module)
-        self.fxa_verifying_keys: list[dict[str, Any]] = []
-
-    def ready(self):
+    def ready(self) -> None:
         import privaterelay.signals  # noqa: F401
 
+        try:
+            del self.fxa_verifying_keys  # Clear cache
+        except AttributeError:
+            pass
+
+    @cached_property
+    def fxa_verifying_keys(self) -> list[dict[str, Any]]:
         resp = requests.get(
             "%s/jwks" % settings.SOCIALACCOUNT_PROVIDERS["fxa"]["OAUTH_ENDPOINT"]
         )
         if resp.status_code == 200:
-            resp_json = resp.json()
-            self.fxa_verifying_keys = resp_json["keys"]
+            keys: list[dict[str, Any]] = resp.json()["keys"]
+            return keys
+        return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,18 @@ mypy_path = "$MYPY_CONFIG_FILE_DIR/mypy_stubs"
 exclude = "env"
 python_version = "3.9"
 show_error_codes = true
-warn_return_any = true
-warn_unused_configs = true
-warn_unused_ignores = true
+strict = true
+
+# Disable these strict checks
+# Order is the recommended enabling order, from highest to lowest priority,
+# from mypy doc "Using mypy with an existing codebase"
+check_untyped_defs = false
+disallow_subclassing_any = false
+disallow_any_generics = false
+disallow_untyped_calls = false
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+no_implicit_reexport = false
 
 [tool.django-stubs]
 django_settings_module = "privaterelay.settings"

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,4 +49,4 @@ mypy==0.991
 types-requests==2.28.11.5
 types-pyOpenSSL==22.1.0.2
 django-stubs==1.13.0
-djangorestframework-stubs==1.7.0
+djangorestframework-stubs==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ responses==0.22.0
 black==22.10.0
 
 # type hinting
-mypy==0.982
+mypy==0.991
 types-requests==2.28.11.5
 types-pyOpenSSL==22.1.0.2
 django-stubs==1.13.0


### PR DESCRIPTION
Update from mypy 0.982 to 0.991 (opened in PR #2822), along with the changes needed to check types without errors or warnings:

* Update djangorestframework-stubs from 1.7.0 to 1.8.0, so that `api/permissions.py` will not error with `Metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases [misc]`
* Switch to downloading FxA verification keys on first use, to speed up application startup and fully type `privaterelay.apps.PrivateRelayConfig`, avoiding warning `By default the bodies of untyped functions are not checked, consider using --check-untyped-defs`
* Add types to `emails.tests.cleaners_tests.setup_server_storage_test_data`, to avoid the same warning
* Convert the helper function `api.tests.views_tests.get_user` into two fixtures `free_user` and `premium_user`, to avoid error `"ClientHandler" has no attribute "_force_user"`.