### PR TITLE
Downgrade to datadog 0.44.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,11 @@ requests==2.28.2
 sentry-sdk==1.16.0
 whitenoise==6.4.0
 
+# issue #3243
+# 0.45.0 implements DogStatsD protocol v1.2, which telegraf does not support as
+# of March 2023
+datadog==0.44.0
+
 # phones app
 phonenumbers==8.13.6
 twilio==7.17.0


### PR DESCRIPTION
Markus uses the [datadog](https://github.com/DataDog/datadogpy) library for generating metrics with tags. The 0.45.0 library adds a Docker container ID, if available, which is not currently supported by telegraf.

Downgrading should address issue #3243.