### PR TITLE
Update Python Dependencies, 2023-04-25

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -918,7 +918,7 @@ sentry_sdk.init(
     dsn=config("SENTRY_DSN", None),
     integrations=[DjangoIntegration()],
     debug=SENTRY_DEBUG,
-    with_locals=DEBUG,
+    include_local_variables=DEBUG,
     release=sentry_release,
     environment=SENTRY_ENVIRONMENT,
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyJWT==2.6.0
 python-decouple==3.8
 pyOpenSSL==23.1.1
 requests==2.28.2
-sentry-sdk==1.16.0
+sentry-sdk==1.20.0
 whitenoise==6.4.0
 
 # phones app

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ sentry-sdk==1.16.0
 whitenoise==6.4.0
 
 # phones app
-phonenumbers==8.13.9
+phonenumbers==8.13.10
 twilio==8.0.0
 vobject==0.9.6.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ pytest-django==4.5.2
 responses==0.23.1
 
 # linting
-black==23.1.0
+black==23.3.0
 
 # type hinting
 mypy==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ dj-database-url==1.3.0
 django-allauth==0.54.0
 django-cors-headers==3.14.0
 django-csp==3.7
-django-debug-toolbar==3.8.1
+django-debug-toolbar==4.0.0
 django-filter==23.1
 django-redis==5.2.0
 django-ftl==0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,4 +48,4 @@ mypy==1.2.0
 types-requests==2.28.11.17
 types-pyOpenSSL==23.1.0.1
 django-stubs==1.16.0
-djangorestframework-stubs==1.9.1
+djangorestframework-stubs==1.10.0


### PR DESCRIPTION
Update dependencies. This covers:

* Bump black from 23.1.0 to 23.3.0 (from PR #3326)
* Bump djangorestframework-stubs from 1.9.1 to 1.10.0 (from PR #3327)
* Bump django-debug-toolbar from 3.8.1 to 4.0.0 (from PR #3328)
* Bump phonenumbers from 8.13.9 to 8.13.10 (from PR #3329)
* Bump sentry-sdk from 1.16.0 to 1.20.0 (from PR #3330)
  * Rename to `sdk_init(include_local_variables)`, changed in sentry-sdk 1.17.0
* Increase from 5 to 10 Python PRs per week
