### PR TITLE
Js updates 2023 05 05

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest-axe": "^3.5.5",
-    "@types/react": "^18.0.38",
+    "@types/react": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "@typescript-eslint/parser": "^5.59.0",
     "babel-jest": "^29.4.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^13.3.1",
-    "@next/eslint-plugin-next": "^13.1.6",
+    "@next/eslint-plugin-next": "^13.3.4",
     "@testing-library/dom": "^9.2.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
     "react-qr-code": "^2.0.11",
     "react-stately": "^3.22.0",
     "react-toastify": "^9.1.2",
-    "swr": "^2.1.0"
+    "swr": "^2.1.5"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^13.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,7 @@
     "react-test-renderer": "^18.2.0",
     "sass": "^1.61.0",
     "stylelint": "^15.6.0",
-    "stylelint-config-recommended-scss": "^10.0.0",
+    "stylelint-config-recommended-scss": "^11.0.0",
     "stylelint-scss": "^4.6.0",
     "typescript": "^5.0.4"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
     "@types/jest-axe": "^3.5.5",
     "@types/react": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
-    "@typescript-eslint/parser": "^5.59.0",
+    "@typescript-eslint/parser": "^5.59.2",
     "babel-jest": "^29.4.2",
     "eslint": "^8.39.0",
     "eslint-config-next": "^13.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/jest-axe": "^3.5.5",
     "@types/react": "^18.2.0",
-    "@typescript-eslint/eslint-plugin": "^5.56.0",
+    "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "babel-jest": "^29.4.2",
     "eslint": "^8.39.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,7 @@
     "next": "^13.3.0",
     "prettier": "2.8.8",
     "react-test-renderer": "^18.2.0",
-    "sass": "^1.61.0",
+    "sass": "^1.62.1",
     "stylelint": "^15.6.0",
     "stylelint-config-recommended-scss": "^11.0.0",
     "stylelint-scss": "^4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "react-test-renderer": "^18.2.0",
         "sass": "^1.61.0",
         "stylelint": "^15.6.0",
-        "stylelint-config-recommended-scss": "^10.0.0",
+        "stylelint-config-recommended-scss": "^11.0.0",
         "stylelint-scss": "^4.6.0",
         "typescript": "^5.0.4"
       }
@@ -12843,27 +12843,27 @@
       }
     },
     "node_modules/stylelint-config-recommended": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-11.0.0.tgz",
-      "integrity": "sha512-SoGIHNI748OCZn6BxFYT83ytWoYETCINVHV3LKScVAWQQauWdvmdDqJC5YXWjpBbxg2E761Tg5aUGKLFOVhEkA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
+      "integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
       "dev": true,
       "peerDependencies": {
-        "stylelint": "^15.3.0"
+        "stylelint": "^15.5.0"
       }
     },
     "node_modules/stylelint-config-recommended-scss": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-10.0.0.tgz",
-      "integrity": "sha512-+YvPgUHi0W5mCJCKdupBCIsWPYNbWuJcRmFtSYujwNg+41ljFknhO9bpY6C+oahv659zW7W1AT7i6DQvJYYr1A==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-11.0.0.tgz",
+      "integrity": "sha512-EDghTDU7aOv2LTsRZvcT1w8mcjUaMhuy+t38iV5I/0Qiu6ixdkRwhLEMul3K/fnB2v9Nwqvb3xpvJfPH+HduDw==",
       "dev": true,
       "dependencies": {
         "postcss-scss": "^4.0.6",
-        "stylelint-config-recommended": "^11.0.0",
+        "stylelint-config-recommended": "^12.0.0",
         "stylelint-scss": "^4.6.0"
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^15.3.0"
+        "stylelint": "^15.5.0"
       },
       "peerDependenciesMeta": {
         "postcss": {
@@ -18459,7 +18459,7 @@
         "react-toastify": "^9.1.2",
         "sass": "^1.61.0",
         "stylelint": "^15.6.0",
-        "stylelint-config-recommended-scss": "^10.0.0",
+        "stylelint-config-recommended-scss": "^11.0.0",
         "stylelint-scss": "^4.6.0",
         "swr": "^2.1.5",
         "typescript": "^5.0.4"
@@ -22424,20 +22424,20 @@
       }
     },
     "stylelint-config-recommended": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-11.0.0.tgz",
-      "integrity": "sha512-SoGIHNI748OCZn6BxFYT83ytWoYETCINVHV3LKScVAWQQauWdvmdDqJC5YXWjpBbxg2E761Tg5aUGKLFOVhEkA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
+      "integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
       "dev": true,
       "requires": {}
     },
     "stylelint-config-recommended-scss": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-10.0.0.tgz",
