### PR TITLE
Make one of the PlanMatrix CTAs the primary one

### DIFF
--- a/frontend/src/components/landing/PlanMatrix.module.scss
+++ b/frontend/src/components/landing/PlanMatrix.module.scss
@@ -326,6 +326,10 @@ table.desktop {
             font-weight: 600;
           }
 
+          .primary-pick-button {
+            width: 100%;
+          }
+
           .pick-button {
             border: 2px solid $color-blue-50;
             border-radius: $border-radius-sm;

--- a/frontend/src/components/landing/PlanMatrix.tsx
+++ b/frontend/src/components/landing/PlanMatrix.tsx
@@ -28,6 +28,7 @@ import { Plan, trackPlanPurchaseStart } from "../../functions/trackPurchase";
 import { setCookie } from "../../functions/cookies";
 import { useL10n } from "../../hooks/l10n";
 import { Localized } from "../Localized";
+import { LinkButton } from "../Button";
 
 type FeatureList = {
   "email-masks": number;
@@ -159,14 +160,14 @@ export const PlanMatrix = (props: Props) => {
                 <span className={styles.price}>
                   {l10n.getString("plan-matrix-price-free")}
                 </span>
-                <a
+                <LinkButton
                   ref={freeButtonDesktopRef}
                   href={getRuntimeConfig().fxaLoginUrl}
                   onClick={() => countSignIn("plan-matrix-free-cta-desktop")}
-                  className={styles["pick-button"]}
+                  className={styles["primary-pick-button"]}
                 >
                   {l10n.getString("plan-matrix-pick")}
-                </a>
+                </LinkButton>
                 {/*
                 The <small> has space for price-related notices (e.g. "* billed
                 annually"). When there is no such notice, we still want to leave
@@ -383,14 +384,14 @@ export const PlanMatrix = (props: Props) => {
               <span className={styles.price}>
                 {l10n.getString("plan-matrix-price-free")}
               </span>
-              <a
+              <LinkButton
                 ref={freeButtonMobileRef}
                 href={getRuntimeConfig().fxaLoginUrl}
                 onClick={() => countSignIn("plan-matrix-free-cta-mobile")}
-                className={styles["pick-button"]}
+                className={styles["primary-pick-button"]}
               >
                 {l10n.getString("plan-matrix-pick")}
-              </a>
+              </LinkButton>
             </div>
           </div>
         </li>


### PR DESCRIPTION
# New feature description

The free plan has the lowest barrier, so is the easiest to access for those quickly scanning to make their way through. Additionally, in some countries, it is the only available option (i.e. the only one that does not lead to a waitlist).

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/210572284-6e9c5dea-71cb-439d-b6e0-c6cc71ffc1c1.png)

# How to test

Look at the plan comparison. The "Sign up" button should be blue instead of an outline, both on desktop and mobile.

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process. - N/A
- [x] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage. - N/A
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
