### PR TITLE
MPP-2958 - Set general body text color and styling

### DIFF
--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -28,13 +28,7 @@
     * {
       box-sizing: border-box;
     }
-
-    #relay-email {
-      font-family: 'inter', Arial, sans-serif; 
-      color: #000000;
-      font-size: 1rem;
-    }
- 
+    
     a.container-link { 
       transition: all 0.2s ease;
       text-underline-offset: 2px;

--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -30,13 +30,9 @@
     }
 
     #relay-email {
-      font-family: 'inter', Arial, sans-serif;
-      color: #3D3D3D;
-    }
-
-    #relay-email p {
-      color: #FFFFFF;
-      font-size: 12px;
+      font-family: 'inter', Arial, sans-serif; 
+      color: #000000;
+      font-size: 1rem;
     }
  
     a.container-link { 

--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -28,6 +28,13 @@
     * {
       box-sizing: border-box;
     }
+
+    #relay-email-header,
+    #relay-email-footer {
+      font-family: 'inter', Arial, sans-serif;  
+      color: #FFFFFF;
+      font-size: 12px;
+    } 
     
     a.container-link { 
       transition: all 0.2s ease;


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-2958

How to test:

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description

Sets color of text for body to black. Body content size is using a relative unit instead of pixels. 

# How to test



# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
