### PR TITLE
Handle FxA change event without emailaddress

### DIFF
--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -127,6 +127,27 @@ class UpdateExtraDataAndEmailTest(TestCase):
         assert sa2.extra_data == extra_data
         assert ea2.email == "user2@example.com"
 
+    def test_update_all_data_no_email_address(self):
+        user = baker.make(User)
+        sa = baker.make(
+            SocialAccount,
+            user=user,
+            provider="fxa",
+            extra_data=json.loads('{"test": "test"}'),
+        )
+        new_extra_data = json.loads('{"test": "updated"}')
+        new_email = "newemail@example.com"
+
+        response = _update_all_data(sa, new_extra_data, new_email)
+
+        assert response.status_code == 202
+
+        sa.refresh_from_db()
+        assert sa.extra_data == new_extra_data
+
+        ea = sa.user.emailaddress_set.get()
+        assert ea.email == new_email
+
 
 @pytest.mark.django_db
 def test_logout_page(client, settings):

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -351,8 +351,11 @@ def _update_all_data(
             social_account.user.email = new_email
             social_account.user.save()
             email_address_record = social_account.user.emailaddress_set.first()
-            email_address_record.email = new_email
-            email_address_record.save()
+            if email_address_record:
+                email_address_record.email = new_email
+                email_address_record.save()
+            else:
+                social_account.user.emailaddress_set.create(email=new_email)
             return HttpResponse("202 Accepted", status=202)
     except IntegrityError as e:
         sentry_sdk.capture_exception(e)


### PR DESCRIPTION
When there is no existing `emailaddress` record for the user in an FxA change event, create a new `emailaddress` record.

This PR fixes #3155.