### PR TITLE
Allow stats area to shrink if not all are visible

### DIFF
--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -214,7 +214,7 @@ $trackerRemovalIndicatorWidth: 20px;
     // stylelint-disable-next-line no-duplicate-selectors
     .main-data & {
       display: flex;
-      flex: 1 0 $content-xs;
+      flex: 0 0 0;
       text-align: center;
     }
     // I've grouped these together under the media query to emphasise that they


### PR DESCRIPTION
I'm not quite sure why I thought the flex-basis of $content-xs was necessarily initially, although I do remember struggling with a number of different values, so I might just have gotten them mixed up in 39602f04526083c12c7da4995c6377892d4dfd64.

However, with this change, both Chinese and English still have the expected (lack of) line breaks, but when not all four mask-related statistics are shown, the stats area doesn't take up more space than necessary.

Specifically, instead of

![image](https://user-images.githubusercontent.com/4251/210580982-56b407c0-bcc7-43fa-8bdf-6979fea56197.png)

it now looks like

![image](https://user-images.githubusercontent.com/4251/210581041-59f410e5-9ed4-413c-b139-84cea58a66a2.png)

How to test: open the dashboard as a free user (i.e. without promo-blocking available). There should be no superfluous whitespace around the mask stats on desktop.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
