### PR TITLE
Mark two flaky tests as slow

### DIFF
--- a/e2e-tests/specs/relay-e2e.spec.ts
+++ b/e2e-tests/specs/relay-e2e.spec.ts
@@ -15,6 +15,10 @@ test.describe('Relay e2e function email forwarding', () => {
       dashboardPage,
       page
     }) => {
+        // This tests creates a new Firefox Account with a new mask, to have
+        // the signup confirmation email show up in the forwarded email count.
+        // This is a pretty slow process:
+        test.slow()
         await dashboardPage.open()
         await checkAuthState(page)
         const forwardedEmailCount = await dashboardPage.checkForwardedEmailCount()

--- a/e2e-tests/specs/relay-general-functionality.spec.ts
+++ b/e2e-tests/specs/relay-general-functionality.spec.ts
@@ -11,6 +11,8 @@ test.describe('Free - General Functionalities, Desktop', () => {
   });
   
   test('Check the free user can only create 5 masks, C1553067', async ({ dashboardPage }) => {
+    // Generating five masks takes a while:
+    test.slow()
     await dashboardPage.generateMask(5)
     
     // After five times, the button becomes greyed-out and the user cannot add other masks anymore (TODO: for a free user from a country where Premium is NOT available).


### PR DESCRIPTION
The "can use masks and receive emails" test has been failing on Firefox ever since our upgrade to Playwright 1.30.0 from 1.24.0: https://github.com/mozilla/fx-private-relay/pull/3098

It's not clear what exactly in the upgrade would cause it to fail consistently, but it was flaky already before that, and the other test was too on Chromium. See e.g.
https://github.com/mozilla/fx-private-relay/actions/runs/4132141922/jobs/7140490726

Hopefully, giving them some more time to resolve should make them pass more consistently. We could also specifically mark the browser they are slow in in the callback, if we want. For more info, see https://playwright.dev/docs/api/class-test#test-slow-1