### PR TITLE
Python dependency updates, November 28, 2022

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ PyJWT==2.5.0
 python-decouple==3.6
 pyOpenSSL==22.1.0
 requests==2.28.1
-sentry-sdk==1.11.0
+sentry-sdk==1.11.1
 whitenoise==6.2.0
 
 # phones app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.26.14
 codetiming==1.4.0
-cryptography==38.0.3
+cryptography==38.0.4
 Django==3.2.16
 dj-database-url==1.0.0
 django-allauth==0.51.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.14
+boto3==1.26.17
 codetiming==1.4.0
 cryptography==38.0.4
 Django==3.2.16


### PR DESCRIPTION
Update Python dependencies. This covers:

* Bump sentry-sdk from 1.11.0 to 1.11.1 (from PR #2849)
* Bump cryptography from 38.0.3 to 38.0.4 (from PR #2853)
* Bump boto3 from 1.26.14 to 1.26.17 (from PR #2864)



