### PR TITLE
Document Firefox OAuth and accept terms of service

### DIFF
--- a/docs/api_auth.md
+++ b/docs/api_auth.md
@@ -42,6 +42,37 @@ sequenceDiagram
     Relay->>Extension: [{id:, address:, etc.}, {id:, address:, etc.}]
 ```
 
+## Firefox OAuth Token Authentication and Accept Terms of Service
+
+Similarly to the add-on, Firefox uses the [the FXA OAuth service][fxa-oauth] /oauth/token endpoint with `scope: ["https://identity.mozilla.com/apps/relay"]` to get the scoped access token that expires every 24 hours (see which calls [`getOAuthToken`][searchfox-getoauthtoken] [`accessTokenWithSessionToken`][searchfox-accesstokenwithsessiontoken]).
+
+After successful OAuth flow with FXA, Firefox uses this token to authenticate all requests to Relay by including an `Authorization: Bearer {fxa-access-token}` header in all API requests. Since the token was generated from FXA and not in Relay, Firefox must hit Relay's /api/v1/terms-accepted-user endpoint to ensure that user has accepted the Terms of Service and for a new user and profile to be created on Relay.
+
+```mermaid
+sequenceDiagram
+    participant Firefox
+    participant FXA
+    participant Relay
+
+rect rgba(34, 0, 51, .09)
+    note right of Firefox: OAuth2 Flow
+    Firefox->>FXA: POST /oauth/token/
+    FXA->>Firefox: JSON: {Relay access token valid for 24 hrs}
+    end
+    Firefox->>Relay: POST /api/v1/terms-accepted-user Authorization: Token {token}
+    Relay->>FXA: POST /v1/introspect {token}
+    FXA->>Relay: 200 OK
+    Relay->>Relay: Create new user and profile on DB if FxA user does not exist
+    Relay->>Firefox: 201 Created or 202 User already exists
+    note right of Firefox: Request new Relay Address
+    Firefox->>Relay: POST /api/v1/relayaddresses Authorization: Token {token}
+    Note over Relay,FXA: FxaTokenAuthentication
+    Relay->>FXA: POST /v1/introspect {token}
+    FXA->>Relay: 200 OK
+    Relay->>Relay: Verify user exists on our DB
+    Relay->>Firefox: 201 Created {"id":, "address":, ...} or 401 Unauthorized
+```
+
 [drf]: https://www.django-rest-framework.org/
 [sessionauthentication]: https://www.django-rest-framework.org/api-guide/authentication/#sessionauthentication
 [tokenauthentication]: https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication
@@ -50,3 +81,4 @@ sequenceDiagram
 [fxa-pkce]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/pkce.md
 [fxa-oauth-token-verify]: https://mozilla.github.io/ecosystem-platform/api#tag/OAuth-Server-API-Overview/operation/postVerify
 [searchfox-getoauthtoken]: https://searchfox.org/mozilla-central/search?q=symbol:%23getOAuthToken&redirect=false
+[searchfox-accesstokenwithsessiontoken]: https://searchfox.org/mozilla-central/search?q=symbol:%23accessTokenWithSessionToken&redirect=false

--- a/docs/api_auth.md
+++ b/docs/api_auth.md
@@ -54,16 +54,20 @@ sequenceDiagram
     participant FXA
     participant Relay
 
-rect rgba(34, 0, 51, .09)
+    rect rgba(204, 153, 255, .09)
     note right of Firefox: OAuth2 Flow
     Firefox->>FXA: POST /oauth/token/
     FXA->>Firefox: JSON: {Relay access token valid for 24 hrs}
     end
+    rect rgba(153, 204, 255, .09)
+    note right of Firefox: Firefox User Accepts ToS
     Firefox->>Relay: POST /api/v1/terms-accepted-user Authorization: Token {token}
     Relay->>FXA: POST /v1/introspect {token}
     FXA->>Relay: 200 OK
-    Relay->>Relay: Create new user and profile on DB if FxA user does not exist
+    Relay->>Relay: Create new user on DB if Fxa user DNE
     Relay->>Firefox: 201 Created or 202 User already exists
+    end
+    rect rgba(255, 255, 153, .09)
     note right of Firefox: Request new Relay Address
     Firefox->>Relay: POST /api/v1/relayaddresses Authorization: Token {token}
     Note over Relay,FXA: FxaTokenAuthentication
@@ -71,6 +75,7 @@ rect rgba(34, 0, 51, .09)
     FXA->>Relay: 200 OK
     Relay->>Relay: Verify user exists on our DB
     Relay->>Firefox: 201 Created {"id":, "address":, ...} or 401 Unauthorized
+    end
 ```
 
 [drf]: https://www.django-rest-framework.org/

--- a/docs/api_auth.md
+++ b/docs/api_auth.md
@@ -46,7 +46,7 @@ sequenceDiagram
 
 Similarly to the add-on, Firefox uses the [the FXA OAuth service][fxa-oauth] /oauth/token endpoint with `scope: ["https://identity.mozilla.com/apps/relay"]` to get the scoped access token that expires every 24 hours (see which calls [`getOAuthToken`][searchfox-getoauthtoken] [`accessTokenWithSessionToken`][searchfox-accesstokenwithsessiontoken]).
 
-After successful OAuth flow with FXA, Firefox uses this token to authenticate all requests to Relay by including an `Authorization: Bearer {fxa-access-token}` header in all API requests. Since the token was generated from FXA and not in Relay, Firefox must hit Relay's /api/v1/terms-accepted-user endpoint to ensure that user has accepted the Terms of Service and for a new user and profile to be created on Relay.
+Like the add-on, Firefox uses this token to authenticate all requests to Relay. Firefox includes an `Authorization: Bearer {fxa-access-token}` header in all API requests. Unlike the add-on, Firefox must first `POST` to the Relay `/api/v1/terms-accepted-user` endpoint to state that the user accepted the Terms of Service. This `POST` will also create the new user and profile records in Relay.
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
This PR addresses [MPP-3071](https://mozilla-hub.atlassian.net/browse/MPP-3071)

How to test:

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).


[MPP-3071]: https://mozilla-hub.atlassian.net/browse/MPP-3071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