### PR TITLE
Api auth refactoring

### DIFF
--- a/api/authentication.py
+++ b/api/authentication.py
@@ -10,70 +10,93 @@ from django.core.cache import cache
 
 from allauth.socialaccount.models import SocialAccount
 from rest_framework.authentication import BaseAuthentication, get_authorization_header
+from rest_framework.exceptions import AuthenticationFailed
 
 
 logger = logging.getLogger("events")
 
 
 def get_cache_key(token):
+    # TODO: token can be a JWT which makes for a really big cache key
     return f"fxa_token_{token}"
+
+
+def introspect_token(introspect_token_url, token, cache_key, cache_timeout):
+    try:
+        fxa_resp = requests.post(introspect_token_url, json={"token": token})
+    except:
+        logger.error(
+            "Could not introspect token with FXA.",
+            extra={"fxa_response": shlex.quote(fxa_resp.text)},
+        )
+        # cache empty response data to prevent FXA failures from causing runaway
+        # HTTP retries
+        fxa_resp_data = {"status_code": None, "json": {}}
+        cache.set(cache_key, fxa_resp_data, cache_timeout)
+        raise AuthenticationFailed("Could not introspect token with FXA.")
+
+    fxa_resp_data = {"status_code": fxa_resp.status_code, "json": {}}
+    try:
+        fxa_resp_data["json"] = fxa_resp.json()
+    except requests.exceptions.JSONDecodeError:
+        logger.error(
+            "JSONDecodeError from FXA introspect response.",
+            extra={"fxa_response": shlex.quote(fxa_resp.text)},
+        )
+        cache.set(cache_key, fxa_resp_data, cache_timeout)
+        raise AuthenticationFailed("JSONDecodeError from FXA introspect response")
+    return fxa_resp_data
 
 
 class FxaTokenAuthentication(BaseAuthentication):
     def authenticate(self, request):
         authorization = get_authorization_header(request).decode()
         if not authorization or not authorization.startswith("Bearer "):
+            # If the request has no Bearer token, return None to attempt the next
+            # auth scheme in the REST_FRAMEWORK AUTHENTICATION_CLASSES list
             return None
 
         token = authorization.split(" ")[1]
         cache_key = get_cache_key(token)
         cached_fxa_resp_data = fxa_resp_data = cache.get(cache_key)
         # set a default cache_timeout, but this will be overriden to match
-        # the 'exp' time returned by FXA
+        # the 'exp' time in the JWT returned by FXA
         cache_timeout = 60
         if not fxa_resp_data:
             introspect_token_url = (
                 "%s/introspect"
                 % settings.SOCIALACCOUNT_PROVIDERS["fxa"]["OAUTH_ENDPOINT"]
             )
-            fxa_resp = requests.post(introspect_token_url, json={"token": token})
-            fxa_resp_data = {"status_code": fxa_resp.status_code, "json": None}
-            try:
-                fxa_resp_data["json"] = fxa_resp.json()
-            except requests.exceptions.JSONDecodeError:
-                logger.error(
-                    "JSONDecodeError from FXA introspect response.",
-                    extra={"fxa_response": shlex.quote(fxa_resp.text)},
-                )
+            fxa_resp_data = introspect_token(
+                introspect_token_url, token, cache_key, cache_timeout
+            )
 
         user = None
-        if (
-            fxa_resp_data
-            and fxa_resp_data["status_code"] == 200
-            and fxa_resp_data["json"]
-            and fxa_resp_data["json"].get("active")
-        ):
+        if not fxa_resp_data["status_code"] == 200:
+            raise AuthenticationFailed("Did not receive a 200 response from FXA.")
 
-            # FxA user is active, check for the associated Relay account
-            fxa_uid = fxa_resp_data.get("json").get("sub")
-            if fxa_uid:
-                try:
-                    sa = SocialAccount.objects.get(uid=fxa_uid, provider="fxa")
-                except SocialAccount.DoesNotExist:
-                    # No Relay account associated with the FxA ID. It might be
-                    # a user who deleted their Relay account since they first
-                    # signed up
-                    pass
-                else:
-                    user = sa.user
+        if not fxa_resp_data["json"].get("active"):
+            raise AuthenticationFailed("FXA returned active: False for token.")
 
