### PR TITLE
Documentation: running npm scripts on frontend as a windows user

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Please refer to our [coding standards](docs/coding-standards.md) for code styles
    cd ../
    ```
 
+   Note: If you're running on Windows, you may run into an issue with usage of environment variables in npm scripts. You can force npm to use git-bash: `npm config set script-shell "C:\\Program Files\\Git\\bin\\bash.exe"`. This the default location, your install may be different.
+
 4. Copy `.env` file for
    [`decouple`](https://pypi.org/project/python-decouple/) config:
 


### PR DESCRIPTION
 # New feature description

Update readme to provide debug help for windows users running npm scripts. We were running into issues where environment variables were breaking our usage of scripts, such as `npm run watch`. 

Example: `"watch_build": "NEXT_PUBLIC_DEBUG=true npm run build"`

This would break OR we would have to rewrite is as ` "watch_build": "set NEXT_PUBLIC_DEBUG=true && npm run build"` which is Windows specific. 
 