### PR TITLE
fix MPP-2744: make FxaTokenAuthentication return a 401 for inactive t…

### DIFF
--- a/api/authentication.py
+++ b/api/authentication.py
@@ -51,8 +51,8 @@ class FxaTokenAuthentication(BaseAuthentication):
     def authenticate_header(self, request):
         # Note: we need to implement this function to make DRF return a 401 status code
         # when we raise AuthenticationFailed, rather than a 403.
-        # See https://www.django-rest-framework.org/api-guide/exceptions/#authenticationfailed
-        return "FXA Bearer:"
+        # See https://www.django-rest-framework.org/api-guide/authentication/#custom-authentication
+        return "Bearer"
 
     def authenticate(self, request):
         authorization = get_authorization_header(request).decode()

--- a/api/tests/authentication_tests.py
+++ b/api/tests/authentication_tests.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-import pytest
 from model_bakery import baker
 import responses
 
@@ -8,9 +7,15 @@ from django.core.cache import cache
 from django.test import RequestFactory, TestCase
 
 from allauth.socialaccount.models import SocialAccount
-from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.test import APIClient
 
 from ..authentication import FxaTokenAuthentication, get_cache_key
+
+
+def _setup_fxa_response(status_code: int, json: dict | str):
+    fxa_verify_path = "https://oauth.stage.mozaws.net/v1/introspect"
+    responses.add(responses.POST, fxa_verify_path, status=status_code, json=json)
+    return {"status_code": status_code, "json": json}
 
 
 class FxaTokenAuthenticationTest(TestCase):
@@ -30,116 +35,121 @@ class FxaTokenAuthenticationTest(TestCase):
         get_addresses_req = self.factory.get(self.path, **headers)
         assert self.auth.authenticate(self.auth, get_addresses_req) == None
 
-    def test_no_token_returns_none(self):
-        headers = {"HTTP_AUTHORIZATION": "Bearer "}
-        get_addresses_req = self.factory.get(self.path, **headers)
-        with pytest.raises(AuthenticationFailed):
-            self.auth.authenticate(self.auth, get_addresses_req)
+    def test_no_token_returns_400(self):
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION="Bearer ")
+        response = client.get("/api/v1/relayaddresses/")
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Missing FXA Token after 'Bearer'."
 
     @responses.activate()
     def test_non_200_resp_from_fxa_raises_error_and_caches(self):
-        responses.add(
-            responses.POST, self.fxa_verify_path, status=401, json={"error": "401"}
-        )
+        fxa_response = _setup_fxa_response(401, {"error": "401"})
         not_found_token = "not-found-123"
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {not_found_token}")
+
         assert cache.get(get_cache_key(not_found_token)) is None
 
-        headers = {"HTTP_AUTHORIZATION": f"Bearer {not_found_token}"}
-        get_addresses_req = self.factory.get(self.path, **headers)
-        with pytest.raises(AuthenticationFailed):
-            self.auth.authenticate(self.auth, get_addresses_req)
+        response = client.get("/api/v1/relayaddresses/")
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Did not receive a 200 response from FXA."
 
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
-        expected = {"status_code": 401, "json": {"error": "401"}}
-        assert cache.get(get_cache_key(not_found_token)) == expected
+        assert cache.get(get_cache_key(not_found_token)) == fxa_response
 
         # now check that the code does NOT make another fxa request
-        with pytest.raises(AuthenticationFailed):
-            assert self.auth.authenticate(self.auth, get_addresses_req) is None
+        response = client.get("/api/v1/relayaddresses/")
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
     @responses.activate()
     def test_non_200_non_json_resp_from_fxa_raises_error_and_caches(self):
-        responses.add(
-            responses.POST, self.fxa_verify_path, status=503, body="Bad gateway error"
-        )
+        fxa_response = _setup_fxa_response(503, "Bad Gateway")
         not_found_token = "fxa-gw-error"
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {not_found_token}")
+
         assert cache.get(get_cache_key(not_found_token)) is None
 
-        headers = {"HTTP_AUTHORIZATION": f"Bearer {not_found_token}"}
-        get_addresses_req = self.factory.get(self.path, **headers)
-        with pytest.raises(AuthenticationFailed):
-            self.auth.authenticate(self.auth, get_addresses_req)
+        response = client.get("/api/v1/relayaddresses/")
+        assert response.status_code == 500
 
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
-        expected = {"status_code": None, "json": {}}
-        assert cache.get(get_cache_key(not_found_token)) == expected
+        assert cache.get(get_cache_key(not_found_token)) == fxa_response
 
         # now check that the code does NOT make another fxa request
