### PR TITLE
Preserve locally-stored mask-website associations

### DIFF
--- a/frontend/src/hooks/localLabels.ts
+++ b/frontend/src/hooks/localLabels.ts
@@ -13,6 +13,7 @@ export type LocalLabel = {
   id: number;
   description: string;
   generated_for?: string;
+  used_on?: string;
 };
 export type SetLocalLabel = (alias: AliasData, newLabel: string) => void;
 export type LocalLabelHook = [LocalLabel[], SetLocalLabel];

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -116,7 +116,11 @@ const Settings: NextPage = () => {
               localLabel.id === alias.id
           );
           if (typeof localLabel !== "undefined") {
-            aliasData.update(alias, { description: localLabel.description });
+            aliasData.update(alias, {
+              description: localLabel.description,
+              generated_for: localLabel.generated_for,
+              used_on: localLabel.used_on,
+            });
           }
         };
         aliasData.randomAliasData.data?.forEach(uploadLocalLabel);


### PR DESCRIPTION
When the user enables server-side label storage, we used to only upload the locally-stored labels, but website associations would be dropped.

Users won't notice immediately since the old associations are still stored in their local cache, but as soon as that gets cleared, the associations will disappear.

How to test: disable server-side storage, then use the add-on to create a mask on a website. If you then open the in-page menu on that website, the mask should be listed as "From this website". Now enable server-side storage, and delete the `relayAddresses` value in the extension storage. The association should be preserved with this fix, whereas it wasn't before.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, I don't think, as it'd just verify parameters to a mock call without any logic beforehand.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
