### PR TITLE
Python dependency updates 2023 03 27.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.26.99
 codetiming==1.4.0
-cryptography==39.0.2
+cryptography==40.0.1
 Django==3.2.18
 dj-database-url==1.2.0
 django-allauth==0.53.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.99
+boto3==1.26.100
 codetiming==1.4.0
 cryptography==40.0.1
 Django==3.2.18


### PR DESCRIPTION
Update dependencies. This covers:

* Bump boto3 from 1.26.99 to 1.26.100 (from PR #3241)
* Bump cryptography from 39.0.2 to 40.0.1 (from PR #3226)