### PR TITLE
Python dependency updates 2023 01 23

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.50
+boto3==1.26.54
 codetiming==1.4.0
 cryptography==39.0.0
 Django==3.2.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,5 +48,5 @@ black==22.12.0
 mypy==0.991
 types-requests==2.28.11.8
 types-pyOpenSSL==23.0.0.2
-django-stubs==1.13.1
+django-stubs==1.13.2
 djangorestframework-stubs==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ black==22.12.0
 
 # type hinting
 mypy==0.991
-types-requests==2.28.11.7
+types-requests==2.28.11.8
 types-pyOpenSSL==23.0.0.1
 django-stubs==1.13.1
 djangorestframework-stubs==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,6 @@ black==22.12.0
 # type hinting
 mypy==0.991
 types-requests==2.28.11.8
-types-pyOpenSSL==23.0.0.1
+types-pyOpenSSL==23.0.0.2
 django-stubs==1.13.1
 djangorestframework-stubs==1.8.0


### PR DESCRIPTION
Update dependencies. This covers:

* Bump boto3 from 1.26.50 to 1.26.54 (from PR #3028)
* Bump django-stubs from 1.13.1 to 1.13.2 (from PR #3027)
* Bump types-pyopenssl from 23.0.0.1 to 23.0.0.2 (from PR #3026)
* Bump types-requests from 2.28.11.7 to 2.28.11.8 (from PR #3025)