### PR TITLE
CSP: Allow fonts on stage, block objects

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -109,6 +109,7 @@ CSP_SCRIPT_SRC = [
     "https://www.google-analytics.com/",
 ]
 CSP_FONT_SRC = ["'self'", "https://relay.firefox.com/"]
+CSP_OBJECT_SRC = ("'none'",)
 if USE_SILK:
     CSP_SCRIPT_SRC.append("'unsafe-inline'")
 

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -108,7 +108,7 @@ CSP_SCRIPT_SRC = [
     "'self'",
     "https://www.google-analytics.com/",
 ]
-CSP_FONT_SRC = ["https://relay.firefox.com/"]
+CSP_FONT_SRC = ["'self'", "https://relay.firefox.com/"]
 if USE_SILK:
     CSP_SCRIPT_SRC.append("'unsafe-inline'")
 


### PR DESCRIPTION
Fonts are unable to load on stage, because it used to have the default of `'self'`, but changed to `'https://relay.firefox.com/'` in https://github.com/mozilla/fx-private-relay/pull/2882, to support emails. This adds `'self'` as well.

I used https://csp-evaluator.withgoogle.com/, and it recommended a `object-src: 'none'` directive, so I'm adding that as well.