### PR TITLE
Update python dependencies,  2023-04-25, part 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ whitenoise==6.4.0
 
 # phones app
 phonenumbers==8.13.10
-twilio==8.0.0
+twilio==8.1.0
 vobject==0.9.6.1
 
 # tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyJWT==2.6.0
 python-decouple==3.8
 pyOpenSSL==23.1.1
 requests==2.28.2
-sentry-sdk==1.20.0
+sentry-sdk==1.21.0
 whitenoise==6.4.0
 
 # phones app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.100
+boto3==1.26.119
 codetiming==1.4.0
 cryptography==40.0.2
 Django==3.2.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,6 @@ black==23.3.0
 # type hinting
 mypy==1.2.0
 types-requests==2.28.11.17
-types-pyOpenSSL==23.1.0.1
+types-pyOpenSSL==23.1.0.2
 django-stubs==1.16.0
 djangorestframework-stubs==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ vobject==0.9.6.1
 
 # tests
 coverage==7.2.3
-model-bakery==1.10.1
+model-bakery==1.11.0
 pytest-cov==4.0.0
 pytest-django==4.5.2
 responses==0.23.1


### PR DESCRIPTION
Update dependencies. This covers:

* Bump model-bakery from 1.10.1 to 1.11.0 (from PR #3343)
* Bump types-pyopenssl from 23.1.0.1 to 23.1.0.2 (from PR #3344)
* Bump twilio from 8.0.0 to 8.1.0 (from PR #3345)
* Bump boto3 from 1.26.100 to 1.26.119 (from PR #3346)
* Bump sentry-sdk from 1.20.0 to 1.21.0 (from PR #3347)