### PR TITLE
fix MPP-1872: update email header premium banner to mention replies

### DIFF
--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -70,7 +70,7 @@
                     {% bold_violet_link SITE_ORIGIN|add:'/premium?utm_source=emails&utm_medium=email&utm_campaign=alias-email&utm_content=header' 'Firefox Relay Premium' as premium_link %}
                     <br />
                     <img width="15" height="15" src="{{ SITE_ORIGIN }}/static/images/email-images/smile-purple.png" style="display: inline-block; width: 15px;" alt="" />
-                    {% ftlmsg 'forwarded-email-header-premium-banner-2' premium_link=premium_link as premium_header_banner %}
+                    {% ftlmsg 'forwarded-email-header-premium-banner-3' premium_link=premium_link as premium_header_banner %}
                     {{ premium_header_banner|safe }}
                   {% endif %}
                   {% if tracker_report_link %}


### PR DESCRIPTION
This PR fixes MPP-1872.

How to test:
1. Go to http://127.0.0.1:8000/emails/wrapped_email_test?has_attachment=0
   * [ ] The email header should include "... and the ability to reply to emails."


- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).