### PR TITLE
Python dependency updates, 2023-03-06

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,6 @@ black==22.12.0
 # type hinting
 mypy==1.0.1
 types-pyOpenSSL==23.0.0.3
-types-requests==2.28.11.13
+types-requests==2.28.11.15
 django-stubs==1.14.0
 djangorestframework-stubs==1.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyJWT==2.6.0
 python-decouple==3.7
 pyOpenSSL==23.0.0
 requests==2.28.2
-sentry-sdk==1.15.0
+sentry-sdk==1.16.0
 whitenoise==6.3.0
 
 # phones app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.81
+boto3==1.26.84
 codetiming==1.4.0
 cryptography==39.0.2
 Django==3.2.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.26.81
 codetiming==1.4.0
-cryptography==39.0.1
+cryptography==39.0.2
 Django==3.2.18
 dj-database-url==1.2.0
 django-allauth==0.52.0


### PR DESCRIPTION
Update dependencies. This covers:

* build(deps): bump types-requests from 2.28.11.13 to 2.28.11.15 (from PR #3157)
* build(deps): bump sentry-sdk from 1.15.0 to 1.16.0 (from PR #3158)
* build(deps): bump cryptography from 39.0.1 to 39.0.2 (from PR #3159)
* build(deps): bump boto3 from 1.26.81 to 1.26.84 (from PR #3160)
