### PR TITLE
Consistently allow missing trailing slashes API routes

### DIFF
--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -594,7 +594,7 @@ def test_vcard_no_lookup_key():
 @pytest.mark.django_db
 def test_vcard_wrong_lookup_key():
     client = APIClient()
-    path = "/api/v1/vCard/wrong-lookup-key"
+    path = "/api/v1/vCard/wrong-lookup-key/"
 
     response = client.get(path)
 
@@ -606,7 +606,7 @@ def test_vcard_valid_lookup_key(phone_user):
     relay_number = _make_relay_number(phone_user)
 
     client = APIClient()
-    path = f"/api/v1/vCard/{relay_number.vcard_lookup_key}"
+    path = f"/api/v1/vCard/{relay_number.vcard_lookup_key}/"
     response = client.get(path)
 
     assert response.status_code == 200
@@ -619,7 +619,7 @@ def test_vcard_valid_lookup_key(phone_user):
 
 def test_resend_welcome_sms_requires_phone_user():
     client = APIClient()
-    path = "/api/v1/realphone/resend_welcome_sms"
+    path = "/api/v1/realphone/resend_welcome_sms/"
     response = client.post(path)
 
     assert response.status_code == 401
@@ -633,7 +633,7 @@ def test_resend_welcome_sms(phone_user, mocked_twilio_client):
     mocked_twilio_client.reset_mock()
     client = APIClient()
     client.force_authenticate(phone_user)
-    path = "/api/v1/realphone/resend_welcome_sms"
+    path = "/api/v1/realphone/resend_welcome_sms/"
     response = client.post(path)
 
     assert response.status_code == 201
@@ -647,7 +647,7 @@ def test_resend_welcome_sms(phone_user, mocked_twilio_client):
 @pytest.mark.django_db
 def test_inbound_sms_no_twilio_signature():
     client = APIClient()
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     response = client.post(path)
 
     assert response.status_code == 400
@@ -659,7 +659,7 @@ def test_inbound_sms_invalid_twilio_signature(mocked_twilio_validator):
     mocked_twilio_validator.validate = Mock(return_value=False)
 
     client = APIClient()
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="invalid")
 
     assert response.status_code == 400
@@ -669,7 +669,7 @@ def test_inbound_sms_invalid_twilio_signature(mocked_twilio_validator):
 @pytest.mark.django_db
 def test_inbound_sms_valid_twilio_signature_bad_data():
     client = APIClient()
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="valid")
 
     assert response.status_code == 400
