### PR TITLE
Add flag management page

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -2,6 +2,8 @@ from rest_framework import permissions
 
 from emails.models import Profile
 
+from waffle import flag_is_active
+
 
 READ_METHODS = ["GET", "HEAD"]
 
@@ -25,3 +27,10 @@ class HasPhoneService(permissions.BasePermission):
             return True
         profile = Profile.objects.get(user=request.user)
         return profile.has_phone
+
+
+class CanManageFlags(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return flag_is_active(request, "manage_flags") and request.user.email.endswith(
+            "@mozilla.com"
+        )

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import User
 from django.db.models import prefetch_related_objects
 
 from rest_framework import serializers, exceptions
+from waffle import get_waffle_flag_model
 
 from emails.models import DomainAddress, Profile, RelayAddress
 
@@ -149,6 +150,19 @@ class UserSerializer(serializers.ModelSerializer):
         model = User
         fields = ["email"]
         read_only_fields = ["email"]
+
+
+class FlagSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = get_waffle_flag_model()
+        fields = [
+            "id",
+            "name",
+            "everyone",
+        ]
+        read_only_fields = [
+            "id",
+        ]
 
 
 class WebcompatIssueSerializer(serializers.Serializer):

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -159,6 +159,7 @@ class FlagSerializer(serializers.ModelSerializer):
             "id",
             "name",
             "everyone",
+            "note",
         ]
         read_only_fields = [
             "id",

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -165,6 +165,16 @@ class FlagSerializer(serializers.ModelSerializer):
             "id",
         ]
 
