### PR TITLE
Use correct l10n checkout when testing migrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,6 +367,7 @@ jobs:
                   echo "# Production tag is ${PROD_TAG}"
                   git fetch --force origin tag ${PROD_TAG}
                   git checkout ${PROD_TAG}
+                  git submodule update --init --recursive
                   git checkout --theirs "${CIRCLE_SHA1}" -- '**/migrations/**'
                   git status
       - unless:
@@ -443,6 +444,7 @@ jobs:
                   echo "# Production tag is ${PROD_TAG}"
                   git fetch --force origin tag ${PROD_TAG}
                   git checkout ${PROD_TAG}
+                  git submodule update --init --recursive
                   git checkout --theirs "${CIRCLE_SHA1}" -- '**/migrations/**'
                   git status
       - run:


### PR DESCRIPTION
When switching to the version of the code that's currently in production, make sure to also switch to the version of the l10n repository that's currently in production. Otherwise, if strings have been removed from the l10n repository that are still being referenced in production, the tests would start failing despite nothing being broken.
