### PR TITLE
MPP-2721: Handle uppercase letters in domain adresses

### DIFF
--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -755,30 +755,26 @@ class GetAddressTest(TestCase):
     @patch("emails.views.incr_if_enabled")
     @patch("emails.views.logger")
     def test_unknown_relay_address_raises(self, logging_mocked, incr_mocked):
-        try:
+        with pytest.raises(RelayAddress.DoesNotExist):
             _get_address(
                 to_address=f"{self.local_portion}@{self.service_domain}",
                 local_portion={self.local_portion},
                 domain_portion=f"{self.service_domain}",
             )
-        except Exception as e:
-            assert e.args[0] == "RelayAddress matching query does not exist."
-            incr_mocked.assert_called_once_with("email_for_unknown_address", 1)
+        incr_mocked.assert_called_once_with("email_for_unknown_address", 1)
 
     @patch("emails.views.incr_if_enabled")
     def test_deleted_relay_address_raises(self, incr_mocked):
         hashed_address = address_hash(self.local_portion, domain=self.service_domain)
         baker.make(DeletedAddress, address_hash=hashed_address)
 
-        try:
+        with pytest.raises(RelayAddress.DoesNotExist):
             _get_address(
                 to_address=f"{self.local_portion}@{self.service_domain}",
                 local_portion=self.local_portion,
                 domain_portion=self.service_domain,
             )
-        except Exception as e:
-            assert e.args[0] == "RelayAddress matching query does not exist."
-            incr_mocked.assert_called_once_with("email_for_deleted_address", 1)
+        incr_mocked.assert_called_once_with("email_for_deleted_address", 1)
 
     @patch("emails.views.incr_if_enabled")
     def test_multiple_deleted_relay_addresses_raises_same_as_one(self, incr_mocked):
@@ -787,15 +783,13 @@ class GetAddressTest(TestCase):
         baker.make(DeletedAddress, address_hash=hashed_address)
         baker.make(DeletedAddress, address_hash=hashed_address)
 
-        try:
+        with pytest.raises(RelayAddress.DoesNotExist):
             _get_address(
                 to_address=f"{self.local_portion}@{self.service_domain}",
                 local_portion=self.local_portion,
                 domain_portion=f"{self.service_domain}",
             )
-        except Exception as e:
-            assert e.args[0] == "RelayAddress matching query does not exist."
-            incr_mocked.assert_called_once_with("email_for_deleted_address_multiple", 1)
+        incr_mocked.assert_called_once_with("email_for_deleted_address_multiple", 1)
 
     @patch("emails.views._get_domain_address")
     def test_existing_domain_address(self, _get_domain_address_mocked):

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -735,9 +735,7 @@ class SnsMessageTest(TestCase):
         assert response.status_code == 200
 
 
-@override_settings(
-    SITE_ORIGIN="https://test.com", RELAY_CHANNEL="test", STATSD_ENABLED=True
-)
+@override_settings(SITE_ORIGIN="https://test.com", STATSD_ENABLED=True)
 class GetAddressTest(TestCase):
     def setUp(self):
         self.user = make_premium_test_user()

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -420,6 +420,18 @@ class SNSNotificationRemoveEmailsInS3Test(TestCase):
         assert response.status_code == 200
         assert response.content == b"noreply address is not supported."
 
+    @patch("emails.views.remove_message_from_s3")
+    def test_noreply_mixed_case_email_in_s3_deleted(self, mocked_message_removed):
+        message_w_email_to_noreply = EMAIL_SNS_BODIES["s3_stored"]["Message"].replace(
+            "sender@test.com", "NoReply@default.com"
+        )
+        notification_w_email_to_noreply = EMAIL_SNS_BODIES["s3_stored"].copy()
+        notification_w_email_to_noreply["Message"] = message_w_email_to_noreply
+        response = _sns_notification(notification_w_email_to_noreply)
+        mocked_message_removed.assert_called_once_with(self.bucket, self.key)
+        assert response.status_code == 200
+        assert response.content == b"noreply address is not supported."
+
     @override_settings(STATSD_ENABLED=True)
     @patch("emails.views.remove_message_from_s3")
     @patch("emails.views._get_keys_from_headers")

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -759,6 +759,24 @@ class GetAddressTest(TestCase):
         )
         assert actual == self.relay_address
 
