### PR TITLE
Prevent mask cards from horizontall overflowing

### DIFF
--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -381,7 +381,7 @@ $trackerRemovalIndicatorWidth: 20px;
 
   .is-expanded & {
     // An arbitrary high value that allows it to expand to its full height:
-    max-height: 100vh;
+    max-height: 1000vh;
     border-color: $color-light-gray-20;
     padding: $spacing-sm 0;
     visibility: visible;

--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -19,10 +19,6 @@ $toggleTransitionDuration: 200ms;
   &.is-disabled {
     background-color: rgba($color-white, 0.5);
   }
-
-  .controls {
-    flex-grow: 2;
-  }
 }
 
 .main-data {
@@ -32,6 +28,7 @@ $toggleTransitionDuration: 200ms;
 }
 
 .controls {
+  min-width: $content-xs;
   display: flex;
   gap: $spacing-xs;
   align-items: center;


### PR DESCRIPTION
Flexbox items by default can't shrink beyond its content sizes, but since we're ellipsizing (is that a word?) the mask address anyway, that is fine here. Hence, we override the default min-width: 0. Also see https://stackoverflow.com/a/38383437

This PR fixes MPP-2645. Or at least, I think so, since it seems to be related to long mask names. It fixes a long-standing annoying issue anyway.

How to test: create a mask with a long name, then resize the viewport. The mask card should no longer overflow. In other words, this:

![image](https://user-images.githubusercontent.com/4251/208435732-5b27223d-b391-4a40-8db9-16fc3e7f91ef.png)

instead of this:

![image](https://user-images.githubusercontent.com/4251/208435836-6b5c738b-ac9c-4775-9fb0-074c4f17c005.png)

----

I also noticed there was a vertical overflow if the contents of a card was larger than the viewport:

![image](https://user-images.githubusercontent.com/4251/208436022-158b2e73-7d2c-4430-bcc3-d7b0f7de9f55.png)

So I also fixed that in 8994889e:

![image](https://user-images.githubusercontent.com/4251/208436082-c303a26e-cfa5-4991-9962-2d51829be1e2.png)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
