### PR TITLE
Python Dependency updates, 2023-02-14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyJWT==2.6.0
 python-decouple==3.7
 pyOpenSSL==23.0.0
 requests==2.28.2
-sentry-sdk==1.14.0
+sentry-sdk==1.15.0
 whitenoise==6.3.0
 
 # phones app

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ sentry-sdk==1.14.0
 whitenoise==6.3.0
 
 # phones app
-phonenumbers==8.13.5
+phonenumbers==8.13.6
 twilio==7.16.2
 vobject==0.9.6.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ django-referrer-policy==1.0
 djangorestframework==3.14.0
 django-waffle==3.0.0
 dockerflow==2022.8.0
-drf-yasg==1.21.4
+drf-yasg==1.21.5
 google-measurement-protocol==1.1.0
 gunicorn==20.1.0
 jwcrypto==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ whitenoise==6.3.0
 
 # phones app
 phonenumbers==8.13.6
-twilio==7.16.2
+twilio==7.16.3
 vobject==0.9.6.1
 
 # tests


### PR DESCRIPTION
Update dependencies. This covers:

* Bump sentry-sdk from 1.14.0 to 1.15.0 (from PR #3086)
* Bump twilio from 7.16.2 to 7.16.3 (from PR #3085)
* Bump drf-yasg from 1.21.4 to 1.21.5 (from PR #3084)
* Bump phonenumbers from 8.13.5 to 8.13.6 (from PR #3083)