### PR TITLE
(WIP) MPP-2479 - Prevent modal from scrolling up on iOS Safari

### DIFF
--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
@@ -15,7 +15,6 @@ import {
   useDialog,
   useModal,
   useOverlay,
-  usePreventScroll,
   useButton,
   AriaOverlayProps,
 } from "react-aria";
@@ -189,7 +188,6 @@ type PickerDialogProps = {
 const PickerDialog = (props: PickerDialogProps & AriaOverlayProps) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const { overlayProps, underlayProps } = useOverlay(props, wrapperRef);
-  usePreventScroll();
   const { modalProps } = useModal();
   const { dialogProps, titleProps } = useDialog({}, wrapperRef);
 

--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -23,7 +23,6 @@ a {
   margin: 0;
 }
 
-html,
 body,
 #__next,
 #overlayProvider {
@@ -35,12 +34,23 @@ body,
   // empty space at the bottom of the page, below the footer.
   // Since the user can scroll in `.non-header-wrapper`, everything outside that
   // that still overflows these elements can safely be hidden:
-  overflow: hidden;
+  // overflow: hidden;
 }
 
 html {
   scroll-behavior: smooth;
   scroll-padding-top: $layout-xl;
+  font-family: $font-stack-base;
+  height: auto;
+
+  @media #{$mq-sm} {
+    // In <Layout> all content is wrapped in a `.non-header-wrapper` that has its
+    // own `overflow` applied, to allow the header and mobile menu to remain fixed
+    // in place. However, in Blink- and WebKit-based browsers, this resulted in
+    // empty space at the bottom of the page, below the footer.
+    // Hence, a height of 100% is applied to the html document
+    height: 100%;
+  }
 
   @media (prefers-reduced-motion) {
     & {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #MPP-2479. I have a couple questions for this one, which I added in a self-review.

How to test:

- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

