### PR TITLE
Python dependency updates 2023 03 27

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pem==21.2.0
 psycopg2==2.9.5
 PyJWT==2.6.0
 python-decouple==3.8
-pyOpenSSL==23.0.0
+pyOpenSSL==23.1.0
 requests==2.28.2
 sentry-sdk==1.16.0
 whitenoise==6.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.85
+boto3==1.26.99
 codetiming==1.4.0
 cryptography==39.0.2
 Django==3.2.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,6 @@ black==23.1.0
 # type hinting
 mypy==1.1.1
 types-pyOpenSSL==23.0.0.4
-types-requests==2.28.11.15
+types-requests==2.28.11.16
 django-stubs==1.14.0
 djangorestframework-stubs==1.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ whitenoise==6.4.0
 
 # phones app
 phonenumbers==8.13.6
-twilio==7.16.5
+twilio==7.17.0
 vobject==0.9.6.1
 
 # tests


### PR DESCRIPTION
Update dependencies. This covers:

* Bump boto3 from 1.26.85 to 1.26.99 (from PR #3228)
* Bump twilio from 7.16.5 to 7.17.0 (from PR #3227)
* Bump pyopenssl from 23.0.0 to 23.1.0 (from PR #3225)
* Bump types-requests from 2.28.11.15 to 2.28.11.16 (from PR #3224)