### PR TITLE
Add additional email meta data fields to Relay emails 

### DIFF
--- a/emails/utils.py
+++ b/emails/utils.py
@@ -148,7 +148,7 @@ def ses_send_raw_email(
 ):
 
     msg_with_headers = _start_message_with_headers(
-        subject, from_address, to_address, reply_address
+        subject, from_address, to_address, reply_address, address
     )
     msg_with_body = _add_body_to_message(msg_with_headers, message_body)
     msg_with_attachments = _add_attachments_to_message(msg_with_body, attachments)
@@ -174,7 +174,9 @@ def ses_send_raw_email(
     return HttpResponse("Sent email to final recipient.", status=200)
 
 
-def _start_message_with_headers(subject, from_address, to_address, reply_address):
+def _start_message_with_headers(
+    subject, from_address, to_address, reply_address, relay_address
+):
     # Create a multipart/mixed parent container.
     msg = MIMEMultipart("mixed")
     # Add subject, from and to lines.
@@ -182,6 +184,11 @@ def _start_message_with_headers(subject, from_address, to_address, reply_address
     msg["From"] = from_address
     msg["To"] = to_address
     msg["Reply-To"] = reply_address
+    if type(relay_address) == RelayAddress:
+        msg["X-RelayAddress-ID"] = str(relay_address.id)
+    if type(relay_address) == DomainAddress:
+        msg["X-DomainAddress-ID"] = str(relay_address.id)
+
     return msg
 
 


### PR DESCRIPTION
# Summary

Add additional metadata field of email mask ID, along with info if it is a relay address or domain address

Jira related story: https://mozilla-hub.atlassian.net/browse/MPP-2620 

# Screenshot (if applicable)

Not applicable.

# How to test

* Required to test: Must be able to send emails from local instance of Relay 

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
