### PR TITLE
Python dependency updates, 2023-05-01

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ black==23.3.0
 
 # type hinting
 mypy==1.2.0
-types-requests==2.28.11.17
+types-requests==2.29.0.0
 types-pyOpenSSL==23.1.0.2
 django-stubs==1.16.0
 djangorestframework-stubs==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.120
+boto3==1.26.123
 codetiming==1.4.0
 cryptography==40.0.2
 Django==3.2.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ psycopg2==2.9.6
 PyJWT==2.6.0
 python-decouple==3.8
 pyOpenSSL==23.1.1
-requests==2.28.2
+requests==2.29.0
 sentry-sdk==1.21.0
 whitenoise==6.4.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,5 +47,5 @@ black==23.3.0
 mypy==1.2.0
 types-requests==2.29.0.0
 types-pyOpenSSL==23.1.0.2
-django-stubs==1.16.0
+django-stubs==4.2.0
 djangorestframework-stubs==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.26.123
 codetiming==1.4.0
 cryptography==40.0.2
 Django==3.2.18
-dj-database-url==1.3.0
+dj-database-url==2.0.0
 django-allauth==0.54.0
 django-cors-headers==3.14.0
 django-csp==3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,4 +48,4 @@ mypy==1.2.0
 types-requests==2.28.11.17
 types-pyOpenSSL==23.1.0.2
 django-stubs==1.16.0
-djangorestframework-stubs==1.10.0
+djangorestframework-stubs==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-allauth==0.54.0
 django-cors-headers==3.14.0
 django-csp==3.7
 django-debug-toolbar==4.0.0
-django-filter==23.1
+django-filter==23.2
 django-redis==5.2.0
 django-ftl==0.14
 django-referrer-policy==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ twilio==8.1.0
 vobject==0.9.6.1
 
 # tests
-coverage==7.2.3
+coverage==7.2.5
 model-bakery==1.11.0
 pytest-cov==4.0.0
 pytest-django==4.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyJWT==2.6.0
 python-decouple==3.8
 pyOpenSSL==23.1.1
 requests==2.29.0
-sentry-sdk==1.21.0
+sentry-sdk==1.21.1
 whitenoise==6.4.0
 
 # phones app

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ sentry-sdk==1.21.1
 whitenoise==6.4.0
 
 # phones app
-phonenumbers==8.13.10
+phonenumbers==8.13.11
 twilio==8.1.0
 vobject==0.9.6.1
 


### PR DESCRIPTION
Update Python dependencies. This covers:

* Bump boto3 from 1.26.120 to 1.26.123 (from PR #3359) - AWS API updates
* Bump requests from 2.28.2 to 2.29.0 (from PR #3360) - use `urllib3` for chunked requests, relax header requirements
* Bump sentry-sdk from 1.21.0 to 1.21.1 (from PR #3361) - minor fixes
* Bump phonenumbers from 8.13.10 to 8.13.11 (from PR #3362) - data update
* Bump django-filter from 23.1 to 23.2 (from PR #3363) - Deprecate schema generation. Recommends [drf-spectacular](https://drf-spectacular.readthedocs.io/en/latest/)
* Bump djangorestframework-stubs from 1.10.0 to 3.14.0 (from PR #3364) - Follow DRF's versioning scheme
* Bump dj-database-url from 1.3.0 to 2.0.0 (from PR #3365) - Packaging changes, questionable major version bump
* Bump types-requests from 2.28.11.17 to 2.29.0.0 (from PR #3366) - follow requests version
* Bump coverage from 7.2.3 to 7.2.5 (from PR #3367) - minor fixes
* Bump django-stubs from 1.16.0 to 4.2.0 (from PR #3368) - Django 4.2 updates, follow Django version