### PR TITLE
Remove extra @ sign from subdomain banner

### DIFF
--- a/frontend/src/components/dashboard/SubdomainPicker.tsx
+++ b/frontend/src/components/dashboard/SubdomainPicker.tsx
@@ -88,7 +88,7 @@ export const SubdomainPicker = (props: Props) => {
             </dt>
             <dd>
               {l10n.getString("banner-set-email-domain-step-two-body", {
-                mozmail: "@mozmail.com",
+                mozmail: "mozmail.com",
               })}
             </dd>
           </dl>


### PR DESCRIPTION
I noticed an extra `@` in the subdomain example in the banner here. Now been removed.
<img width="491" alt="image" src="https://user-images.githubusercontent.com/13066134/233723372-8eec4973-c7cd-493b-a3eb-c68a44e5f724.png">
 

