### PR TITLE
MPP-2635: Update SMS error strings

### DIFF
--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -873,7 +873,7 @@ def test_inbound_sms_reply_not_storing_phone_log(phone_user, mocked_twilio_clien
     call_kwargs = mocked_twilio_client.messages.create.call_args.kwargs
     assert call_kwargs["to"] == real_phone.number
     assert call_kwargs["from_"] == relay_number.number
-    assert call_kwargs["body"].startswith("To reply, you must allow ")
+    assert call_kwargs["body"].startswith("The reply feature requires \u2068Firefox ")
     assert f"{settings.SITE_ORIGIN}" in call_kwargs["body"]
 
 

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -142,7 +142,8 @@ class RealPhoneViewSet(SaveToRequestUser, viewsets.ModelViewSet):
             if not valid_record:
                 incr_if_enabled("phones_RealPhoneViewSet.create.invalid_verification")
                 raise exceptions.ValidationError(
-                    "Could not find that verification_code for user and number. It may have expired."
+                    "Could not find that verification_code for user and number."
+                    " It may have expired."
                 )
 
             headers = self.get_success_headers(serializer.validated_data)
@@ -278,7 +279,7 @@ class RelayNumberViewSet(SaveToRequestUser, viewsets.ModelViewSet):
         [test-creds]: https://www.twilio.com/docs/iam/test-credentials
         [test-numbers]: https://www.twilio.com/docs/iam/test-credentials#test-incoming-phone-numbers-parameters-PhoneNumber
         [e164]: https://en.wikipedia.org/wiki/E.164
-        """
+        """  # noqa: E501  # ignore long line for URL
         incr_if_enabled("phones_RelayNumberViewSet.create")
         existing_number = RelayNumber.objects.filter(user=request.user)
         if existing_number:
@@ -292,7 +293,8 @@ class RelayNumberViewSet(SaveToRequestUser, viewsets.ModelViewSet):
         The authenticated user must have a subscription that grants one of the
         `SUBSCRIPTIONS_WITH_PHONE` capabilities.
 
-        The `{id}` should match a previously-`POST`ed resource that belongs to the authenticated user.
+        The `{id}` should match a previously-`POST`ed resource that belongs to
+        the authenticated user.
 
         This is primarily used to toggle the `enabled` field.
         """
@@ -305,8 +307,10 @@ class RelayNumberViewSet(SaveToRequestUser, viewsets.ModelViewSet):
         Returns suggested relay numbers for the authenticated user.
 
         Based on the user's real number, returns available relay numbers:
-          * `same_prefix_options`: Numbers that match as much of the user's real number as possible.
-          * `other_areas_options`: Numbers that exactly match the user's real number, in a different area code.
+          * `same_prefix_options`: Numbers that match as much of the user's
+            real number as possible.
+          * `other_areas_options`: Numbers that exactly match the user's real
+            number, in a different area code.
           * `same_area_options`: Other numbers in the same area code as the user.
           * `random_options`: Available numbers in the user's country
         """
@@ -328,7 +332,7 @@ class RelayNumberViewSet(SaveToRequestUser, viewsets.ModelViewSet):
             * Will be passed to `AvailablePhoneNumbers` `area_code` param
 
         [apn]: https://www.twilio.com/docs/phone-numbers/api/availablephonenumberlocal-resource#read-multiple-availablephonenumberlocal-resources
-        """
+        """  # noqa: E501  # ignore long line for URL
         incr_if_enabled("phones_RelayNumberViewSet.search")
         real_phone = get_verified_realphone_records(request.user).first()
         if real_phone:
@@ -366,7 +370,10 @@ def _validate_number(request):
         country = None
         if hasattr(request, "country"):
             country = request.country
-        error_message = f"number must be in E.164 format, or in local national format of the country detected: {country}"
+        error_message = (
+            "number must be in E.164 format, or in local national format of the"
+            f" country detected: {country}"
+        )
         raise exceptions.ValidationError(error_message)
 
     e164_number = f"+{parsed_number.country_code}{parsed_number.national_number}"

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -505,7 +505,7 @@ def inbound_sms(request):
         except RelaySMSException as sms_exception:
             # Send a translated message to the user
             ftl_code = sms_exception.get_codes().replace("_", "-")
-            ftl_id = f"relay-sms-error-{ftl_code}"
+            ftl_id = f"sms-error-{ftl_code}"
             with django_ftl.override(real_phone.user.profile.language):
                 user_message = ftl_bundle.format(ftl_id, sms_exception.error_context())
             twilio_client().messages.create(

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -688,8 +688,9 @@ class RelaySMSException(Exception):
 class NoPhoneLog(RelaySMSException):
     default_code = "no_phone_log"
     default_detail_template = (
-        "You can only reply if you allow Firefox Relay to keep a log of your callers"
-        " and text senders. See {account_settings_url}."
+        "To reply, you must allow Firefox Relay to keep a log of your callers"
+        " and text senders. You can update this under “Caller and texts log” here:"
+        "{account_settings_url}."
     )
 
     def error_context(self) -> ErrorContextType:
@@ -700,7 +701,10 @@ class NoPhoneLog(RelaySMSException):
 
 class NoPreviousSender(RelaySMSException):
     default_code = "no_previous_sender"
-    default_detail = "Message failed to send. Could not find a previous text sender."
+    default_detail = (
+        "Message failed to send. You can only reply to phone numbers that have sent"
+        " you a text message."
+    )
 
 
 class ShortPrefixException(RelaySMSException):

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -694,7 +694,7 @@ class NoPhoneLog(RelaySMSException):
 
     def error_context(self) -> ErrorContextType:
         return {
-            "account_settings_url": f"{settings.SITE_ORIGIN or ''}/accounts/settings"
+            "account_settings_url": f"{settings.SITE_ORIGIN or ''}/accounts/settings/"
         }
 
 

--- a/privaterelay/ftl_bundles.py
+++ b/privaterelay/ftl_bundles.py
@@ -22,4 +22,6 @@ class RelayMessageFinder(DjangoMessageFinder):
         return base_dirs + pending_dirs
 
 
-main = Bundle(["app.ftl", "brands.ftl", "pending.ftl"], finder=RelayMessageFinder())
+main = Bundle(
+    ["app.ftl", "brands.ftl", "phones.ftl", "pending.ftl"], finder=RelayMessageFinder()
+)

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -6,24 +6,24 @@
 
 ## Relay SMS reply errors
 
-relay-sms-error-no-previous-sender = Message failed to send. You can only reply to phone numbers that have sent you a text message.
+sms-error-no-previous-sender = Message failed to send. You can only reply to phone numbers that have sent you a text message.
 # Variables
 #   $account_settings_url (string) - The URL of the Relay account settings, to enable logs
-relay-sms-error-no-phone-log = To reply, you must allow { -brand-name-firefox-relay } to keep a log of your callers and text senders. You can update this under “Caller and texts log” here: { $account_settings_url }
+sms-error-no-phone-log = To reply, you must allow { -brand-name-firefox-relay } to keep a log of your callers and text senders. You can update this under “Caller and texts log” here: { $account_settings_url }
 
 # Variables
 #   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number
-relay-sms-error-short-prefix-matches-no-senders = Message failed to send. There is no phone number in this thread ending in { $short_prefix }. Please check the number and try again.
+sms-error-short-prefix-matches-no-senders = Message failed to send. There is no phone number in this thread ending in { $short_prefix }. Please check the number and try again.
 # Variables
 #   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number
-relay-sms-error-multiple-number-matches = Message failed to send. There is more than one phone number in this thread ending in { $short_prefix }. To retry, start your message with the complete number.
+sms-error-multiple-number-matches = Message failed to send. There is more than one phone number in this thread ending in { $short_prefix }. To retry, start your message with the complete number.
 # Variables
 #   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number
-relay-sms-error-no-body-after-short-prefix = Message failed to send. Please include a message after the phone number ending in { $short_prefix }.
+sms-error-no-body-after-short-prefix = Message failed to send. Please include a message after the phone number ending in { $short_prefix }.
 
 # Variables
 #   $full_number (string) - A phone number, such as '+13025551234' or '1 (302) 555-1234'
-relay-sms-error-full-number-matches-no-senders = Message failed to send. There is no previous sender with the phone number { $full_number }. Please check the number and try again.
+sms-error-full-number-matches-no-senders = Message failed to send. There is no previous sender with the phone number { $full_number }. Please check the number and try again.
 # Variables
 #   $full_number (string) - A phone number, such as '+13025551234' or '1 (302) 555-1234'
-relay-sms-error-no-body-after-full-number = Message failed to send. Please include a message after the phone number { $full_number }.
+sms-error-no-body-after-full-number = Message failed to send. Please include a message after the phone number { $full_number }.

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -6,10 +6,10 @@
 
 ## Relay SMS reply errors
 
-relay-sms-error-no-previous-sender = Message failed to send. Could not find a previous text sender.
+relay-sms-error-no-previous-sender = Message failed to send. You can only reply to phone numbers that have sent you a text message.
 # Variables
 #   $account_settings_url (string) - The URL of the Relay account settings, to enable logs
-relay-sms-error-no-phone-log = You can only reply if you allow { -brand-name-firefox-relay } to keep a log of your callers and text senders. See { $account_settings_url }.
+relay-sms-error-no-phone-log = To reply, you must allow { -brand-name-firefox-relay } to keep a log of your callers and text senders. You can update this under “Caller and texts log” here: { $account_settings_url }
 
 # Variables
 #   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number
@@ -19,7 +19,7 @@ relay-sms-error-short-prefix-matches-no-senders = Message failed to send. There 
 relay-sms-error-multiple-number-matches = Message failed to send. There is more than one phone number in this thread ending in { $short_prefix }. To retry, start your message with the complete number.
 # Variables
 #   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number
-relay-sms-error-no-body-after-short-prefix = Message failed to send. Please include a message after the sender identifier { $short_prefix }.
+relay-sms-error-no-body-after-short-prefix = Message failed to send. Please include a message after the phone number ending in { $short_prefix }.
 
 # Variables
 #   $full_number (string) - A phone number, such as '+13025551234' or '1 (302) 555-1234'

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -9,7 +9,7 @@
 sms-error-no-previous-sender = Message failed to send. You can only reply to phone numbers that have sent you a text message.
 # Variables
 #   $account_settings_url (string) - The URL of the Relay account settings, to enable logs
-sms-error-no-phone-log = To reply, you must allow { -brand-name-firefox-relay } to keep a log of your callers and text senders. You can update this under “Caller and texts log” here: { $account_settings_url }
+sms-error-no-phone-log = The reply feature requires { -brand-name-firefox-relay } to keep a log of your callers and text senders. You can reply to future messages by enabling “Caller and texts log” in Settings: { $account_settings_url }
 
 # Variables
 #   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number


### PR DESCRIPTION
Update SMS error strings as specified in [MPPUX-771](https://mozilla-hub.atlassian.net/browse/MPPUX-771). This change is mirrored in https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/120/.
