### PR TITLE
MPP-3019 Remove footer for istock photos on relay home page

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -227,9 +227,6 @@ export const Layout = (props: Props) => {
                 </li>
               </ul>
             </div>
-            <small className={styles["stock-photo-disclaimer"]}>
-              {l10n.getString("nav-footer-stock-photo-legal")}
-            </small>
           </footer>
         </div>
       </div>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3019
 
<!-- When adding a new feature: -->

# New feature description

Remove footer for istock photos on relay home page

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/3924990/232149569-db3960d9-a3be-477a-aa56-b6c7189bbd1e.png)

# How to test 

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
