### PR TITLE
Allow datadog 0.45.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,11 +28,6 @@ requests==2.28.2
 sentry-sdk==1.16.0
 whitenoise==6.4.0
 
-# issue #3243
-# 0.45.0 implements DogStatsD protocol v1.2, which telegraf does not support as
-# of March 2023
-datadog==0.45.0
-
 # phones app
 phonenumbers==8.13.6
 twilio==7.17.0


### PR DESCRIPTION
markus 4.2.0 disables DogStatsD protocol v1.2 by default. This only affects Kubernetes deployments, so testing will be in stage. Fixes #3243.