-      "integrity": "sha512-+YvPgUHi0W5mCJCKdupBCIsWPYNbWuJcRmFtSYujwNg+41ljFknhO9bpY6C+oahv659zW7W1AT7i6DQvJYYr1A==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-11.0.0.tgz",
+      "integrity": "sha512-EDghTDU7aOv2LTsRZvcT1w8mcjUaMhuy+t38iV5I/0Qiu6ixdkRwhLEMul3K/fnB2v9Nwqvb3xpvJfPH+HduDw==",
       "dev": true,
       "requires": {
         "postcss-scss": "^4.0.6",
-        "stylelint-config-recommended": "^11.0.0",
+        "stylelint-config-recommended": "^12.0.0",
         "stylelint-scss": "^4.6.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "react-qr-code": "^2.0.11",
         "react-stately": "^3.22.0",
         "react-toastify": "^9.1.2",
-        "swr": "^2.1.0"
+        "swr": "^2.1.5"
       },
       "devDependencies": {
         "@next/bundle-analyzer": "^13.3.1",
@@ -12992,9 +12992,9 @@
       "dev": true
     },
     "node_modules/swr": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.1.3.tgz",
-      "integrity": "sha512-g3ApxIM4Fjbd6vvEAlW60hJlKcYxHb+wtehogTygrh6Jsw7wNagv9m4Oj5Gq6zvvZw0tcyhVGL9L0oISvl3sUw==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.1.5.tgz",
+      "integrity": "sha512-/OhfZMcEpuz77KavXST5q6XE9nrOBOVcBLWjMT+oAE/kQHyE3PASrevXCtQDZ8aamntOfFkbVJp7Il9tNBQWrw==",
       "dependencies": {
         "use-sync-external-store": "^1.2.0"
       },
@@ -18461,7 +18461,7 @@
         "stylelint": "^15.6.0",
         "stylelint-config-recommended-scss": "^10.0.0",
         "stylelint-scss": "^4.6.0",
-        "swr": "^2.1.0",
+        "swr": "^2.1.5",
         "typescript": "^5.0.4"
       },
       "dependencies": {
@@ -22497,9 +22497,9 @@
       "dev": true
     },
     "swr": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.1.3.tgz",
