### PR TITLE
Prevent subdomain explainer overflowing on mobile

### DIFF
--- a/frontend/src/components/dashboard/subdomain/SubdomainIndicator.module.scss
+++ b/frontend/src/components/dashboard/subdomain/SubdomainIndicator.module.scss
@@ -17,8 +17,12 @@
   background-color: $color-white;
   box-shadow: $box-shadow-sm;
   border-radius: $border-radius-md;
-  max-width: $content-sm;
   padding: $spacing-lg;
+  // On small screens, appear as a modal at the top of the viewport:
+  top: $spacing-lg;
+  left: $spacing-lg;
+  right: $spacing-lg;
+  position: absolute;
 
   &::before {
     content: "";
@@ -29,6 +33,18 @@
     left: $spacing-2xl;
     transform: rotate(45deg);
     background-color: $color-white;
+    display: none;
+  }
+
+  @media screen and #{$mq-md} {
+    // On wider screens, the popover is attached to the indicator:
+    inset: unset;
+    position: unset;
+    max-width: $content-sm;
+
+    &::before {
+      display: initial;
+    }
   }
 
   h3 {

--- a/frontend/src/components/dashboard/subdomain/SubdomainIndicator.tsx
+++ b/frontend/src/components/dashboard/subdomain/SubdomainIndicator.tsx
@@ -22,6 +22,7 @@ import styles from "./SubdomainIndicator.module.scss";
 import { CloseIcon } from "../../Icons";
 import { getRuntimeConfig } from "../../../config";
 import { AddressPickerModal } from "../aliases/AddressPickerModal";
+import { useMinViewportWidth } from "../../../hooks/mediaQuery";
 
 export type Props = {
   subdomain: string | null;
@@ -165,6 +166,7 @@ type ExplainerProps = AriaOverlayProps & {
 const Explainer = forwardRef<HTMLDivElement, ExplainerProps>(
   function ExplainerWithForwardedRef(props, overlayRef) {
     const { l10n } = useLocalization();
+    const isWideScreen = useMinViewportWidth("md");
 
     const { overlayProps } = useOverlay(
       props,
@@ -178,9 +180,12 @@ const Explainer = forwardRef<HTMLDivElement, ExplainerProps>(
       overlayRef as RefObject<HTMLDivElement>
     );
 
+    // On small screens, this is a dialog at the top of the viewport.
+    // On wider screens, it is a popover attached to the indicator:
+    const positionProps = isWideScreen ? props.positionProps : {};
     const mergedOverlayProps = mergeProps(
       overlayProps,
-      props.positionProps,
+      positionProps,
       dialogProps,
       modalProps
     );


### PR DESCRIPTION
This changes the popover into a dialog on small screens, so it can overlap the indicator.

This PR fixes MPP-2648.

How to test: log in with a user with a custom subdomain set. On a small screen, position the viewport such that the button labelled with the chosen subdomain is in the middle of the screen, then click it. Before this change, there would not be enough room for the popover above the button, so its content would break out of it:

![image](https://user-images.githubusercontent.com/4251/208426104-4dc86b77-54ed-4919-b710-77bb4345b751.png)

After this change, it is instead a dialog, and overlaps the button:

![image](https://user-images.githubusercontent.com/4251/208426394-8c81c281-45b6-4774-91a5-09f5a72befa6.png)

On wider screens, the behaviour should be unchanged.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
