### PR TITLE
Python Dependency updates, February 6, 2023

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,5 +47,5 @@ black==22.12.0
 mypy==0.991
 types-requests==2.28.11.8
 types-pyOpenSSL==23.0.0.2
-django-stubs==1.13.2
+django-stubs==1.14.0
 djangorestframework-stubs==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ whitenoise==6.3.0
 
 # phones app
 phonenumbers==8.13.5
-twilio==7.16.1
+twilio==7.16.2
 vobject==0.9.6.1
 
 # tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.59
+boto3==1.26.64
 codetiming==1.4.0
 cryptography==39.0.0
 Django==3.2.17


### PR DESCRIPTION
Update dependencies. This covers:

* Bump boto3 from 1.26.59 to 1.26.64 (from PR #3071)
* Bump django-stubs from 1.13.2 to 1.14.0 (from PR #3070)
* Bump twilio from 7.16.1 to 7.16.2 (from PR #3069)