### PR TITLE
fix MPP-2621: add_user_to_group command to add users to groups

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -294,6 +294,12 @@ class Profile(models.Model):
     def has_phone(self):
         if not self.fxa:
             return False
+        if settings.RELAY_CHANNEL != "prod" and not settings.IN_PYTEST:
+            try:
+                phone_flag = Flag.objects.get(name="phones")
+            except Flag.DoesNotExist:
+                return False
+            return phone_flag.is_active_for_user(self.user)
         flags = Flag.objects.filter(name="free_phones")
         for flag in flags:
             if flag.is_active_for_user(self.user):

--- a/emails/models.py
+++ b/emails/models.py
@@ -299,7 +299,8 @@ class Profile(models.Model):
                 phone_flag = Flag.objects.get(name="phones")
             except Flag.DoesNotExist:
                 return False
-            return phone_flag.is_active_for_user(self.user)
+            if not phone_flag.is_active_for_user(self.user):
+                return False
         flags = Flag.objects.filter(name="free_phones")
         for flag in flags:
             if flag.is_active_for_user(self.user):

--- a/privaterelay/management/commands/add_user_to_group.py
+++ b/privaterelay/management/commands/add_user_to_group.py
@@ -1,0 +1,16 @@
+from django.contrib.auth.models import Group, User
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Add a user (by email address) to a group (by name)"
+
+    def add_arguments(self, parser):
+        parser.add_argument("email", nargs=1)
+        parser.add_argument("group", nargs=1)
+
+    def handle(self, *args, **options):
+        user = User.objects.get(email=options["email"][0])
+        group = Group.objects.get(name=options["group"][0])
+        group.user_set.add(user)
+        print(f"Added {user} to {group}")


### PR DESCRIPTION
This PR fixes MPP-2621. It restores a `phone` feature flag check in non-`prod` Relay environments, and includes instructions and a new command to:
1. Create a new `stage_phone_users` group
2. Enable the `phones` flag for this group
3. Add users to the `stage_phone_users` group to enable `phones` for them.

How to test:
1. Change the `phones` waffle flag to `Everyone: None`:
   `python manage.py waffle_flag phones`
4. Check that phone features no longer work for any users
   * [ ] Check the "Phone number" tab at the top of the site is gone
   * [ ] Phone API endpoints at http://127.0.0.1:8000/api/v1/ should return permission denied
5. Create a new `stage_phone_users` group:
   `python manage.py get_or_create_user_group stage_phone_users`
6. Change the `phones` waffle flag to `Everyone: None ... group(s): ['stage_phone_users']`:
   `python manage.py waffle_flag phones`
7. Use this new command to add a user to the group:
   `python manage.py add_user_to_group <your-users@emailaddress.com> stage_phone_users`
8. Check that phone features only work for the user from step 5
   * [ ] Check the "Phone number" tab at the top of the site is back!
   * [ ] Phone API endpoints at http://127.0.0.1:8000/api/v1/ should work!

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).