### PR TITLE
Python dependency updates, 2023-03-01

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ whitenoise==6.3.0
 
 # phones app
 phonenumbers==8.13.6
-twilio==7.16.3
+twilio==7.16.4
 vobject==0.9.6.1
 
 # tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.64
+boto3==1.26.79
 codetiming==1.4.0
 cryptography==39.0.1
 Django==3.2.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,4 +48,4 @@ mypy==1.0.1
 types-pyOpenSSL==23.0.0.3
 types-requests==2.28.11.13
 django-stubs==1.14.0
-djangorestframework-stubs==1.8.0
+djangorestframework-stubs==1.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cryptography==39.0.1
 Django==3.2.18
 dj-database-url==1.2.0
 django-allauth==0.52.0
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
 django-csp==3.7
 django-debug-toolbar==3.8.1
 django-filter==22.1


### PR DESCRIPTION
Update dependencies. This covers:

* Bump django-cors-headers from 3.13.0 to 3.14.0 (from PR #3130)
* Bump djangorestframework-stubs from 1.8.0 to 1.9.1 (from PR #3131)
* Bump boto3 from 1.26.64 to 1.26.79 (from PR #3132)
* Bump twilio from 7.16.3 to 7.16.4 (from PR #3133)