-        with pytest.raises(AuthenticationFailed):
-            assert self.auth.authenticate(self.auth, get_addresses_req) is None
+        response = client.get("/api/v1/relayaddresses/")
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
     @responses.activate()
-    def test_200_resp_from_fxa_inactive_token_raises_error(self):
-        responses.add(
-            responses.POST, self.fxa_verify_path, status=200, json={"active": False}
-        )
+    def test_inactive_token_responds_with_401(self):
+        fxa_response = _setup_fxa_response(200, {"active": False})
         inactive_token = "inactive-123"
-        headers = {"HTTP_AUTHORIZATION": f"Bearer {inactive_token}"}
-        get_addresses_req = self.factory.get(self.path, **headers)
-        with pytest.raises(AuthenticationFailed):
-            assert self.auth.authenticate(self.auth, get_addresses_req) == None
-        assert responses.assert_call_count(self.fxa_verify_path, 1) is True
-        expected = {"status_code": 200, "json": {"active": False}}
-        assert cache.get(get_cache_key(inactive_token)) == expected
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {inactive_token}")
 
-        # the code does NOT make another fxa request
-        with pytest.raises(AuthenticationFailed):
-            assert self.auth.authenticate(self.auth, get_addresses_req) is None
+        assert cache.get(get_cache_key(inactive_token)) is None
+
+        response = client.get("/api/v1/relayaddresses/")
+        assert response.status_code == 401
+        assert response.json()["detail"] == "FXA returned active: False for token."
+        assert responses.assert_call_count(self.fxa_verify_path, 1) is True
+        assert cache.get(get_cache_key(inactive_token)) == fxa_response
+
+        # now check that the code does NOT make another fxa request
+        response = client.get("/api/v1/relayaddresses/")
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
     @responses.activate()
