### PR TITLE
MPP-2557 Email mask search doesn't work when pasting a value

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -201,9 +201,9 @@ export const AliasList = (props: Props) => {
       </Localized>
     ) : null;
 
-  const handleOnChange = (value: string) => { 
+  const handleOnChange = (value: string) => {
     // removes Unicode characters found within the range of 0080 to FFFF
-    setStringFilterInput(value.replace(/[\u{0080}-\u{FFFF}]/gu,"")); 
+    setStringFilterInput(value.replace(/[\u{0080}-\u{FFFF}]/gu, ""));
   };
 
   return (

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -201,6 +201,11 @@ export const AliasList = (props: Props) => {
       </Localized>
     ) : null;
 
+  const handleOnChange = (value: string) => { 
+    // removes Unicode characters found within the range of 0080 to FFFF
+    setStringFilterInput(value.replace(/[\u{0080}-\u{FFFF}]/gu,"")); 
+  };
+
   return (
     <section>
       <div className={styles.controls}>
@@ -216,7 +221,7 @@ export const AliasList = (props: Props) => {
           </VisuallyHidden>
           <input
             value={stringFilterInput}
-            onChange={(e) => setStringFilterInput(e.target.value)}
+            onChange={(e) => handleOnChange(e.target.value)}
             type="search"
             name="stringFilter"
             id="stringFilter"


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-2557 
 
<!-- When adding a new feature: -->

# New feature description
This removes unicode characters from mask search input field in the range of 0080 - FFFF

# Screenshot (if applicable)  

https://user-images.githubusercontent.com/3924990/223929508-ef910392-6f39-4710-a9c0-87ecce9a895d.mp4


# How to test

(from @groovecoder 's original post)
To reproduce it, copy the mask FROM A FORWARDED EMAIL HEADER.

I.e., if I copy zraxcgs95@relay.firefox.com... and then paste it into the search field - it works fine.

If I copy ⁨`<U+2068>`resume@lloan.mozmail.com`<U+2069>`⁩ (note: it has unicode characters around it!) from a forwarded email header and paste it into the search field - it doesn’t work.

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
