### PR TITLE
for MPP-2855: update inbound_sms_iq to handle replies

### DIFF
--- a/api/tests/iq_views_tests.py
+++ b/api/tests/iq_views_tests.py
@@ -18,6 +18,7 @@ from rest_framework.test import RequestsClient
 
 if settings.PHONES_ENABLED:
     from api.views.phones import compute_iq_mac
+    from phones.models import InboundContact
 
 from phones.tests.models_tests import make_phone_test_user
 from api.tests.phones_views_tests import _make_real_phone, _make_relay_number
@@ -25,6 +26,7 @@ from api.tests.phones_views_tests import _make_real_phone, _make_relay_number
 
 API_ROOT = "http://127.0.0.1:8000"
 INBOUND_SMS_PATH = f"{API_ROOT}/api/v1/inbound_sms_iq/"
+IQ_MESSAGE_PATH = "https://messagebroker.inteliquent.com/msgbroker/rest/publishMessages"
 
 
 @pytest.fixture()
@@ -137,6 +139,10 @@ def test_iq_endpoint_unknown_number():
     assert "Could not find relay number." in resp_body[0]
 
 
+def _iq_fmt(e164_number: str) -> str:
+    return "1" + str(phonenumbers.parse(e164_number, "E164").national_number)
+
+
 @pytest.mark.django_db(transaction=True)
 def test_iq_endpoint_disabled_number(phone_user, mocked_twilio_client):
     # TODO: should we return empty 200 to iQ when number is disabled?
@@ -145,7 +151,7 @@ def test_iq_endpoint_disabled_number(phone_user, mocked_twilio_client):
     relay_number.enabled = False
     relay_number.save()
     client = _prepare_valid_iq_request_client()