+    def test_uppercase_local_part_of_existing_relay_address(self):
+        """Case-insensitive matching is used for the local part of relay addresses."""
+        actual = _get_address(
+            to_address="Relay123@test.com",
+            local_portion="Relay123",
+            domain_portion="test.com",
+        )
+        assert actual == self.relay_address
+
+    def test_uppercase_domain_part_of_existing_relay_address(self):
+        """Case-insensitive matching is used for the domain part of relay addresses."""
+        actual = _get_address(
+            to_address="relay123@Test.Com",
+            local_portion="relay123",
+            domain_portion="Test.Com",
+        )
+        assert actual == self.relay_address
+
     def test_unknown_relay_address_raises(self):
         with pytest.raises(RelayAddress.DoesNotExist), MetricsMock() as mm:
             _get_address(
@@ -798,11 +816,29 @@ class GetAddressTest(TestCase):
         assert actual == self.domain_address
 
     def test_uppercase_local_part_of_existing_domain_address(self):
-        """Uppercase letters are allowed in the local part of a domain address."""
+        """Case-insensitive matching is used in the local part of a domain address."""
         actual = _get_address(
             to_address="Domain@subdomain.test.com",
             local_portion="Domain",
             domain_portion="subdomain.test.com",
+        )
+        assert actual == self.domain_address
+
+    def test_uppercase_subdomain_part_of_existing_domain_address(self):
+        """Case-insensitive matching is used in the subdomain of a domain address."""
+        actual = _get_address(
+            to_address="domain@SubDomain.test.com",
+            local_portion="domain",
+            domain_portion="SubDomain.test.com",
+        )
+        assert actual == self.domain_address
+
+    def test_uppercase_domain_part_of_existing_domain_address(self):
+        """Case-insensitive matching is used in the domain part of a domain address."""
+        actual = _get_address(
+            to_address="domain@subdomain.Test.Com",
+            local_portion="domain",
+            domain_portion="subdomain.Test.Com",
         )
         assert actual == self.domain_address
 

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -261,7 +261,8 @@ class ComplaintHandlingTest(TestCase):
     @override_settings(STATSD_ENABLED=True)
     def test_notification_type_complaint(self):
         """
-        A notificationType of complaint increments a counter, logs details, and returns 200.
+        A notificationType of complaint increments a counter, logs details, and
+        returns 200.
 
         Example derived from:
         https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html#complaint-object
@@ -274,7 +275,9 @@ class ComplaintHandlingTest(TestCase):
                 "complaintFeedbackType": "abuse",
                 "arrivalDate": "2009-12-03T04:24:21.000-05:00",
                 "timestamp": "2012-05-25T14:59:38.623Z",
-                "feedbackId": "000001378603177f-18c07c78-fa81-4a58-9dd1-fedc3cb8f49a-000000",
+                "feedbackId": (
+                    "000001378603177f-18c07c78-fa81-4a58-9dd1-fedc3cb8f49a-000000"
+                ),
             },
         }
         json_body = {"Message": json.dumps(complaint)}
@@ -423,7 +426,9 @@ class SNSNotificationRemoveEmailsInS3Test(TestCase):
     def test_noreply_headers_reply_email_in_s3_deleted(
         self, mocked_get_keys, mocked_message_removed
     ):
-        """If replies@... email has no "In-Reply-To" header, delete email, return 400."""
+        """
+        If replies@... email has no "In-Reply-To" header, delete email, return 400.
+        """
         mocked_get_keys.side_effect = ReplyHeadersNotFound()
 
         with MetricsMock() as mm:
@@ -1136,7 +1141,8 @@ def test_wrapped_email_test(
         "Yes" if int(num_level_one_email_trackers_removed) else "No"
     )
     assert (
-        f"<dt>has_num_level_one_email_trackers_removed</dt><dd>{has_num_level_one_email_trackers_removed}</dd>"
+        "<dt>has_num_level_one_email_trackers_removed</dt>"
+        f"<dd>{has_num_level_one_email_trackers_removed}</dd>"
     ) in no_space_html
 
 
@@ -1144,7 +1150,10 @@ def test_wrapped_email_test(
 @pytest.mark.parametrize("content_type", ("text/plain", "text/html"))
 @pytest.mark.django_db
 def test_reply_requires_premium_test(rf, forwarded, content_type):
-    url = f"/emails/reply_requires_premium_test?forwarded={forwarded}&content-type={content_type}"
+    url = (
+        "/emails/reply_requires_premium_test"
+        f"?forwarded={forwarded}&content-type={content_type}"
+    )
     request = rf.get(url)
     response = reply_requires_premium_test(request)
     assert response.status_code == 200

--- a/emails/views.py
+++ b/emails/views.py
@@ -400,7 +400,7 @@ def _sns_message(message_json):
         # TODO: Add metric
         return HttpResponse("Malformed to field.", status=400)
 
-    if to_local_portion == "noreply":
+    if to_local_portion.lower() == "noreply":
         incr_if_enabled("email_for_noreply_address", 1)
         return HttpResponse("noreply address is not supported.")
     try:
@@ -415,7 +415,7 @@ def _sns_message(message_json):
         CannotMakeAddressException,
         DeletedAddress.MultipleObjectsReturned,
     ):
-        if to_local_portion == "replies":
+        if to_local_portion.lower() == "replies":
             response = _handle_reply(from_address, message_json, to_address)
         else:
             response = HttpResponse("Address does not exist", status=404)

--- a/emails/views.py
+++ b/emails/views.py
@@ -179,8 +179,10 @@ def wrapped_email_test(request):
         has_tracker_report_link = False
     if has_tracker_report_link:
         tracker_report_link = (
-            '/tracker-report/#{"sender": "sender@example.com", "received_at": 1658434657,'
-            + '"trackers": {"fake-tracker.example.com": 2}}'
+            "/tracker-report/#{"
+            '"sender": "sender@example.com", '
+            '"received_at": 1658434657, '
+            '"trackers": {"fake-tracker.example.com": 2}}'
         )
     else:
         tracker_report_link = ""
@@ -662,8 +664,8 @@ def _build_reply_requires_premium_email(
     message_id,
     decrypted_metadata,
 ):
-    # If we haven't forwaded a first reply for this user yet, _reply_allowed will forward.
-    # So, tell the user we forwarded it.
+    # If we haven't forwaded a first reply for this user yet, _reply_allowed
+    # will forward.  So, tell the user we forwarded it.
     forwarded = not reply_record.address.user.profile.forwarded_first_reply
     sender = ""
     if decrypted_metadata is not None:
@@ -982,7 +984,8 @@ def _get_text_html_attachments(message_json):
     bytes_email_message = message_from_bytes(message_content, policy=policy.default)
 
     text_content, html_content, attachments = _get_all_contents(bytes_email_message)
-    # TODO add logs on the entire size of the email and the time it takes to download/process
+    # TODO: add logs on the entire size of the email and the time it takes to
+    # download/process
     return text_content, html_content, attachments, email_size
 
 


### PR DESCRIPTION
When a domain address is created on the website, it is always lowercase. When a domain address is created in the field (such as asking for an email to send a receipt for checkout), it may include capital letters, as noted in MPP-2721. This PR allows capital letters in the local portion of a domain address, so that these are equivalent:

* `hotel@mysubdomain.mozmail.com` (how it appears in the database and the dashboard)
* `Hotel@mysubdomain.mozmail.com`
* `HOTEL@mysubdomain.mozmail.com`

Capitals in the subdomain portion are not allowed by the code, but are also not allowed domain names, so (most?) mail clients and server would also allow:

* `Hotel@MySubdomain.mozmail.com`

In addition:

* Wrap some long lines to fix flake8
* Re-write the `GetAddressTest` tests, to fix some existing issues (such as tests passing when expected exception is not raised) and some aesthetic issues (test order, longer than needed test names, consistent names)

## How to test

* Get emails working locally, with a custom subdomain and a domain address, and with `./manage.py process_emails_from_sqs` running
* Send an email to an existing domain address, but with a capital letter in the local part (for example, `Domain@subdomain.mymail.com` for `domain@subdomain.mymail.com`)
    * [x] The email is delivered to the true address
    * [x] The dashboard Forwarded count is incremented (after refresh)
* Send an email to a new domain address, with a capital letter in the local part (for example, `NewAddress@subdomain.mymail.com`)
    * [x] The email is delivered to the true address
    * [x] The dashboard shows the new domain address with lower-case letters (after refresh)
* Send an email to with a capital letter in the subdomain part (for example, `TryThis@Subdomain.mymail.com`)
    * [x] The email is delivered to the true address
    * [x] The dashboard shows the new domain address with lower-case letters (after refresh)

## Checklist

- [x] I've added unit tests to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
