### PR TITLE
MPP-2920 - Fix webkit/chromium page breaking bug when switching forwarding controls

### DIFF
--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -27,15 +27,7 @@ html,
 body,
 #__next,
 #overlayProvider {
-  height: 100%;
   font-family: $font-stack-base;
-  // In <Layout> all content is wrapped in a `.non-header-wrapper` that has its
-  // own `overflow` applied, to allow the header and mobile menu to remain fixed
-  // in place. However, in Blink- and WebKit-based browsers, this resulted in
-  // empty space at the bottom of the page, below the footer.
-  // Since the user can scroll in `.non-header-wrapper`, everything outside that
-  // that still overflows these elements can safely be hidden:
-  overflow: hidden;
 }
 
 html {


### PR DESCRIPTION
<!-- When fixing a bug: -->

This PR fixes #MPP-2920 

On Chrome, ensure that toggling forwarding states (e.g. all to none) does not result in the page breaking.

TODO: https://github.com/mozilla/fx-private-relay/issues/3223 This fix will open up this bug.

How to test:

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