+    def validate(self, data):
+        if (data.get("name", "").lower() == "manage_flags") or (
+            hasattr(self, "instance")
+            and getattr(self.instance, "name", "").lower() == "manage_flags"
+        ):
+            raise serializers.ValidationError(
+                "Changing the `manage_flags` flag is not allowed."
+            )
+        return super().validate(data)
+
 
 class WebcompatIssueSerializer(serializers.Serializer):
     issue_on_domain = serializers.URLField(

--- a/api/urls.py
+++ b/api/urls.py
@@ -9,6 +9,7 @@ from .views import (
     RelayAddressViewSet,
     ProfileViewSet,
     UserViewSet,
+    FlagViewSet,
     report_webcompat_issue,
     runtime_data,
     schema_view,
@@ -33,6 +34,7 @@ api_router.register(r"domainaddresses", DomainAddressViewSet, "domainaddress")
 api_router.register(r"relayaddresses", RelayAddressViewSet, "relayaddress")
 api_router.register(r"profiles", ProfileViewSet, "profiles")
 api_router.register(r"users", UserViewSet, "user")
+api_router.register(r"flags", FlagViewSet, "flag")
 
 
 urlpatterns = [

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -209,7 +209,7 @@ class FlagFilter(filters.FilterSet):
         ]
 
 
-class FlagViewSet(SaveToRequestUser, viewsets.ModelViewSet):
+class FlagViewSet(viewsets.ModelViewSet):
     serializer_class = FlagSerializer
     permission_classes = [permissions.IsAuthenticated, CanManageFlags]
     filterset_class = FlagFilter
@@ -218,22 +218,6 @@ class FlagViewSet(SaveToRequestUser, viewsets.ModelViewSet):
     def get_queryset(self):
         flags = get_waffle_flag_model().objects
         return flags
-
-    def perform_create(self, serializer):
-        if serializer.validated_data["name"].strip().lower() == "manage_flags":
-            raise ValidationError("Changing the `manage_flags` flag is not allowed.")
-        try:
-            serializer.save()
-        except IntegrityError as e:
-            raise ConflictError({"name": serializer.validated_data["name"]})
-
-    def perform_update(self, serializer):
-        if serializer.data["name"].strip().lower() == "manage_flags":
-            raise ValidationError("Changing the `manage_flags` flag is not allowed.")
-        try:
-            serializer.save()
-        except IntegrityError as e:
-            raise ConflictError({"name": serializer.validated_data["name"]})
 
 
 @swagger_auto_schema(methods=["post"], request_body=WebcompatIssueSerializer)

--- a/frontend/src/hooks/api/runtimeData.ts
+++ b/frontend/src/hooks/api/runtimeData.ts
@@ -4,6 +4,7 @@ import { useApiV1 } from "./api";
 type CountryCode = string;
 type LanguageCode = string;
 export type FlagNames =
+  | "manage_flags"
   | "interview_recruitment"
   | "new_from_address"
   | "tracker_removal"

--- a/frontend/src/pages/flags.module.scss
+++ b/frontend/src/pages/flags.module.scss
@@ -27,6 +27,10 @@
         color: $color-green-80;
       }
 
+      &.is-non-global {
+        text-decoration: line-through;
+      }
+
       td {
         display: flex;
         align-items: center;

--- a/frontend/src/pages/flags.module.scss
+++ b/frontend/src/pages/flags.module.scss
@@ -1,0 +1,82 @@
+@import "../styles/tokens.scss";
+@import "~@mozilla-protocol/core/protocol/css/includes/lib";
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $spacing-2xl;
+  padding: $spacing-2xl;
+  height: 100%;
+
+  .flag-list {
+    thead {
+      display: none;
+    }
+
+    tbody {
+      display: flex;
+      flex-direction: column;
+      gap: $spacing-sm;
+    }
+    tr {
+      display: flex;
+      gap: $spacing-xs;
+
+      &.is-active td:first-of-type {
+        color: $color-green-80;
+      }
+
+      td {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        &:first-of-type {
+          text-align: center;
+
+          svg {
+            display: inline-block;
+          }
+        }
+
+        &:last-of-type {
+          font-family: monospace;
+        }
+      }
+    }
+  }
+
+  .flag-form {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-lg;
+    width: $content-sm;
+
+    p {
+      border: 1px solid $color-yellow-20;
+      background-color: $color-yellow-05;
+      padding: $spacing-md;
+    }
+
+    output {
+      font-family: monospace;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: $spacing-sm;
+
+      label {
+        @include text-body-md;
+      }
+
+      input {
+        @include text-body-md;
+        font-family: monospace;
+        padding: $spacing-xs $spacing-sm;
+      }
+    }
+  }
+}

--- a/frontend/src/pages/flags.page.tsx
+++ b/frontend/src/pages/flags.page.tsx
@@ -58,6 +58,20 @@ const Flags: NextPage = () => {
     }
 
     const enable = actionInput === "enable";
+    const existingFlag = flags.find((flag) => flag.name === flagInput);
+
+    if (existingFlag?.everyone === null) {
+      toast(
+        <>
+          The flag <output>{flagInput}</output> already has a non-global value,
+          and therefore cannot be {enable ? "enabled" : "disabled"} for
+          everyone.
+        </>,
+        { type: "error" }
+      );
+      return;
+    }
+
     const response = await createOrUpdate(flagInput, enable);
     flagData.mutate();
     if (response.ok) {
@@ -99,7 +113,11 @@ const Flags: NextPage = () => {
               <tr
                 key={flag.name}
                 className={
-                  flag.everyone ? styles["is-active"] : styles["is-inactive"]
+                  flag.everyone === null
+                    ? styles["is-non-global"]
+                    : flag.everyone
+                    ? styles["is-active"]
+                    : styles["is-inactive"]
                 }
               >
                 <td>

--- a/frontend/src/pages/flags.page.tsx
+++ b/frontend/src/pages/flags.page.tsx
@@ -143,6 +143,7 @@ const Flags: NextPage = () => {
               type="text"
               id="action"
               autoComplete="off"
+              pattern="(?!manage_flags)"
               required={true}
               placeholder={`e.g. \`${flags[0]?.name}\``}
               value={flagInput}

--- a/frontend/src/pages/flags.page.tsx
+++ b/frontend/src/pages/flags.page.tsx
@@ -154,7 +154,7 @@ const Flags: NextPage = () => {
   );
 };
 
-type Flag = { id: number; name: string; everyone: boolean };
+type Flag = { id: number; name: string; everyone: boolean; note: string };
 function useFlagData() {
   const flagData: SWRResponse<Flag[], unknown> = useApiV1("/flags/");
   return flagData;

--- a/frontend/src/pages/flags.page.tsx
+++ b/frontend/src/pages/flags.page.tsx
@@ -1,0 +1,163 @@
+import { FormEventHandler, useState } from "react";
+import { NextPage } from "next";
+import { SWRResponse } from "swr";
+import styles from "./flags.module.scss";
+import { Layout } from "../components/layout/Layout";
+import { Button } from "../components/Button";
+import { getRuntimeConfig } from "../config";
+import { useRuntimeData } from "../hooks/api/runtimeData";
+import { isFlagActive } from "../functions/waffle";
+import { apiFetch, useApiV1 } from "../hooks/api/api";
+import { BlockIcon, CheckIcon } from "../components/Icons";
+import { toast } from "react-toastify";
+
+const Flags: NextPage = () => {
+  const runtimeData = useRuntimeData();
+  const flagData = useFlagData();
+  const [actionInput, setActionInput] = useState("");
+  const [flagInput, setFlagInput] = useState("");
+
+  if (!runtimeData.data) {
+    return null;
+  }
+
+  if (!isFlagActive(runtimeData.data, "manage_flags") || flagData.error) {
+    document.location.assign(getRuntimeConfig().fxaLoginUrl);
+    return null;
+  }
+
+  const flags =
+    flagData.data?.filter((flag) => flag.name !== "manage_flags") ?? [];
+
+  async function createOrUpdate(flagName: string, enable: boolean) {
+    const existingFlag = flagData.data?.find((flag) => flag.name === flagName);
+
+    if (existingFlag) {
+      return apiFetch(`/flags/${existingFlag.id}/`, {
+        method: "PATCH",
+        body: JSON.stringify({
+          everyone: enable,
+        }),
+      });
+    }
+
+    return await apiFetch("/flags/", {
+      method: "POST",
+      body: JSON.stringify({
+        name: flagName,
+        everyone: enable,
+      }),
+    });
+  }
+
+  const onSubmit: FormEventHandler = async (event) => {
+    event.preventDefault();
+
+    if (!["enable", "disable"].includes(actionInput)) {
+      return;
+    }
+
+    const enable = actionInput === "enable";
+    const response = await createOrUpdate(flagInput, enable);
+    flagData.mutate();
+    if (response.ok) {
+      toast(
+        <>
+          Flag <output>{flagInput}</output> {enable ? "enabled" : "disabled"}{" "}
+          successfully
+        </>,
+        { type: "success" }
+      );
+      // Don't make it too easy to update multiple flags in a row
+      // (to avoid making mistakes):
+      setActionInput("");
+      setFlagInput("");
+    } else {
+      toast(
+        <>
+          Something went wrong {enable ? "enabling" : "disabling"} flag{" "}
+          <output>{flagInput}</output>
+        </>,
+        { type: "error" }
+      );
+    }
+    return;
+  };
+
+  return (
+    <Layout runtimeData={runtimeData.data}>
+      <main className={styles.wrapper}>
+        <table className={styles["flag-list"]}>
+          <thead>
+            <tr>
+              <th>Active?</th>
+              <th>Flag</th>
+            </tr>
+          </thead>
+          <tbody>
+            {flags.map((flag) => (
+              <tr
+                key={flag.name}
+                className={
+                  flag.everyone ? styles["is-active"] : styles["is-inactive"]
+                }
+              >
+                <td>
+                  {flag.everyone ? (
+                    <CheckIcon alt="Active" />
+                  ) : (
+                    <BlockIcon alt="Inactive" />
+                  )}
+                </td>
+                <td>{flag.name}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <form onSubmit={onSubmit} className={styles["flag-form"]}>
+          <p>
+            To avoid accidentally enabling/disabling the wrong flags, you have
+            to type out explicitly what action to take.
+          </p>
+          <div className={styles.field}>
+            <label htmlFor="action">Which flag do you want to modify?</label>
+            <input
+              type="text"
+              id="action"
+              autoComplete="off"
+              required={true}
+              placeholder={`e.g. \`${flags[0]?.name}\``}
+              value={flagInput}
+              onChange={(e) => setFlagInput(e.target.value)}
+            />
+          </div>
+          <div className={styles.field}>
+            <label htmlFor="action">
+              Do you want to <output>enable</output> or <output>disable</output>{" "}
+              it?
+            </label>
+            <input
+              type="text"
+              id="action"
+              autoComplete="off"
+              pattern="enable|disable"
+              required={true}
+              placeholder="`enable` or `disable`"
+              value={actionInput}
+              onChange={(e) => setActionInput(e.target.value)}
+            />
+          </div>
+          <Button type="submit">Set flag status</Button>
+        </form>
+      </main>
+    </Layout>
+  );
+};
+
+type Flag = { id: number; name: string; everyone: boolean };
+function useFlagData() {
+  const flagData: SWRResponse<Flag[], unknown> = useApiV1("/flags/");
+  return flagData;
+}
+
+export default Flags;


### PR DESCRIPTION
This adds the ability for anyone with an `@mozilla.com` email address and for whom the `manage_flags` flag is enabled, to enable or disable a flag for everyone.

Submitting for consideration; not sure yet whether this is a good approach. In particular, this statement [on the Waffle site](https://waffle.readthedocs.io/en/stable/about/goals.html) is not too reassuring:

> Waffle is *not* designed to be secure, or be a replacement for permissions

Although the code also checks whether a user is authenticated and has an `@mozilla.com` address, I wonder if there's more we'd need to check for, e.g. if we could somehow attach [model permissions](https://www.django-rest-framework.org/api-guide/permissions/#djangomodelpermissions) on Waffle's flags model.

This also probably won't be the final approach, but could potentially satisfy our needs until the real solution is in place - perhaps even just enabling this when `RELAY_CHANNEL` is not `prod`.