### PR TITLE
[MPP-2029] Anchor Link / Scroll to Subdomain Registration Form 

### DIFF
--- a/frontend/src/components/dashboard/SubdomainPicker.tsx
+++ b/frontend/src/components/dashboard/SubdomainPicker.tsx
@@ -9,6 +9,7 @@ import { SubdomainConfirmationModal } from "./subdomain/ConfirmationModal";
 import { getRuntimeConfig } from "../../config";
 import { useL10n } from "../../hooks/l10n";
 import Link from "next/link";
+import { useFlaggedAnchorLinks } from "../../hooks/flaggedAnchorLinks";
 
 export type Props = {
   profile: ProfileData;
@@ -24,6 +25,10 @@ export const SubdomainPicker = (props: Props) => {
   const [partialSubdomain, setPartialSubdomain] = useState("");
 
   const modalState = useOverlayTriggerState({});
+
+  // When <SubdomainPicker> gets added to the page, if there's an anchor link in the
+  // URL pointing to register a subdomain, scroll to that banner:
+  useFlaggedAnchorLinks([props.profile], ["mpp-choose-subdomain"]);
 
   if (
     !props.profile.has_premium ||


### PR DESCRIPTION
This PR fixes [MPP-2029](https://mozilla-hub.atlassian.net/browse/MPP-2029)

How to test:

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] ~I've added a unit test to test for potential regressions of this bug.~
- [ ] ~I've added or updated relevant docs in the docs/ directory.~
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
This PR fixes [MPP-2029](https://mozilla-hub.atlassian.net/browse/MPP-2029)

## Testing Steps

- Start with an account that has the following:
  - Is premium
  - Has NOT registered a subdomain
  - Has skipped onboarding
  - Has at least ONE mask
- Visit `127.0.0.1:8000/accounts/profile#mpp-choose-subdomain` (or whichever local instance you have running) 
- **Expected:** Your screen should scroll down to the subdomain entry form

## Screenshots

![image](https://user-images.githubusercontent.com/2692333/230979496-849b79f6-29e3-47b7-8a9f-3aaab8a7576e.png)





[MPP-2029]: https://mozilla-hub.atlassian.net/browse/MPP-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPP-2029]: https://mozilla-hub.atlassian.net/browse/MPP-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