### PR TITLE
MPP-2881: Run tests with Django 4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,6 +351,9 @@ jobs:
       - run:
           name: Set test defaults
           command: cp .env-dist .env
+      - run:
+          name: Create empty staticfiles directory
+          command: mkdir -p staticfiles
       - when:
           condition: << parameters.production_with_new_migrations >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,6 +527,19 @@ workflows:
             tags:
               only: /.*/
 
+      - python_job:
+          name: django 4.2 test
+          # YAML ">-" removes newlines, including the last, needed for
+          # multi-step command that can fail.
+          command: >-
+            pip install --pre --upgrade "Django<5";
+            pytest --maxfail=3 --junit-xml=job-results/pytest-django-4-2.xml .
+          has_results: true
+          allow_fail: true
+          filters:
+            tags:
+              only: /.*/
+
       - test_frontend:
           requires:
             - build_frontend


### PR DESCRIPTION
For MPP-2881 / Issue #3126, run our tests against the beta release of Django 4.2