### PR TITLE
Dependency updates - December 5, 2022

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.17
+boto3==1.26.22
 codetiming==1.4.0
 cryptography==38.0.4
 Django==3.2.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ whitenoise==6.2.0
 
 # phones app
 phonenumbers==8.13.0
-twilio==7.15.3
+twilio==7.15.4
 vobject==0.9.6.1
 
 # tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ sentry-sdk==1.11.1
 whitenoise==6.2.0
 
 # phones app
-phonenumbers==8.13.0
+phonenumbers==8.13.1
 twilio==7.15.4
 vobject==0.9.6.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ dj-database-url==1.0.0
 django-allauth==0.51.0
 django-cors-headers==3.13.0
 django-csp==3.7
-django-debug-toolbar==3.7.0
+django-debug-toolbar==3.8.1
 django-filter==22.1
 django-redis==5.2.0
 django-ftl==0.13


### PR DESCRIPTION
Update Python dependencies. This covers:

* Bump boto3 from 1.26.17 to 1.26.22 (from PR #2869) - AWS API updates
* Bump twilio from 7.15.3 to 7.15.4 (from PR #2870) - API updates
* Bump django-debug-toolbar from 3.7.0 to 3.8.1 (from PR #2871) - Python 3.11 support
* Bump phonenumbers from 8.13.0 to 8.13.1 (from PR #2872) - Metadata updates