### PR TITLE
MPP-2544 Remove + from copy function within phones dashboard

### DIFF
--- a/frontend/src/components/phones/dashboard/PhoneDashboard.tsx
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.tsx
@@ -101,7 +101,9 @@ export const PhoneDashboard = (props: Props) => {
 
   const copyPhoneNumber: MouseEventHandler<HTMLButtonElement> = () => {
     if (relayNumberData?.number) {
-      navigator.clipboard.writeText(relayNumberData.number);
+      // removing the + from the number to make it easier to copy
+      const RelayNumber = relayNumberData.number.replace("+1", "");
+      navigator.clipboard.writeText(RelayNumber);
       setJustCopiedPhoneNumber(true);
       setTimeout(() => setJustCopiedPhoneNumber(false), 1000);
     }

--- a/frontend/src/components/phones/dashboard/PhoneDashboard.tsx
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.tsx
@@ -102,7 +102,7 @@ export const PhoneDashboard = (props: Props) => {
   const copyPhoneNumber: MouseEventHandler<HTMLButtonElement> = () => {
     if (relayNumberData?.number) {
       // removing the + from the number to make it easier to copy
-      const RelayNumber = relayNumberData.number.replace("+1", "");
+      const RelayNumber = relayNumberData.number.replace("+", "");
       navigator.clipboard.writeText(RelayNumber);
       setJustCopiedPhoneNumber(true);
       setTimeout(() => setJustCopiedPhoneNumber(false), 1000);


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-2544
 
<!-- When adding a new feature: -->

# New feature description

When a user currently copies and pastes the relay phone number from a dashboard it presents the number as: +14153600134 but most of the time we give out phone numbers in the US we do not need to include the plus sign. 

This PR removes the "+" from the copy action so only the numbers are copied.

# Screenshot (if applicable)

<img width="776" alt="image" src="https://user-images.githubusercontent.com/3924990/210106510-2cdca70f-1499-4f6e-a1bd-1829a4c8e18d.png">

# How to test

Get to phones dashboard. To do so, you must have an active sub and relay number. See screenshot above - try using the copy functionality - the copied number should not have the "+" in it. 

You can use the Netlify version here: https://deploy-preview-2957--fx-relay-demo.netlify.app/phone/ (full)

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
