### PR TITLE
Python dependency updates 2023 01 31

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ sentry-sdk==1.13.0
 whitenoise==6.3.0
 
 # phones app
-phonenumbers==8.13.4
+phonenumbers==8.13.5
 twilio==7.16.1
 vobject==0.9.6.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ vobject==0.9.6.1
 
 # tests
 coverage==7.1.0
-model-bakery==1.9.0
+model-bakery==1.10.1
 pytest-cov==4.0.0
 pytest-django==4.5.2
 responses==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ twilio==7.16.1
 vobject==0.9.6.1
 
 # tests
-coverage==7.0.5
+coverage==7.1.0
 model-bakery==1.9.0
 pytest-cov==4.0.0
 pytest-django==4.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyJWT==2.6.0
 python-decouple==3.7
 pyOpenSSL==23.0.0
 requests==2.28.2
-sentry-sdk==1.13.0
+sentry-sdk==1.14.0
 whitenoise==6.3.0
 
 # phones app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.54
+boto3==1.26.59
 codetiming==1.4.0
 cryptography==39.0.0
 Django==3.2.16


### PR DESCRIPTION
Update dependencies. This covers:

* Bump model-bakery from 1.9.0 to 1.10.1 (from PR #3049)
* Bump sentry-sdk from 1.13.0 to 1.14.0 (from PR #3048)
* Bump coverage from 7.0.5 to 7.1.0 (from PR #3047)
* Bump boto3 from 1.26.54 to 1.26.59 (from PR #3046)
* Bump phonenumbers from 8.13.4 to 8.13.5 (from PR #3045)