### PR TITLE
Prevent waitlists from extending beyond the sides

### DIFF
--- a/frontend/src/components/waitlist/WaitlistPage.module.scss
+++ b/frontend/src/components/waitlist/WaitlistPage.module.scss
@@ -11,6 +11,7 @@
 
   .form {
     width: $content-lg;
+    max-width: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -22,6 +23,7 @@
       flex-direction: column;
       gap: $spacing-sm;
       width: $content-md;
+      max-width: 100%;
 
       .control {
         display: flex;


### PR DESCRIPTION
This PR fixes the waitlist pages being too wide on mobile.

How to test: open e.g. `/premium/waitlist/` on mobile. The page should fit in the viewport, horizontally.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
