### PR TITLE
Preserve query params on dashboard redirect

### DIFF
--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -56,7 +56,12 @@ class RedirectRootIfLoggedIn:
         # in, use a server-side redirect to send them to the dashboard,
         # rather than handling that on the client-side:
         if request.path == "/" and settings.SESSION_COOKIE_NAME in request.COOKIES:
-            return redirect("accounts/profile/")
+            query_string = (
+                "?" + request.META["QUERY_STRING"]
+                if request.META["QUERY_STRING"]
+                else ""
+            )
+            return redirect("accounts/profile/" + query_string)
 
         response = self.get_response(request)
         return response


### PR DESCRIPTION
This PR fixes MPP-2636. When the user is linked to relay.firefox.com from somewhere else with query parameters are appended, and the user is logged in, they will be redirected to `/account/profile/`. However, that means the query parameters will not be preserved. This is problematic for e.g. `utm_` parameters, which are processed by client-side JavaScript and hence only read after the redirect has completed.

With this PR, the redirect simply appends the query parameters for the original URL to the new URL.

How to test: be logged in, navigate to the root of the website with query parameters (e.g. `?test`) appended. They should be appended to `/account/profile/` (e.g. `/account/profile/?test`).

I didn't see any other middleware tests, so I didn't add a test for this. With some pointers I could give that a shot.

I also don't think there's a security risk here, but it's probably good if someone else gave that a bit of thought as well.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
