### PR TITLE
Fix React 18 errors

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -21,6 +21,23 @@ module.exports = {
     // but we try to avoid implicitly casting values (see e.g. reviews of
     // https://github.com/mozilla/fx-private-relay/pull/2315):
     eqeqeq: ["error", "always"],
+    "no-restricted-imports": [
+      "error",
+      {
+        paths: [
+          {
+            // The `useL10n` hook works around the problem of the user's locale
+            // not being known at build time, which could potentially cause the
+            // prerendered text content to be mismatched compared to the first
+            // client-side render. Hence, we should only use that hook:
+            name: "@fluent/react",
+            importNames: ["useLocalization", "Localized"],
+            message:
+              "Please use the `useL10n` hook from `/src/hooks/l10n.ts` instead of `useLocalization` from @fluent/react, and the `Localized` component from `/src/components/Localized.tsx` instead of from @fluent/react.",
+          },
+        ],
+      },
+    ],
   },
   overrides: [
     {

--- a/frontend/__mocks__/components/Localized.tsx
+++ b/frontend/__mocks__/components/Localized.tsx
@@ -1,15 +1,6 @@
-import { ReactNode, cloneElement, isValidElement } from "react";
+import { cloneElement, isValidElement, ReactNode } from "react";
 
-export const mockFluentReact = {
-  useLocalization: () => {
-    return {
-      l10n: {
-        getString: (id: string, vars?: Record<string, string>) =>
-          `l10n string: [${id}], with vars: ${JSON.stringify(vars ?? {})}`,
-        bundles: [{ locales: ["en-GB"] }],
-      },
-    };
-  },
+export const mockLocalizedModule = {
   Localized: (props: {
     children: ReactNode;
     id: string;

--- a/frontend/__mocks__/hooks/l10n.ts
+++ b/frontend/__mocks__/hooks/l10n.ts
@@ -1,0 +1,9 @@
+export const mockUseL10nModule = {
+  useL10n: () => {
+    return {
+      getString: (id: string, vars?: Record<string, string>) =>
+        `l10n string: [${id}], with vars: ${JSON.stringify(vars ?? {})}`,
+      bundles: [{ locales: ["en-GB"] }],
+    };
+  },
+};

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from "react";
 import { OutboundLink } from "react-ga";
-import { useLocalization } from "@fluent/react";
 import Link from "next/link";
 import styles from "./Banner.module.scss";
 import { useLocalDismissal } from "../hooks/localDismissal";
 import { CloseIcon, WarningFilledIcon, InfoFilledIcon } from "./Icons";
 import { useGaViewPing } from "../hooks/gaViewPing";
+import { useL10n } from "../hooks/l10n";
 
 export type BannerProps = {
   children: ReactNode;
@@ -32,7 +32,7 @@ export const Banner = (props: BannerProps) => {
   const dismissal = useLocalDismissal(props.dismissal?.key ?? "unused", {
     duration: props.dismissal?.duration,
   });
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const type = props.type ?? "warning";
 
   const warningIcon = (

--- a/frontend/src/components/CountdownTimer.tsx
+++ b/frontend/src/components/CountdownTimer.tsx
@@ -1,4 +1,4 @@
-import { useLocalization } from "@fluent/react";
+import { useL10n } from "../hooks/l10n";
 import styles from "./CountdownTimer.module.scss";
 
 export type Props = {
@@ -6,7 +6,7 @@ export type Props = {
 };
 
 export const CountdownTimer = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const { remainingDays, remainingHours, remainingMinutes, remainingSeconds } =
     getRemainingTimeParts(props.remainingTimeInMs);

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -2,8 +2,8 @@
 //       then added to react-icons: https://react-icons.github.io/react-icons/.
 //       These manually-created components are a workaround until that is done.
 
-import { useLocalization } from "@fluent/react";
 import { SVGProps } from "react";
+import { useL10n } from "../hooks/l10n";
 import styles from "./Icons.module.scss";
 
 /** Info button that inherits the text color of its container */
@@ -150,7 +150,7 @@ export const BentoIcon = (
 export const NewTabIcon = (
   props: SVGProps<SVGSVGElement> & { alt?: string }
 ) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <svg

--- a/frontend/src/components/Localized.tsx
+++ b/frontend/src/components/Localized.tsx
@@ -1,5 +1,37 @@
 import { LocalizedProps, Localized as OriginalLocalized } from "@fluent/react";
+import { useEffect, useState } from "react";
+import { useL10n } from "../hooks/l10n";
 
+/**
+ * Wraps @fluent/react's Localized to be consistent between prerender and first render
+ *
+ * React will throw a tantrum if the HTML rendered during the build differs from
+ * the DOM rendered by React when running client-side. However, at build-time we
+ * don't yet know the user's locale. Thus, if we render strings in the user's
+ * locale on the first client-side render, we'll make React unhappy, and who
+ * wants that?
+ *
+ * To work around this, the useL10n hook makes sure that the English strings are
+ * rendered when both prerendering and doing the first client-side render, and
+ * only after that use the language that aligns with the user's preferences.
+ * Thus, while pre-rendering and during the first client-side render, we call
+ * out to that hook.
+ *
+ * This means tags embedded in the localised strings won't get added initially,
+ * but since that's only for SEO and the initial render, that's acceptable.
+ */
 export const Localized = (props: LocalizedProps) => {
+  const [isPrerendering, setIsPrerendering] = useState(true);
+  const l10n = useL10n();
+
+  useEffect(() => {
+    setIsPrerendering(false);
+  }, []);
+
+  if (isPrerendering) {
+    // `useL10n` makes sure that this is a prerenderable string
+    return <>{l10n.getString(props.id, props.vars)}</>;
+  }
+
   return <OriginalLocalized {...props} />;
 };

--- a/frontend/src/components/Localized.tsx
+++ b/frontend/src/components/Localized.tsx
@@ -1,3 +1,7 @@
+// Imports of `Localized` from @fluent/react are forbidden because the component
+// in this file should be used instead, but of course this component can use it
+// just fine:
+// eslint-disable-next-line no-restricted-imports
 import { LocalizedProps, Localized as OriginalLocalized } from "@fluent/react";
 import { useEffect, useState } from "react";
 import { useL10n } from "../hooks/l10n";

--- a/frontend/src/components/Localized.tsx
+++ b/frontend/src/components/Localized.tsx
@@ -1,0 +1,5 @@
+import { LocalizedProps, Localized as OriginalLocalized } from "@fluent/react";
+
+export const Localized = (props: LocalizedProps) => {
+  return <OriginalLocalized {...props} />;
+};

--- a/frontend/src/components/ReactAriaI18nProvider.tsx
+++ b/frontend/src/components/ReactAriaI18nProvider.tsx
@@ -1,7 +1,7 @@
-import { useLocalization } from "@fluent/react";
 import { ReactChild } from "react";
 import { I18nProvider } from "react-aria";
 import { getLocale } from "../functions/getLocale";
+import { useL10n } from "../hooks/l10n";
 
 /**
  * React-aria has some components (e.g. `<DismissButton>`) that include their
@@ -9,7 +9,7 @@ import { getLocale } from "../functions/getLocale";
  * rest of the application does.
  */
 export const ReactAriaI18nProvider = (props: { children: ReactChild }) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const locale = getLocale(l10n);
 
   return <I18nProvider locale={locale}>{props.children}</I18nProvider>;

--- a/frontend/src/components/dashboard/Onboarding.tsx
+++ b/frontend/src/components/dashboard/Onboarding.tsx
@@ -1,9 +1,9 @@
-import { useLocalization } from "@fluent/react";
 import styles from "./Onboarding.module.scss";
 import IconImage from "./images/onboarding-step-2.svg";
 import RightClickImage from "./images/onboarding-step-3.svg";
 import { AliasData } from "../../hooks/api/aliases";
 import { Button } from "../Button";
+import { useL10n } from "../../hooks/l10n";
 
 export type Props = {
   aliases: AliasData[];
@@ -14,7 +14,7 @@ export type Props = {
  * Shows the user instructions on how to use Relay if they don't have aliases yet.
  */
 export const Onboarding = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   if (props.aliases.length > 0) {
     return null;

--- a/frontend/src/components/dashboard/PremiumOnboarding.tsx
+++ b/frontend/src/components/dashboard/PremiumOnboarding.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useLocalization } from "@fluent/react";
 import { event as gaEvent } from "react-ga";
 import { useOverlayTriggerState } from "react-stately";
 import styles from "./PremiumOnboarding.module.scss";
@@ -20,6 +19,7 @@ import {
   supportsAnExtension,
 } from "../../functions/userAgent";
 import { CheckBadgeIcon } from "../Icons";
+import { useL10n } from "../../hooks/l10n";
 
 export type Props = {
   profile: ProfileData;
@@ -31,7 +31,7 @@ export type Props = {
  * Shows the user how to take advantage of Premium features when they've just upgraded.
  */
 export const PremiumOnboarding = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const getStartedButtonRef = useGaViewPing({
     category: "Premium Onboarding",
     label: "onboarding-step-1-continue",
@@ -243,7 +243,7 @@ export const PremiumOnboarding = (props: Props) => {
 };
 
 const StepOne = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const isLargeScreen = useMinViewportWidth("md");
 
   return (
@@ -285,7 +285,7 @@ type Step2Props = {
   onPickSubdomain: (subdomain: string) => void;
 };
 const StepTwo = (props: Step2Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const subdomain =
     typeof props.profile.subdomain === "string" ? (
@@ -342,7 +342,7 @@ type Step2SubdomainPickerProps = {
   profile: ProfileData;
 };
 const Step2SubdomainPicker = (props: Step2SubdomainPickerProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const [chosenSubdomain, setChosenSubdomain] = useState("");
   const [partialSubdomain, setPartialSubdomain] = useState("");
 
@@ -393,7 +393,7 @@ const Step2SubdomainPicker = (props: Step2SubdomainPickerProps) => {
 };
 
 const StepThree = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <div className={`${styles.step} ${styles["step-addon"]}`}>
@@ -430,7 +430,7 @@ const StepThree = () => {
 };
 
 const StepThreeTitle = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const isLargeScreen = useMinViewportWidth("md");
   if (!isLargeScreen) {
     return <h2>{l10n.getString("multi-part-onboarding-reply-headline")}</h2>;
@@ -508,7 +508,7 @@ const AddonDescription = () => {
 const AddonDescriptionHeader = ({
   headerMessageId,
 }: Pick<AddonDescriptionProps, "headerMessageId">) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   if (!supportsAnExtension()) {
     return null;
   }
@@ -518,7 +518,7 @@ const AddonDescriptionHeader = ({
 const AddonDescriptionParagraph = ({
   paragraphMessageId,
 }: Pick<AddonDescriptionProps, "paragraphMessageId">) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   if (!supportsAnExtension()) {
     return null;
   }
@@ -529,7 +529,7 @@ const AddonDescriptionLinkButton = ({
   linkHref,
   linkMessageId,
 }: Pick<AddonDescriptionProps, "linkHref" | "linkMessageId">) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   if (!supportsAnExtension()) {
     return null;
   }

--- a/frontend/src/components/dashboard/PremiumPromoBanners.tsx
+++ b/frontend/src/components/dashboard/PremiumPromoBanners.tsx
@@ -1,8 +1,8 @@
-import { useLocalization } from "@fluent/react";
 import { ReactNode } from "react";
 import styles from "./ProfileBanners.module.scss";
 import PhoneIllustration from "./images/phone-premium-promo.svg";
 import { Banner } from "../Banner";
+import { useL10n } from "../../hooks/l10n";
 
 export type Props = {
   showFirstPremiumBanner?: boolean;
@@ -35,7 +35,7 @@ export const PremiumPromoBanners = (props: Props) => {
 const phoneImage = <img src={PhoneIllustration.src} alt="" />;
 
 const StopSpamBanner = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <Banner
@@ -58,7 +58,7 @@ const StopSpamBanner = () => {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const AdvancedIdentityBanner = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <Banner
@@ -83,7 +83,7 @@ const AdvancedIdentityBanner = () => {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ControlReceiverBanner = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <Banner
@@ -108,7 +108,7 @@ const ControlReceiverBanner = () => {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ExtraProtectionBanner = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <Banner

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -1,4 +1,3 @@
-import { Localized, useLocalization } from "@fluent/react";
 import { ReactNode } from "react";
 import styles from "./ProfileBanners.module.scss";
 import FirefoxLogo from "./images/fx-logo.svg";
@@ -28,6 +27,8 @@ import { SubdomainPicker } from "./SubdomainPicker";
 import { useMinViewportWidth } from "../../hooks/mediaQuery";
 import { AliasData } from "../../hooks/api/aliases";
 import { PremiumPromoBanners } from "./PremiumPromoBanners";
+import { useL10n } from "../../hooks/l10n";
+import { Localized } from "../Localized";
 
 export type Props = {
   profile: ProfileData;
@@ -129,7 +130,7 @@ type BounceBannerProps = {
   profile: ProfileData;
 };
 const BounceBanner = (props: BounceBannerProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <Banner type="warning" title={l10n.getString("banner-bounced-headline")}>
@@ -151,7 +152,7 @@ const BounceBanner = (props: BounceBannerProps) => {
 };
 
 const NoFirefoxBanner = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <Banner
@@ -172,7 +173,7 @@ const NoFirefoxBanner = () => {
 };
 
 const NoAddonBanner = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <Banner
@@ -194,7 +195,7 @@ const NoAddonBanner = () => {
 };
 
 const NoChromeExtensionBanner = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <Banner
@@ -229,7 +230,7 @@ type BundleBannerProps = {
 // Unused but left in for when we no longer want to use <LoyalistPremiumBanner>
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const NoPremiumBanner = (props: NoPremiumBannerProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <Banner
@@ -254,7 +255,7 @@ const NoPremiumBanner = (props: NoPremiumBannerProps) => {
 };
 
 const LoyalistPremiumBanner = (props: NoPremiumBannerProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <Banner
@@ -288,7 +289,7 @@ const LoyalistPremiumBanner = (props: NoPremiumBannerProps) => {
 };
 
 const BundlePromoBanner = (props: BundleBannerProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <Banner

--- a/frontend/src/components/dashboard/SubdomainPicker.tsx
+++ b/frontend/src/components/dashboard/SubdomainPicker.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { useLocalization } from "@fluent/react";
 import { useOverlayTriggerState } from "react-stately";
 import { useState } from "react";
 import styles from "./SubdomainPicker.module.scss";
@@ -8,6 +7,7 @@ import { ProfileData } from "../../hooks/api/profile";
 import { SubdomainSearchForm } from "./subdomain/SearchForm";
 import { SubdomainConfirmationModal } from "./subdomain/ConfirmationModal";
 import { getRuntimeConfig } from "../../config";
+import { useL10n } from "../../hooks/l10n";
 
 export type Props = {
   profile: ProfileData;
@@ -18,7 +18,7 @@ export type Props = {
  * Allows the user to search for available subdomains, and pops up a modal to claim it if available.
  */
 export const SubdomainPicker = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const [chosenSubdomain, setChosenSubdomain] = useState("");
   const [partialSubdomain, setPartialSubdomain] = useState("");
 

--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from "react";
 import Link from "next/link";
-import { ReactLocalization, useLocalization } from "@fluent/react";
+import { ReactLocalization } from "@fluent/react";
 import {
   OverlayContainer,
   FocusScope,
@@ -24,6 +24,7 @@ import { InfoIcon } from "../../Icons";
 import { getRuntimeConfig } from "../../../config";
 import { Button } from "../../Button";
 import { InfoTooltip } from "../../InfoTooltip";
+import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
   isOpen: boolean;
@@ -37,7 +38,7 @@ export type Props = {
  * while also being educated on why they don't need to do that.
  */
 export const AddressPickerModal = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const [address, setAddress] = useState("");
   const [promotionalsBlocking, setPromotionalsBlocking] = useState(false);
   const cancelButtonRef = useRef<HTMLButtonElement>(null);

--- a/frontend/src/components/dashboard/aliases/Alias.tsx
+++ b/frontend/src/components/dashboard/aliases/Alias.tsx
@@ -1,5 +1,4 @@
 import { useRef, useState, ReactNode } from "react";
-import { Localized, useLocalization } from "@fluent/react";
 import { useToggleState, useTooltipTriggerState } from "react-stately";
 import {
   mergeProps,
@@ -27,6 +26,8 @@ import { BlockLevel, BlockLevelSlider } from "./BlockLevelSlider";
 import { RuntimeData } from "../../../hooks/api/runtimeData";
 import { isFlagActive } from "../../../functions/waffle";
 import { isPeriodicalPremiumAvailableInCountry } from "../../../functions/getPlan";
+import { useL10n } from "../../../hooks/l10n";
+import { Localized } from "../../Localized";
 
 export type Props = {
   alias: AliasData;
@@ -44,7 +45,7 @@ export type Props = {
  * A card to manage (toggle it on/off, view details, ...) a single alias.
  */
 export const Alias = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const [justCopied, setJustCopied] = useState(false);
 
   const expandButtonRef = useRef<HTMLButtonElement>(null);
@@ -245,7 +246,7 @@ type StatsProps = {
   runtimeData?: RuntimeData;
 };
 const Stats = (props: StatsProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const numberFormatter = new Intl.NumberFormat(getLocale(l10n), {
     notation: "compact",
     compactDisplay: "short",
@@ -307,7 +308,7 @@ type TooltipProps = {
   children: ReactNode;
 };
 const ForwardedTooltip = (props: TooltipProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const triggerState = useTooltipTriggerState({ delay: 0 });
   const triggerRef = useRef<HTMLSpanElement>(null);
   const tooltipTrigger = useTooltipTrigger({}, triggerState, triggerRef);
@@ -347,7 +348,7 @@ const ForwardedTooltip = (props: TooltipProps) => {
 };
 
 const BlockedTooltip = (props: TooltipProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const triggerState = useTooltipTriggerState({ delay: 0 });
   const triggerRef = useRef<HTMLSpanElement>(null);
   const tooltipTrigger = useTooltipTrigger({}, triggerState, triggerRef);
@@ -375,7 +376,7 @@ const BlockedTooltip = (props: TooltipProps) => {
 };
 
 const TrackersRemovedTooltip = (props: TooltipProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const triggerState = useTooltipTriggerState({ delay: 0 });
   const triggerRef = useRef<HTMLSpanElement>(null);
   const tooltipTrigger = useTooltipTrigger({}, triggerState, triggerRef);
@@ -411,7 +412,7 @@ const TrackersRemovedTooltip = (props: TooltipProps) => {
 };
 
 const RepliesTooltip = (props: TooltipProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const triggerState = useTooltipTriggerState({ delay: 0 });
   const triggerRef = useRef<HTMLSpanElement>(null);
   const tooltipTrigger = useTooltipTrigger({}, triggerState, triggerRef);
@@ -443,7 +444,7 @@ type BlockLevelLabelProps = {
   alias: AliasData;
 };
 const BlockLevelLabel = (props: BlockLevelLabelProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   if (props.alias.enabled === false) {
     return (
       <b
@@ -472,7 +473,7 @@ type TrackerRemovalIndicatorProps = {
   profile: ProfileData;
 };
 const TrackerRemovalIndicator = (props: TrackerRemovalIndicatorProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const tooltipState = useTooltipTriggerState({ delay: 0 });
   const triggerRef = useRef<HTMLButtonElement>(null);
   const { triggerProps, tooltipProps: triggerTooltipProps } = useTooltipTrigger(

--- a/frontend/src/components/dashboard/aliases/AliasDeletionButton.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButton.tsx
@@ -1,4 +1,3 @@
-import { Localized, useLocalization } from "@fluent/react";
 import {
   OverlayContainer,
   FocusScope,
@@ -24,6 +23,8 @@ import {
   getFullAddress,
   isRandomAlias,
 } from "../../../hooks/api/aliases";
+import { useL10n } from "../../../hooks/l10n";
+import { Localized } from "../../Localized";
 
 export type Props = {
   alias: AliasData;
@@ -34,7 +35,7 @@ export type Props = {
  * A button to delete a given alias, which will pop up a confirmation modal before deleting.
  */
 export const AliasDeletionButton = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const [confirmCheckbox, setConfirmCheckbox] = useState(false);
 
   const openModalButtonRef = useRef<HTMLButtonElement>(null);

--- a/frontend/src/components/dashboard/aliases/AliasGenerationButton.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasGenerationButton.test.tsx
@@ -7,13 +7,13 @@ import {
   getMockRuntimeDataWithoutPremium,
   getMockRuntimeDataWithPeriodicalPremium,
 } from "../../../../__mocks__/hooks/api/runtimeData";
-import { mockFluentReact } from "../../../../__mocks__/modules/fluent__react";
+import { mockUseL10nModule } from "../../../../__mocks__/hooks/l10n";
 
 import { AliasGenerationButton } from "./AliasGenerationButton";
 
-jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("../../../config.ts", () => mockConfigModule);
 jest.mock("../../../hooks/gaViewPing.ts");
+jest.mock("../../../hooks/l10n.ts", () => mockUseL10nModule);
 
 describe("<AliasGenerationButton>", () => {
   it("displays a usable button to generate an alias for a free user not at the alias limit", () => {

--- a/frontend/src/components/dashboard/aliases/AliasGenerationButton.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasGenerationButton.tsx
@@ -1,4 +1,3 @@
-import { useLocalization } from "@fluent/react";
 import {
   FocusScope,
   useOverlay,
@@ -32,6 +31,7 @@ import { RuntimeData } from "../../../hooks/api/runtimeData";
 import { isPeriodicalPremiumAvailableInCountry } from "../../../functions/getPlan";
 import { useGaViewPing } from "../../../hooks/gaViewPing";
 import { AddressPickerModal } from "./AddressPickerModal";
+import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
   aliases: AliasData[];
@@ -53,7 +53,7 @@ export type Props = {
  * user is able to.
  */
 export const AliasGenerationButton = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const getUnlimitedButtonRef = useGaViewPing({
     category: "Purchase Button",
     label: "profile-create-alias-upgrade-promo",
@@ -113,7 +113,7 @@ type AliasTypeMenuProps = {
   ) => void;
 };
 const AliasTypeMenu = (props: AliasTypeMenuProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const modalState = useOverlayTriggerState({});
 
   const onAction = (key: Key) => {
@@ -169,7 +169,7 @@ type AliasTypeMenuButtonProps = Parameters<typeof useMenuTriggerState>[0] & {
   onAction: AriaMenuItemProps["onAction"];
 };
 const AliasTypeMenuButton = (props: AliasTypeMenuButtonProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const triggerState = useMenuTriggerState(props);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const { menuTriggerProps, menuProps } = useMenuTrigger(

--- a/frontend/src/components/dashboard/aliases/AliasList.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.test.tsx
@@ -1,14 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { mockLocalizedModule } from "../../../../__mocks__/components/Localized";
 import { mockConfigModule } from "../../../../__mocks__/configMock";
 import { getMockRandomAlias } from "../../../../__mocks__/hooks/api/aliases";
 import { getMockProfileData } from "../../../../__mocks__/hooks/api/profile";
+import { mockUseL10nModule } from "../../../../__mocks__/hooks/l10n";
 import * as LocalLabelsMock from "../../../../__mocks__/hooks/localLabels";
-import { mockFluentReact } from "../../../../__mocks__/modules/fluent__react";
 import { AliasList } from "./AliasList";
 
-jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("../../../config.ts", () => mockConfigModule);
+jest.mock("../../../hooks/l10n.ts", () => mockUseL10nModule);
+jest.mock("../../../components/Localized.tsx", () => mockLocalizedModule);
 LocalLabelsMock.setMockLocalLabels();
 
 describe("<AliasList>", () => {

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -1,4 +1,3 @@
-import { Localized, useLocalization } from "@fluent/react";
 import { useState, useEffect } from "react";
 import { VisuallyHidden } from "react-aria";
 import styles from "./AliasList.module.scss";
@@ -13,6 +12,8 @@ import { useLocalLabels } from "../../../hooks/localLabels";
 import { AliasGenerationButton } from "./AliasGenerationButton";
 import { SearchIcon } from "../../Icons";
 import { useFlaggedAnchorLinks } from "../../../hooks/flaggedAnchorLinks";
+import { useL10n } from "../../../hooks/l10n";
+import { Localized } from "../../Localized";
 
 export type Props = {
   aliases: AliasData[];
@@ -32,7 +33,7 @@ export type Props = {
  * Display a list of <Alias> cards, with the ability to filter them or create a new alias.
  */
 export const AliasList = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const [stringFilterInput, setStringFilterInput] = useState("");
   const [stringFilterVisible, setStringFilterVisible] = useState(false);
   const [categoryFilters, setCategoryFilters] = useState<SelectedFilters>({});

--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.tsx
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.tsx
@@ -1,4 +1,4 @@
-import { ReactLocalization, useLocalization } from "@fluent/react";
+import { ReactLocalization } from "@fluent/react";
 import { HTMLAttributes, ReactNode, useRef } from "react";
 import {
   FocusScope,
@@ -31,6 +31,7 @@ import UmbrellaOpen from "./images/umbrella-open.svg";
 import UmbrellaOpenMobile from "./images/umbrella-open-mobile.svg";
 import { AliasData } from "../../../hooks/api/aliases";
 import { CloseIcon, LockIcon } from "../../Icons";
+import { useL10n } from "../../../hooks/l10n";
 
 export type BlockLevel = "none" | "promotional" | "all";
 export type Props = {
@@ -46,7 +47,7 @@ export type Props = {
 const onlyThumbIndex = 0;
 
 export const BlockLevelSlider = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const trackRef = useRef<HTMLDivElement>(null);
   const numberFormatter = new SliderValueFormatter(l10n);
   const sliderSettings: Parameters<typeof useSliderState>[0] = {
@@ -246,7 +247,7 @@ const Thumb = (props: ThumbProps) => {
 };
 
 const BlockLevelDescription = (props: { level: BlockLevel }) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   if (props.level === "none") {
     return (
@@ -350,7 +351,7 @@ type PromotionalTooltipProps = {
   premiumAvailableInCountry: boolean;
 };
 const PromotionalTooltip = (props: PromotionalTooltipProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const overlayRef = useRef<HTMLDivElement>(null);
   const { overlayProps, underlayProps } = useOverlay(
     { isOpen: true, onClose: props.onClose, isDismissable: true },

--- a/frontend/src/components/dashboard/aliases/CategoryFilter.tsx
+++ b/frontend/src/components/dashboard/aliases/CategoryFilter.tsx
@@ -15,12 +15,12 @@ import {
   useOverlayPosition,
   useButton,
 } from "react-aria";
-import { useLocalization } from "@fluent/react";
 import styles from "./CategoryFilter.module.scss";
 import { Filters } from "../../../functions/filterAliases";
 import { useOverlayTriggerState } from "react-stately";
 import { Button } from "../../Button";
 import { FilterIcon } from "../../Icons";
+import { useL10n } from "../../../hooks/l10n";
 
 export type SelectedFilters = {
   domainType?: Filters["domainType"];
@@ -41,7 +41,7 @@ type OnCloseParams = {
  * Menu to select alias filters to apply, based on properties like being random or custom, or enabled or disabled.
  */
 export const CategoryFilter = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const menuState = useOverlayTriggerState({});
   const triggerRef = useRef<HTMLButtonElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -109,7 +109,7 @@ const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
     { selectedFilters, onClose, isOpen, ...otherProps },
     overlayRef
   ) {
-    const { l10n } = useLocalization();
+    const l10n = useL10n();
     const [domainType, setDomainType] = useState<Filters["domainType"]>(
       selectedFilters.domainType
     );

--- a/frontend/src/components/dashboard/aliases/LabelEditor.tsx
+++ b/frontend/src/components/dashboard/aliases/LabelEditor.tsx
@@ -1,4 +1,3 @@
-import { useLocalization } from "@fluent/react";
 import {
   FocusEventHandler,
   FormEventHandler,
@@ -6,6 +5,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useL10n } from "../../../hooks/l10n";
 import styles from "./LabelEditor.module.scss";
 
 export type Props = {
@@ -17,7 +17,7 @@ export type Props = {
  * Input field that allows the user to update the label of an alias.
  */
 export const LabelEditor = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const [inputValue, setInputValue] = useState(props.label);
   const formRef = useRef<HTMLFormElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);

--- a/frontend/src/components/dashboard/subdomain/ConfirmationForm.tsx
+++ b/frontend/src/components/dashboard/subdomain/ConfirmationForm.tsx
@@ -1,8 +1,9 @@
-import { useLocalization, Localized } from "@fluent/react";
 import styles from "./ConfirmationForm.module.scss";
 import { Button } from "../../Button";
 import { FormEventHandler, useRef, useState } from "react";
 import { useButton } from "react-aria";
+import { useL10n } from "../../../hooks/l10n";
+import { Localized } from "../../Localized";
 
 export type Props = {
   subdomain: string;
@@ -16,7 +17,7 @@ export type Props = {
  * Primarily used in {@link ConfirmationModal}.
  */
 export const SubdomainConfirmationForm = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const [confirmCheckbox, setConfirmCheckbox] = useState(false);
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const cancelButton = useButton(

--- a/frontend/src/components/dashboard/subdomain/ConfirmationModal.tsx
+++ b/frontend/src/components/dashboard/subdomain/ConfirmationModal.tsx
@@ -1,5 +1,4 @@
 import { ReactElement, ReactNode, useRef } from "react";
-import { useLocalization, Localized } from "@fluent/react";
 import {
   OverlayContainer,
   FocusScope,
@@ -15,6 +14,8 @@ import partyIllustration from "./images/success-party.svg";
 import { SubdomainConfirmationForm } from "./ConfirmationForm";
 import { getRuntimeConfig } from "../../../config";
 import { Button } from "../../Button";
+import { useL10n } from "../../../hooks/l10n";
+import { Localized } from "../../Localized";
 
 export type Props = {
   subdomain: string;
@@ -40,7 +41,7 @@ export const SubdomainConfirmationModal = (props: Props) => {
 };
 
 const ConfirmModal = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <PickerDialog
@@ -74,7 +75,7 @@ const ConfirmModal = (props: Props) => {
 };
 
 const SuccessModal = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <div className={styles["picked-confirmation"]}>

--- a/frontend/src/components/dashboard/subdomain/SearchForm.tsx
+++ b/frontend/src/components/dashboard/subdomain/SearchForm.tsx
@@ -1,8 +1,8 @@
-import { useLocalization } from "@fluent/react";
 import { FormEventHandler, ChangeEventHandler, useState } from "react";
 import { VisuallyHidden } from "react-aria";
 import { toast } from "react-toastify";
 import { authenticatedFetch } from "../../../hooks/api/api";
+import { useL10n } from "../../../hooks/l10n";
 import { Button } from "../../Button";
 
 export type Props = {
@@ -14,7 +14,7 @@ export type Props = {
  * Form with which the user can check whether a given subdomain is still available for them to claim.
  */
 export const SubdomainSearchForm = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const [subdomainInput, setSubdomainInput] = useState("");
 
   const onSubmit: FormEventHandler = async (event) => {

--- a/frontend/src/components/dashboard/subdomain/SubdomainIndicator.tsx
+++ b/frontend/src/components/dashboard/subdomain/SubdomainIndicator.tsx
@@ -1,4 +1,3 @@
-import { useLocalization } from "@fluent/react";
 import {
   useButton,
   useOverlay,
@@ -23,6 +22,7 @@ import { CloseIcon } from "../../Icons";
 import { getRuntimeConfig } from "../../../config";
 import { AddressPickerModal } from "../aliases/AddressPickerModal";
 import { useMinViewportWidth } from "../../../hooks/mediaQuery";
+import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
   subdomain: string | null;
@@ -56,7 +56,7 @@ type ExplainerTriggerProps = {
   ) => void;
 };
 const ExplainerTrigger = (props: ExplainerTriggerProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const explainerState = useOverlayTriggerState({});
   const addressPickerState = useOverlayTriggerState({});
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -165,7 +165,7 @@ type ExplainerProps = AriaOverlayProps & {
 };
 const Explainer = forwardRef<HTMLDivElement, ExplainerProps>(
   function ExplainerWithForwardedRef(props, overlayRef) {
-    const { l10n } = useLocalization();
+    const l10n = useL10n();
     const isWideScreen = useMinViewportWidth("md");
 
     const { overlayProps } = useOverlay(

--- a/frontend/src/components/dashboard/tips/CustomAliasTip.tsx
+++ b/frontend/src/components/dashboard/tips/CustomAliasTip.tsx
@@ -1,7 +1,7 @@
-import { useLocalization } from "@fluent/react";
 import styles from "./CustomAliasTip.module.scss";
 import { getRuntimeConfig } from "../../../config";
 import { getLocale } from "../../../functions/getLocale";
+import { useL10n } from "../../../hooks/l10n";
 
 export type CustomAliasTipProps = {
   subdomain?: string;
@@ -11,7 +11,7 @@ export type CustomAliasTipProps = {
  * so it can't use {@see GenericTip}.
  */
 export const CustomAliasTip = (props: CustomAliasTipProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const subdomainElement =
     typeof props.subdomain === "string" ? (

--- a/frontend/src/components/dashboard/tips/GenericTip.tsx
+++ b/frontend/src/components/dashboard/tips/GenericTip.tsx
@@ -1,6 +1,6 @@
-import { useLocalization } from "@fluent/react";
 import { ReactNode } from "react";
 import { getLocale } from "../../../functions/getLocale";
+import { useL10n } from "../../../hooks/l10n";
 import styles from "./GenericTip.module.scss";
 
 export type GenericTipProps = {
@@ -13,7 +13,7 @@ export type GenericTipProps = {
 // This component will probably be used for future tips that are yet to be added:
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const GenericTip = (props: GenericTipProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const sources = Object.entries(props.videos ?? {}).map(([type, source]) => (
     <source key={source} type={type} src={source} />

--- a/frontend/src/components/dashboard/tips/Tips.tsx
+++ b/frontend/src/components/dashboard/tips/Tips.tsx
@@ -6,7 +6,6 @@ import {
   useCallback,
   RefObject,
 } from "react";
-import { useLocalization } from "@fluent/react";
 import Link from "next/link";
 import { useTabList, useTabPanel, useTab } from "react-aria";
 import { useTabListState, TabListState, Item } from "react-stately";
@@ -27,6 +26,7 @@ import { useRelayNumber } from "../../../hooks/api/relayNumber";
 import { RuntimeData } from "../../../hooks/api/runtimeData";
 import { isFlagActive } from "../../../functions/waffle";
 import { GenericTip } from "./GenericTip";
+import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
   profile: ProfileData;
@@ -45,7 +45,7 @@ export type TipEntry = {
  * Panel to be used on the bottom of the page, displaying tips relevant to the user.
  */
 export const Tips = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const [isExpanded, setIsExpanded] = useState(false);
   const [wrapperRef, wrapperIsInView] = useInView({ threshold: 1 });
   const relayNumberData = useRelayNumber({ disable: !props.profile.has_phone });
@@ -277,7 +277,7 @@ type PanelDotProps = {
   tabListState: TabListState<object>;
 };
 const PanelDot = (props: PanelDotProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const dotRef = useRef<HTMLDivElement>(null);
   const { tabProps } = useTab(
     { key: props.item.key },

--- a/frontend/src/components/landing/BundleBanner.tsx
+++ b/frontend/src/components/landing/BundleBanner.tsx
@@ -1,5 +1,4 @@
 import { FluentVariable } from "@fluent/bundle";
-import { Localized, useLocalization } from "@fluent/react";
 import {
   getBundlePrice,
   getBundleSubscribeLink,
@@ -17,6 +16,8 @@ import bundleFloatThree from "./images/bundle-float-3.svg";
 import bundleLogo from "./images/vpn-and-relay-logo.svg";
 import { trackPlanPurchaseStart } from "../../functions/trackPurchase";
 import { useGaViewPing } from "../../hooks/gaViewPing";
+import { useL10n } from "../../hooks/l10n";
+import { Localized } from "../Localized";
 
 export type Props = {
   runtimeData: RuntimeData;
@@ -30,7 +31,7 @@ type FloatingFeaturesProps = {
 };
 
 const FloatingFeatures = (props: FloatingFeaturesProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const text = props.vars ? (
     <Localized id={props.text} vars={props.vars}>
@@ -53,7 +54,7 @@ const FloatingFeatures = (props: FloatingFeaturesProps) => {
 };
 
 export const BundleBanner = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const mainImage = (
     <img

--- a/frontend/src/components/landing/DemoPhone.tsx
+++ b/frontend/src/components/landing/DemoPhone.tsx
@@ -1,4 +1,3 @@
-import { useLocalization } from "@fluent/react";
 import styles from "./DemoPhone.module.scss";
 import BgImage from "./images/hero-image-bg.svg";
 import PremiumScreenshot from "./images/hero-image-premium.png";
@@ -9,6 +8,7 @@ import FgImage from "./images/hero-image-fg.svg";
 import FgImageDe from "./images/hero-image-fg-de.svg";
 import FgImageFr from "./images/hero-image-fg-fr.svg";
 import { getLocale } from "../../functions/getLocale";
+import { useL10n } from "../../hooks/l10n";
 
 export type Props = {
   premium?: boolean;
@@ -18,7 +18,7 @@ export type Props = {
  * Image of a phone showing the Relay interface, either the Premium or regular UI as desired.
  */
 export const DemoPhone = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const lang = getLocale(l10n).split("-")[0] ?? "en";
 
   return (

--- a/frontend/src/components/landing/PhoneBanner.tsx
+++ b/frontend/src/components/landing/PhoneBanner.tsx
@@ -1,4 +1,3 @@
-import { useLocalization } from "@fluent/react";
 import { StaticImageData } from "next/image";
 import { useId } from "react-aria";
 import { ReactElement } from "react";
@@ -9,13 +8,14 @@ import floatClock from "./images/phone-float-clock.svg";
 import floatAccount from "./images/phone-float-account.svg";
 import floatHeart from "./images/phone-float-heart.png";
 import floatPhone from "./images/phone-float-phone.png";
+import { useL10n } from "../../hooks/l10n";
 
 export type Props = {
   cta: ReactElement;
 };
 
 export const PhoneBanner = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <div className={styles.wrapper}>

--- a/frontend/src/components/landing/PlanMatrix.tsx
+++ b/frontend/src/components/landing/PlanMatrix.tsx
@@ -1,4 +1,3 @@
-import { Localized, useLocalization } from "@fluent/react";
 import { useTab, useTabList, useTabPanel, VisuallyHidden } from "react-aria";
 import { Key, ReactNode, useRef } from "react";
 import Link from "next/link";
@@ -27,6 +26,8 @@ import { getRuntimeConfig } from "../../config";
 import { useGaViewPing } from "../../hooks/gaViewPing";
 import { Plan, trackPlanPurchaseStart } from "../../functions/trackPurchase";
 import { setCookie } from "../../functions/cookies";
+import { useL10n } from "../../hooks/l10n";
+import { Localized } from "../Localized";
 
 type FeatureList = {
   "email-masks": number;
@@ -73,7 +74,7 @@ export type Props = {
  * Matrix to compare and choose between the different plans available to the user.
  */
 export const PlanMatrix = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const freeButtonDesktopRef = useGaViewPing({
     category: "Sign In",
     label: "plan-matrix-free-cta-desktop",
@@ -633,7 +634,7 @@ type MobileFeatureListProps = {
   list: FeatureList;
 };
 const MobileFeatureList = (props: MobileFeatureListProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const lis = Object.entries(props.list)
     .filter(
@@ -684,7 +685,7 @@ type AvailabilityListingProps = {
   availability: FeatureList[keyof FeatureList];
 };
 const AvailabilityListing = (props: AvailabilityListingProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   if (typeof props.availability === "number") {
     if (props.availability === Number.POSITIVE_INFINITY) {
@@ -721,7 +722,7 @@ type PricingToggleProps = {
   };
 };
 const PricingToggle = (props: PricingToggleProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const yearlyButtonRef = useGaViewPing(props.yearlyBilled.gaViewPing);
   const monthlyButtonRef = useGaViewPing(props.monthlyBilled.gaViewPing);
 

--- a/frontend/src/components/landing/Reviews.tsx
+++ b/frontend/src/components/landing/Reviews.tsx
@@ -1,4 +1,3 @@
-import { useLocalization } from "@fluent/react";
 import { TouchEventHandler, useRef, useState } from "react";
 import { useButton } from "react-aria";
 import FxBrowserLogo from "./images/fx-logo.svg";
@@ -10,6 +9,7 @@ import {
 } from "../Icons";
 import styles from "./Reviews.module.scss";
 import { getLocale } from "../../functions/getLocale";
+import { useL10n } from "../../hooks/l10n";
 
 // We want to ensure only these values can be used for a rating.
 export type Rating = 1 | 2 | 3 | 4 | 5;
@@ -30,7 +30,7 @@ export const Reviews = () => {
     useState<Direction>("left");
   const [touchStart, setTouchStart] = useState(0);
   const [touchEnd, setTouchEnd] = useState(0);
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const slideLeftButtonRef = useRef<HTMLButtonElement>(null);
 

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -6,7 +6,6 @@ import {
   useState,
 } from "react";
 import Link from "next/link";
-import { useLocalization } from "@fluent/react";
 import { ToastContainer, toast, Slide } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import styles from "./Layout.module.scss";
@@ -29,6 +28,7 @@ import { PageMetadata } from "./PageMetadata";
 import { RuntimeData } from "../../hooks/api/runtimeData";
 import { useRouter } from "next/router";
 import { isPhonesAvailableInCountry } from "../../functions/getPlan";
+import { useL10n } from "../../hooks/l10n";
 
 export type Props = {
   children: ReactNode;
@@ -40,7 +40,7 @@ export type Props = {
  * Standard page layout for Relay, wrapping its children in the relevant header and footer.
  */
 export const Layout = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const profiles = useProfiles();
   const isLoggedIn = useIsLoggedIn();
   const router = useRouter();

--- a/frontend/src/components/layout/PageMetadata.tsx
+++ b/frontend/src/components/layout/PageMetadata.tsx
@@ -1,12 +1,12 @@
 import Head from "next/head";
-import { useLocalization } from "@fluent/react";
 import { useRouter } from "next/router";
 import favicon from "../../../public/favicon.svg";
 import socialMediaImage from "./images/share-relay.jpg";
 import { getRuntimeConfig } from "../../config";
+import { useL10n } from "../../hooks/l10n";
 
 export const PageMetadata = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const router = useRouter();
 
   return (

--- a/frontend/src/components/layout/navigation/AppPicker.tsx
+++ b/frontend/src/components/layout/navigation/AppPicker.tsx
@@ -28,7 +28,6 @@ import {
   RefObject,
 } from "react";
 import { AriaMenuItemProps } from "@react-aria/menu";
-import { useLocalization } from "@fluent/react";
 import { event as gaEvent } from "react-ga";
 import styles from "./AppPicker.module.scss";
 import FirefoxLogo from "../images/fx.png";
@@ -40,6 +39,7 @@ import FxMobileLogo from "../images/fx-mobile.png";
 import { Props as LayoutProps } from "../Layout";
 import { getRuntimeConfig } from "../../../config";
 import { BentoIcon } from "../../Icons";
+import { useL10n } from "../../../hooks/l10n";
 
 const getProducts = (referringSiteUrl: string) => ({
   monitor: {
@@ -86,7 +86,7 @@ export type Props = {
  * Menu that can be opened to see other relevant products Mozilla has available for people.
  */
 export const AppPicker = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const products = getProducts(
     typeof document !== "undefined"
@@ -230,7 +230,7 @@ const AppPickerTrigger = ({
   style,
   ...otherProps
 }: AppPickerTriggerProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const appPickerTriggerState = useMenuTriggerState(otherProps);
   const isFirstRenderDone = useRef(false);
 
@@ -293,7 +293,7 @@ type AppPickerPopupProps = TreeProps<Record<string, never>> & {
   autoFocus?: MenuTriggerState["focusStrategy"];
 };
 const AppPickerPopup = (props: AppPickerPopupProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const popupState = useTreeState({ ...props, selectionMode: "none" });
 
   const popupRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/components/layout/navigation/DashboardSwitcher.tsx
+++ b/frontend/src/components/layout/navigation/DashboardSwitcher.tsx
@@ -1,13 +1,13 @@
-import { useLocalization } from "@fluent/react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import styles from "./DashboardSwitcher.module.scss";
 import { MaskIcon, PhoneIcon } from "../../Icons";
+import { useL10n } from "../../../hooks/l10n";
 
 /** Component that allows the user to switch between the Email and Phone masks dashboards. */
 export const DashboardSwitcher = () => {
   const router = useRouter();
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     /* Email and Phone Duo Header on Mobile */

--- a/frontend/src/components/layout/navigation/MenuToggle.tsx
+++ b/frontend/src/components/layout/navigation/MenuToggle.tsx
@@ -1,4 +1,4 @@
-import { useLocalization } from "@fluent/react";
+import { useL10n } from "../../../hooks/l10n";
 import { CloseIcon, MenuIcon } from "../../Icons";
 
 export type Props = {
@@ -6,7 +6,7 @@ export type Props = {
 };
 
 export const MenuToggle = (props: Props): JSX.Element => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const { toggleState } = props;
 
   const closeMenuIcon = (

--- a/frontend/src/components/layout/navigation/MobileNavigation.tsx
+++ b/frontend/src/components/layout/navigation/MobileNavigation.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { useLocalization } from "@fluent/react";
 import styles from "./MobileNavigation.module.scss";
 import { SignUpButton } from "./SignUpButton";
 import {
@@ -16,6 +15,7 @@ import {
 import { useRuntimeData } from "../../../hooks/api/runtimeData";
 import { getRuntimeConfig } from "../../../config";
 import { getCsrfToken } from "../../../functions/cookies";
+import { useL10n } from "../../../hooks/l10n";
 
 export type MenuItem = {
   url: string;
@@ -42,7 +42,7 @@ export const MobileNavigation = (props: Props) => {
     userEmail,
     userAvatar,
   } = props;
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const runtimeData = useRuntimeData();
   const { supportUrl } = getRuntimeConfig();
 

--- a/frontend/src/components/layout/navigation/Navigation.test.tsx
+++ b/frontend/src/components/layout/navigation/Navigation.test.tsx
@@ -8,19 +8,19 @@ import {
 } from "../../../../__mocks__/hooks/api/runtimeData";
 import { setMockUserData } from "../../../../__mocks__/hooks/api/user";
 import { mockUseFxaFlowTrackerModule } from "../../../../__mocks__/hooks/fxaFlowTracker";
-import { mockFluentReact } from "../../../../__mocks__/modules/fluent__react";
+import { mockUseL10nModule } from "../../../../__mocks__/hooks/l10n";
 import { mockNextRouter } from "../../../../__mocks__/modules/next__router";
 import { mockReactIntersectionObsever } from "../../../../__mocks__/modules/react-intersection-observer";
 
 import { Navigation } from "./Navigation";
 
-jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("next/router", () => mockNextRouter);
 jest.mock("react-intersection-observer", () => mockReactIntersectionObsever);
 jest.mock(
   "../../../hooks/fxaFlowTracker.ts",
   () => mockUseFxaFlowTrackerModule
 );
+jest.mock("../../../hooks/l10n.ts", () => mockUseL10nModule);
 jest.mock("../../../config.ts", () => mockConfigModule);
 
 setMockRuntimeData();

--- a/frontend/src/components/layout/navigation/Navigation.tsx
+++ b/frontend/src/components/layout/navigation/Navigation.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useLocalization } from "@fluent/react";
 import styles from "./Navigation.module.scss";
 import { SignUpButton } from "./SignUpButton";
 import { SignInButton } from "./SignInButton";
@@ -15,6 +14,7 @@ import {
   isPeriodicalPremiumAvailableInCountry,
   isPhonesAvailableInCountry,
 } from "../../../functions/getPlan";
+import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
   theme: "free" | "premium";
@@ -26,7 +26,7 @@ export type Props = {
 };
 /** Switch between the different pages of the Relay website. */
 export const Navigation = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const runtimeData = useRuntimeData();
   const router = useRouter();
   const {

--- a/frontend/src/components/layout/navigation/SignInButton.tsx
+++ b/frontend/src/components/layout/navigation/SignInButton.tsx
@@ -1,15 +1,15 @@
-import { useLocalization } from "@fluent/react";
 import { event as gaEvent } from "react-ga";
 import styles from "./SignInButton.module.scss";
 import { setCookie } from "../../../functions/cookies";
 import { getLoginUrl, useFxaFlowTracker } from "../../../hooks/fxaFlowTracker";
+import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
   className?: string;
 };
 
 export const SignInButton = (props: Props): JSX.Element => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const signInFxaFlowTracker = useFxaFlowTracker({
     category: "Sign In",
     label: "nav-profile-sign-in",

--- a/frontend/src/components/layout/navigation/SignUpButton.tsx
+++ b/frontend/src/components/layout/navigation/SignUpButton.tsx
@@ -1,14 +1,14 @@
-import { useLocalization } from "@fluent/react";
 import { event as gaEvent } from "react-ga";
 import styles from "./SignUpButton.module.scss";
 import { setCookie } from "../../../functions/cookies";
 import { getLoginUrl, useFxaFlowTracker } from "../../../hooks/fxaFlowTracker";
+import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
   className: string;
 };
 export const SignUpButton = (props: Props): JSX.Element => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const signUpFxaFlowTracker = useFxaFlowTracker({
     category: "Sign In",
     label: "nav-profile-sign-up",

--- a/frontend/src/components/layout/navigation/UpgradeButton.tsx
+++ b/frontend/src/components/layout/navigation/UpgradeButton.tsx
@@ -1,10 +1,10 @@
-import { useLocalization } from "@fluent/react";
 import styles from "./UpgradeButton.module.scss";
 import { useGaViewPing } from "../../../hooks/gaViewPing";
 import Link from "next/link";
+import { useL10n } from "../../../hooks/l10n";
 
 export const UpgradeButton = (): JSX.Element => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const upgradeButtonRef = useGaViewPing({
     category: "Purchase Button",
     label: "navbar-upgrade-button",

--- a/frontend/src/components/layout/navigation/UserMenu.tsx
+++ b/frontend/src/components/layout/navigation/UserMenu.tsx
@@ -20,7 +20,6 @@ import {
 } from "react-aria";
 import { HTMLAttributes, Key, ReactNode, useRef, useState } from "react";
 import { AriaMenuItemProps } from "@react-aria/menu";
-import { useLocalization } from "@fluent/react";
 import Link from "next/link";
 import { event as gaEvent } from "react-ga";
 import styles from "./UserMenu.module.scss";
@@ -37,6 +36,7 @@ import { getRuntimeConfig } from "../../../config";
 import { getCsrfToken } from "../../../functions/cookies";
 import { useRuntimeData } from "../../../hooks/api/runtimeData";
 import { setCookie } from "../../../functions/cookies";
+import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
   style: string;
@@ -48,7 +48,7 @@ export const UserMenu = (props: Props) => {
   const runtimeData = useRuntimeData();
   const profileData = useProfiles();
   const usersData = useUsers();
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const itemKeys = {
     account: "account",
@@ -215,7 +215,7 @@ const UserMenuTrigger = ({
   style,
   ...otherProps
 }: UserMenuTriggerProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const userMenuTriggerState = useMenuTriggerState(otherProps);
 
   const triggerButtonRef = useRef<HTMLButtonElement>(null);

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.test.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.test.tsx
@@ -1,16 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mockGetLocaleModule } from "../../../../../__mocks__/functions/getLocale";
-import { mockFluentReact } from "../../../../../__mocks__/modules/fluent__react";
+import { mockUseL10nModule } from "../../../../../__mocks__/hooks/l10n";
 import { mockReactGa } from "../../../../../__mocks__/modules/react-ga";
 
 import { WhatsNewDashboard } from "./WhatsNewDashboard";
 import { WhatsNewEntry } from "./WhatsNewMenu";
 
-jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("react-ga", () => mockReactGa);
 jest.mock("../../../../functions/getLocale.ts", () => mockGetLocaleModule);
 jest.mock("../../../../hooks/gaViewPing.ts");
+jest.mock("../../../../hooks/l10n.ts", () => mockUseL10nModule);
 
 function getMockEntry(
   id: number,

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.tsx
@@ -1,4 +1,3 @@
-import { useLocalization } from "@fluent/react";
 import { Key, ReactNode, useRef, useState } from "react";
 import { useTab, useTabList, useTabPanel } from "react-aria";
 import { Item, TabListState, useTabListState } from "react-stately";
@@ -7,6 +6,7 @@ import { CloseIcon } from "../../../Icons";
 import styles from "./WhatsNewDashboard.module.scss";
 import { WhatsNewList } from "./WhatsNewList";
 import { WhatsNewEntry } from "./WhatsNewMenu";
+import { useL10n } from "../../../../hooks/l10n";
 
 export type Props = {
   new: WhatsNewEntry[];
@@ -15,7 +15,7 @@ export type Props = {
 };
 
 export const WhatsNewDashboard = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const [expandedEntry, setExpandedEntry] = useState<WhatsNewEntry>();
   // `onClearAll` is undefined when there are no entries,
   // which signals to <Tabs> that the "Clear all" button should not be shown.
@@ -107,7 +107,7 @@ type TabProps = Parameters<typeof useTabListState>[0] & {
   onClearAll?: () => void;
 };
 const Tabs = (props: TabProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const tabListState = useTabListState(props);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const { tabListProps } = useTabList(props, tabListState, wrapperRef);

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewList.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewList.tsx
@@ -1,8 +1,8 @@
-import { useLocalization } from "@fluent/react";
 import { Key, ReactNode, useRef } from "react";
 import { useMenu, useMenuItem } from "react-aria";
 import { Item, TreeProps, TreeState, useTreeState } from "react-stately";
 import { useGaViewPing } from "../../../../hooks/gaViewPing";
+import { useL10n } from "../../../../hooks/l10n";
 import EmptyStateHero from "./images/empty-hero.png";
 import styles from "./WhatsNewList.module.scss";
 import { WhatsNewEntry } from "./WhatsNewMenu";
@@ -14,7 +14,7 @@ export type Props = {
 };
 
 export const WhatsNewList = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   if (props.entries.length === 0) {
     return (

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -5,7 +5,6 @@ import {
   RefObject,
   useRef,
 } from "react";
-import { useLocalization } from "@fluent/react";
 import {
   DismissButton,
   FocusScope,
@@ -64,6 +63,7 @@ import {
 import { CountdownTimer } from "../../../CountdownTimer";
 import Link from "next/link";
 import { GiftIcon } from "../../../Icons";
+import { useL10n } from "../../../../hooks/l10n";
 
 export type WhatsNewEntry = {
   title: string;
@@ -110,7 +110,7 @@ const CtaLinkButton = (props: CtaProps) => {
 };
 
 export const WhatsNewMenu = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const triggerState = useOverlayTriggerState({
     onOpenChange(isOpen) {

--- a/frontend/src/components/layout/topmessage/CsatSurvey.test.tsx
+++ b/frontend/src/components/layout/topmessage/CsatSurvey.test.tsx
@@ -2,14 +2,14 @@ import { render, screen } from "@testing-library/react";
 import { mockCookiesModule } from "../../../../__mocks__/functions/cookies";
 import { mockGetLocaleModule } from "../../../../__mocks__/functions/getLocale";
 import { getMockProfileData } from "../../../../__mocks__/hooks/api/profile";
-import { mockFluentReact } from "../../../../__mocks__/modules/fluent__react";
+import { mockUseL10nModule } from "../../../../__mocks__/hooks/l10n";
 
 import { CsatSurvey } from "./CsatSurvey";
 
-jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("../../../functions/cookies.ts", () => mockCookiesModule);
 jest.mock("../../../functions/getLocale.ts", () => mockGetLocaleModule);
 jest.mock("../../../hooks/firstSeen.ts");
+jest.mock("../../../hooks/l10n.ts", () => mockUseL10nModule);
 
 describe("The CSAT survey", () => {
   it("does not display the survey if the user has joined within the last week", () => {

--- a/frontend/src/components/layout/topmessage/CsatSurvey.tsx
+++ b/frontend/src/components/layout/topmessage/CsatSurvey.tsx
@@ -5,12 +5,12 @@ import {
   DismissOptions,
   useLocalDismissal,
 } from "../../../hooks/localDismissal";
-import { useLocalization } from "@fluent/react";
 import { ProfileData } from "../../../hooks/api/profile";
 import { CloseIcon } from "../../Icons";
 import { parseDate } from "../../../functions/parseDate";
 import { useState } from "react";
 import { getLocale } from "../../../functions/getLocale";
+import { useL10n } from "../../../hooks/l10n";
 
 type SurveyLinks = {
   "Very Dissatisfied": string;
@@ -66,7 +66,7 @@ export const CsatSurvey = (props: Props) => {
     { duration: 90 * 24 * 60 * 60 }
   );
   const firstSeen = useFirstSeen();
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const [answer, setAnswer] = useState<keyof SurveyLinks>();
 
   let reasonToShow:

--- a/frontend/src/components/layout/topmessage/InterviewRecruitment.tsx
+++ b/frontend/src/components/layout/topmessage/InterviewRecruitment.tsx
@@ -1,9 +1,9 @@
-import { useLocalization } from "@fluent/react";
 import { event as gaEvent } from "react-ga";
 import styles from "./InterviewRecruitment.module.scss";
 import { CloseIcon } from "../../Icons";
 import { useLocalDismissal } from "../../../hooks/localDismissal";
 import { useGaViewPing } from "../../../hooks/gaViewPing";
+import { useL10n } from "../../../hooks/l10n";
 
 /**
  * Ask people whether they're be interested in discussing their experience in using Relay.
@@ -15,7 +15,7 @@ export const InterviewRecruitment = () => {
   const recruitmentLabel =
     "Want to help improve Firefox Relay? We'd love to hear what you think. Research participants receive a $50 gift card.";
 
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const dismissal = useLocalDismissal("interview-recruitment-2022-08");
   const linkRef = useGaViewPing({
     category: "Recruitment",

--- a/frontend/src/components/layout/topmessage/NpsSurvey.tsx
+++ b/frontend/src/components/layout/topmessage/NpsSurvey.tsx
@@ -3,9 +3,9 @@ import styles from "./NpsSurvey.module.scss";
 import { useFirstSeen } from "../../../hooks/firstSeen";
 import { useLocalDismissal } from "../../../hooks/localDismissal";
 import { useIsLoggedIn } from "../../../hooks/session";
-import { useLocalization } from "@fluent/react";
 import { useProfiles } from "../../../hooks/api/profile";
 import { CloseIcon } from "../../Icons";
+import { useL10n } from "../../../hooks/l10n";
 
 /**
  * Quickly survey the user for input to our Net Promotor Score.
@@ -20,7 +20,7 @@ export const NpsSurvey = () => {
   );
   const firstSeen = useFirstSeen();
   const isLoggedIn = useIsLoggedIn();
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const hasBeenUserForThreeDays =
     isLoggedIn &&

--- a/frontend/src/components/layout/topmessage/PhoneSurvey.tsx
+++ b/frontend/src/components/layout/topmessage/PhoneSurvey.tsx
@@ -1,10 +1,10 @@
-import { useLocalization } from "@fluent/react";
 import { event as gaEvent } from "react-ga";
 import styles from "./PhoneSurvey.module.scss";
 import { CloseIcon } from "../../Icons";
 import { useLocalDismissal } from "../../../hooks/localDismissal";
 import { useGaViewPing } from "../../../hooks/gaViewPing";
 import { useRelayNumber } from "../../../hooks/api/relayNumber";
+import { useL10n } from "../../../hooks/l10n";
 
 /**
  * Ask people whether they're be interested in discussing their experience in using Relay.
@@ -17,7 +17,7 @@ export const PhoneSurvey = () => {
   const recruitmentLabel =
     "Answer 4 questions about phone masking to help improve your experience.";
 
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const dismissal = useLocalDismissal("phone-survey-2022-11");
   const linkRef = useGaViewPing({
     category: "Phone launch survey",

--- a/frontend/src/components/layout/topmessage/TopMessage.tsx
+++ b/frontend/src/components/layout/topmessage/TopMessage.tsx
@@ -1,4 +1,3 @@
-import { useLocalization } from "@fluent/react";
 import { useRouter } from "next/router";
 import { ProfileData } from "../../../hooks/api/profile";
 import { InterviewRecruitment } from "./InterviewRecruitment";
@@ -7,6 +6,7 @@ import { RuntimeData } from "../../../hooks/api/runtimeData";
 import { isFlagActive } from "../../../functions/waffle";
 import { getLocale } from "../../../functions/getLocale";
 import { PhoneSurvey } from "./PhoneSurvey";
+import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
   profile?: ProfileData;
@@ -14,7 +14,7 @@ export type Props = {
 };
 
 export const TopMessage = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const router = useRouter();
 
   if (

--- a/frontend/src/components/phones/dashboard/PhoneDashboard.tsx
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.tsx
@@ -11,7 +11,6 @@ import {
 } from "../../Icons";
 import { MouseEventHandler, useRef, useState } from "react";
 import { VerifiedPhone } from "../../../hooks/api/realPhone";
-import { useLocalization } from "@fluent/react";
 import { useInboundContact } from "../../../hooks/api/inboundContact";
 import { ProfileData } from "../../../hooks/api/profile";
 import { SendersPanelView } from "./SendersPanelView";
@@ -22,6 +21,7 @@ import { Tips } from "../../dashboard/tips/Tips";
 import { RuntimeData } from "../../../hooks/api/runtimeData";
 import { DismissalData } from "../../../hooks/localDismissal";
 import { Banner } from "../../Banner";
+import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
   profile: ProfileData;
@@ -34,7 +34,7 @@ export type Props = {
 };
 
 export const PhoneDashboard = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const relayNumber = useRelayNumber();
   const relayNumberData = relayNumber.data?.[0];
   const formattedPhoneNumber = formatPhone(props.realPhone.number ?? "", {

--- a/frontend/src/components/phones/dashboard/PhoneWelcomeView.tsx
+++ b/frontend/src/components/phones/dashboard/PhoneWelcomeView.tsx
@@ -1,5 +1,4 @@
 import styles from "./PhoneWelcomeView.module.scss";
-import { Localized, useLocalization } from "@fluent/react";
 import SavingRelayContactImg from "./images/save-relay-as-a-contact.svg";
 import SavingRelayContactDemoImg from "./images/save-relay-contact-demo.svg";
 import ReplyingMessagesImg from "./images/reply-to-messages.svg";
@@ -10,6 +9,8 @@ import { Button } from "../../Button";
 import { DismissalData } from "../../../hooks/localDismissal";
 import { toast } from "react-toastify";
 import { ProfileData } from "../../../hooks/api/profile";
+import { useL10n } from "../../../hooks/l10n";
+import { Localized } from "../../Localized";
 
 type PhoneInstructionProps = {
   image: ReactNode;
@@ -54,7 +55,7 @@ type PhoneWelcomePageProps = {
 };
 
 export const PhoneWelcomeView = (props: PhoneWelcomePageProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   // The unlocalized strings here are demo data
   const BlockSenderDemo = (

--- a/frontend/src/components/phones/dashboard/SendersPanelView.tsx
+++ b/frontend/src/components/phones/dashboard/SendersPanelView.tsx
@@ -7,12 +7,12 @@ import {
 } from "../../../components/Icons";
 import disabledSendersDataIllustration from "./images/sender-data-disabled-illustration.svg";
 import emptySenderDataIllustration from "./images/sender-data-empty-illustration.svg";
-import { useLocalization } from "@fluent/react";
 import { useInboundContact } from "../../../hooks/api/inboundContact";
 import { OutboundLink } from "react-ga";
 import { formatPhone } from "../../../functions/formatPhone";
 import { parseDate } from "../../../functions/parseDate";
 import { getLocale } from "../../../functions/getLocale";
+import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
   type: "primary" | "disabled" | "empty";
@@ -20,7 +20,7 @@ export type Props = {
 };
 
 export const SendersPanelView = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const inboundContactData = useInboundContact();
   const inboundArray = inboundContactData.data;
   const dateTimeFormatter = new Intl.DateTimeFormat(getLocale(l10n), {

--- a/frontend/src/components/phones/onboarding/PurchasePhonesPlan.tsx
+++ b/frontend/src/components/phones/onboarding/PurchasePhonesPlan.tsx
@@ -1,4 +1,3 @@
-import { useLocalization } from "@fluent/react";
 import styles from "./PurchasePhonesPlan.module.scss";
 import WomanPhone from "./images/woman-phone.svg";
 import { LinkButton } from "../../Button";
@@ -17,13 +16,14 @@ import {
 } from "react-stately";
 import { Key, ReactNode, useRef } from "react";
 import { useTab, useTabList, useTabPanel } from "react-aria";
+import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
   runtimeData: RuntimeDataWithPhonesAvailable;
 };
 
 export const PurchasePhonesPlan = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <main className={styles.wrapper}>
@@ -52,7 +52,7 @@ type PricingToggleProps = {
   runtimeData: RuntimeDataWithPhonesAvailable;
 };
 const PricingToggle = (props: PricingToggleProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const yearlyButtonRef = useGaViewPing({
     category: "Purchase yearly Premium+phones button",
     label: "phone-onboarding-purchase-yearly-cta",

--- a/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
+++ b/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
@@ -1,5 +1,4 @@
 import { ChangeEventHandler, FormEventHandler, useState } from "react";
-import { Localized, useLocalization } from "@fluent/react";
 import styles from "./RealPhoneSetup.module.scss";
 import PhoneVerify from "./images/phone-verify.svg";
 import EnterVerifyCode from "./images/enter-verify-code.svg";
@@ -16,6 +15,8 @@ import { RuntimeData } from "../../../hooks/api/runtimeData";
 import { parseDate } from "../../../functions/parseDate";
 import { formatPhone } from "../../../functions/formatPhone";
 import { useInterval } from "../../../hooks/interval";
+import { useL10n } from "../../../hooks/l10n";
+import { Localized } from "../../Localized";
 
 type RealPhoneSetupProps = {
   unverifiedRealPhones: Array<UnverifiedPhone>;
@@ -67,7 +68,7 @@ type RealPhoneFormProps = {
 };
 
 const RealPhoneForm = (props: RealPhoneFormProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const phoneNumberData = useRealPhonesData();
   const [phoneNumber, setPhoneNumber] = useState("");
   const [phoneNumberSubmitted, setPhoneNumberSubmitted] = useState("");
@@ -190,7 +191,7 @@ type RealPhoneVerificationProps = {
   onGoBack: () => void;
 };
 const RealPhoneVerification = (props: RealPhoneVerificationProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const phoneWithMostRecentlySentVerificationCode =
     getPhoneWithMostRecentlySentVerificationCode(
       props.phonesPendingVerification

--- a/frontend/src/components/phones/onboarding/RelayNumberConfirmationModal.tsx
+++ b/frontend/src/components/phones/onboarding/RelayNumberConfirmationModal.tsx
@@ -1,5 +1,4 @@
 import { ReactNode, useRef } from "react";
-import { useLocalization } from "@fluent/react";
 import {
   OverlayContainer,
   FocusScope,
@@ -13,6 +12,7 @@ import styles from "./RelayNumberConfirmationModal.module.scss";
 import { CloseIcon } from "../../Icons";
 import { Button } from "../../Button";
 import { formatPhone } from "../../../functions/formatPhone";
+import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
   onClose: () => void;
@@ -22,7 +22,7 @@ export type Props = {
 };
 
 export const RelayNumberConfirmationModal = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <OverlayContainer>

--- a/frontend/src/components/phones/onboarding/RelayNumberPicker.tsx
+++ b/frontend/src/components/phones/onboarding/RelayNumberPicker.tsx
@@ -4,7 +4,6 @@ import {
   MouseEventHandler,
   useState,
 } from "react";
-import { useLocalization } from "@fluent/react";
 import { useOverlayTriggerState } from "react-stately";
 import styles from "./RelayNumberPicker.module.scss";
 import EnteryVerifyCodeSuccess from "./images/verify-code-success.svg";
@@ -18,6 +17,7 @@ import {
 import { formatPhone } from "../../../functions/formatPhone";
 import { RefreshIcon } from "../../Icons";
 import { RelayNumberConfirmationModal } from "./RelayNumberConfirmationModal";
+import { useL10n } from "../../../hooks/l10n";
 
 type RelayNumberPickerProps = {
   onComplete: () => void;
@@ -48,7 +48,7 @@ type RelayNumberIntroProps = {
   onStart: () => void;
 };
 const RelayNumberIntro = (props: RelayNumberIntroProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <div
@@ -90,7 +90,7 @@ type RelayNumberSelectionProps = {
   search: (search: string) => Promise<RelayNumberSuggestion[] | undefined>;
 };
 const RelayNumberSelection = (props: RelayNumberSelectionProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const relayNumberSuggestionsData = useRelayNumberSuggestions();
   const [phoneNumber, setPhoneNumber] = useState("");
   const [searchValue, setSearchValue] = useState("");
@@ -293,7 +293,7 @@ type RelayNumberConfirmationProps = {
   onComplete: () => void;
 };
 const RelayNumberConfirmation = (props: RelayNumberConfirmationProps) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   return (
     <div

--- a/frontend/src/components/waitlist/CountryPicker.tsx
+++ b/frontend/src/components/waitlist/CountryPicker.tsx
@@ -1,6 +1,6 @@
-import { useLocalization } from "@fluent/react";
 import { SelectHTMLAttributes, useEffect, useState } from "react";
 import { getLocale } from "../../functions/getLocale";
+import { useL10n } from "../../hooks/l10n";
 
 type LocaleDisplayNames = Record<string, string>;
 type Territories = {
@@ -15,7 +15,7 @@ type Territories = {
 };
 export type Props = SelectHTMLAttributes<HTMLSelectElement>;
 export const CountryPicker = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const currentLocale = getLocale(l10n);
   const [localeDisplayNames, setLocaleDisplayNames] =
     useState<LocaleDisplayNames>();

--- a/frontend/src/components/waitlist/LocalePicker.tsx
+++ b/frontend/src/components/waitlist/LocalePicker.tsx
@@ -1,6 +1,6 @@
-import { useLocalization } from "@fluent/react";
 import { SelectHTMLAttributes, useEffect, useState } from "react";
 import { getLocale } from "../../functions/getLocale";
+import { useL10n } from "../../hooks/l10n";
 
 type LocaleDisplayNames = Record<string, string>;
 type Languages = {
@@ -17,7 +17,7 @@ export type Props = SelectHTMLAttributes<HTMLSelectElement> & {
   supportedLocales: string[];
 };
 export const LocalePicker = ({ supportedLocales, ...selectProps }: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const currentLocale = getLocale(l10n);
   const [localeDisplayNames, setLocaleDisplayNames] =
     useState<LocaleDisplayNames>();

--- a/frontend/src/components/waitlist/WaitlistPage.test.tsx
+++ b/frontend/src/components/waitlist/WaitlistPage.test.tsx
@@ -4,22 +4,24 @@ import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import { type Props as CountryPickerProps } from "./CountryPicker";
 import { type Props as LocalePickerProps } from "./LocalePicker";
-import { mockFluentReact } from "../../../__mocks__/modules/fluent__react";
 import { mockNextRouter } from "../../../__mocks__/modules/next__router";
 import { mockConfigModule } from "../../../__mocks__/configMock";
 import { setMockRuntimeData } from "../../../__mocks__/hooks/api/runtimeData";
 import { setMockUserData } from "../../../__mocks__/hooks/api/user";
 import { setMockProfileData } from "../../../__mocks__/hooks/api/profile";
 import { mockUseFxaFlowTrackerModule } from "../../../__mocks__/hooks/fxaFlowTracker";
+import { mockUseL10nModule } from "../../../__mocks__/hooks/l10n";
+import { mockLocalizedModule } from "../../../__mocks__/components/Localized";
 
 import { WaitlistPage } from "./WaitlistPage";
 
-jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("next/router", () => mockNextRouter);
 jest.mock("../../config.ts", () => mockConfigModule);
 jest.mock("../../hooks/gaViewPing.ts");
 jest.mock("../../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
-jest.mock("../../components/waitlist/CountryPicker.tsx", () => ({
+jest.mock("../../hooks/l10n.ts", () => mockUseL10nModule);
+jest.mock("../Localized.tsx", () => mockLocalizedModule);
+jest.mock("../waitlist/CountryPicker.tsx", () => ({
   // We're mocking out the country picker because it dynamically imports the
   // list of available countries, which would mean the test would have to mock
   // out that import's Promise and wait for that to resolve, distracting from

--- a/frontend/src/components/waitlist/WaitlistPage.tsx
+++ b/frontend/src/components/waitlist/WaitlistPage.tsx
@@ -1,4 +1,3 @@
-import { useLocalization } from "@fluent/react";
 import styles from "./WaitlistPage.module.scss";
 import { Layout } from "../layout/Layout";
 import { Button } from "../Button";
@@ -9,6 +8,7 @@ import { CountryPicker } from "./CountryPicker";
 import { useRuntimeData } from "../../hooks/api/runtimeData";
 import { LocalePicker } from "./LocalePicker";
 import { useUsers } from "../../hooks/api/user";
+import { useL10n } from "../../hooks/l10n";
 
 export type Props = {
   supportedLocales: string[];
@@ -19,7 +19,7 @@ export type Props = {
 };
 
 export const WaitlistPage = (props: Props) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const currentLocale = getLocale(l10n);
   const runtimeData = useRuntimeData();
   const currentCountry =

--- a/frontend/src/functions/getL10n.ts
+++ b/frontend/src/functions/getL10n.ts
@@ -3,10 +3,11 @@ import { negotiateLanguages } from "@fluent/langneg";
 import { MarkupParser, ReactLocalization } from "@fluent/react";
 
 /**
+ * @param options Set `deterministicLocales` to `true` to ensure the `en` bundle is loaded.
  * @returns Initialise `@fluent/react`.
  * @todo Get the relevant .ftl injected by the server.
  */
-export function getL10n() {
+export function getL10n(options: { deterministicLocales: boolean }) {
   // Store all translations as a simple object which is available
   // synchronously and bundled with the rest of the code.
   // Also, `require` isn't usually valid JS, so skip type checking for that:
@@ -35,7 +36,11 @@ export function getL10n() {
   function* generateBundles(userLocales: typeof navigator.languages) {
     // Choose locales that are best for the user.
     const currentLocales = negotiateLanguages(
-      userLocales as string[],
+      // During pre-render, no locales are available yet. To avoid a mismatch
+      // between pre-rendered HTML and the DOM generated in the first render,
+      // we don't load locales dependent on the user's preferences on first
+      // render either:
+      options.deterministicLocales ? [] : (userLocales as string[]),
       Object.keys(RESOURCES),
       { defaultLocale: "en" }
     );

--- a/frontend/src/hooks/l10n.ts
+++ b/frontend/src/hooks/l10n.ts
@@ -1,0 +1,7 @@
+import { ReactLocalization, useLocalization } from "@fluent/react";
+
+export const useL10n = (): ReactLocalization => {
+  const { l10n } = useLocalization();
+
+  return l10n;
+};

--- a/frontend/src/hooks/l10n.ts
+++ b/frontend/src/hooks/l10n.ts
@@ -1,7 +1,49 @@
 import { ReactLocalization, useLocalization } from "@fluent/react";
+import { useEffect, useState } from "react";
 
+/**
+ * Wraps @fluent/react's useLocalization to be consistent between prerender and first render
+ *
+ * React will throw a tantrum if the HTML rendered during the build differs from
+ * the DOM rendered by React when running client-side. However, at build-time we
+ * don't yet know the user's locale. Thus, if we render strings in the user's
+ * locale on the first client-side render, we'll make React unhappy, and who
+ * wants that?
+ *
+ * To work around this, this hook makes sure that the English strings are
+ * rendered when both prerendering and doing the first client-side render, and
+ * only after that use the language that aligns with the user's preferences.
+ */
 export const useL10n = (): ReactLocalization => {
   const { l10n } = useLocalization();
+  const [isPrerendering, setIsPrerendering] = useState(true);
+
+  useEffect(() => {
+    setIsPrerendering(false);
+  }, []);
+
+  if (isPrerendering) {
+    const prerenderingL10n: ReactLocalization = {
+      getBundle: l10n.getBundle,
+      bundles: l10n.bundles,
+      parseMarkup: l10n.parseMarkup,
+      areBundlesEmpty: l10n.areBundlesEmpty,
+      reportError: l10n.reportError,
+      getString: (id, vars, fallback) => {
+        const bundle = l10n.getBundle("en");
+        if (bundle) {
+          const message = bundle.getMessage(id);
+          if (message && message.value) {
+            return bundle.formatPattern(message.value, vars);
+          }
+        }
+
+        return l10n.getString(id, vars, fallback);
+      },
+    };
+
+    return prerenderingL10n;
+  }
 
   return l10n;
 };

--- a/frontend/src/hooks/l10n.ts
+++ b/frontend/src/hooks/l10n.ts
@@ -1,3 +1,6 @@
+// Imports of `useLocalization` are forbidden because the hook in this file
+// should be used instead, but of course this hook can use it just fine:
+// eslint-disable-next-line no-restricted-imports
 import { ReactLocalization, useLocalization } from "@fluent/react";
 import { useEffect, useState } from "react";
 

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -1,4 +1,3 @@
-import { Localized, useLocalization } from "@fluent/react";
 import type { NextPage } from "next";
 import {
   forwardRef,
@@ -51,6 +50,8 @@ import { isFlagActive } from "../../functions/waffle";
 import { DashboardSwitcher } from "../../components/layout/navigation/DashboardSwitcher";
 import { usePurchaseTracker } from "../../hooks/purchaseTracker";
 import { PremiumPromoBanners } from "../../components/dashboard/PremiumPromoBanners";
+import { useL10n } from "../../hooks/l10n";
+import { Localized } from "../../components/Localized";
 
 const Profile: NextPage = () => {
   const runtimeData = useRuntimeData();
@@ -58,7 +59,7 @@ const Profile: NextPage = () => {
   const userData = useUsers();
   const aliasData = useAliases();
   const addonData = useAddonData();
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const bottomBannerSubscriptionLinkRef = useGaViewPing({
     category: "Purchase Button",
     label: "profile-bottom-promo",
@@ -423,7 +424,7 @@ const Profile: NextPage = () => {
 };
 
 const StatExplainer = (props: { children: React.ReactNode }) => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const explainerState = useMenuTriggerState({});
   const overlayRef = useRef<HTMLDivElement>(null);
   const openButtonRef = useRef<HTMLButtonElement>(null);

--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
-import { mockFluentReact } from "../../../__mocks__/modules/fluent__react";
 import { mockNextRouter } from "../../../__mocks__/modules/next__router";
 import { mockReactGa } from "../../../__mocks__/modules/react-ga";
 import { mockReactIntersectionObsever } from "../../../__mocks__/modules/react-intersection-observer";
@@ -32,6 +31,8 @@ import {
 import { mockUseFxaFlowTrackerModule } from "../../../__mocks__/hooks/fxaFlowTracker";
 import { setMockAddonData } from "../../../__mocks__/hooks/addon";
 import { setMockRelayNumberData } from "../../../__mocks__/hooks/api/relayNumber";
+import { mockUseL10nModule } from "../../../__mocks__/hooks/l10n";
+import { mockLocalizedModule } from "../../../__mocks__/components/Localized";
 
 // Important: make sure mocks are imported *before* the page under test:
 import Profile from "./profile.page";
@@ -39,7 +40,6 @@ import { AliasUpdateFn } from "../../hooks/api/aliases";
 import { ProfileUpdateFn } from "../../hooks/api/profile";
 import { RuntimeConfig } from "../../config";
 
-jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("next/router", () => mockNextRouter);
 jest.mock("react-ga", () => mockReactGa);
 jest.mock("react-intersection-observer", () => mockReactIntersectionObsever);
@@ -58,6 +58,8 @@ jest.mock("../../hooks/api/api.ts", () => ({
 }));
 jest.mock("../../hooks/gaViewPing.ts");
 jest.mock("../../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
+jest.mock("../../hooks/l10n.ts", () => mockUseL10nModule);
+jest.mock("../../components/Localized.tsx", () => mockLocalizedModule);
 
 setMockAliasesData();
 setMockProfileData();

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -1,4 +1,3 @@
-import { useLocalization } from "@fluent/react";
 import type { NextPage } from "next";
 import {
   FormEventHandler,
@@ -30,11 +29,12 @@ import { useRuntimeData } from "../../hooks/api/runtimeData";
 import { useAddonData } from "../../hooks/addon";
 import { isFlagActive } from "../../functions/waffle";
 import { isPhonesAvailableInCountry } from "../../functions/getPlan";
+import { useL10n } from "../../hooks/l10n";
 
 const Settings: NextPage = () => {
   const runtimeData = useRuntimeData();
   const profileData = useProfiles();
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const [localLabels] = useLocalLabels();
   const aliasData = useAliases();
   const addonData = useAddonData();

--- a/frontend/src/pages/accounts/settings.test.tsx
+++ b/frontend/src/pages/accounts/settings.test.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
-import { mockFluentReact } from "../../../__mocks__/modules/fluent__react";
 import { mockNextRouter } from "../../../__mocks__/modules/next__router";
 import { mockReactGa } from "../../../__mocks__/modules/react-ga";
 import { mockConfigModule } from "../../../__mocks__/configMock";
@@ -10,15 +9,18 @@ import { setMockProfileData } from "../../../__mocks__/hooks/api/profile";
 import { setMockAliasesData } from "../../../__mocks__/hooks/api/aliases";
 import { setMockRuntimeData } from "../../../__mocks__/hooks/api/runtimeData";
 import { setMockAddonData } from "../../../__mocks__/hooks/addon";
+import { mockUseL10nModule } from "../../../__mocks__/hooks/l10n";
+import { mockLocalizedModule } from "../../../__mocks__/components/Localized";
 
 // Important: make sure mocks are imported *before* the page under test:
 import Settings from "./settings.page";
 
-jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("next/router", () => mockNextRouter);
 jest.mock("react-ga", () => mockReactGa);
 jest.mock("../../config.ts", () => mockConfigModule);
 jest.mock("../../hooks/gaViewPing.ts");
+jest.mock("../../hooks/l10n.ts", () => mockUseL10nModule);
+jest.mock("../../components/Localized.tsx", () => mockLocalizedModule);
 
 setMockAliasesData();
 setMockProfileData();

--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -1,15 +1,16 @@
 import { NextPage } from "next";
 import { ReactNode } from "react";
-import { Localized, useLocalization } from "@fluent/react";
 import styles from "./faq.module.scss";
 import { Layout } from "../components/layout/Layout";
 import { getRuntimeConfig } from "../config";
 import { useRuntimeData } from "../hooks/api/runtimeData";
 import { isFlagActive } from "../functions/waffle";
 import { isPhonesAvailableInCountry } from "../functions/getPlan";
+import { useL10n } from "../hooks/l10n";
+import { Localized } from "../components/Localized";
 
 const Faq: NextPage = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const runtimeData = useRuntimeData();
 
   const phoneMaskingFaqs = isPhonesAvailableInCountry(runtimeData.data) ? (

--- a/frontend/src/pages/faq.test.tsx
+++ b/frontend/src/pages/faq.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
+import { mockLocalizedModule } from "../../__mocks__/components/Localized";
 import { mockConfigModule } from "../../__mocks__/configMock";
 import { setMockProfileData } from "../../__mocks__/hooks/api/profile";
 import {
@@ -9,18 +10,19 @@ import {
   setMockRuntimeDataOnce,
 } from "../../__mocks__/hooks/api/runtimeData";
 import { mockUseFxaFlowTrackerModule } from "../../__mocks__/hooks/fxaFlowTracker";
-import { mockFluentReact } from "../../__mocks__/modules/fluent__react";
+import { mockUseL10nModule } from "../../__mocks__/hooks/l10n";
 import { mockNextRouter } from "../../__mocks__/modules/next__router";
 import { mockReactGa } from "../../__mocks__/modules/react-ga";
 
 import Faq from "./faq.page";
 
-jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("next/router", () => mockNextRouter);
 jest.mock("react-ga", () => mockReactGa);
 jest.mock("../config.ts", () => mockConfigModule);
 jest.mock("../hooks/gaViewPing.ts");
 jest.mock("../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
+jest.mock("../hooks/l10n.ts", () => mockUseL10nModule);
+jest.mock("../components/Localized.tsx", () => mockLocalizedModule);
 
 setMockRuntimeData();
 setMockProfileData(null);

--- a/frontend/src/pages/index.page.tsx
+++ b/frontend/src/pages/index.page.tsx
@@ -1,7 +1,6 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import Link from "next/link";
-import { useLocalization } from "@fluent/react";
 import { event as gaEvent } from "react-ga";
 import styles from "./index.module.scss";
 import Testimonials from "../../public/images/hero-brands.svg";
@@ -41,9 +40,10 @@ import { PlanMatrix } from "../components/landing/PlanMatrix";
 import { BundleBanner } from "../components/landing/BundleBanner";
 import { PhoneBanner } from "../components/landing/PhoneBanner";
 import { useFlaggedAnchorLinks } from "../hooks/flaggedAnchorLinks";
+import { useL10n } from "../hooks/l10n";
 
 const Home: NextPage = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const router = useRouter();
   const runtimeData = useRuntimeData();
   const userData = useUsers();

--- a/frontend/src/pages/index.test.tsx
+++ b/frontend/src/pages/index.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
+import { mockLocalizedModule } from "../../__mocks__/components/Localized";
 import { mockConfigModule } from "../../__mocks__/configMock";
 import { setMockProfileData } from "../../__mocks__/hooks/api/profile";
 import {
@@ -10,18 +11,19 @@ import {
   setMockRuntimeDataOnce,
 } from "../../__mocks__/hooks/api/runtimeData";
 import { mockUseFxaFlowTrackerModule } from "../../__mocks__/hooks/fxaFlowTracker";
-import { mockFluentReact } from "../../__mocks__/modules/fluent__react";
+import { mockUseL10nModule } from "../../__mocks__/hooks/l10n";
 import { mockNextRouter } from "../../__mocks__/modules/next__router";
 import { mockReactGa } from "../../__mocks__/modules/react-ga";
 
 import Home from "./index.page";
 
-jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("next/router", () => mockNextRouter);
 jest.mock("react-ga", () => mockReactGa);
 jest.mock("../config.ts", () => mockConfigModule);
 jest.mock("../hooks/gaViewPing.ts");
 jest.mock("../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
+jest.mock("../hooks/l10n.ts", () => mockUseL10nModule);
+jest.mock("../components/Localized.tsx", () => mockLocalizedModule);
 
 setMockRuntimeData();
 setMockProfileData(null);

--- a/frontend/src/pages/phone.test.tsx
+++ b/frontend/src/pages/phone.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
+import { mockLocalizedModule } from "../../__mocks__/components/Localized";
 import { mockConfigModule } from "../../__mocks__/configMock";
 import { setMockInboundContactData } from "../../__mocks__/hooks/api/inboundContact";
 import {
@@ -21,17 +22,18 @@ import {
   setMockRuntimeDataOnce,
 } from "../../__mocks__/hooks/api/runtimeData";
 import { setMockUserData } from "../../__mocks__/hooks/api/user";
-import { mockFluentReact } from "../../__mocks__/modules/fluent__react";
+import { mockUseL10nModule } from "../../__mocks__/hooks/l10n";
 import { mockNextRouter } from "../../__mocks__/modules/next__router";
 import { mockReactGa } from "../../__mocks__/modules/react-ga";
 
 import PhoneDashboard from "./phone.page";
 
-jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("next/router", () => mockNextRouter);
 jest.mock("react-ga", () => mockReactGa);
 jest.mock("../config.ts", () => mockConfigModule);
 jest.mock("../hooks/gaViewPing.ts");
+jest.mock("../hooks/l10n.ts", () => mockUseL10nModule);
+jest.mock("../components/Localized.tsx", () => mockLocalizedModule);
 
 setMockProfileData();
 setMockUserData();

--- a/frontend/src/pages/phone/waitlist.page.tsx
+++ b/frontend/src/pages/phone/waitlist.page.tsx
@@ -1,12 +1,13 @@
-import { Localized, useLocalization } from "@fluent/react";
 import { NextPage } from "next";
+import { Localized } from "../../components/Localized";
 import { WaitlistPage } from "../../components/waitlist/WaitlistPage";
+import { useL10n } from "../../hooks/l10n";
 
 /** These are the languages that marketing can send emails in: */
 const supportedLocales = ["en", "es", "pl", "pt", "ja"];
 
 const PhoneWaitlist: NextPage = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const legalese = (
     <>

--- a/frontend/src/pages/premium.page.tsx
+++ b/frontend/src/pages/premium.page.tsx
@@ -1,5 +1,4 @@
 import { NextPage } from "next";
-import { Localized, useLocalization } from "@fluent/react";
 import { event as gaEvent } from "react-ga";
 import styles from "./premium.module.scss";
 import PerkIllustrationUnlimited from "../../public/images/perk-unlimited.svg";
@@ -36,9 +35,11 @@ import { PlanMatrix } from "../components/landing/PlanMatrix";
 import { BundleBanner } from "../components/landing/BundleBanner";
 import { PhoneBanner } from "../components/landing/PhoneBanner";
 import { useFlaggedAnchorLinks } from "../hooks/flaggedAnchorLinks";
+import { useL10n } from "../hooks/l10n";
+import { Localized } from "../components/Localized";
 
 const PremiumPromo: NextPage = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const runtimeData = useRuntimeData();
   useFlaggedAnchorLinks([runtimeData.data]);
   const heroCtaRef = useGaViewPing({

--- a/frontend/src/pages/premium.test.tsx
+++ b/frontend/src/pages/premium.test.tsx
@@ -1,19 +1,21 @@
 import { act, render } from "@testing-library/react";
 import { axe } from "jest-axe";
+import { mockLocalizedModule } from "../../__mocks__/components/Localized";
 import { mockConfigModule } from "../../__mocks__/configMock";
 import { mockUseFxaFlowTrackerModule } from "../../__mocks__/hooks/fxaFlowTracker";
-import { mockFluentReact } from "../../__mocks__/modules/fluent__react";
+import { mockUseL10nModule } from "../../__mocks__/hooks/l10n";
 import { mockNextRouter } from "../../__mocks__/modules/next__router";
 import { mockReactGa } from "../../__mocks__/modules/react-ga";
 
 import PremiumPromo from "./premium.page";
 
-jest.mock("@fluent/react", () => mockFluentReact);
 jest.mock("next/router", () => mockNextRouter);
 jest.mock("react-ga", () => mockReactGa);
 jest.mock("../config.ts", () => mockConfigModule);
 jest.mock("../hooks/gaViewPing.ts");
 jest.mock("../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
+jest.mock("../hooks/l10n.ts", () => mockUseL10nModule);
+jest.mock("../components/Localized.tsx", () => mockLocalizedModule);
 
 describe("The promotional page about Relay Premium", () => {
   describe("under axe accessibility testing", () => {

--- a/frontend/src/pages/premium/waitlist.page.tsx
+++ b/frontend/src/pages/premium/waitlist.page.tsx
@@ -1,12 +1,13 @@
-import { Localized, useLocalization } from "@fluent/react";
 import { NextPage } from "next";
 import { WaitlistPage } from "../../components/waitlist/WaitlistPage";
+import { useL10n } from "../../hooks/l10n";
+import { Localized } from "../../components/Localized";
 
 /** These are the languages that marketing can send emails in: */
 const supportedLocales = ["en", "es", "pl", "pt", "ja"];
 
 const PremiumWaitlist: NextPage = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const legalese = (
     <>

--- a/frontend/src/pages/tracker-report.page.tsx
+++ b/frontend/src/pages/tracker-report.page.tsx
@@ -1,4 +1,3 @@
-import { useLocalization } from "@fluent/react";
 import { NextPage } from "next";
 import { useEffect, useState } from "react";
 import styles from "./tracker-report.module.scss";
@@ -12,6 +11,7 @@ import {
 } from "../components/Icons";
 import Link from "next/link";
 import { FaqAccordion } from "../components/landing/FaqAccordion";
+import { useL10n } from "../hooks/l10n";
 
 // Paste this in your browser console to get a report URL:
 // { let url = new URL("http://localhost:3000/tracker-report"); url.hash = JSON.stringify({ sender: "email@example.com", received_at: Date.now(), trackers: { "ads.facebook.com": 1, "ads.googletagmanager.com": 2 } }); url.href }
@@ -26,7 +26,7 @@ type ReportData = {
 };
 
 const TrackerReport: NextPage = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const [reportData, setReportData] = useState<ReportData | null>();
 
   useEffect(() => {

--- a/frontend/src/pages/vpn-relay-welcome.page.tsx
+++ b/frontend/src/pages/vpn-relay-welcome.page.tsx
@@ -1,5 +1,4 @@
 import { NextPage } from "next";
-import { useLocalization } from "@fluent/react";
 import { Layout } from "../components/layout/Layout";
 import logo from "../components/layout/images/relay-logo.svg";
 import logoType from "../components/layout/images/fx-private-relay-premium-logotype-dark.svg";
@@ -10,9 +9,10 @@ import { useEffect } from "react";
 import { authenticatedFetch } from "../hooks/api/api";
 import Link from "next/link";
 import { LinkButton } from "../components/Button";
+import { useL10n } from "../hooks/l10n";
 
 const VpnRelayWelcome: NextPage = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
   const referringSiteUrl =
     typeof document !== "undefined"
       ? document.location.host

--- a/frontend/src/pages/vpn-relay/waitlist.page.tsx
+++ b/frontend/src/pages/vpn-relay/waitlist.page.tsx
@@ -1,12 +1,13 @@
-import { Localized, useLocalization } from "@fluent/react";
 import { NextPage } from "next";
+import { Localized } from "../../components/Localized";
 import { WaitlistPage } from "../../components/waitlist/WaitlistPage";
+import { useL10n } from "../../hooks/l10n";
 
 /** These are the languages that marketing can send emails in: */
 const supportedLocales = ["en", "es", "pl", "pt", "ja"];
 
 const BundleWaitlist: NextPage = () => {
-  const { l10n } = useLocalization();
+  const l10n = useL10n();
 
   const legalese = (
     <>


### PR DESCRIPTION
This PR fixes does two things:

1. It adds a wrapper around `@fluent/react` (79d699b81cf657b17b8e36812219c7d8ddd771d8 - pretty tedious)
2. It ensures that React's first render only renders English strings, and only then switches to the user's locale. (7e6c09a9687a08b01467bd6a358c115e6042f39d - the interesting code to review)

(For review, it's probably best to **just scan through the first commit**, and then [only look at the other two](https://github.com/mozilla/fx-private-relay/pull/2929/files/79d699b81cf657b17b8e36812219c7d8ddd771d8..a0edf8d13ab402f9d62b0a9711f1448377e10a18).) 

The first has the (nice, IMHO) side effect that we can now do `const l10n = useL10n()` instead of needing to destructure: `const { l10n } = useLocalization()`.

The second is already recommended for React 17, but actually causes issues if not done in React 18, specifically the ones from https://github.com/mozilla/fx-private-relay/pull/2836. Thus, this PR should pave the way for https://github.com/mozilla/fx-private-relay/pull/2856, I think.

And finally, it enables a lint rule that warns us if we accidentally re-introduce the error (a0edf8d).

How to test: upgrade to React 18 (e.g. by checking out #2856, then `npm install`). If you run it and visit e.g. `/premium/waitlist` with your browser language set to something other than `en-US`, you should see the error from #2836. If you then merge in this branch, that error should be gone.

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug. (Updated existing ones.)
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
