### PR TITLE
Have Dependabot also check the root lockfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/frontend"
+    directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
In the switchover to the newest Node and associated npm versions, I regenerated the lockfiles, which resulted in a single lockfile at the root of the repository, like in the example at https://docs.npmjs.com/cli/v7/using-npm/workspaces#defining-workspaces

However, it looks like Dependabot is now unable to update that lockfile, because it's only looking at the `/frontend` directory (this is why [the JS Dependabot PRs](https://github.com/mozilla/fx-private-relay/pulls?q=is%3Apr+is%3Aopen+label%3Ajavascript) have failing builds). Having it look at the root as well should hopefully fix that. (If not, we might want to look at removing the top-level package.json and the use of a workspace, since the root isn't an npm project anyway.)
