### PR TITLE
Python dependency updates 2023 04 03

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ drf-yasg==1.21.5
 google-measurement-protocol==1.1.0
 gunicorn==20.1.0
 jwcrypto==1.4.2
-markus[datadog]==4.1.0
+markus[datadog]==4.2.0
 pem==21.2.0
 psycopg2==2.9.5
 PyJWT==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ whitenoise==6.4.0
 # issue #3243
 # 0.45.0 implements DogStatsD protocol v1.2, which telegraf does not support as
 # of March 2023
-datadog==0.44.0
+datadog==0.45.0
 
 # phones app
 phonenumbers==8.13.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,6 +51,6 @@ black==23.1.0
 # type hinting
 mypy==1.1.1
 types-pyOpenSSL==23.0.0.4
-types-requests==2.28.11.16
+types-requests==2.28.11.17
 django-stubs==1.14.0
 djangorestframework-stubs==1.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ black==23.1.0
 
 # type hinting
 mypy==1.1.1
-types-pyOpenSSL==23.0.0.4
 types-requests==2.28.11.17
+types-pyOpenSSL==23.0.0.4
 django-stubs==1.14.0
 djangorestframework-stubs==1.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.26.100
 codetiming==1.4.0
 cryptography==40.0.1
 Django==3.2.18
-dj-database-url==1.2.0
+dj-database-url==1.3.0
 django-allauth==0.53.1
 django-cors-headers==3.14.0
 django-csp==3.7


### PR DESCRIPTION
Update dependencies. This covers:

* Bump markus from 4.1.0 to 4.2.0 (from PR #3254)
* Bump datadog from 0.44.0 to 0.45.0 (from PR #3255)
* Bump dj-database-url from 1.2.0 to 1.3.0 (from PR #3253)
* Bump types-pyopenssl from 23.0.0.4 to 23.1.0.1 (from PR #3252)
* Bump types-requests from 2.28.11.16 to 2.28.11.17 (from PR #3251)