### PR TITLE
Remove promoted pending strings, update comment

### DIFF
--- a/emails/templates/emails/reply_requires_premium.html
+++ b/emails/templates/emails/reply_requires_premium.html
@@ -1,6 +1,6 @@
 {% comment %}
-  Note that Django only loads strings from `app.ftl` and `brands.ftl`,
-  so make sure all email strings are included in that file.
+  Note that Django only loads strings from `app.ftl`, `brands.ftl`, and `phones.ftl`
+  so make sure all email strings are included in those files.
 {% endcomment %}
 {% load ftl %}
 {% load email_extras %}

--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -1,6 +1,6 @@
 {% comment %}
-  Note that Django only loads strings from `app.ftl` and `brands.ftl`,
-  so make sure all email strings are included in that file.
+  Note that Django only loads strings from `app.ftl`, `brands.ftl`, and `phones.ftl`
+  so make sure all email strings are included in those files.
 {% endcomment %}
 {% load ftl %}
 {% load email_extras %}

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -23,30 +23,6 @@ relay-email-forwarded-from = Forwarded from
 # $number - the number of email trackers removed
 relay-email-trackers-removed = { $number } email trackers removed
 
-## Relay SMS reply errors
-
-relay-sms-error-no-previous-sender = Message failed to send. Could not find a previous text sender.
-# Variables
-#   $account_settings_url (string) - The URL of the Relay account settings, to enable logs
-relay-sms-error-no-phone-log = You can only reply if you allow { -brand-name-firefox-relay } to keep a log of your callers and text senders. See { $account_settings_url }.
-
-# Variables
-#   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number
-relay-sms-error-short-prefix-matches-no-senders = Message failed to send. There is no phone number in this thread ending in { $short_prefix }. Please check the number and try again.
-# Variables
-#   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number
-relay-sms-error-multiple-number-matches = Message failed to send. There is more than one phone number in this thread ending in { $short_prefix }. To retry, start your message with the complete number.
-# Variables
-#   $short_prefix (string) - A four-digit code, such as '1234', that matches the end of a phone number
-relay-sms-error-no-body-after-short-prefix = Message failed to send. Please include a message after the sender identifier { $short_prefix }.
-
-# Variables
-#   $full_number (string) - A phone number, such as '+13025551234' or '1 (302) 555-1234'
-relay-sms-error-full-number-matches-no-senders = Message failed to send. There is no previous sender with the phone number { $full_number }. Please check the number and try again.
-# Variables
-#   $full_number (string) - A phone number, such as '+13025551234' or '1 (302) 555-1234'
-relay-sms-error-no-body-after-full-number = Message failed to send. Please include a message after the phone number { $full_number }.
-
 ## Email sent to free users who try to reply
 
 # Variables


### PR DESCRIPTION
Re-remove the SMS reply translations from `pending.ftl`. These were removed in PR #2903 but came back in the rebase for PR #2882.

Update the note that states which Fluent files are loaded, to sync with `ftl_bundles.py`:

https://github.com/mozilla/fx-private-relay/blob/80bf0f5c36f5c217a9e8b8a9d8a84701fd21fa75/privaterelay/ftl_bundles.py#L25-L27