@@ -685,7 +685,7 @@ def test_inbound_sms_valid_twilio_signature_unknown_number(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {"From": "+15556660000", "To": unknown_number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -700,7 +700,7 @@ def test_inbound_sms_valid_twilio_signature_good_data(phone_user, mocked_twilio_
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {"From": "+15556660000", "To": relay_number.number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -723,7 +723,7 @@ def test_inbound_sms_valid_twilio_signature_disabled_number(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {"From": "+15556660000", "To": relay_number.number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -746,7 +746,7 @@ def test_inbound_sms_to_number_with_no_remaining_texts(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {"From": "+15556660000", "To": relay_number.number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -766,7 +766,7 @@ def test_inbound_sms_reply_with_no_remaining_texts(phone_user, mocked_twilio_cli
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {"From": "+12223334444", "To": relay_number.number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -790,7 +790,7 @@ def test_inbound_sms_valid_twilio_signature_no_phone_log(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {"From": inbound_number, "To": relay_number.number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -817,7 +817,7 @@ def test_inbound_sms_valid_twilio_signature_blocked_contact(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {"From": inbound_number, "To": relay_number.number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -862,7 +862,7 @@ def test_inbound_sms_reply_not_storing_phone_log(phone_user, mocked_twilio_clien
     profile.save()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {"From": real_phone.number, "To": relay_number.number, "Body": "test reply"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -883,7 +883,7 @@ def test_inbound_sms_reply_no_previous_sender(phone_user, mocked_twilio_client):
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {"From": real_phone.number, "To": relay_number.number, "Body": "test reply"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -906,7 +906,7 @@ def test_inbound_sms_reply(phone_user: User, mocked_twilio_client: Client) -> No
 
     # Setup: Recieve a text from a contact
     client = APIClient()
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     contact_number = "+15556660000"
     data = {"From": contact_number, "To": relay_number.number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
@@ -938,7 +938,7 @@ def test_inbound_sms_reply_to_first_caller(
 
     # Setup: Recieve a text from a contact
     client = APIClient()
-    sms_path = "/api/v1/inbound_sms"
+    sms_path = "/api/v1/inbound_sms/"
     contact_number = "+15556660000"
     data = {"From": contact_number, "To": relay_number.number, "Body": "test body"}
     response = client.post(sms_path, data, HTTP_X_TWILIO_SIGNATURE="valid")
@@ -947,7 +947,7 @@ def test_inbound_sms_reply_to_first_caller(
     assert relay_number.texts_forwarded == 1
 
     # Setup: Recieve a call from the same contact
-    voice_path = "/api/v1/inbound_call"
+    voice_path = "/api/v1/inbound_call/"
     data = {"Caller": contact_number, "Called": relay_number.number}
     response = client.post(voice_path, data, HTTP_X_TWILIO_SIGNATURE="valid")
     assert response.status_code == 201
@@ -978,7 +978,7 @@ def test_inbound_sms_reply_to_caller(
 
     # Setup: Recieve a text from first contact
     client = APIClient()
-    sms_path = "/api/v1/inbound_sms"
+    sms_path = "/api/v1/inbound_sms/"
     contact1_number = "+13015550000"
     data = {
         "From": contact1_number,
@@ -1003,7 +1003,7 @@ def test_inbound_sms_reply_to_caller(
     assert relay_number.texts_forwarded == 2
 
     # Setup: Recieve a call from second contact
-    voice_path = "/api/v1/inbound_call"
+    voice_path = "/api/v1/inbound_call/"
     data = {"Caller": contact2_number, "Called": relay_number.number}
     response = client.post(voice_path, data, HTTP_X_TWILIO_SIGNATURE="valid")
     assert response.status_code == 201
@@ -1046,7 +1046,7 @@ def test_inbound_sms_reply_pre_transition(
     # Test: Send a reply to contact
     mocked_twilio_client.reset_mock()
     client = APIClient()
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {"From": real_phone.number, "To": relay_number.number, "Body": "test reply"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -1066,7 +1066,7 @@ def test_inbound_sms_reply_no_multi_replies(phone_user, mocked_twilio_client) ->
     relay_number = _make_relay_number(phone_user, enabled=True)
 
     # Setup: Contact with number ending in 0000
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     contact1 = "+13015550000"
     data = {"From": contact1, "To": relay_number.number, "Body": "Hi!"}
     client = APIClient()
@@ -1134,14 +1134,14 @@ def multi_reply(
     for number, contact_type in contacts:
         if contact_type == "text":
             response = client.post(
-                "/api/v1/inbound_sms",
+                "/api/v1/inbound_sms/",
                 {"From": number, "To": relay_number.number, "Body": "Hi!"},
                 HTTP_X_TWILIO_SIGNATURE="valid",
             )
         else:
             assert contact_type == "call"
             response = client.post(
-                "/api/v1/inbound_call",
+                "/api/v1/inbound_call/",
                 {"Caller": number, "Called": relay_number.number},
                 HTTP_X_TWILIO_SIGNATURE="valid",
             )
@@ -1174,7 +1174,7 @@ def test_inbound_sms_reply_one_match(
 ) -> None:
     """A prefix that matches a single contact sends to that contact."""
     relay_number = multi_reply.relay_number
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {
         "From": multi_reply.real_phone.number,
         "To": relay_number.number,
@@ -1196,7 +1196,7 @@ def test_inbound_sms_reply_one_match(
 def test_inbound_sms_reply_full_number_wins(multi_reply: MultiReplyFixture) -> None:
     """If a prefix could be a short code or a full number, pick full number."""
     relay_number = multi_reply.relay_number
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {
         "From": multi_reply.real_phone.number,
         "To": relay_number.number,
@@ -1220,7 +1220,7 @@ def test_inbound_sms_reply_short_prefix_never_text(
 ) -> None:
     """A contact that only called can be texted via short prefix."""
     relay_number = multi_reply.relay_number
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {
         "From": multi_reply.real_phone.number,
         "To": relay_number.number,
@@ -1244,7 +1244,7 @@ def test_inbound_sms_reply_full_prefix_never_text(
 ) -> None:
     """A contact that only called can be texted via full number."""
     relay_number = multi_reply.relay_number
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {
         "From": multi_reply.real_phone.number,
         "To": relay_number.number,
@@ -1313,7 +1313,7 @@ def test_inbound_sms_reply_prefix_errors(
 ) -> None:
     """If a prefixed message has an issue, the user gets advice."""
     relay_number = multi_reply.relay_number
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {
         "From": multi_reply.real_phone.number,
         "To": relay_number.number,
@@ -1337,7 +1337,7 @@ def test_inbound_sms_reply_no_prefix_last_sender(
 ) -> None:
     """If there is no detected prefix, send message to the last text contact."""
     relay_number = multi_reply.relay_number
-    path = "/api/v1/inbound_sms"
+    path = "/api/v1/inbound_sms/"
     data = {
         "From": multi_reply.real_phone.number,
         "To": relay_number.number,
@@ -1651,7 +1651,7 @@ def test_phone_get_inbound_contact_requires_relay_number(phone_user):
 @pytest.mark.django_db
 def test_inbound_call_no_twilio_signature():
     client = APIClient()
-    path = "/api/v1/inbound_call"
+    path = "/api/v1/inbound_call/"
     response = client.post(path)
 
     assert response.status_code == 400
@@ -1663,7 +1663,7 @@ def test_inbound_call_invalid_twilio_signature(mocked_twilio_validator):
     mocked_twilio_validator.validate = Mock(return_value=False)
 
     client = APIClient()
-    path = "/api/v1/inbound_call"
+    path = "/api/v1/inbound_call/"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="invalid")
 
     assert response.status_code == 400
@@ -1673,7 +1673,7 @@ def test_inbound_call_invalid_twilio_signature(mocked_twilio_validator):
 @pytest.mark.django_db
 def test_inbound_call_valid_twilio_signature_bad_data():
     client = APIClient()
-    path = "/api/v1/inbound_call"
+    path = "/api/v1/inbound_call/"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="valid")
 
     assert response.status_code == 400
@@ -1690,7 +1690,7 @@ def test_inbound_call_valid_twilio_signature_unknown_number(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_call"
+    path = "/api/v1/inbound_call/"
     data = {"Caller": caller_number, "Called": unknown_number}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -1708,7 +1708,7 @@ def test_inbound_call_valid_twilio_signature_good_data(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_call"
+    path = "/api/v1/inbound_call/"
     data = {"Caller": caller_number, "Called": relay_number.number}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -1734,7 +1734,7 @@ def test_inbound_call_valid_twilio_signature_disabled_number(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_call"
+    path = "/api/v1/inbound_call/"
     data = {"Caller": caller_number, "Called": relay_number.number}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -1755,7 +1755,7 @@ def test_inbound_call_valid_twilio_signature_no_remaining_seconds(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_call"
+    path = "/api/v1/inbound_call/"
     data = {"Caller": caller_number, "Called": relay_number.number}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -1771,7 +1771,7 @@ def test_voice_status_invalid_twilio_signature(mocked_twilio_validator):
     mocked_twilio_validator.validate = Mock(return_value=False)
 
     client = APIClient()
-    path = "/api/v1/voice_status"
+    path = "/api/v1/voice_status/"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="invalid")
 
     assert response.status_code == 400
@@ -1780,7 +1780,7 @@ def test_voice_status_invalid_twilio_signature(mocked_twilio_validator):
 
 def test_voice_status_missing_required_params_error():
     client = APIClient()
-    path = "/api/v1/voice_status"
+    path = "/api/v1/voice_status/"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="valid")
     assert response.status_code == 400
     assert "Missing Called, Callstatus" in response.data[0].title()
@@ -1792,7 +1792,7 @@ def test_voice_status_not_completed_does_nothing(phone_user):
     pre_request_remaining_seconds = relay_number.remaining_seconds
 
     client = APIClient()
-    path = "/api/v1/voice_status"
+    path = "/api/v1/voice_status/"
     data = {
         "CallSid": "CA1234567890abcdef1234567890abcdef",
         "Called": relay_number.number,
@@ -1811,7 +1811,7 @@ def test_voice_status_completed_no_duration_error(phone_user):
     pre_request_remaining_seconds = relay_number.remaining_seconds
 
     client = APIClient()
-    path = "/api/v1/voice_status"
+    path = "/api/v1/voice_status/"
     data = {
         "CallSid": "CA1234567890abcdef1234567890abcdef",
         "Called": relay_number.number,
@@ -1830,7 +1830,7 @@ def test_voice_status_completed_reduces_remaining_seconds(
     mocked_events_info, phone_user
 ):
     # TODO: This test should fail since the Relay Number is disabled and
-    # the POST to our /api/v1/voice_status should ignore the the reduced remaining seconds.
+    # the POST to our /api/v1/voice_status/ should ignore the the reduced remaining seconds.
     # This is currently passing because the voice_status() is not checking
     # if the user's Relay Number has hit the limit or is disabled (bug logged in MPP-2452).
     # Keeping this test so we can correct it once MPP-2452 is completed.
@@ -1839,7 +1839,7 @@ def test_voice_status_completed_reduces_remaining_seconds(
     pre_request_remaining_seconds = relay_number.remaining_seconds
 
     client = APIClient()
-    path = "/api/v1/voice_status"
+    path = "/api/v1/voice_status/"
     data = {
         "CallSid": "CA1234567890abcdef1234567890abcdef",
         "Called": relay_number.number,
@@ -1862,7 +1862,7 @@ def test_voice_status_completed_reduces_remaining_seconds_to_negative_value(
     relay_number = _make_relay_number(phone_user, enabled=True, remaining_seconds=0)
 
     client = APIClient()
-    path = "/api/v1/voice_status"
+    path = "/api/v1/voice_status/"
     data = {
         "CallSid": "CA1234567890abcdef1234567890abcdef",
         "Called": relay_number.number,
@@ -1894,7 +1894,7 @@ def test_voice_status_completed_deletes_call_from_twilio(
     call_sid = "CA1234567890abcdef1234567890abcdef"
 
     client = APIClient()
-    path = "/api/v1/voice_status"
+    path = "/api/v1/voice_status/"
     data = {
         "CallSid": call_sid,
         "Called": relay_number.number,
@@ -1916,7 +1916,7 @@ def test_sms_status_invalid_twilio_signature(mocked_twilio_validator):
     mocked_twilio_validator.validate = Mock(return_value=False)
 
     client = APIClient()
-    path = "/api/v1/sms_status"
+    path = "/api/v1/sms_status/"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="invalid")
 
     assert response.status_code == 400
@@ -1925,7 +1925,7 @@ def test_sms_status_invalid_twilio_signature(mocked_twilio_validator):
 
 def test_sms_status_missing_required_params_error():
     client = APIClient()
-    path = "/api/v1/sms_status"
+    path = "/api/v1/sms_status/"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="valid")
     assert response.status_code == 400
     assert "Missing Smsstatus Or Messagesid" in response.data[0].title()
@@ -1933,7 +1933,7 @@ def test_sms_status_missing_required_params_error():
 
 def test_sms_status_before_delivered_does_nothing(mocked_twilio_client):
     client = APIClient()
-    path = "/api/v1/sms_status"
+    path = "/api/v1/sms_status/"
     response = client.post(
         path,
         {
@@ -1948,7 +1948,7 @@ def test_sms_status_before_delivered_does_nothing(mocked_twilio_client):
 
 def test_sms_status_delivered_deletes_message_from_twilio(mocked_twilio_client):
     client = APIClient()
-    path = "/api/v1/sms_status"
+    path = "/api/v1/sms_status/"
     message_sid = "SM1234567890abcdef1234567890abcdef"
     mock_message = Mock(spec=["delete"])
     mocked_twilio_client.messages = Mock(return_value=mock_message)

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -594,7 +594,7 @@ def test_vcard_no_lookup_key():
 @pytest.mark.django_db
 def test_vcard_wrong_lookup_key():
     client = APIClient()
-    path = "/api/v1/vCard/wrong-lookup-key/"
+    path = "/api/v1/vCard/wrong-lookup-key"
 
     response = client.get(path)
 
@@ -606,7 +606,7 @@ def test_vcard_valid_lookup_key(phone_user):
     relay_number = _make_relay_number(phone_user)
 
     client = APIClient()
-    path = f"/api/v1/vCard/{relay_number.vcard_lookup_key}/"
+    path = f"/api/v1/vCard/{relay_number.vcard_lookup_key}"
     response = client.get(path)
 
     assert response.status_code == 200
@@ -647,7 +647,7 @@ def test_resend_welcome_sms(phone_user, mocked_twilio_client):
 @pytest.mark.django_db
 def test_inbound_sms_no_twilio_signature():
     client = APIClient()
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     response = client.post(path)
 
     assert response.status_code == 400
@@ -659,7 +659,7 @@ def test_inbound_sms_invalid_twilio_signature(mocked_twilio_validator):
     mocked_twilio_validator.validate = Mock(return_value=False)
 
     client = APIClient()
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="invalid")
 
     assert response.status_code == 400
@@ -669,7 +669,7 @@ def test_inbound_sms_invalid_twilio_signature(mocked_twilio_validator):
 @pytest.mark.django_db
 def test_inbound_sms_valid_twilio_signature_bad_data():
     client = APIClient()
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="valid")
 
     assert response.status_code == 400
@@ -685,7 +685,7 @@ def test_inbound_sms_valid_twilio_signature_unknown_number(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {"From": "+15556660000", "To": unknown_number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -700,7 +700,7 @@ def test_inbound_sms_valid_twilio_signature_good_data(phone_user, mocked_twilio_
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {"From": "+15556660000", "To": relay_number.number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -723,7 +723,7 @@ def test_inbound_sms_valid_twilio_signature_disabled_number(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {"From": "+15556660000", "To": relay_number.number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -746,7 +746,7 @@ def test_inbound_sms_to_number_with_no_remaining_texts(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {"From": "+15556660000", "To": relay_number.number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -766,7 +766,7 @@ def test_inbound_sms_reply_with_no_remaining_texts(phone_user, mocked_twilio_cli
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {"From": "+12223334444", "To": relay_number.number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -790,7 +790,7 @@ def test_inbound_sms_valid_twilio_signature_no_phone_log(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {"From": inbound_number, "To": relay_number.number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -817,7 +817,7 @@ def test_inbound_sms_valid_twilio_signature_blocked_contact(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {"From": inbound_number, "To": relay_number.number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -862,7 +862,7 @@ def test_inbound_sms_reply_not_storing_phone_log(phone_user, mocked_twilio_clien
     profile.save()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {"From": real_phone.number, "To": relay_number.number, "Body": "test reply"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -883,7 +883,7 @@ def test_inbound_sms_reply_no_previous_sender(phone_user, mocked_twilio_client):
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {"From": real_phone.number, "To": relay_number.number, "Body": "test reply"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -906,7 +906,7 @@ def test_inbound_sms_reply(phone_user: User, mocked_twilio_client: Client) -> No
 
     # Setup: Recieve a text from a contact
     client = APIClient()
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     contact_number = "+15556660000"
     data = {"From": contact_number, "To": relay_number.number, "Body": "test body"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
@@ -938,7 +938,7 @@ def test_inbound_sms_reply_to_first_caller(
 
     # Setup: Recieve a text from a contact
     client = APIClient()
-    sms_path = "/api/v1/inbound_sms/"
+    sms_path = "/api/v1/inbound_sms"
     contact_number = "+15556660000"
     data = {"From": contact_number, "To": relay_number.number, "Body": "test body"}
     response = client.post(sms_path, data, HTTP_X_TWILIO_SIGNATURE="valid")
@@ -947,7 +947,7 @@ def test_inbound_sms_reply_to_first_caller(
     assert relay_number.texts_forwarded == 1
 
     # Setup: Recieve a call from the same contact
-    voice_path = "/api/v1/inbound_call/"
+    voice_path = "/api/v1/inbound_call"
     data = {"Caller": contact_number, "Called": relay_number.number}
     response = client.post(voice_path, data, HTTP_X_TWILIO_SIGNATURE="valid")
     assert response.status_code == 201
@@ -978,7 +978,7 @@ def test_inbound_sms_reply_to_caller(
 
     # Setup: Recieve a text from first contact
     client = APIClient()
-    sms_path = "/api/v1/inbound_sms/"
+    sms_path = "/api/v1/inbound_sms"
     contact1_number = "+13015550000"
     data = {
         "From": contact1_number,
@@ -1003,7 +1003,7 @@ def test_inbound_sms_reply_to_caller(
     assert relay_number.texts_forwarded == 2
 
     # Setup: Recieve a call from second contact
-    voice_path = "/api/v1/inbound_call/"
+    voice_path = "/api/v1/inbound_call"
     data = {"Caller": contact2_number, "Called": relay_number.number}
     response = client.post(voice_path, data, HTTP_X_TWILIO_SIGNATURE="valid")
     assert response.status_code == 201
@@ -1046,7 +1046,7 @@ def test_inbound_sms_reply_pre_transition(
     # Test: Send a reply to contact
     mocked_twilio_client.reset_mock()
     client = APIClient()
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {"From": real_phone.number, "To": relay_number.number, "Body": "test reply"}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -1066,7 +1066,7 @@ def test_inbound_sms_reply_no_multi_replies(phone_user, mocked_twilio_client) ->
     relay_number = _make_relay_number(phone_user, enabled=True)
 
     # Setup: Contact with number ending in 0000
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     contact1 = "+13015550000"
     data = {"From": contact1, "To": relay_number.number, "Body": "Hi!"}
     client = APIClient()
@@ -1134,14 +1134,14 @@ def multi_reply(
     for number, contact_type in contacts:
         if contact_type == "text":
             response = client.post(
-                "/api/v1/inbound_sms/",
+                "/api/v1/inbound_sms",
                 {"From": number, "To": relay_number.number, "Body": "Hi!"},
                 HTTP_X_TWILIO_SIGNATURE="valid",
             )
         else:
             assert contact_type == "call"
             response = client.post(
-                "/api/v1/inbound_call/",
+                "/api/v1/inbound_call",
                 {"Caller": number, "Called": relay_number.number},
                 HTTP_X_TWILIO_SIGNATURE="valid",
             )
@@ -1174,7 +1174,7 @@ def test_inbound_sms_reply_one_match(
 ) -> None:
     """A prefix that matches a single contact sends to that contact."""
     relay_number = multi_reply.relay_number
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {
         "From": multi_reply.real_phone.number,
         "To": relay_number.number,
@@ -1196,7 +1196,7 @@ def test_inbound_sms_reply_one_match(
 def test_inbound_sms_reply_full_number_wins(multi_reply: MultiReplyFixture) -> None:
     """If a prefix could be a short code or a full number, pick full number."""
     relay_number = multi_reply.relay_number
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {
         "From": multi_reply.real_phone.number,
         "To": relay_number.number,
@@ -1220,7 +1220,7 @@ def test_inbound_sms_reply_short_prefix_never_text(
 ) -> None:
     """A contact that only called can be texted via short prefix."""
     relay_number = multi_reply.relay_number
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {
         "From": multi_reply.real_phone.number,
         "To": relay_number.number,
@@ -1244,7 +1244,7 @@ def test_inbound_sms_reply_full_prefix_never_text(
 ) -> None:
     """A contact that only called can be texted via full number."""
     relay_number = multi_reply.relay_number
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {
         "From": multi_reply.real_phone.number,
         "To": relay_number.number,
@@ -1313,7 +1313,7 @@ def test_inbound_sms_reply_prefix_errors(
 ) -> None:
     """If a prefixed message has an issue, the user gets advice."""
     relay_number = multi_reply.relay_number
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {
         "From": multi_reply.real_phone.number,
         "To": relay_number.number,
@@ -1337,7 +1337,7 @@ def test_inbound_sms_reply_no_prefix_last_sender(
 ) -> None:
     """If there is no detected prefix, send message to the last text contact."""
     relay_number = multi_reply.relay_number
-    path = "/api/v1/inbound_sms/"
+    path = "/api/v1/inbound_sms"
     data = {
         "From": multi_reply.real_phone.number,
         "To": relay_number.number,
@@ -1651,7 +1651,7 @@ def test_phone_get_inbound_contact_requires_relay_number(phone_user):
 @pytest.mark.django_db
 def test_inbound_call_no_twilio_signature():
     client = APIClient()
-    path = "/api/v1/inbound_call/"
+    path = "/api/v1/inbound_call"
     response = client.post(path)
 
     assert response.status_code == 400
@@ -1663,7 +1663,7 @@ def test_inbound_call_invalid_twilio_signature(mocked_twilio_validator):
     mocked_twilio_validator.validate = Mock(return_value=False)
 
     client = APIClient()
-    path = "/api/v1/inbound_call/"
+    path = "/api/v1/inbound_call"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="invalid")
 
     assert response.status_code == 400
@@ -1673,7 +1673,7 @@ def test_inbound_call_invalid_twilio_signature(mocked_twilio_validator):
 @pytest.mark.django_db
 def test_inbound_call_valid_twilio_signature_bad_data():
     client = APIClient()
-    path = "/api/v1/inbound_call/"
+    path = "/api/v1/inbound_call"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="valid")
 
     assert response.status_code == 400
@@ -1690,7 +1690,7 @@ def test_inbound_call_valid_twilio_signature_unknown_number(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_call/"
+    path = "/api/v1/inbound_call"
     data = {"Caller": caller_number, "Called": unknown_number}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -1708,7 +1708,7 @@ def test_inbound_call_valid_twilio_signature_good_data(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_call/"
+    path = "/api/v1/inbound_call"
     data = {"Caller": caller_number, "Called": relay_number.number}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -1734,7 +1734,7 @@ def test_inbound_call_valid_twilio_signature_disabled_number(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_call/"
+    path = "/api/v1/inbound_call"
     data = {"Caller": caller_number, "Called": relay_number.number}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -1755,7 +1755,7 @@ def test_inbound_call_valid_twilio_signature_no_remaining_seconds(
     mocked_twilio_client.reset_mock()
 
     client = APIClient()
-    path = "/api/v1/inbound_call/"
+    path = "/api/v1/inbound_call"
     data = {"Caller": caller_number, "Called": relay_number.number}
     response = client.post(path, data, HTTP_X_TWILIO_SIGNATURE="valid")
 
@@ -1771,7 +1771,7 @@ def test_voice_status_invalid_twilio_signature(mocked_twilio_validator):
     mocked_twilio_validator.validate = Mock(return_value=False)
 
     client = APIClient()
-    path = "/api/v1/voice_status/"
+    path = "/api/v1/voice_status"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="invalid")
 
     assert response.status_code == 400
@@ -1780,7 +1780,7 @@ def test_voice_status_invalid_twilio_signature(mocked_twilio_validator):
 
 def test_voice_status_missing_required_params_error():
     client = APIClient()
-    path = "/api/v1/voice_status/"
+    path = "/api/v1/voice_status"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="valid")
     assert response.status_code == 400
     assert "Missing Called, Callstatus" in response.data[0].title()
@@ -1792,7 +1792,7 @@ def test_voice_status_not_completed_does_nothing(phone_user):
     pre_request_remaining_seconds = relay_number.remaining_seconds
 
     client = APIClient()
-    path = "/api/v1/voice_status/"
+    path = "/api/v1/voice_status"
     data = {
         "CallSid": "CA1234567890abcdef1234567890abcdef",
         "Called": relay_number.number,
@@ -1811,7 +1811,7 @@ def test_voice_status_completed_no_duration_error(phone_user):
     pre_request_remaining_seconds = relay_number.remaining_seconds
 
     client = APIClient()
-    path = "/api/v1/voice_status/"
+    path = "/api/v1/voice_status"
     data = {
         "CallSid": "CA1234567890abcdef1234567890abcdef",
         "Called": relay_number.number,
@@ -1830,7 +1830,7 @@ def test_voice_status_completed_reduces_remaining_seconds(
     mocked_events_info, phone_user
 ):
     # TODO: This test should fail since the Relay Number is disabled and
-    # the POST to our /api/v1/voice_status/ should ignore the the reduced remaining seconds.
+    # the POST to our /api/v1/voice_status should ignore the the reduced remaining seconds.
     # This is currently passing because the voice_status() is not checking
     # if the user's Relay Number has hit the limit or is disabled (bug logged in MPP-2452).
     # Keeping this test so we can correct it once MPP-2452 is completed.
@@ -1839,7 +1839,7 @@ def test_voice_status_completed_reduces_remaining_seconds(
     pre_request_remaining_seconds = relay_number.remaining_seconds
 
     client = APIClient()
-    path = "/api/v1/voice_status/"
+    path = "/api/v1/voice_status"
     data = {
         "CallSid": "CA1234567890abcdef1234567890abcdef",
         "Called": relay_number.number,
@@ -1862,7 +1862,7 @@ def test_voice_status_completed_reduces_remaining_seconds_to_negative_value(
     relay_number = _make_relay_number(phone_user, enabled=True, remaining_seconds=0)
 
     client = APIClient()
-    path = "/api/v1/voice_status/"
+    path = "/api/v1/voice_status"
     data = {
         "CallSid": "CA1234567890abcdef1234567890abcdef",
         "Called": relay_number.number,
@@ -1894,7 +1894,7 @@ def test_voice_status_completed_deletes_call_from_twilio(
     call_sid = "CA1234567890abcdef1234567890abcdef"
 
     client = APIClient()
-    path = "/api/v1/voice_status/"
+    path = "/api/v1/voice_status"
     data = {
         "CallSid": call_sid,
         "Called": relay_number.number,
@@ -1916,7 +1916,7 @@ def test_sms_status_invalid_twilio_signature(mocked_twilio_validator):
     mocked_twilio_validator.validate = Mock(return_value=False)
 
     client = APIClient()
-    path = "/api/v1/sms_status/"
+    path = "/api/v1/sms_status"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="invalid")
 
     assert response.status_code == 400
@@ -1925,7 +1925,7 @@ def test_sms_status_invalid_twilio_signature(mocked_twilio_validator):
 
 def test_sms_status_missing_required_params_error():
     client = APIClient()
-    path = "/api/v1/sms_status/"
+    path = "/api/v1/sms_status"
     response = client.post(path, {}, HTTP_X_TWILIO_SIGNATURE="valid")
     assert response.status_code == 400
     assert "Missing Smsstatus Or Messagesid" in response.data[0].title()
@@ -1933,7 +1933,7 @@ def test_sms_status_missing_required_params_error():
 
 def test_sms_status_before_delivered_does_nothing(mocked_twilio_client):
     client = APIClient()
-    path = "/api/v1/sms_status/"
+    path = "/api/v1/sms_status"
     response = client.post(
         path,
         {
@@ -1948,7 +1948,7 @@ def test_sms_status_before_delivered_does_nothing(mocked_twilio_client):
 
 def test_sms_status_delivered_deletes_message_from_twilio(mocked_twilio_client):
     client = APIClient()
-    path = "/api/v1/sms_status/"
+    path = "/api/v1/sms_status"
     message_sid = "SM1234567890abcdef1234567890abcdef"
     mock_message = Mock(spec=["delete"])
     mocked_twilio_client.messages = Mock(return_value=mock_message)

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -52,7 +52,7 @@ def test_swagger_format(client, format):
 
 @pytest.mark.parametrize("subpath", ("swagger", "swagger.", "swagger.txt"))
 def test_swagger_unknown_format(client, subpath):
-    path = f"/api/v1/{subpath}"
+    path = f"/api/v1/{subpath}/"
     response = client.get(path)
     assert response.status_code == 404
 

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -44,7 +44,7 @@ def prem_api_client(premium_user: User) -> APIClient:
 @pytest.mark.parametrize("format", ("yaml", "json"))
 @override_settings(API_DOCS_ENABLED=True)
 def test_swagger_format(client, format):
-    path = f"/api/v1/swagger.{format}"
+    path = f"/api/v1/swagger.{format}/"
     response = client.get(path)
     assert response.status_code == 200
     assert response["Content-Type"].startswith(f"application/{format}")
@@ -59,7 +59,7 @@ def test_swagger_unknown_format(client, subpath):
 
 @pytest.mark.django_db
 def test_runtime_data(client):
-    path = "/api/v1/runtime_data"
+    path = "/api/v1/runtime_data/"
     response = client.get(path)
     assert response.status_code == 200
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -38,7 +38,17 @@ api_router.register(r"flags", FlagViewSet, "flag")
 
 
 urlpatterns = [
+    path(
+        "v1/runtime_data",
+        runtime_data,
+        name="runtime_data_deprecate_after_updating_clients",
+    ),
     path("v1/runtime_data/", runtime_data, name="runtime_data"),
+    path(
+        "v1/report_webcompat_issue",
+        report_webcompat_issue,
+        name="report_webcompat_issue_deprecate_after_updating_clients",
+    ),
     path(
         "v1/report_webcompat_issue/",
         report_webcompat_issue,
@@ -75,11 +85,44 @@ if settings.PHONES_ENABLED:
     api_router.register(r"relaynumber", RelayNumberViewSet, "relay_number")
     api_router.register(r"inboundcontact", InboundContactViewSet, "inbound_contact")
     urlpatterns += [
+        # TODO: Update Twilio webhooks to versions with trailing slashes,
+        #       then remove versions without trailing slashes (Django's
+        #       APPEND_SLASH option will then make those redirect).
+        path(
+            "v1/inbound_sms",
+            inbound_sms,
+            name="inbound_sms_deprecate_after_updating_clients",
+        ),
         path("v1/inbound_sms/", inbound_sms, name="inbound_sms"),
+        path(
+            "v1/inbound_call",
+            inbound_call,
+            name="inbound_call_deprecate_after_updating_clients",
+        ),
         path("v1/inbound_call/", inbound_call, name="inbound_call"),
+        path(
+            "v1/voice_status",
+            voice_status,
+            name="voice_status_deprecate_after_updating_clients",
+        ),
         path("v1/voice_status/", voice_status, name="voice_status"),
+        path(
+            "v1/sms_status",
+            sms_status,
+            name="sms_status_deprecate_after_updating_clients",
+        ),
         path("v1/sms_status/", sms_status, name="sms_status"),
+        path(
+            "v1/vCard/<lookup_key>",
+            vCard,
+            name="vCard_deprecate_after_updating_clients",
+        ),
         path("v1/vCard/<lookup_key>/", vCard, name="vCard"),
+        path(
+            "v1/realphone/resend_welcome_sms",
+            resend_welcome_sms,
+            name="resend_welcome_sms_deprecate_after_updating_clients",
+        ),
         path(
             "v1/realphone/resend_welcome_sms/",
             resend_welcome_sms,

--- a/api/urls.py
+++ b/api/urls.py
@@ -38,14 +38,14 @@ api_router.register(r"flags", FlagViewSet, "flag")
 
 
 urlpatterns = [
-    path("v1/runtime_data", runtime_data, name="runtime_data"),
+    path("v1/runtime_data/", runtime_data, name="runtime_data"),
     path(
-        "v1/report_webcompat_issue",
+        "v1/report_webcompat_issue/",
         report_webcompat_issue,
         name="report_webcompat_issue",
     ),
     path(
-        "v1/swagger<swagger_format:format>",
+        "v1/swagger<swagger_format:format>/",
         enable_if_setting("API_DOCS_ENABLED")(schema_view.without_ui(cache_timeout=0)),
         name="schema-json",
     ),
@@ -75,13 +75,13 @@ if settings.PHONES_ENABLED:
     api_router.register(r"relaynumber", RelayNumberViewSet, "relay_number")
     api_router.register(r"inboundcontact", InboundContactViewSet, "inbound_contact")
     urlpatterns += [
-        path("v1/inbound_sms", inbound_sms, name="inbound_sms"),
-        path("v1/inbound_call", inbound_call, name="inbound_call"),
-        path("v1/voice_status", voice_status, name="voice_status"),
-        path("v1/sms_status", sms_status, name="sms_status"),
-        path("v1/vCard/<lookup_key>", vCard, name="vCard"),
+        path("v1/inbound_sms/", inbound_sms, name="inbound_sms"),
+        path("v1/inbound_call/", inbound_call, name="inbound_call"),
+        path("v1/voice_status/", voice_status, name="voice_status"),
+        path("v1/sms_status/", sms_status, name="sms_status"),
+        path("v1/vCard/<lookup_key>/", vCard, name="vCard"),
         path(
-            "v1/realphone/resend_welcome_sms",
+            "v1/realphone/resend_welcome_sms/",
             resend_welcome_sms,
             name="resend_welcome_sms",
         ),


### PR DESCRIPTION
Like API routes added by api_router, it is still allowed to omit the trailing slash, but with this change, it's _also_ allowed to add a trailing slash, just like for all the api_router routes.

This works because by default, Django's APPEND_SLASH option is True (see [1]), so if a route without a trailing slash it found, it will append it, but not vice versa (i.e. a trailing slash will not be automatically stripped).

[1] https://docs.djangoproject.com/en/dev/ref/middleware/#django.middleware.common.CommonMiddleware

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege. - N/A
- [ ] All acceptance criteria are met. - N/A
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process. - N/A
- [x] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage. - N/A
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