-                    # cache fxa_resp_data for as long as access_token is valid
-                    # Note: FXA iat and exp are timestamps in *milliseconds*
-                    fxa_token_exp_time = int(
-                        fxa_resp_data.get("json").get("exp") / 1000
-                    )
-                    now_time = int(datetime.now(timezone.utc).timestamp())
-                    cache_timeout = fxa_token_exp_time - now_time
+        # FxA user is active, check for the associated Relay account
+        fxa_uid = fxa_resp_data.get("json").get("sub")
+        if not fxa_uid:
+            raise AuthenticationFailed(
+                "Authenticated user does not have a Relay account."
+            )
+        try:
+            sa = SocialAccount.objects.get(uid=fxa_uid, provider="fxa")
+        except SocialAccount.DoesNotExist:
+            raise AuthenticationFailed(
+                "Authenticated user does not have a Relay account."
+            )
+        user = sa.user
+
+        # cache fxa_resp_data for as long as access_token is valid
+        # Note: FXA iat and exp are timestamps in *milliseconds*
+        fxa_token_exp_time = int(fxa_resp_data.get("json").get("exp") / 1000)
+        now_time = int(datetime.now(timezone.utc).timestamp())
+        cache_timeout = fxa_token_exp_time - now_time
 
         # Store FxA response for 60 seconds (errors, inactive users, etc.) or
         # until access_token expires (matched Relay user)
@@ -81,6 +104,6 @@ class FxaTokenAuthentication(BaseAuthentication):
             cache.set(cache_key, fxa_resp_data, cache_timeout)
 
         if user:
-            return (user, None)
+            return (user, token)
         else:
-            return None
+            raise AuthenticationFailed()

--- a/api/authentication.py
+++ b/api/authentication.py
@@ -45,6 +45,7 @@ def introspect_token(introspect_token_url, token, cache_key, cache_timeout):
         )
         cache.set(cache_key, fxa_resp_data, cache_timeout)
         raise AuthenticationFailed("JSONDecodeError from FXA introspect response")
+    cache.set(cache_key, fxa_resp_data, cache_timeout)
     return fxa_resp_data
 
 

--- a/api/authentication.py
+++ b/api/authentication.py
@@ -72,6 +72,9 @@ class FxaTokenAuthentication(BaseAuthentication):
                 cache.set(cache_key, fxa_resp_data, cache_timeout)
 
         user = None
+        if fxa_resp_data["status_code"] is None:
+            raise AuthenticationFailed("Previous FXA call failed, wait to retry.")
+
         if not fxa_resp_data["status_code"] == 200:
             raise AuthenticationFailed("Did not receive a 200 response from FXA.")
 

--- a/api/tests/authentication_tests.py
+++ b/api/tests/authentication_tests.py
@@ -33,10 +33,11 @@ class FxaTokenAuthenticationTest(TestCase):
     def test_no_token_returns_none(self):
         headers = {"HTTP_AUTHORIZATION": "Bearer "}
         get_addresses_req = self.factory.get(self.path, **headers)
-        assert self.auth.authenticate(self.auth, get_addresses_req) == None
+        with pytest.raises(AuthenticationFailed):
+            self.auth.authenticate(self.auth, get_addresses_req)
 
     @responses.activate()
-    def test_non_200_resp_from_fxa_returns_none_and_caches(self):
+    def test_non_200_resp_from_fxa_raises_error_and_caches(self):
         responses.add(
             responses.POST, self.fxa_verify_path, status=401, json={"error": "401"}
         )
@@ -45,19 +46,20 @@ class FxaTokenAuthenticationTest(TestCase):
 
         headers = {"HTTP_AUTHORIZATION": f"Bearer {not_found_token}"}
         get_addresses_req = self.factory.get(self.path, **headers)
-        auth_return = self.auth.authenticate(self.auth, get_addresses_req)
+        with pytest.raises(AuthenticationFailed):
+            self.auth.authenticate(self.auth, get_addresses_req)
 
-        assert auth_return == None
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
         expected = {"status_code": 401, "json": {"error": "401"}}
         assert cache.get(get_cache_key(not_found_token)) == expected
 
         # now check that the code does NOT make another fxa request