-    def test_200_resp_from_fxa_no_matching_user_raises_AuthenficationFailed(self):
-        response_json = {"active": True, "sub": "not-a-relay-user"}
-        responses.add(
-            responses.POST, self.fxa_verify_path, status=200, json=response_json
+    def test_200_resp_from_fxa_no_matching_user_raises_APIException(self):
+        fxa_response = _setup_fxa_response(
+            200, {"active": True, "sub": "not-a-relay-user"}
         )
         non_user_token = "non-user-123"
-        headers = {"HTTP_AUTHORIZATION": f"Bearer {non_user_token}"}
-        get_addresses_req = self.factory.get(self.path, **headers)
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {non_user_token}")
 
-        with pytest.raises(AuthenticationFailed):
-            self.auth.authenticate(self.auth, get_addresses_req)
-        expected = {"status_code": 200, "json": response_json}
-        assert cache.get(get_cache_key(non_user_token)) == expected
+        assert cache.get(get_cache_key(non_user_token)) is None
+
+        response = client.get("/api/v1/relayaddresses/")
+        assert response.status_code == 403
+        assert (
+            response.json()["detail"]
+            == "Authenticated user does not have a Relay account."
+        )
+        assert cache.get(get_cache_key(non_user_token)) == fxa_response
 
         # the code does NOT make another fxa request
-        with pytest.raises(AuthenticationFailed):
-            self.auth.authenticate(self.auth, get_addresses_req)
+        response = client.get("/api/v1/relayaddresses/")
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
     @responses.activate()
     def test_200_resp_from_fxa_for_user_returns_user_and_caches(self):
         self.sa = baker.make(SocialAccount, uid=self.uid, provider="fxa")
         user_token = "user-123"
-        assert cache.get(get_cache_key(user_token)) is None
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {user_token}")
         now_time = int(datetime.now().timestamp())
         # Note: FXA iat and exp are timestamps in *milliseconds*
         exp_time = (now_time + 60 * 60) * 1000
-        response_json = {"active": True, "sub": self.uid, "exp": exp_time}
-        responses.add(
-            responses.POST, self.fxa_verify_path, status=200, json=response_json
+        fxa_response = _setup_fxa_response(
+            200, {"active": True, "sub": self.uid, "exp": exp_time}
         )
 
+        assert cache.get(get_cache_key(user_token)) is None
+
+        # check the endpoint status code
+        response = client.get("/api/v1/relayaddresses/")
+        assert response.status_code == 200
+        assert responses.assert_call_count(self.fxa_verify_path, 1) is True
+        assert cache.get(get_cache_key(user_token)) == fxa_response
+
+        # check the function returns the right user
         headers = {"HTTP_AUTHORIZATION": f"Bearer {user_token}"}
         get_addresses_req = self.factory.get(self.path, **headers)
         auth_return = self.auth.authenticate(self.auth, get_addresses_req)
         assert auth_return == (self.sa.user, user_token)
-        assert responses.assert_call_count(self.fxa_verify_path, 1) is True
-        expected = {"status_code": 200, "json": response_json}
-        assert cache.get(get_cache_key(user_token)) == expected
 
-        # now check that the code does NOT make another fxa request
-        auth_return = self.auth.authenticate(self.auth, get_addresses_req)
+        # now check that the 2nd call did NOT make another fxa request
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
+        assert cache.get(get_cache_key(user_token)) == fxa_response

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -86,7 +86,7 @@ def test_phone_get_endpoints_require_auth(endpoint):
     client = APIClient()
     path = f"/api/v1/{endpoint}/"
     response = client.get(path)
-    assert response.status_code == 403
+    assert response.status_code == 401
 
     free_user = baker.make(User)
     client.force_authenticate(free_user)
@@ -622,7 +622,7 @@ def test_resend_welcome_sms_requires_phone_user():
     path = "/api/v1/realphone/resend_welcome_sms"
     response = client.post(path)
 
-    assert response.status_code == 403
+    assert response.status_code == 401
 
 
 def test_resend_welcome_sms(phone_user, mocked_twilio_client):

--- a/api/tests/serializers_tests.py
+++ b/api/tests/serializers_tests.py
@@ -20,7 +20,7 @@ class PremiumValidatorsTest(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + free_token.key)
         response = self.client.patch(url, data, format="json")
 
-        assert response.status_code == 403
+        assert response.status_code == 401
         assert free_alias.block_list_emails == False
 
     def test_non_premium_can_clear_block_list_emails(self):

--- a/frontend/src/apiMocks/handlers.ts
+++ b/frontend/src/apiMocks/handlers.ts
@@ -70,7 +70,7 @@ export function getHandlers(
   addGetHandler("/api/v1/users/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
-      return res(ctx.status(403));
+      return res(ctx.status(401));
     }
 
     return res(ctx.status(200), ctx.json([mockedUsers[mockId]]));
@@ -108,7 +108,7 @@ export function getHandlers(
   addGetHandler("/api/v1/profiles/", (req, res, ctx) => {
     const mockId = getMockId(req);
     if (mockId === null) {
-      return res(ctx.status(403));
+      return res(ctx.status(401));
     }
 
     return res(ctx.status(200), ctx.json([mockedProfiles[mockId]]));

--- a/frontend/src/hooks/api/profile.ts
+++ b/frontend/src/hooks/api/profile.ts
@@ -49,8 +49,8 @@ export function useProfiles(): SWRResponse<ProfilesData, unknown> & {
       revalidate,
       revalidateOpts
     ) => {
-      if (error instanceof FetchError && error.response.status === 403) {
-        // When the user is not logged in, this API returns a 403.
+      if (error instanceof FetchError && error.response.status === 401) {
+        // When the user is not logged in, this API returns a 401.
         // If so, do not retry.
         return;
       }

--- a/frontend/src/hooks/api/user.ts
+++ b/frontend/src/hooks/api/user.ts
@@ -19,8 +19,8 @@ export function useUsers() {
       revalidate,
       revalidateOpts
     ) => {
-      if (error instanceof FetchError && error.response.status === 403) {
-        // When the user is not logged in, this API returns a 403.
+      if (error instanceof FetchError && error.response.status === 401) {
+        // When the user is not logged in, this API returns a 401.
         // If so, do not retry.
         return;
       }


### PR DESCRIPTION
…okens

This PR fixes #MPP-2744.

How to test:
0. Run `pytest`
1. Sign into either [this branch of the add-on](https://github.com/mozilla/fx-private-relay-add-on/tree/new-auth-mpp-1531), or [this RN mobile app](https://github.com/codemist/fx-private-relay-mobile-app) to get a Relay-scoped FXA token for stage FXA.
2. Send requests at the API with `Authorization: Bearer <token-from-step-1>`
   * [x] Those requests should work!
3. Wait for the token from step 1 to expire (24 hours?)
4. Send requests at the API with `Authorization: Bearer <token-from-step-1>`
   * [ ] Those requests should receive a `401` response

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).