### PR TITLE
Wrapped email template styling update

### DIFF
--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -29,23 +29,23 @@
       box-sizing: border-box;
     }
 
-    body {
+    #relay-email {
       font-family: 'inter', Arial, sans-serif;
       color: #3D3D3D;
     }
 
-    p {
+    #relay-email p {
       color: #FFFFFF;
       font-size: 12px;
     }
  
-    a { 
+    a.container-link { 
       transition: all 0.2s ease;
       text-underline-offset: 2px;
       font-family: 'inter medium', Arial, sans-serif;
     }
 
-    a:hover {
+    a.container-link:hover {
       color: #20123ad5;
       transition: all 0.2s ease;
     }
@@ -55,9 +55,9 @@
       font-size: 12px;
     }
 
-    a:hover,
-    a:focus,
-    a:active {
+    a.container-link:hover,
+    a.container-link:focus,
+    a.container-link:active {
       transition: all 0.2s ease;
     }
 
@@ -66,22 +66,7 @@
       vertical-align: bottom; 
     }
 
-    @media screen and (max-width: 768px) {
-      .header-block {
-        display: block;
-        width: 100%;
-        text-align: left;
-      }
-
-      .header-block:nth-child(2) {
-        margin-left: 40px;
-      }
-
-      .header-block:nth-child(2)>p {
-        width: 100%;
-        display: block;
-      }
-
+    @media screen and (max-width: 768px) { 
       .footer-block {
         display: block;
         width: 100%;
@@ -92,19 +77,58 @@
         height: 45px;
         width: auto;
       }
-    }   
+
+      .header-block-left,
+      .header-block-right {
+        display: block;
+        width: 100%;
+        text-align: left;
+      }
+
+      .header-block-right {
+        margin-left: 40px;
+      }
+
+      .relay-trackers-removed,
+      .relay-mask {
+        width: 100%;
+        display: block;
+      } 
+    }  
+    /* this deals with long email addresses */
+    .forwarded-from-email {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 500px;
+      } 
+    @media screen and (max-width: 1200px) {
+      .forwarded-from-email {
+        width: 300px;
+      }
+    }
+    @media screen and (max-width: 768px){
+      .forwarded-from-email { 
+        width: 250px;
+      }  
+    }
+    @media screen and (max-width: 425px) {
+      .forwarded-from-email { 
+        width: 200px;
+      }
+    }
     </style>
   </head>
-  <body style="padding: 0; margin: 0;">
+  <body id="relay-email" style="padding: 0; margin: 0;">
     <!-- Header -->
     <table id="relay-email-header" width="100%" bgcolor="#3D3D3D" style="background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom: 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align="center">
       <tr> 
-        <td class="header-block" width="50%" align="left" style="padding-top: 5px;"> 
+        <td class="header-block-left" width="50%" align="left" style="padding-top: 5px;"> 
           <img width="30" src="{{ SITE_ORIGIN }}/static/images/email-images/relay-icon.png" style="margin-right: 5px; display: inline-block; vertical-align: top;" alt="relay icon"/>   
            
           <p style="margin-top: 0; margin-bottom: 5px; display: inline-block;"> 
             {% with display_email|striptags|urlencode as mask_url %}
-            <span style="display: block; color: #FFFFFF;"> 
+            <span class="forwarded-from-email" style="display: block; color: #FFFFFF;"> 
             {% ftlmsg 'relay-email-forwarded-from' %} 
             <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile/#{{ mask_url }}" style="margin-right: 30px;color: #FFFFFF;"> {{ display_email|striptags }} </a>
             {% endwith %}
@@ -121,8 +145,8 @@
           </p>  
             
         </td> 
-        <td class="header-block" width="50%" align="right"> 
-          <p style="margin: 0 30px 0 0; display: inline-block; color: #FFFFFF;">
+        <td class="header-block-right" width="50%" align="right"> 
+          <p class="relay-trackers-removed" style="margin: 0 30px 0 0; display: inline-block; color: #FFFFFF;">
             <img class="email-trackers-removed-icon" width="15" src="{{ SITE_ORIGIN }}/static/images/email-images/email-trackers-removed-icon.png" alt="email trackers removed icon"/>   
             {% comment %}
               Create this as a link if we have a report link to show 
@@ -137,7 +161,7 @@
           </p> 
 
           {% with display_email|striptags|urlencode as mask_url %}
-          <p style="margin: 0; display: inline-block;"> 
+          <p class="relay-mask" style="margin: 0; display: inline-block;"> 
               {% if has_premium %}
               <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile/#{{ mask_url }}" style="color: #FFFFFF;"> 
                 {% ftlmsg 'relay-email-manage-this-mask' %}

--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -96,69 +96,65 @@
     </style>
   </head>
   <body style="padding: 0; margin: 0;">
-    <table width="100%" bgcolor="#3D3D3D" style="background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom: 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align="center">
-      <tr>
-          <td align="center" valign="top" width="100%" style="padding-top: 0px; padding-bottom: 0px;">
-          <table width="100%" style="max-width:1200px; text-align: center; border-collapse: collapse;">
-              <tr> 
-                <td class="header-block" width="50%" align="left" style="padding-top: 5px;"> 
-                  <img width="30" src="{{ SITE_ORIGIN }}/static/images/email-images/relay-icon.png" style="margin-right: 5px; display: inline-block; vertical-align: top;" alt="relay icon"/>   
-                   
-                  <p style="margin-top: 0; margin-bottom: 5px; display: inline-block;"> 
-                    {% with display_email|striptags|urlencode as mask_url %}
-                    <span style="display: block; color: #FFFFFF;"> 
-                    {% ftlmsg 'relay-email-forwarded-from' %} 
-                    <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile/#{{ mask_url }}" style="margin-right: 30px;color: #FFFFFF;"> {{ display_email|striptags }} </a>
-                    {% endwith %}
-                    </span> 
+    <!-- Header -->
+    <table id="relay-email-header" width="100%" bgcolor="#3D3D3D" style="background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom: 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align="center">
+      <tr> 
+        <td class="header-block" width="50%" align="left" style="padding-top: 5px;"> 
+          <img width="30" src="{{ SITE_ORIGIN }}/static/images/email-images/relay-icon.png" style="margin-right: 5px; display: inline-block; vertical-align: top;" alt="relay icon"/>   
+           
+          <p style="margin-top: 0; margin-bottom: 5px; display: inline-block;"> 
+            {% with display_email|striptags|urlencode as mask_url %}
+            <span style="display: block; color: #FFFFFF;"> 
+            {% ftlmsg 'relay-email-forwarded-from' %} 
+            <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile/#{{ mask_url }}" style="margin-right: 30px;color: #FFFFFF;"> {{ display_email|striptags }} </a>
+            {% endwith %}
+            </span> 
 
-                  <span style="margin-top: 0; margin-bottom: 5px; display: block;color: #FFFFFF;">{% ftlmsg 'relay-email-by-line' %} <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile" style="margin-right: 30px;color: #FFFFFF;">
-                    {% if has_premium %} 
-                      {% ftlmsg 'relay-email-premium-by-line-link' %} 
-                    {% else %}
-                      {% ftlmsg 'relay-email-by-line-link' %}
-                    {% endif %}
-                  </a>
-                  </span>
-                  </p>  
-                    
-                </td> 
-                <td class="header-block" width="50%" align="right"> 
-                  <p style="margin: 0 30px 0 0; display: inline-block; color: #FFFFFF;">
-                    <img class="email-trackers-removed-icon" width="15" src="{{ SITE_ORIGIN }}/static/images/email-images/email-trackers-removed-icon.png" alt="email trackers removed icon"/>   
-                    {% comment %}
-                      Create this as a link if we have a report link to show 
-                    {% endcomment %}
-                    {% if tracker_report_link %}
-                    <a class="container-link" href="{{ tracker_report_link  }}" style="color: #FFFFFF;"> 
-                      {% ftlmsg 'relay-email-trackers-removed' number=num_level_one_email_trackers_removed %}
-                    </a>
-                    {% else %}
-                      {% ftlmsg 'relay-email-trackers-removed' number=num_level_one_email_trackers_removed %}
-                    {% endif %}
-                  </p> 
+          <span style="margin-top: 0; margin-bottom: 5px; display: block;color: #FFFFFF;">{% ftlmsg 'relay-email-by-line' %} <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile" style="margin-right: 30px;color: #FFFFFF;">
+            {% if has_premium %} 
+              {% ftlmsg 'relay-email-premium-by-line-link' %} 
+            {% else %}
+              {% ftlmsg 'relay-email-by-line-link' %}
+            {% endif %}
+          </a>
+          </span>
+          </p>  
+            
+        </td> 
+        <td class="header-block" width="50%" align="right"> 
+          <p style="margin: 0 30px 0 0; display: inline-block; color: #FFFFFF;">
+            <img class="email-trackers-removed-icon" width="15" src="{{ SITE_ORIGIN }}/static/images/email-images/email-trackers-removed-icon.png" alt="email trackers removed icon"/>   
+            {% comment %}
+              Create this as a link if we have a report link to show 
+            {% endcomment %}
+            {% if tracker_report_link %}
+            <a class="container-link" href="{{ tracker_report_link  }}" style="color: #FFFFFF;"> 
+              {% ftlmsg 'relay-email-trackers-removed' number=num_level_one_email_trackers_removed %}
+            </a>
+            {% else %}
+              {% ftlmsg 'relay-email-trackers-removed' number=num_level_one_email_trackers_removed %}
+            {% endif %}
+          </p> 
 
-                  {% with display_email|striptags|urlencode as mask_url %}
-                  <p style="margin: 0; display: inline-block;"> 
-                      {% if has_premium %}
-                      <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile/#{{ mask_url }}" style="color: #FFFFFF;"> 
-                        {% ftlmsg 'relay-email-manage-this-mask' %}
-                      </a>
-                      {% else %} 
-                      <a class="container-link" href="{{ SITE_ORIGIN }}/premium" style="color: #FFFFFF;"> 
-                        {% ftlmsg 'relay-email-upgrade-for-more-protection' %}
-                      </a>
-                      {% endif %} 
-                  </p> 
-                  {% endwith %}
-                </td> 
-              </tr>
-          </table>
-          </td>
+          {% with display_email|striptags|urlencode as mask_url %}
+          <p style="margin: 0; display: inline-block;"> 
+              {% if has_premium %}
+              <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile/#{{ mask_url }}" style="color: #FFFFFF;"> 
+                {% ftlmsg 'relay-email-manage-this-mask' %}
+              </a>
+              {% else %} 
+              <a class="container-link" href="{{ SITE_ORIGIN }}/premium" style="color: #FFFFFF;"> 
+                {% ftlmsg 'relay-email-upgrade-for-more-protection' %}
+              </a>
+              {% endif %} 
+          </p> 
+          {% endwith %}
+        </td> 
       </tr>
     </table>   
    
-    <table width="100%" style="padding: 0; max-width:700px;" align="center">
+    <!-- Email Body -->
+    <table id="relay-email-body" width="100%" style="padding: 0; max-width:700px;" align="center">
       <tr>
         <td width="100%" style="padding-left: 15px; padding-right: 15px;">
           {{ original_html|safe }}
@@ -166,24 +162,20 @@
       </tr>
     </table>
 
-    <table width="100%" bgcolor="#3D3D3D" style="background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom: 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align="center">
+    <!-- Footer -->
+    <table id="relay-email-footer" width="100%" bgcolor="#3D3D3D" style="background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom: 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align="center">
       <tr>
-        <td align="center" valign="top" width="100%" style=" padding-top: 0px; padding-bottom: 0px;">
-          <table width="100%" style="max-width:1200px; text-align: center; border-collapse: collapse;">
-              <tr>
-                <td class="footer-block" width="50%" align="left">  
-                  <a class="container-link" href="{{ SITE_ORIGIN }}"> 
-                    <img width="110" src="{{ SITE_ORIGIN }}/static/images/email-images/relay-logo-emails-dark-bg.png" style="margin: 0;" alt="relay logo"/>   
-                  </a>
-                </td>
-                <td class="footer-block" width="50%" align="right">  
-                  <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile" style="color: #FFFFFF;">{% ftlmsg 'relay-email-your-dashboard' %}</a>  
-                </td> 
-              </tr>
-          </table>
+        <td class="footer-block" width="50%" align="left">  
+          <a class="container-link" href="{{ SITE_ORIGIN }}"> 
+            <img width="110" src="{{ SITE_ORIGIN }}/static/images/email-images/relay-logo-emails-dark-bg.png" style="margin: 0;" alt="relay logo"/>   
+          </a>
         </td>
+        <td class="footer-block" width="50%" align="right">  
+          <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile" style="color: #FFFFFF;">{% ftlmsg 'relay-email-your-dashboard' %}</a>  
+        </td> 
       </tr>
-  </table>  
+    </table>  
+
   </body>
 </html>
 {% endwithftl %}

--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -106,13 +106,13 @@
                    
                   <p style="margin-top: 0; margin-bottom: 5px; display: inline-block;"> 
                     {% with display_email|striptags|urlencode as mask_url %}
-                    <span style="display: block;"> 
+                    <span style="display: block; color: #FFFFFF;"> 
                     {% ftlmsg 'relay-email-forwarded-from' %} 
-                    <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile/#{{ mask_url }}" style="margin-right: 30px;"> {{ display_email|striptags }} </a>
+                    <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile/#{{ mask_url }}" style="margin-right: 30px;color: #FFFFFF;"> {{ display_email|striptags }} </a>
                     {% endwith %}
                     </span> 
 
-                  <span style="margin-top: 0; margin-bottom: 5px; display: block;">{% ftlmsg 'relay-email-by-line' %} <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile" style="margin-right: 30px;">
+                  <span style="margin-top: 0; margin-bottom: 5px; display: block;color: #FFFFFF;">{% ftlmsg 'relay-email-by-line' %} <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile" style="margin-right: 30px;color: #FFFFFF;">
                     {% if has_premium %} 
                       {% ftlmsg 'relay-email-premium-by-line-link' %} 
                     {% else %}
@@ -124,13 +124,13 @@
                     
                 </td> 
                 <td class="header-block" width="50%" align="right"> 
-                  <p style="margin: 0 30px 0 0; display: inline-block;">
+                  <p style="margin: 0 30px 0 0; display: inline-block; color: #FFFFFF;">
                     <img class="email-trackers-removed-icon" width="15" src="{{ SITE_ORIGIN }}/static/images/email-images/email-trackers-removed-icon.png" alt="email trackers removed icon"/>   
                     {% comment %}
                       Create this as a link if we have a report link to show 
                     {% endcomment %}
                     {% if tracker_report_link %}
-                    <a class="container-link" href="{{ tracker_report_link  }}"> 
+                    <a class="container-link" href="{{ tracker_report_link  }}" style="color: #FFFFFF;"> 
                       {% ftlmsg 'relay-email-trackers-removed' number=num_level_one_email_trackers_removed %}
                     </a>
                     {% else %}
@@ -141,11 +141,11 @@
                   {% with display_email|striptags|urlencode as mask_url %}
                   <p style="margin: 0; display: inline-block;"> 
                       {% if has_premium %}
-                      <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile/#{{ mask_url }}"> 
+                      <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile/#{{ mask_url }}" style="color: #FFFFFF;"> 
                         {% ftlmsg 'relay-email-manage-this-mask' %}
                       </a>
                       {% else %} 
-                      <a class="container-link" href="{{ SITE_ORIGIN }}/premium"> 
+                      <a class="container-link" href="{{ SITE_ORIGIN }}/premium" style="color: #FFFFFF;"> 
                         {% ftlmsg 'relay-email-upgrade-for-more-protection' %}
                       </a>
                       {% endif %} 
@@ -177,7 +177,7 @@
                   </a>
                 </td>
                 <td class="footer-block" width="50%" align="right">  
-                  <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile">{% ftlmsg 'relay-email-your-dashboard' %}</a>  
+                  <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile" style="color: #FFFFFF;">{% ftlmsg 'relay-email-your-dashboard' %}</a>  
                 </td> 
               </tr>
           </table>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes issues with template styling and addresses issues with long emails breaking the layout. 
 
<!-- When adding a new feature: -->

# New feature description

Styling for text in headers and footers is inline, explicit. Long email addresses that break layouts are also addressed. Lastly, this also removes some unnecessary HTML. 

# Screenshot (if applicable)


https://user-images.githubusercontent.com/3924990/225429625-b3696eab-3633-4e54-8505-334ee4f5bddb.mp4



# How to test

Run the Relay backend server and go to: http://127.0.0.1:8000/emails/wrapped_email_test 

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
