### PR TITLE
circleci: Only store pytest results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ jobs:
             exit $TEST_STATUS
 
       - store_test_results:
-          path: /tmp/workspace/test-results
+          path: /tmp/workspace/test-results/pytest
 
       - persist_to_workspace:
           root: /tmp/workspace


### PR DESCRIPTION
Between [build 11713](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/11713/workflows/9a4be9d8-eaba-40de-b8ac-a4a3cd3a04d6/jobs/77879) on Monday, Jan 30th and [build 11714](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/11714/workflows/6cb3d7b9-185c-476a-af53-bbdc160fa435/jobs/77893) on Tuesday, Jan 31st, the "Uploading test results" step started appearing as red for failure. The step output is the same, the `build_test_backend` job continues to succeed, and the [test tab](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/11714/workflows/6cb3d7b9-185c-476a-af53-bbdc160fa435/jobs/77893/tests) continues to be populated from the `pytest` results.

![build 11713 green](https://user-images.githubusercontent.com/286017/219090486-972407aa-7cb2-4f29-a456-6dcf52109bd6.png)

![build 11714 red](https://user-images.githubusercontent.com/286017/219090524-590107ae-43c5-48dc-bcac-e5b3878df234.png)

To avoid confusion over the "failed" step, only upload the `pytest` results in the "Uploading test results" step. See the [CircleCI results for this PR](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/11920/workflows/65066590-eace-45ef-8c43-302bf580924b/jobs/80304) to see that it works.