### PR TITLE
Mobile fixes for landing page

### DIFF
--- a/frontend/src/components/landing/DemoPhone.module.scss
+++ b/frontend/src/components/landing/DemoPhone.module.scss
@@ -2,8 +2,12 @@
 
 .container {
   position: relative;
+  background-color: $color-light-gray-10;
+  border-radius: $border-radius-lg;
   text-align: center;
-  height: 600px;
+  // This leaves some space below the phone on mobile, and is based on the rough
+  // size of the phone image on small screens:
+  height: 650px;
 
   @media screen and #{$mq-lg} {
     width: 400px;

--- a/frontend/src/components/landing/PlanMatrix.module.scss
+++ b/frontend/src/components/landing/PlanMatrix.module.scss
@@ -232,6 +232,7 @@ table.desktop {
       flex-direction: column;
       align-items: center;
       gap: $spacing-lg;
+      max-width: 100%;
       background-color: $color-white;
       border-radius: $border-radius-md;
       padding: $spacing-md;
@@ -266,6 +267,7 @@ table.desktop {
 
         li {
           display: flex;
+          gap: $spacing-xs;
 
           .description {
             flex: 1 0 auto;
@@ -276,7 +278,7 @@ table.desktop {
             }
           }
           .availability {
-            flex: 0 1 $layout-lg;
+            flex: 0 1 $layout-2xs;
             display: flex;
             align-items: center;
             justify-content: center;

--- a/frontend/src/pages/premium.module.scss
+++ b/frontend/src/pages/premium.module.scss
@@ -8,7 +8,7 @@
   width: $content-max;
   max-width: 100%;
   margin: 0 auto;
-  padding: $spacing-2xl;
+  padding: $spacing-lg;
 
   @media screen and #{$mq-md} {
     flex-direction: row;


### PR DESCRIPTION
This PR fixes two issues mentioned in MPP-2660 for very thin screens (iPhone 12 pro):

- The landing page has horizontal scrolling because the pricing cards don't fit (f2998f567eed7ddee6e9947b81e334e0c4e6767d)
- The frame of the phone with the website demo wasn't visible (d003d421df3814179711dbddbc1aede8578097b6)

Note that the latter was because both the frame and the page background were white. I took some (bad) design liberty and just added a grey backdrop there for now:

![image](https://user-images.githubusercontent.com/4251/208682358-10747749-cdf6-4235-ba30-bcf9de3f5e31.png)

How to test: be logged out, resize your viewport to the iPhone 12 Pro's size, then check for horizontal scrolling and that the phone frame is visible.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
