### PR TITLE
Python dependency updates 2023 03 20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ codetiming==1.4.0
 cryptography==39.0.2
 Django==3.2.18
 dj-database-url==1.2.0
-django-allauth==0.52.0
+django-allauth==0.53.0
 django-cors-headers==3.14.0
 django-csp==3.7
 django-debug-toolbar==3.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ whitenoise==6.4.0
 
 # phones app
 phonenumbers==8.13.6
-twilio==7.16.4
+twilio==7.16.5
 vobject==0.9.6.1
 
 # tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ coverage==7.2.2
 model-bakery==1.10.1
 pytest-cov==4.0.0
 pytest-django==4.5.2
-responses==0.22.0
+responses==0.23.1
 
 # linting
 black==23.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ twilio==7.16.4
 vobject==0.9.6.1
 
 # tests
-coverage==7.2.1
+coverage==7.2.2
 model-bakery==1.10.1
 pytest-cov==4.0.0
 pytest-django==4.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ black==23.1.0
 
 # type hinting
 mypy==1.1.1
-types-pyOpenSSL==23.0.0.3
+types-pyOpenSSL==23.0.0.4
 types-requests==2.28.11.15
 django-stubs==1.14.0
 djangorestframework-stubs==1.9.1


### PR DESCRIPTION
Update dependencies. This covers:

* Bump types-pyopenssl from 23.0.0.3 to 23.0.0.4 (from PR #3202)
* Bump responses from 0.22.0 to 0.23.1 (from PR #3201)
* Bump twilio from 7.16.4 to 7.16.5 (from PR #3200)
* Bump django-allauth from 0.52.0 to 0.53.0 (from PR #3199)
* Bump coverage from 7.2.1 to 7.2.2 (from PR #3198)