### PR TITLE
Prevent the Relay number copy icon from shrinking

### DIFF
--- a/frontend/src/components/phones/dashboard/PhoneDashboard.module.scss
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.module.scss
@@ -271,7 +271,7 @@
     min-height: $content-xs;
 
     .header-phone-number {
-      @include text-body-lg;
+      @include text-body-md;
       @include font-firefox;
       display: flex;
       justify-content: center;
@@ -279,6 +279,10 @@
 
       @media screen and #{$mq-sm} {
         @include text-body-xl;
+      }
+
+      .copy-controls {
+        flex: 1 0 auto;
       }
     }
 

--- a/frontend/src/components/phones/dashboard/PhoneDashboard.tsx
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.tsx
@@ -8,7 +8,7 @@ import {
   ForwardIcon,
   BlockIcon,
   ChevronRightIcon,
-} from "../../../components/Icons";
+} from "../../Icons";
 import { MouseEventHandler, useRef, useState } from "react";
 import { VerifiedPhone } from "../../../hooks/api/realPhone";
 import { useLocalization } from "@fluent/react";

--- a/frontend/src/pages/phone.page.tsx
+++ b/frontend/src/pages/phone.page.tsx
@@ -5,7 +5,7 @@ import { useUsers } from "../hooks/api/user";
 import { PhoneOnboarding } from "../components/phones/onboarding/PhoneOnboarding";
 import { useRelayNumber } from "../hooks/api/relayNumber";
 import { useEffect, useState } from "react";
-import { PhoneDashboard } from "../components/phones/dashboard/Dashboard";
+import { PhoneDashboard } from "../components/phones/dashboard/PhoneDashboard";
 import { getRuntimeConfig } from "../config";
 import { PurchasePhonesPlan } from "../components/phones/onboarding/PurchasePhonesPlan";
 import { isVerified, useRealPhonesData } from "../hooks/api/realPhone";


### PR DESCRIPTION
This PR fixes MPP-2651.

Before:

![image](https://user-images.githubusercontent.com/4251/208920477-10e2eea9-e464-403b-9fae-b2aeced5731f.png)

After:

![image](https://user-images.githubusercontent.com/4251/208920806-6c0a3344-d874-47b1-b4e2-e198a1e99ff5.png)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
