### PR TITLE
Prevent banner icon from taking up too much space

### DIFF
--- a/frontend/src/components/Banner.module.scss
+++ b/frontend/src/components/Banner.module.scss
@@ -148,7 +148,7 @@
   }
 
   .icon {
-    flex: 1 0 auto;
+    flex: 0 0 auto;
     margin-right: $spacing-md;
 
     .warning & {


### PR DESCRIPTION
This is a followup to #2907. The icon was set to grow if there was more space, but it really just needs to stay the same size - no shrinking, no growing.

It was set to not shrink in 693f7ad24b53ee495b1a0a2eebdaf5e3f8280ac1, but erroneously also to grow. This broke it on desktop:

![image](https://user-images.githubusercontent.com/4251/208938486-7cf50a85-ab20-4070-9a8b-1ece51afbfb6.png)

With this change it's back at

![image](https://user-images.githubusercontent.com/4251/208938535-3faddc02-669b-4686-89eb-5d0e386ead1a.png)

How to test: open a page with the banner shown. There should be no superfluous whitespace around the icon.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
