### PR TITLE
Python dependency updates, 2023-04-17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ sentry-sdk==1.16.0
 whitenoise==6.4.0
 
 # phones app
-phonenumbers==8.13.6
+phonenumbers==8.13.9
 twilio==8.0.0
 vobject==0.9.6.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.26.100
 codetiming==1.4.0
-cryptography==40.0.1
+cryptography==40.0.2
 Django==3.2.18
 dj-database-url==1.3.0
 django-allauth==0.54.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-allauth==0.54.0
 django-cors-headers==3.14.0
 django-csp==3.7
 django-debug-toolbar==3.8.1
-django-filter==22.1
+django-filter==23.1
 django-redis==5.2.0
 django-ftl==0.14
 django-referrer-policy==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ responses==0.23.1
 black==23.1.0
 
 # type hinting
-mypy==1.1.1
+mypy==1.2.0
 types-requests==2.28.11.17
 types-pyOpenSSL==23.1.0.1
 django-stubs==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ whitenoise==6.4.0
 
 # phones app
 phonenumbers==8.13.6
-twilio==7.17.0
+twilio==8.0.0
 vobject==0.9.6.1
 
 # tests


### PR DESCRIPTION
Update Python dependencies. This covers:

* Bump twilio from 7.17.0 to 8.0.0 (from PR #3298) - more data in lookup API, support single proprietor 10DLC campaigns.
* Bump mypy from 1.1.1 to 1.2.0 (from PR #3299) - Tuning and fixes, no changes in our code
* Bump cryptography from 40.0.1 to 40.0.2 (from PR #3300) - SSL library updates
* Bump phonenumbers from 8.13.6 to 8.13.9 (from PR #3301) - Upstream metadata changes
* Bump django-filter from 22.1 to 23.1 (from PR #3302) - Django 4.2 support