-        assert self.auth.authenticate(self.auth, get_addresses_req) is None
+        with pytest.raises(AuthenticationFailed):
+            assert self.auth.authenticate(self.auth, get_addresses_req) is None
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
     @responses.activate()
-    def test_non_200_non_json_resp_from_fxa_returns_none_and_caches(self):
+    def test_non_200_non_json_resp_from_fxa_raises_error_and_caches(self):
         responses.add(
             responses.POST, self.fxa_verify_path, status=503, body="Bad gateway error"
         )
@@ -66,32 +68,35 @@ class FxaTokenAuthenticationTest(TestCase):
 
         headers = {"HTTP_AUTHORIZATION": f"Bearer {not_found_token}"}
         get_addresses_req = self.factory.get(self.path, **headers)
-        auth_return = self.auth.authenticate(self.auth, get_addresses_req)
+        with pytest.raises(AuthenticationFailed):
+            self.auth.authenticate(self.auth, get_addresses_req)
 
-        assert auth_return == None
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
-        expected = {"status_code": 503, "json": None}
+        expected = {"status_code": 503, "json": {}}
         assert cache.get(get_cache_key(not_found_token)) == expected
 
         # now check that the code does NOT make another fxa request
-        assert self.auth.authenticate(self.auth, get_addresses_req) is None
+        with pytest.raises(AuthenticationFailed):
+            assert self.auth.authenticate(self.auth, get_addresses_req) is None
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
     @responses.activate()
-    def test_200_resp_from_fxa_inactive_token_returns_none(self):
+    def test_200_resp_from_fxa_inactive_token_raises_error(self):
         responses.add(
             responses.POST, self.fxa_verify_path, status=200, json={"active": False}
         )
         inactive_token = "inactive-123"
         headers = {"HTTP_AUTHORIZATION": f"Bearer {inactive_token}"}
         get_addresses_req = self.factory.get(self.path, **headers)
-        assert self.auth.authenticate(self.auth, get_addresses_req) == None
+        with pytest.raises(AuthenticationFailed):
+            assert self.auth.authenticate(self.auth, get_addresses_req) == None
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
         expected = {"status_code": 200, "json": {"active": False}}
         assert cache.get(get_cache_key(inactive_token)) == expected
 
         # the code does NOT make another fxa request
-        assert self.auth.authenticate(self.auth, get_addresses_req) is None
+        with pytest.raises(AuthenticationFailed):
+            assert self.auth.authenticate(self.auth, get_addresses_req) is None
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
     @responses.activate()
@@ -130,7 +135,7 @@ class FxaTokenAuthenticationTest(TestCase):
         headers = {"HTTP_AUTHORIZATION": f"Bearer {user_token}"}
         get_addresses_req = self.factory.get(self.path, **headers)
         auth_return = self.auth.authenticate(self.auth, get_addresses_req)
-        assert auth_return == (self.sa.user, None)
+        assert auth_return == (self.sa.user, user_token)
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
         expected = {"status_code": 200, "json": response_json}
         assert cache.get(get_cache_key(user_token)) == expected

--- a/api/tests/authentication_tests.py
+++ b/api/tests/authentication_tests.py
@@ -72,7 +72,7 @@ class FxaTokenAuthenticationTest(TestCase):
             self.auth.authenticate(self.auth, get_addresses_req)
 
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
-        expected = {"status_code": 503, "json": {}}
+        expected = {"status_code": None, "json": {}}
         assert cache.get(get_cache_key(not_found_token)) == expected
 
         # now check that the code does NOT make another fxa request

--- a/docs/api_auth.md
+++ b/docs/api_auth.md
@@ -3,7 +3,7 @@
 The Relay API is built on [Django REST Framework][drf] and authenticates
 requests with any of 3 methods:
 
