### PR TITLE
Prevent subdomain preview on desktop overflowing

### DIFF
--- a/frontend/src/components/dashboard/PremiumOnboarding.module.scss
+++ b/frontend/src/components/dashboard/PremiumOnboarding.module.scss
@@ -49,6 +49,7 @@
 
     .content {
       max-width: 100%;
+      min-width: $content-xs;
     }
 
     .description-caption {

--- a/frontend/src/components/dashboard/SubdomainPicker.module.scss
+++ b/frontend/src/components/dashboard/SubdomainPicker.module.scss
@@ -37,6 +37,7 @@
 
   .description {
     max-width: 100%;
+    min-width: $content-xs;
     border-color: $color-light-gray-30;
     border-width: 1px;
     border-bottom-style: solid;


### PR DESCRIPTION
Flex children have a `min-width: auto` by default. By overriding that, they no longer grow when their content grows. See https://stackoverflow.com/a/38383437.

This PR fixes MPP-2649.

How to test: on desktop, open the onboarding flow with a Premium user. When typing a long subdomain name, the page layout should no longer change; instead, the name gets truncated with an ellipsis at some point.

This is in onboarding:

![image](https://user-images.githubusercontent.com/4251/208933720-62a0b791-d979-4d36-b731-4ba06f097125.png)

And on the dashboard:

![image](https://user-images.githubusercontent.com/4251/208933840-6de7ede1-85dc-4280-862d-92f546dab48d.png)

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