-      "integrity": "sha512-g3ApxIM4Fjbd6vvEAlW60hJlKcYxHb+wtehogTygrh6Jsw7wNagv9m4Oj5Gq6zvvZw0tcyhVGL9L0oISvl3sUw==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.1.5.tgz",
+      "integrity": "sha512-/OhfZMcEpuz77KavXST5q6XE9nrOBOVcBLWjMT+oAE/kQHyE3PASrevXCtQDZ8aamntOfFkbVJp7Il9tNBQWrw==",
       "requires": {
         "use-sync-external-store": "^1.2.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/jest-axe": "^3.5.5",
         "@types/react": "^18.2.0",
-        "@typescript-eslint/eslint-plugin": "^5.56.0",
+        "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
         "babel-jest": "^29.4.2",
         "eslint": "^8.39.0",
@@ -3780,15 +3780,15 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.58.0.tgz",
-      "integrity": "sha512-vxHvLhH0qgBd3/tW6/VccptSfc8FxPQIkmNTVLWcCOVqSBvqpnKkBTYrhcGlXfSnd78azwe+PsjYFj0X34/njA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.2.tgz",
+      "integrity": "sha512-yVrXupeHjRxLDcPKL10sGQ/QlVrA8J5IYOEWVqk0lJaSZP7X5DfnP7Ns3cc74/blmbipQ1htFNVGsHX6wsYm0A==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/type-utils": "5.58.0",
-        "@typescript-eslint/utils": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/type-utils": "5.59.2",
+        "@typescript-eslint/utils": "5.59.2",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -3978,13 +3978,13 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.58.0.tgz",
-      "integrity": "sha512-b+w8ypN5CFvrXWQb9Ow9T4/6LC2MikNf1viLkYTiTbkQl46CnR69w7lajz1icW0TBsYmlpg+mRzFJ4LEJ8X9NA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.2.tgz",
+      "integrity": "sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0"
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3995,13 +3995,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.58.0.tgz",
-      "integrity": "sha512-FF5vP/SKAFJ+LmR9PENql7fQVVgGDOS+dq3j+cKl9iW/9VuZC/8CFmzIP0DLKXfWKpRHawJiG70rVH+xZZbp8w==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.2.tgz",
+      "integrity": "sha512-b1LS2phBOsEy/T381bxkkywfQXkV1dWda/z0PhnIy3bC5+rQWQDS7fk9CSpcXBccPY27Z6vBEuaPBCKCgYezyQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.58.0",
-        "@typescript-eslint/utils": "5.58.0",
+        "@typescript-eslint/typescript-estree": "5.59.2",
+        "@typescript-eslint/utils": "5.59.2",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -4022,9 +4022,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.58.0.tgz",
-      "integrity": "sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.2.tgz",
+      "integrity": "sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4035,13 +4035,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.58.0.tgz",
-      "integrity": "sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.2.tgz",
+      "integrity": "sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -4074,9 +4074,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4095,17 +4095,17 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.58.0.tgz",
-      "integrity": "sha512-gAmLOTFXMXOC+zP1fsqm3VceKSBQJNzV385Ok3+yzlavNHZoedajjS4UyS21gabJYcobuigQPs/z71A9MdJFqQ==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.2.tgz",
+      "integrity": "sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/typescript-estree": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/typescript-estree": "5.59.2",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -4151,12 +4151,12 @@
       "license": "ISC"
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.58.0.tgz",
-      "integrity": "sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.2.tgz",
+      "integrity": "sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
+        "@typescript-eslint/types": "5.59.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -16649,15 +16649,15 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.58.0.tgz",
-      "integrity": "sha512-vxHvLhH0qgBd3/tW6/VccptSfc8FxPQIkmNTVLWcCOVqSBvqpnKkBTYrhcGlXfSnd78azwe+PsjYFj0X34/njA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.2.tgz",
+      "integrity": "sha512-yVrXupeHjRxLDcPKL10sGQ/QlVrA8J5IYOEWVqk0lJaSZP7X5DfnP7Ns3cc74/blmbipQ1htFNVGsHX6wsYm0A==",
       "dev": true,
       "requires": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/type-utils": "5.58.0",
-        "@typescript-eslint/utils": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/type-utils": "5.59.2",
+        "@typescript-eslint/utils": "5.59.2",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -16766,41 +16766,41 @@
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.58.0.tgz",
-      "integrity": "sha512-b+w8ypN5CFvrXWQb9Ow9T4/6LC2MikNf1viLkYTiTbkQl46CnR69w7lajz1icW0TBsYmlpg+mRzFJ4LEJ8X9NA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.2.tgz",
+      "integrity": "sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0"
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.58.0.tgz",
-      "integrity": "sha512-FF5vP/SKAFJ+LmR9PENql7fQVVgGDOS+dq3j+cKl9iW/9VuZC/8CFmzIP0DLKXfWKpRHawJiG70rVH+xZZbp8w==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.2.tgz",
+      "integrity": "sha512-b1LS2phBOsEy/T381bxkkywfQXkV1dWda/z0PhnIy3bC5+rQWQDS7fk9CSpcXBccPY27Z6vBEuaPBCKCgYezyQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.58.0",
-        "@typescript-eslint/utils": "5.58.0",
+        "@typescript-eslint/typescript-estree": "5.59.2",
+        "@typescript-eslint/utils": "5.59.2",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.58.0.tgz",
-      "integrity": "sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.2.tgz",
+      "integrity": "sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.58.0.tgz",
-      "integrity": "sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.2.tgz",
+      "integrity": "sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -16818,9 +16818,9 @@
           }
         },
         "semver": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-          "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -16835,17 +16835,17 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.58.0.tgz",
-      "integrity": "sha512-gAmLOTFXMXOC+zP1fsqm3VceKSBQJNzV385Ok3+yzlavNHZoedajjS4UyS21gabJYcobuigQPs/z71A9MdJFqQ==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.2.tgz",
+      "integrity": "sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/typescript-estree": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/typescript-estree": "5.59.2",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -16871,12 +16871,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.58.0.tgz",
-      "integrity": "sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.2.tgz",
+      "integrity": "sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.58.0",
+        "@typescript-eslint/types": "5.59.2",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -18448,7 +18448,7 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/jest-axe": "^3.5.5",
         "@types/react": "^18.2.0",
