### PR TITLE
MPP-2609 Ignore updating phone stats if not yet billing cycle

### DIFF
--- a/privaterelay/management/commands/update_phone_remaining_stats.py
+++ b/privaterelay/management/commands/update_phone_remaining_stats.py
@@ -23,6 +23,13 @@ def update_phone_remaining_stats():
     updated_profiles = []
     for social_account in accounts_with_phones:
         profile = social_account.user.profile
+        if not profile.date_phone_subscription_checked:
+            first_billing_date = profile.date_subscribed_phone + timedelta(
+                settings.DAYS_PER_BILLING_CYCLE
+            )
+            if datetime.now(timezone.utc) < first_billing_date:
+                # Not yet billing cycle, ignore updating phone stats
+                continue
         # Has it been more than 30 days since we last checked the user's phone
         # subscription?
         if (

--- a/privaterelay/tests/mgmt_update_phone_remaining_stats_tests.py
+++ b/privaterelay/tests/mgmt_update_phone_remaining_stats_tests.py
@@ -35,7 +35,20 @@ def test_no_accounts_with_phones(db):
     update_phone_remaining_stats()
 
 
-def test_one_account_with_phones_checked_1_day_ago(phone_user):
+def test_one_account_with_phones_subscribed_3_day_ago_does_not_update_stats(phone_user):
+    profile = Profile.objects.get(user=phone_user)
+    datetime_now = datetime.now(timezone.utc)
+    profile.date_subscribed_phone = datetime_now - timedelta(3)
+    profile.save()
+
+    updated_profiles = update_phone_remaining_stats()
+
+    profile.refresh_from_db()
+    assert profile.date_phone_subscription_checked == None
+    assert len(updated_profiles) == 0
+
+
+def test_one_account_with_phones_checked_1_day_ago_does_not_update_stats(phone_user):
     profile = Profile.objects.get(user=phone_user)
     pre_update_datetime = datetime.now(timezone.utc) - timedelta(1)
     profile.date_phone_subscription_checked = pre_update_datetime


### PR DESCRIPTION
Expecting that this job will run once everyday, there was a bug where when the `update_phone_remaining_stats` command was ran a user whose phone subscription has not renewed yet will also get their phone stats reset and will use the date the stats renewed to checked for future renewals erroneously. To fix that bug, this PR checks that if the user is being updated for the first time (`date_phone_subscription_checked==None`) we skip the user from updating phone stats if their billing cycle **has not** past.

<!-- When fixing a bug: -->

How to test:
## Before this change, check that phone stats were updated even though it has not reached billing cycle
1. Create a user with phone subscription that started today and use some minutes and/or texts
2. Run `./manage.py update_phone_remaining_stats`
3. Check that the minutes and texts are updated. **Expected Results**: Phone stats are not renewed because the subscription has not reached billing cycle

## After this change, check that phone stats **WERE NOT** updated since the billing cycle was not reached
1. Create a user with phone subscription that started today and use some minutes and/or texts
2. Run `./manage.py update_phone_remaining_stats`
3. Phone stats did not change

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