-- [FXA OAuth Token Authentication](fxa-oauth-token-authentication)
+- [FXA OAuth Token Authentication](#fxa-oauth-token-authentication)
 - [`SessionAuthentication`][sessionauthentication]
 - [`TokenAuthentication`][tokenauthentication]
 

--- a/docs/api_auth.md
+++ b/docs/api_auth.md
@@ -1,12 +1,15 @@
 # Relay API Authentication
+
 The Relay API is built on [Django REST Framework][drf] and authenticates
 requests with any of 3 methods:
-* [FXA OAuth Token Authentication](fxa-oauth-token-authentication)
-* [`SessionAuthentication`][SessionAuthentication]
-* [`TokenAuthentication`][TokenAuthentication]
+
+- [FXA OAuth Token Authentication](fxa-oauth-token-authentication)
+- [`SessionAuthentication`][sessionauthentication]
+- [`TokenAuthentication`][tokenauthentication]
 
 ## FXA OAuth Token Authentication
-The Relay add-on uses the [`identity.launchWebAuthFlow` API][mdn-webauthflow]
+
+Add-ons can use the [`identity.launchWebAuthFlow` API][mdn-webauthflow]
 to perform an OAuth2 flow with [the FXA OAuth service][fxa-oauth], including
 [PKCE][fxa-pkce].
 
@@ -40,9 +43,9 @@ sequenceDiagram
 ```
 
 [drf]: https://www.django-rest-framework.org/
-[SessionAuthentication]: https://www.django-rest-framework.org/api-guide/authentication/#sessionauthentication
-[TokenAuthentication]: https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication
-[mdn-webauthflow]: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/identity/launchWebAuthFlow 
+[sessionauthentication]: https://www.django-rest-framework.org/api-guide/authentication/#sessionauthentication
+[tokenauthentication]: https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication
+[mdn-webauthflow]: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/identity/launchWebAuthFlow
 [fxa-oauth]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/api.md
 [fxa-pkce]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/pkce.md
 [fxa-oauth-token-verify]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/api.md#post-v1verify

--- a/phones/apps.py
+++ b/phones/apps.py
@@ -25,9 +25,11 @@ class PhonesConfig(AppConfig):
     def twiml_app(self) -> InstanceResource:
         if not settings.TWILIO_SMS_APPLICATION_SID:
             raise Exception("Must define TWILIO_SMS_APPLICATION_SID")
-        return self.twilio_client.applications(
+        instance = self.twilio_client.applications(
             settings.TWILIO_SMS_APPLICATION_SID
         ).fetch()
+        assert isinstance(instance, InstanceResource)
+        return instance
 
     @cached_property
     def twilio_test_client(self) -> Client:


### PR DESCRIPTION
This PR supports #MPP-2405. The Firefox credential manager is receiving `403` errors from the API endpoints, but without reliable steps to reproduce. This change refactors the API `FxaTokenAuthentication` to add more detailed logging of the various possible error scenarios. This log data will help us determine if the `403` errors have a common underlying cause and how to fix it.

## How to test:
### First, you need to get a "Relay-scoped" stage FXA access token
Firefox [will](https://phabricator.services.mozilla.com/D158155) requests "Relay-[scoped](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/scopes.md#url-scopes)" access tokens from FXA. (Our Relay scope URL is `https://identity.mozilla.com/apps/relay`.) It's not easy, but this is honestly maybe the easiest way to get such a token:
1. Clone [the add-on repo](https://github.com/mozilla/fx-private-relay-add-on/) locally
2. Change it to the `new-auth-mpp-1531` branch
3. `npm instsall` dependencies
4. `npm run dev` to run Firefox with the Relay add-on installed
5. Go to about:debugging#/runtime/this-firefox
6. Click "Inspect" next to the Firefox Relay add-on to open Developer Tools for it
7. Open the "Network" panel of the Developer Tools
8. Back in the `moz-extension://...` tab, click "Sign Up / In" to go thru the FXA stage auth flow
9. In the "Network" panel, look for the request to http://127.0.0.1:8000/api/v1/relayaddresses/
10. The request headers should include `authorization: Bearer ...`


### Use the API endpoints with the access token 
```
curl -H "Content-Type: application/json" -H "Authorization: Bearer abc123" http://127.0.0.1:8000/api/v1/relayaddresses/
curl -H "Content-Type: application/json" -H "Authorization: Bearer abc123" http://127.0.0.1:8000/api/v1/profiles/
etc.
```

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).