-        "@typescript-eslint/eslint-plugin": "^5.56.0",
+        "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
         "babel-jest": "^29.4.2",
         "chokidar-cli": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       },
       "devDependencies": {
         "@next/bundle-analyzer": "^13.3.1",
-        "@next/eslint-plugin-next": "^13.1.6",
+        "@next/eslint-plugin-next": "^13.3.4",
         "@testing-library/dom": "^9.2.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
@@ -1705,9 +1705,9 @@
       "dev": true
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.3.1.tgz",
-      "integrity": "sha512-Hpd74UrYGF+bq9bBSRDXRsRfaWkPpcwjhvachy3sr/R/5fY6feC0T0s047pUthyqcaeNsqKOY1nUGQQJNm4WyA==",
+      "version": "13.3.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.3.4.tgz",
+      "integrity": "sha512-mvS+HafOPy31oJbAi920WJXMdjbyb4v5FAMr9PeGZfRIdEcsLkA3mU/ZvmwzovJgP3nAWw2e2yM8iIFW8VpvIA==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
@@ -5790,6 +5790,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@next/eslint-plugin-next": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.3.1.tgz",
+      "integrity": "sha512-Hpd74UrYGF+bq9bBSRDXRsRfaWkPpcwjhvachy3sr/R/5fY6feC0T0s047pUthyqcaeNsqKOY1nUGQQJNm4WyA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "7.1.7"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -15072,9 +15081,9 @@
       "dev": true
     },
     "@next/eslint-plugin-next": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.3.1.tgz",
-      "integrity": "sha512-Hpd74UrYGF+bq9bBSRDXRsRfaWkPpcwjhvachy3sr/R/5fY6feC0T0s047pUthyqcaeNsqKOY1nUGQQJNm4WyA==",
+      "version": "13.3.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.3.4.tgz",
+      "integrity": "sha512-mvS+HafOPy31oJbAi920WJXMdjbyb4v5FAMr9PeGZfRIdEcsLkA3mU/ZvmwzovJgP3nAWw2e2yM8iIFW8VpvIA==",
       "dev": true,
       "requires": {
         "glob": "7.1.7"
@@ -18018,6 +18027,17 @@
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-react": "^7.31.7",
         "eslint-plugin-react-hooks": "^4.5.0"
+      },
+      "dependencies": {
+        "@next/eslint-plugin-next": {
+          "version": "13.3.1",
+          "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.3.1.tgz",
+          "integrity": "sha512-Hpd74UrYGF+bq9bBSRDXRsRfaWkPpcwjhvachy3sr/R/5fY6feC0T0s047pUthyqcaeNsqKOY1nUGQQJNm4WyA==",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.7"
+          }
+        }
       }
     },
     "eslint-import-resolver-node": {
@@ -18421,7 +18441,7 @@
         "@fluent/react": "^0.15.0",
         "@mozilla-protocol/core": "^16.1.0",
         "@next/bundle-analyzer": "^13.3.1",
-        "@next/eslint-plugin-next": "^13.1.6",
+        "@next/eslint-plugin-next": "^13.3.4",
         "@testing-library/dom": "^9.2.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
         "@types/jest-axe": "^3.5.5",
-        "@types/react": "^18.0.38",
+        "@types/react": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
         "@typescript-eslint/parser": "^5.59.0",
         "babel-jest": "^29.4.2",
@@ -3713,9 +3713,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.0.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.38.tgz",
-      "integrity": "sha512-ExsidLLSzYj4cvaQjGnQCk4HFfVT9+EZ9XZsQ8Hsrcn8QNgXtpZ3m9vSIC2MWtx7jHictK6wYhQgGh6ic58oOw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -16582,9 +16582,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.0.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.38.tgz",
-      "integrity": "sha512-ExsidLLSzYj4cvaQjGnQCk4HFfVT9+EZ9XZsQ8Hsrcn8QNgXtpZ3m9vSIC2MWtx7jHictK6wYhQgGh6ic58oOw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -18427,7 +18427,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
         "@types/jest-axe": "^3.5.5",
-        "@types/react": "^18.0.38",
+        "@types/react": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
         "@typescript-eslint/parser": "^5.59.0",
         "babel-jest": "^29.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@types/jest-axe": "^3.5.5",
         "@types/react": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
-        "@typescript-eslint/parser": "^5.59.0",
+        "@typescript-eslint/parser": "^5.59.2",
         "babel-jest": "^29.4.2",
         "eslint": "^8.39.0",
         "eslint-config-next": "^13.3.1",
@@ -3844,14 +3844,14 @@
       "license": "ISC"
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.0.tgz",
-      "integrity": "sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.2.tgz",
+      "integrity": "sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.59.0",
-        "@typescript-eslint/types": "5.59.0",
-        "@typescript-eslint/typescript-estree": "5.59.0",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/typescript-estree": "5.59.2",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3871,13 +3871,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz",
-      "integrity": "sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.2.tgz",
+      "integrity": "sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.0",
-        "@typescript-eslint/visitor-keys": "5.59.0"
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3888,9 +3888,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "5.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.0.tgz",
-      "integrity": "sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.2.tgz",
+      "integrity": "sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3901,13 +3901,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz",
-      "integrity": "sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.2.tgz",
+      "integrity": "sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.0",
-        "@typescript-eslint/visitor-keys": "5.59.0",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -3928,12 +3928,12 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz",
-      "integrity": "sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.2.tgz",
+      "integrity": "sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/types": "5.59.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -16687,41 +16687,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.0.tgz",
-      "integrity": "sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.2.tgz",
+      "integrity": "sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.59.0",
-        "@typescript-eslint/types": "5.59.0",
-        "@typescript-eslint/typescript-estree": "5.59.0",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/typescript-estree": "5.59.2",
         "debug": "^4.3.4"
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "5.59.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz",
-          "integrity": "sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==",
+          "version": "5.59.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.2.tgz",
+          "integrity": "sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.59.0",
-            "@typescript-eslint/visitor-keys": "5.59.0"
+            "@typescript-eslint/types": "5.59.2",
+            "@typescript-eslint/visitor-keys": "5.59.2"
           }
         },
         "@typescript-eslint/types": {
-          "version": "5.59.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.0.tgz",
-          "integrity": "sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==",
+          "version": "5.59.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.2.tgz",
+          "integrity": "sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "5.59.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz",
-          "integrity": "sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==",
+          "version": "5.59.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.2.tgz",
+          "integrity": "sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.59.0",
-            "@typescript-eslint/visitor-keys": "5.59.0",
+            "@typescript-eslint/types": "5.59.2",
+            "@typescript-eslint/visitor-keys": "5.59.2",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
@@ -16730,12 +16730,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.59.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz",
-          "integrity": "sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==",
+          "version": "5.59.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.2.tgz",
+          "integrity": "sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.59.0",
+            "@typescript-eslint/types": "5.59.2",
             "eslint-visitor-keys": "^3.3.0"
           }
         },
