### PR TITLE
circleci: Use --workspace instead of app-dir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@
 #
 version: 2.1
 orbs:
-  node: circleci/node@5.0.3
+  node: circleci/node@5.1.0
   python: circleci/python@2.1.1
   heroku: circleci/heroku@1.2.6
 commands:
@@ -38,11 +38,10 @@ jobs:
       - node/install:
           node-version: '18'
       - node/install-packages:
-          app-dir: ./frontend/
+        override-ci-command: npm ci --workspace frontend
       - run:
           name: Build Code
-          command: npm run build
-          working_directory: ./frontend/
+          command: npm run build --workspace frontend
       - save_cache:
           key: v1-frontend-build-{{ .Branch }}-{{ .Revision }}
           paths:
@@ -59,24 +58,20 @@ jobs:
       - node/install:
           node-version: '18'
       - node/install-packages:
-          app-dir: ./frontend/
-
+        override-ci-command: npm ci --workspace frontend
       - run:
           name: Check licences of frontend dependencies
-          command: npm run licensecheck
-          working_directory: ./frontend/
+          command: npm run licensecheck --workspace frontend
       - run:
           name: Lint Code
-          command: npm run lint -- --max-warnings=0
-          working_directory: ./frontend/
+          command: npm run lint --workspace frontend -- --max-warnings=0
       - run:
           name: Test Code
           command: |
             mkdir --parents /tmp/workspace/test-results/frontend-coverage
-            npm test -- \
+            npm test --workspace frontend -- \
               --ci \
               --coverageDirectory=/tmp/workspace/test-results/frontend-coverage
-          working_directory: ./frontend/
       - store_test_results:
           path: frontend/junit.xml
       - store_artifacts:


### PR DESCRIPTION
Run commands with ``--workspace frontend`` instead of setting ``app-dir`` to frontend, so that the CircleCI node orb will see ``package-lock.json`` in the root folder when caching dependencies.

In recent [build 11916](https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/11916/workflows/880480f7-e8a6-46be-a97f-f712b8d6590e/jobs/80256), the package cache steps are failing due to missing `package-lock.json`:

![build 11916 red](https://user-images.githubusercontent.com/286017/219100905-af09c1d8-a96a-441a-b3ba-521c500a4416.png)

This error started around the update to Node 18.

The error on Restoring Cache is:

> `error computing cache key: template: cacheKey:1:41: executing "cacheKey" at <checksum "/tmp/node-project-lockfile">: error calling checksum: open /tmp/node-project-lockfile: no such file or directory`


and the error on Saving Cache:

> `Error computing cache key: template: cacheKey:1:41: executing "cacheKey" at <checksum "/tmp/node-project-lockfile">: error calling checksum: open /tmp/node-project-lockfile: no such file or directory`

This file is created in the previous step "Determine lockfile", which looks in the current directory:

```sh
# Link corresponding lock file to a temporary file used by cache commands
if [ -f "package-lock.json" ]; then
    echo "Found package-lock.json file, assuming lockfile"
    cp package-lock.json $TARGET_DIR/node-project-lockfile
elif [ -f "npm-shrinkwrap.json" ]; then
    echo "Found npm-shrinkwrap.json file, assuming lockfile"
    cp npm-shrinkwrap.json $TARGET_DIR/node-project-lockfile
elif [ -f "yarn.lock" ]; then
    echo "Found yarn.lock file, assuming lockfile"
    cp yarn.lock $TARGET_DIR/node-project-lockfile
fi
```

By running in the root directory, CircleCI should find the `package-lock.json` file.