### PR TITLE
Update to Django 3.2.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.26.64
 codetiming==1.4.0
 cryptography==39.0.1
-Django==3.2.17
+Django==3.2.18
 dj-database-url==1.2.0
 django-allauth==0.52.0
 django-cors-headers==3.13.0


### PR DESCRIPTION
3.2.18 is a [security release](https://www.djangoproject.com/weblog/2023/feb/14/security-releases/) that addresses a denial-of-service attack via multi-part upload forms. Since we do not use Django's upload feature, this is not a risk to Relay, but we'd like to update for security releases as soon as we can.