### PR TITLE
Don't break layout when pricing notice grows

### DIFF
--- a/frontend/src/components/landing/PlanMatrix.module.scss
+++ b/frontend/src/components/landing/PlanMatrix.module.scss
@@ -159,23 +159,33 @@ table.desktop {
       border-bottom-right-radius: $spacing-sm;
     }
 
+    tr {
+      // The actual height will be determined by the contents, but by giving the
+      // <tr> an explicit height, `.pricing` can have its height set to 100% to
+      // make it stretch the entire height of the row:
+      height: 1px;
+    }
+
     td {
       vertical-align: top;
+      height: 100%;
     }
 
     .pricing {
       display: flex;
       flex-direction: column;
+      justify-content: space-between;
       gap: $spacing-md;
       width: 100%;
+      height: 100%;
       text-align: center;
       $pricing-toggle-height: 35px;
 
       &.single-price {
-        padding-top: $spacing-md + $pricing-toggle-height;
+        justify-content: flex-end;
       }
       .pricing-toggle-wrapper {
-        height: $pricing-toggle-height;
+        min-height: $pricing-toggle-height;
       }
 
       .discount-notice {

--- a/frontend/src/components/landing/PlanMatrix.tsx
+++ b/frontend/src/components/landing/PlanMatrix.tsx
@@ -191,6 +191,13 @@ export const PlanMatrix = (props: Props) => {
                 >
                   {l10n.getString("plan-matrix-pick")}
                 </a>
+                {/*
+                The <small> has space for price-related notices (e.g. "* billed
+                annually"). When there is no such notice, we still want to leave
+                space for it to prevent the page from jumping around; hence the
+                empty <small>.
+                */}
+                <small>&nbsp;</small>
               </div>
             </div>
           </td>
@@ -726,6 +733,13 @@ const PricingToggle = (props: PricingToggleProps) => {
         >
           {l10n.getString("plan-matrix-pick")}
         </a>
+        {/*
+        The <small> has space for price-related notices (e.g. "* billed
+        annually"). When there is no such notice, we still want to leave
+        space for it to prevent the page from jumping around; hence the
+        empty <small>.
+        */}
+        <small>&nbsp;</small>
       </Item>
     </PricingTabs>
   );


### PR DESCRIPTION
In some languages, the string "Save 40% on regular VPN price" takes up more than one line. With this change, the bottom row will just grow along with it, while keeping everything aligned.

This PR fixes MPP-2605.

How to test: on desktop with your language set to French or Spanish, and with the bundle available in your country, view the landing page. The pricing cards should be aligned.

Before:

![image](https://user-images.githubusercontent.com/4251/208929949-ead8dfb9-22e8-4ade-b845-841a20029b47.png)

After:

![image](https://user-images.githubusercontent.com/4251/208930074-d0a65c70-fa28-4aef-a5d8-b9c5365e0a8d.png)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
