### PR TITLE
Python updates 2023 04 10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,5 +47,5 @@ black==23.1.0
 mypy==1.1.1
 types-requests==2.28.11.17
 types-pyOpenSSL==23.1.0.1
-django-stubs==1.14.0
+django-stubs==1.16.0
 djangorestframework-stubs==1.9.1


### PR DESCRIPTION
Update dependencies. This covers:

* Bump django-stubs from 1.14.0 to 1.16.0 (from PR #3276)
* Bump coverage from 7.2.2 to 7.2.3 (from PR #3275)
* Bump django-allauth from 0.53.1 to 0.54.0 (from PR #3274)
* Bump pyopenssl from 23.1.0 to 23.1.1 (from PR #3273)
* Bump psycopg2 from 2.9.5 to 2.9.6 (from PR #3272)