### PR TITLE
MPP-2833: Update backend FTL files after refactor

### DIFF
--- a/privaterelay/ftl_bundles.py
+++ b/privaterelay/ftl_bundles.py
@@ -23,5 +23,12 @@ class RelayMessageFinder(DjangoMessageFinder):
 
 
 main = Bundle(
-    ["app.ftl", "brands.ftl", "phones.ftl", "pending.ftl"], finder=RelayMessageFinder()
+    [
+        "brands.ftl",  # Brand names, used in other messages
+        "layout.ftl",  # Strings in HTML <meta> tags, etc.
+        "misc.ftl",  # Error messages
+        "pending.ftl",  # The backend pending translations, ./en/pending.ftl
+        "phones.ftl",  # SMS errors
+    ],
+    finder=RelayMessageFinder(),
 )

--- a/privaterelay/ftl_bundles.py
+++ b/privaterelay/ftl_bundles.py
@@ -22,6 +22,10 @@ class RelayMessageFinder(DjangoMessageFinder):
         return base_dirs + pending_dirs
 
 
+# The django_ftl package requires the names of the Fluent files.
+# Only the ones with strings used by the backend are loaded.
+# See frontend/src/functions/getL10n.ts for frontend bundle setup.
+# The frontend, which uses more strings, loads all files ending in .ftl.
 main = Bundle(
     [
         "brands.ftl",  # Brand names, used in other messages


### PR DESCRIPTION
`app.ftl` has been split, and the strings are in now in `layout.ftl` and `misc.ftl`.

Backend strings are translated two ways:

* The tag `{% ftlmsg %}` in the remaining templates
* Calls to `ftl_bundles.main.format`, often `ftl_bundle.format` after an import rename

Here's the IDs I found on the backend:

In `misc.ftl`:
```
api-error-*
first-reply-forwarded
manage-your-masks
other-reply-not-forwarded-2
replies-not-included-in-free-account-header
replies-only-available-with-premium
reply-not-sent-header
upgrade-for-more-protection
upgrade-to-premium
upgrade-to-reply-to-future-emails
```

In `layout.ftl`:
```
meta-description-2
meta-title
nav-profile-sign-out
nav-profile-sign-out-confirm

```

In `phones.ftl`:
```
sms-error-*
```

in https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/pending_locales/en/pending.ftl (should be moved to https://github.com/mozilla-l10n/fx-private-relay-l10n) via PR:
```
relay-email-by-line
relay-email-by-line-link
relay-email-forwarded-from
relay-email-manage-this-mask
relay-email-premium-by-line-link
relay-email-trackers-removed
relay-email-upgrade-for-more-protection
relay-email-your-dashboard
```

I believe this PR catches all the translations. Let's see if CircleCI agrees...