-    formatted_to = str(phonenumbers.parse(relay_number.number, "E164").national_number)
+    formatted_to = _iq_fmt(relay_number.number)
     data = {
         "from": "5556660000",
         "to": [
@@ -161,15 +167,12 @@ def test_iq_endpoint_disabled_number(phone_user, mocked_twilio_client):
 @pytest.mark.django_db(transaction=True)
 @responses.activate()
 def test_iq_endpoint_success(phone_user):
-    iq_message_path = (
-        "https://messagebroker.inteliquent.com/msgbroker/rest/publishMessages"
-    )
-    responses.add(responses.POST, iq_message_path, status=200)
+    responses.add(responses.POST, IQ_MESSAGE_PATH, status=200)
     _make_real_phone(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user, "inteliquent")
     pre_inbound_remaining_texts = relay_number.remaining_texts
     client = _prepare_valid_iq_request_client()
-    formatted_to = str(phonenumbers.parse(relay_number.number, "E164").national_number)
+    formatted_to = _iq_fmt(relay_number.number)
     data = {
         "from": "5556660000",
         "to": [
@@ -184,3 +187,112 @@ def test_iq_endpoint_success(phone_user):
     relay_number.refresh_from_db()
     assert relay_number.texts_forwarded == 1
     assert relay_number.remaining_texts == pre_inbound_remaining_texts - 1
+
+
+@pytest.mark.django_db(transaction=True)
+@responses.activate()
+def test_reply_with_no_remaining_texts(phone_user):
+    rsp = responses.add(responses.POST, IQ_MESSAGE_PATH, status=200)
+    real_phone = _make_real_phone(phone_user, verified=True)
+    relay_number = _make_relay_number(phone_user, "inteliquent")
+    relay_number.remaining_texts = 0
+    relay_number.save()
+
+    client = _prepare_valid_iq_request_client()
+    formatted_to = _iq_fmt(relay_number.number)
+    formatted_from = _iq_fmt(real_phone.number)
+    data = {
+        "from": formatted_from,
+        "to": [
+            formatted_to,
+        ],
+        "text": "test reply",
+    }
+    resp = client.post(INBOUND_SMS_PATH, json=data)
+
+    assert resp.status_code == 400
+    decoded_content = resp.content.decode()
+    assert "Number is out of texts" in decoded_content
+    assert rsp.call_count == 0
+    relay_number.refresh_from_db()
+    assert relay_number.remaining_texts == 0
+
+
+@pytest.mark.django_db(transaction=True)
+@responses.activate()
+def test_reply_without_previous_sender_error(phone_user):
+    real_phone = _make_real_phone(phone_user, verified=True)
+    relay_number = _make_relay_number(phone_user, "inteliquent")
+    client = _prepare_valid_iq_request_client()
+    formatted_to = _iq_fmt(relay_number.number)
+    formatted_from = _iq_fmt(real_phone.number)
+    error_msg = "You can only reply to phone numbers that have sent you a text message."
+    rsp = responses.add(
+        responses.POST,
+        IQ_MESSAGE_PATH,
+        status=200,
+        match=[
+            responses.matchers.json_params_matcher(
+                {
+                    "from": formatted_to,
+                    "to": [formatted_from],
+                    "text": f"Message failed to send. {error_msg}",
+                }
+            )
+        ],
+    )
+
+    data = {
+        "from": formatted_from,
+        "to": [
+            formatted_to,
+        ],
+        "text": "test reply",
+    }
+    resp = client.post(INBOUND_SMS_PATH, json=data)
+
+    assert resp.status_code == 400
+    decoded_content = resp.content.decode()
+    assert error_msg in decoded_content
+    assert rsp.call_count == 1
+
+
+@pytest.mark.django_db(transaction=True)
+@responses.activate()
+def test_reply_with_previous_sender_works(phone_user):
+    real_phone = _make_real_phone(phone_user, verified=True)
+    relay_number = _make_relay_number(phone_user, "inteliquent")
+    inbound_contact = InboundContact.objects.create(
+        relay_number=relay_number, inbound_number="+15556660000"
+    )
+    client = _prepare_valid_iq_request_client()
+    formatted_contact = _iq_fmt(inbound_contact.inbound_number)
+    formatted_relay = _iq_fmt(relay_number.number)
+    formatted_real = _iq_fmt(real_phone.number)
+
+    rsp = responses.add(
+        responses.POST,
+        IQ_MESSAGE_PATH,
+        status=200,
+        match=[
+            responses.matchers.json_params_matcher(
+                {
+                    "from": formatted_relay,
+                    "to": [formatted_contact],
+                    "text": "test reply",
+                }
+            )
+        ],
+    )
+
+    data = {
+        "from": formatted_real,
+        "to": [
+            formatted_relay,
+        ],
+        "text": "test reply",
+    }
+    resp = client.post(INBOUND_SMS_PATH, json=data)
+
+    assert resp.status_code == 200
+    assert rsp.call_count == 1

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -1093,6 +1093,9 @@ def _check_disabled(relay_number, contact_type):
 
 
 def _check_remaining(relay_number, resource_type):
+    # Check the owner of the relay number (still) has phone service
+    if not relay_number.user.profile.has_phone:
+        raise exceptions.ValidationError("Number owner does not have phone service")
     model_attr = f"remaining_{resource_type}"
     if getattr(relay_number, model_attr) <= 0:
         incr_if_enabled(f"phones_out_of_{resource_type}")


### PR DESCRIPTION
Also refactors some duplicate code into new consolidated functions:
* _get_user_error_message to translate sms errors
* _prepare_sms_reply and _send_sms_reply to separate twilio/iq code

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR is #MPP-2855.

How to test:
1. Follow the "How to test" steps from PR #3082 
2. When you receive the test message to the iQ-powered Relay number, send a reply
    * [x] It should forward the reply back, and it should keep allowing more replies
    * [x] It should reduce the "remaining texts" of the number each time

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] Added tests
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] ~l10n changes have been submitted to the l10n repository, if any.~