### PR TITLE
Python dependency updates, 2022-12-13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,5 +48,5 @@ black==22.10.0
 mypy==0.991
 types-requests==2.28.11.5
 types-pyOpenSSL==22.1.0.2
-django-stubs==1.13.0
+django-stubs==1.13.1
 djangorestframework-stubs==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ sentry-sdk==1.11.1
 whitenoise==6.2.0
 
 # phones app
-phonenumbers==8.13.1
+phonenumbers==8.13.2
 twilio==7.15.4
 vobject==0.9.6.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.22
+boto3==1.26.27
 codetiming==1.4.0
 cryptography==38.0.4
 Django==3.2.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pytest-django==4.5.2
 responses==0.22.0
 
 # linting
-black==22.10.0
+black==22.12.0
 
 # type hinting
 mypy==0.991


### PR DESCRIPTION
Weekly Python dependency updates. This covers:

* Bump boto3 from 1.26.22 to 1.26.27 (from PR #2886)
* Bump django-stubs from 1.13.0 to 1.13.1 (from PR #2887)
* Bump black from 22.10.0 to 22.12.0 (from PR #2888)
* Bump phonenumbers from 8.13.1 to 8.13.2 (from PR #2889)