@@ -18449,7 +18449,7 @@
         "@types/jest-axe": "^3.5.5",
         "@types/react": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
-        "@typescript-eslint/parser": "^5.59.0",
+        "@typescript-eslint/parser": "^5.59.2",
         "babel-jest": "^29.4.2",
         "chokidar-cli": "^3.0.0",
         "cldr-localenames-modern": "^43.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "next": "^13.3.0",
         "prettier": "2.8.8",
         "react-test-renderer": "^18.2.0",
-        "sass": "^1.61.0",
+        "sass": "^1.62.1",
         "stylelint": "^15.6.0",
         "stylelint-config-recommended-scss": "^11.0.0",
         "stylelint-scss": "^4.6.0",
@@ -12322,9 +12322,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.0.tgz",
-      "integrity": "sha512-Q4USplo4pLYgCi+XlipZCWUQz5pkg/ruSSgJ0WRDSb/+3z9tXUOkQ7QPYn4XrhZKYAK4HlpaQecRwKLJX6+DBg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
+      "integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -18457,7 +18457,7 @@
         "react-stately": "^3.22.0",
         "react-test-renderer": "^18.2.0",
         "react-toastify": "^9.1.2",
-        "sass": "^1.61.0",
+        "sass": "^1.62.1",
         "stylelint": "^15.6.0",
         "stylelint-config-recommended-scss": "^11.0.0",
         "stylelint-scss": "^4.6.0",
@@ -22044,9 +22044,9 @@
       "version": "2.1.2"
     },
     "sass": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.0.tgz",
-      "integrity": "sha512-Q4USplo4pLYgCi+XlipZCWUQz5pkg/ruSSgJ0WRDSb/+3z9tXUOkQ7QPYn4XrhZKYAK4HlpaQecRwKLJX6+DBg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
+      "integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",


### PR DESCRIPTION
Update dependencies. This covers:

* Bump @typescript-eslint/eslint-plugin from 5.58.0 to 5.59.2 (from PR #3376)
* Bump @typescript-eslint/parser from 5.59.0 to 5.59.2 (from PR #3375)
* Bump @next/eslint-plugin-next from 13.3.1 to 13.3.4 (from PR #3374)
* Bump sass from 1.62.0 to 1.62.1 (from PR #3369)
* Bump stylelint-config-recommended-scss from 10.0.0 to 11.0.0 (from PR #3353)
* Bump swr from 2.1.3 to 2.1.5 (from PR #3350)
* Bump @types/react from 18.0.38 to 18.2.0 (from PR #3349)