### PR TITLE
Js updates 2023 05 05 b

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^13.3.1",
-    "@next/eslint-plugin-next": "^13.3.4",
+    "@next/eslint-plugin-next": "^13.4.1",
     "@testing-library/dom": "^9.2.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "jest-junit": "^16.0.0",
     "license-checker": "^25.0.1",
     "lint-staged": "^13.2.0",
-    "next": "^13.3.0",
+    "next": "^13.4.1",
     "prettier": "2.8.8",
     "react-test-renderer": "^18.2.0",
     "sass": "^1.62.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest-axe": "^3.5.5",
-    "@types/react": "^18.2.0",
+    "@types/react": "^18.2.5",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "babel-jest": "^29.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       },
       "devDependencies": {
         "@next/bundle-analyzer": "^13.3.1",
-        "@next/eslint-plugin-next": "^13.3.4",
+        "@next/eslint-plugin-next": "^13.4.1",
         "@testing-library/dom": "^9.2.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
@@ -1705,9 +1705,9 @@
       "dev": true
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "13.3.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.3.4.tgz",
-      "integrity": "sha512-mvS+HafOPy31oJbAi920WJXMdjbyb4v5FAMr9PeGZfRIdEcsLkA3mU/ZvmwzovJgP3nAWw2e2yM8iIFW8VpvIA==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.1.tgz",
+      "integrity": "sha512-tVPS/2FKlA3ANCRCYZVT5jdbUKasBU8LG6bYqcNhyORDFTlDYa4cAWQJjZ7msIgLwMQIbL8CAsxrOL8maa/4Lg==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
@@ -15081,9 +15081,9 @@
       "dev": true
     },
     "@next/eslint-plugin-next": {
-      "version": "13.3.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.3.4.tgz",
-      "integrity": "sha512-mvS+HafOPy31oJbAi920WJXMdjbyb4v5FAMr9PeGZfRIdEcsLkA3mU/ZvmwzovJgP3nAWw2e2yM8iIFW8VpvIA==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.1.tgz",
+      "integrity": "sha512-tVPS/2FKlA3ANCRCYZVT5jdbUKasBU8LG6bYqcNhyORDFTlDYa4cAWQJjZ7msIgLwMQIbL8CAsxrOL8maa/4Lg==",
       "dev": true,
       "requires": {
         "glob": "7.1.7"
@@ -18441,7 +18441,7 @@
         "@fluent/react": "^0.15.0",
         "@mozilla-protocol/core": "^16.1.0",
         "@next/bundle-analyzer": "^13.3.1",
-        "@next/eslint-plugin-next": "^13.3.4",
+        "@next/eslint-plugin-next": "^13.4.1",
         "@testing-library/dom": "^9.2.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "jest-junit": "^16.0.0",
         "license-checker": "^25.0.1",
         "lint-staged": "^13.2.0",
-        "next": "^13.3.0",
+        "next": "^13.4.1",
         "prettier": "2.8.8",
         "react-test-renderer": "^18.2.0",
         "sass": "^1.62.1",
@@ -1699,9 +1699,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.3.0.tgz",
-      "integrity": "sha512-AjppRV4uG3No7L1plinoTQETH+j2F10TEnrMfzbTUYwze5sBUPveeeBAPZPm8OkJZ1epq9OyYKhZrvbD6/9HCQ==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.1.tgz",
+      "integrity": "sha512-eD6WCBMFjLFooLM19SIhSkWBHtaFrZFfg2Cxnyl3vS3DAdFRfnx5TY2RxlkuKXdIRCC0ySbtK9JXXt8qLCqzZg==",
       "dev": true
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1714,9 +1714,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.3.0.tgz",
-      "integrity": "sha512-DmIQCNq6JtccLPPBzf0dgh2vzMWt5wjxbP71pCi5EWpWYE3MsP6FcRXi4MlAmFNDQOfcFXR2r7kBeG1LpZUh1w==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.1.tgz",
+      "integrity": "sha512-eF8ARHtYfnoYtDa6xFHriUKA/Mfj/cCbmKb3NofeKhMccs65G6/loZ15a6wYCCx4rPAd6x4t1WmVYtri7EdeBg==",
       "cpu": [
         "arm64"
       ],
@@ -1730,9 +1730,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.3.0.tgz",
-      "integrity": "sha512-oQoqFa88OGgwnYlnAGHVct618FRI/749se0N3S8t9Bzdv5CRbscnO0RcX901+YnNK4Q6yeiizfgO3b7kogtsZg==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.1.tgz",
+      "integrity": "sha512-7cmDgF9tGWTgn5Gw+vP17miJbH4wcraMHDCOHTYWkO/VeKT73dUWG23TNRLfgtCNSPgH4V5B4uLHoZTanx9bAw==",
       "cpu": [
         "x64"
       ],
@@ -1746,9 +1746,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.3.0.tgz",
-      "integrity": "sha512-Wzz2p/WqAJUqTVoLo6H18WMeAXo3i+9DkPDae4oQG8LMloJ3if4NEZTnOnTUlro6cq+S/W4pTGa97nWTrOjbGw==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.1.tgz",
+      "integrity": "sha512-qwJqmCri2ie8aTtE5gjTSr8S6O8B67KCYgVZhv9gKH44yvc/zXbAY8u23QGULsYOyh1islWE5sWfQNLOj9iryg==",
       "cpu": [
         "arm64"
       ],
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.3.0.tgz",
-      "integrity": "sha512-xPVrIQOQo9WXJYgmoTlMnAD/HlR/1e1ZIWGbwIzEirXBVBqMARUulBEIKdC19zuvoJ477qZJgBDCKtKEykCpyQ==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.1.tgz",
+      "integrity": "sha512-qcC54tWNGDv/VVIFkazxhqH1Bnagjfs4enzELVRlUOoJPD2BGJTPI7z08pQPbbgxLtRiu8gl2mXvpB8WlOkMeA==",
       "cpu": [
         "arm64"
       ],
@@ -1778,9 +1778,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.3.0.tgz",
-      "integrity": "sha512-jOFlpGuPD7W2tuXVJP4wt9a3cpNxWAPcloq5EfMJRiXsBBOjLVFZA7boXYxEBzSVgUiVVr1V9T0HFM7pULJ1qA==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.1.tgz",
+      "integrity": "sha512-9TeWFlpLsBosZ+tsm/rWBaMwt5It9tPH8m3nawZqFUUrZyGRfGcI67js774vtx0k3rL9qbyY6+3pw9BCVpaYUA==",
       "cpu": [
         "x64"
       ],
@@ -1794,9 +1794,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.3.0.tgz",
-      "integrity": "sha512-2OwKlzaBgmuet9XYHc3KwsEilzb04F540rlRXkAcjMHL7eCxB7uZIGtsVvKOnQLvC/elrUegwSw1+5f7WmfyOw==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.1.tgz",
+      "integrity": "sha512-sNDGaWmSqTS4QRUzw61wl4mVPeSqNIr1OOjLlQTRuyInxMxtqImRqdvzDvFTlDfdeUMU/DZhWGYoHrXLlZXe6A==",
       "cpu": [
         "x64"
       ],
@@ -1810,9 +1810,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.3.0.tgz",
-      "integrity": "sha512-OeHiA6YEvndxT46g+rzFK/MQTfftKxJmzslERMu9LDdC6Kez0bdrgEYed5eXFK2Z1viKZJCGRlhd06rBusyztA==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.1.tgz",
+      "integrity": "sha512-+CXZC7u1iXdLRudecoUYbhbsXpglYv8KFYsFxKBPn7kg+bk7eJo738wAA4jXIl8grTF2mPdmO93JOQym+BlYGA==",
       "cpu": [
         "arm64"
       ],
@@ -1826,9 +1826,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.3.0.tgz",
-      "integrity": "sha512-4aB7K9mcVK1lYEzpOpqWrXHEZympU3oK65fnNcY1Qc4HLJFLJj8AViuqQd4jjjPNuV4sl8jAwTz3gN5VNGWB7w==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.1.tgz",
+      "integrity": "sha512-vIoXVVc7UYO68VwVMDKwJC2+HqAZQtCYiVlApyKEeIPIQpz2gpufzGxk1z3/gwrJt/kJ5CDZjlhYDCzd3hdz+g==",
       "cpu": [
         "ia32"
       ],
@@ -1842,9 +1842,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.3.0.tgz",
-      "integrity": "sha512-Reer6rkLLcoOvB0dd66+Y7WrWVFH7sEEkF/4bJCIfsSKnTStTYaHtwIJAwbqnt9I392Tqvku0KkoqZOryWV9LQ==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.1.tgz",
+      "integrity": "sha512-n8V5ImLQZibKTu10UUdI3nIeTLkliEXe628qxqW9v8My3BAH2a7H0SaCqkV2OgqFnn8sG1wxKYw9/SNJ632kSA==",
       "cpu": [
         "x64"
       ],
@@ -10934,34 +10934,35 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.3.0.tgz",
-      "integrity": "sha512-OVTw8MpIPa12+DCUkPqRGPS3thlJPcwae2ZL4xti3iBff27goH024xy4q2lhlsdoYiKOi8Kz6uJoLW/GXwgfOA==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.1.tgz",
+      "integrity": "sha512-JBw2kAIyhKDpjhEWvNVoFeIzNp9xNxg8wrthDOtMctfn3EpqGCmW0FSviNyGgOSOSn6zDaX48pmvbdf6X2W9xA==",
       "dev": true,
       "dependencies": {
-        "@next/env": "13.3.0",
-        "@swc/helpers": "0.4.14",
+        "@next/env": "13.4.1",
+        "@swc/helpers": "0.5.1",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
-        "styled-jsx": "5.1.1"
+        "styled-jsx": "5.1.1",
+        "zod": "3.21.4"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=14.6.0"
+        "node": ">=16.8.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.3.0",
-        "@next/swc-darwin-x64": "13.3.0",
-        "@next/swc-linux-arm64-gnu": "13.3.0",
-        "@next/swc-linux-arm64-musl": "13.3.0",
-        "@next/swc-linux-x64-gnu": "13.3.0",
-        "@next/swc-linux-x64-musl": "13.3.0",
-        "@next/swc-win32-arm64-msvc": "13.3.0",
-        "@next/swc-win32-ia32-msvc": "13.3.0",
-        "@next/swc-win32-x64-msvc": "13.3.0"
+        "@next/swc-darwin-arm64": "13.4.1",
+        "@next/swc-darwin-x64": "13.4.1",
+        "@next/swc-linux-arm64-gnu": "13.4.1",
+        "@next/swc-linux-arm64-musl": "13.4.1",
+        "@next/swc-linux-x64-gnu": "13.4.1",
+        "@next/swc-linux-x64-musl": "13.4.1",
+        "@next/swc-win32-arm64-msvc": "13.4.1",
+        "@next/swc-win32-ia32-msvc": "13.4.1",
+        "@next/swc-win32-x64-msvc": "13.4.1"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -10984,6 +10985,15 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -14051,6 +14061,15 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -15075,9 +15094,9 @@
       }
     },
     "@next/env": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.3.0.tgz",
-      "integrity": "sha512-AjppRV4uG3No7L1plinoTQETH+j2F10TEnrMfzbTUYwze5sBUPveeeBAPZPm8OkJZ1epq9OyYKhZrvbD6/9HCQ==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.1.tgz",
+      "integrity": "sha512-eD6WCBMFjLFooLM19SIhSkWBHtaFrZFfg2Cxnyl3vS3DAdFRfnx5TY2RxlkuKXdIRCC0ySbtK9JXXt8qLCqzZg==",
       "dev": true
     },
     "@next/eslint-plugin-next": {
@@ -15090,65 +15109,65 @@
       }
     },
     "@next/swc-darwin-arm64": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.3.0.tgz",
-      "integrity": "sha512-DmIQCNq6JtccLPPBzf0dgh2vzMWt5wjxbP71pCi5EWpWYE3MsP6FcRXi4MlAmFNDQOfcFXR2r7kBeG1LpZUh1w==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.1.tgz",
+      "integrity": "sha512-eF8ARHtYfnoYtDa6xFHriUKA/Mfj/cCbmKb3NofeKhMccs65G6/loZ15a6wYCCx4rPAd6x4t1WmVYtri7EdeBg==",
       "dev": true,
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.3.0.tgz",
-      "integrity": "sha512-oQoqFa88OGgwnYlnAGHVct618FRI/749se0N3S8t9Bzdv5CRbscnO0RcX901+YnNK4Q6yeiizfgO3b7kogtsZg==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.1.tgz",
+      "integrity": "sha512-7cmDgF9tGWTgn5Gw+vP17miJbH4wcraMHDCOHTYWkO/VeKT73dUWG23TNRLfgtCNSPgH4V5B4uLHoZTanx9bAw==",
       "dev": true,
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.3.0.tgz",
-      "integrity": "sha512-Wzz2p/WqAJUqTVoLo6H18WMeAXo3i+9DkPDae4oQG8LMloJ3if4NEZTnOnTUlro6cq+S/W4pTGa97nWTrOjbGw==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.1.tgz",
+      "integrity": "sha512-qwJqmCri2ie8aTtE5gjTSr8S6O8B67KCYgVZhv9gKH44yvc/zXbAY8u23QGULsYOyh1islWE5sWfQNLOj9iryg==",
       "dev": true,
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.3.0.tgz",
-      "integrity": "sha512-xPVrIQOQo9WXJYgmoTlMnAD/HlR/1e1ZIWGbwIzEirXBVBqMARUulBEIKdC19zuvoJ477qZJgBDCKtKEykCpyQ==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.1.tgz",
+      "integrity": "sha512-qcC54tWNGDv/VVIFkazxhqH1Bnagjfs4enzELVRlUOoJPD2BGJTPI7z08pQPbbgxLtRiu8gl2mXvpB8WlOkMeA==",
       "dev": true,
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.3.0.tgz",
-      "integrity": "sha512-jOFlpGuPD7W2tuXVJP4wt9a3cpNxWAPcloq5EfMJRiXsBBOjLVFZA7boXYxEBzSVgUiVVr1V9T0HFM7pULJ1qA==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.1.tgz",
+      "integrity": "sha512-9TeWFlpLsBosZ+tsm/rWBaMwt5It9tPH8m3nawZqFUUrZyGRfGcI67js774vtx0k3rL9qbyY6+3pw9BCVpaYUA==",
       "dev": true,
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.3.0.tgz",
-      "integrity": "sha512-2OwKlzaBgmuet9XYHc3KwsEilzb04F540rlRXkAcjMHL7eCxB7uZIGtsVvKOnQLvC/elrUegwSw1+5f7WmfyOw==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.1.tgz",
+      "integrity": "sha512-sNDGaWmSqTS4QRUzw61wl4mVPeSqNIr1OOjLlQTRuyInxMxtqImRqdvzDvFTlDfdeUMU/DZhWGYoHrXLlZXe6A==",
       "dev": true,
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.3.0.tgz",
-      "integrity": "sha512-OeHiA6YEvndxT46g+rzFK/MQTfftKxJmzslERMu9LDdC6Kez0bdrgEYed5eXFK2Z1viKZJCGRlhd06rBusyztA==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.1.tgz",
+      "integrity": "sha512-+CXZC7u1iXdLRudecoUYbhbsXpglYv8KFYsFxKBPn7kg+bk7eJo738wAA4jXIl8grTF2mPdmO93JOQym+BlYGA==",
       "dev": true,
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.3.0.tgz",
-      "integrity": "sha512-4aB7K9mcVK1lYEzpOpqWrXHEZympU3oK65fnNcY1Qc4HLJFLJj8AViuqQd4jjjPNuV4sl8jAwTz3gN5VNGWB7w==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.1.tgz",
+      "integrity": "sha512-vIoXVVc7UYO68VwVMDKwJC2+HqAZQtCYiVlApyKEeIPIQpz2gpufzGxk1z3/gwrJt/kJ5CDZjlhYDCzd3hdz+g==",
       "dev": true,
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.3.0.tgz",
-      "integrity": "sha512-Reer6rkLLcoOvB0dd66+Y7WrWVFH7sEEkF/4bJCIfsSKnTStTYaHtwIJAwbqnt9I392Tqvku0KkoqZOryWV9LQ==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.1.tgz",
+      "integrity": "sha512-n8V5ImLQZibKTu10UUdI3nIeTLkliEXe628qxqW9v8My3BAH2a7H0SaCqkV2OgqFnn8sG1wxKYw9/SNJ632kSA==",
       "dev": true,
       "optional": true
     },
@@ -18466,7 +18485,7 @@
         "license-checker": "^25.0.1",
         "lint-staged": "^13.2.0",
         "msw": "^1.2.1",
-        "next": "^13.3.0",
+        "next": "^13.4.1",
         "prettier": "2.8.8",
         "react": "18.2.0",
         "react-aria": "^3.24.0",
@@ -21228,28 +21247,38 @@
       "dev": true
     },
     "next": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.3.0.tgz",
-      "integrity": "sha512-OVTw8MpIPa12+DCUkPqRGPS3thlJPcwae2ZL4xti3iBff27goH024xy4q2lhlsdoYiKOi8Kz6uJoLW/GXwgfOA==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.1.tgz",
+      "integrity": "sha512-JBw2kAIyhKDpjhEWvNVoFeIzNp9xNxg8wrthDOtMctfn3EpqGCmW0FSviNyGgOSOSn6zDaX48pmvbdf6X2W9xA==",
       "dev": true,
       "requires": {
-        "@next/env": "13.3.0",
-        "@next/swc-darwin-arm64": "13.3.0",
-        "@next/swc-darwin-x64": "13.3.0",
-        "@next/swc-linux-arm64-gnu": "13.3.0",
-        "@next/swc-linux-arm64-musl": "13.3.0",
-        "@next/swc-linux-x64-gnu": "13.3.0",
-        "@next/swc-linux-x64-musl": "13.3.0",
-        "@next/swc-win32-arm64-msvc": "13.3.0",
-        "@next/swc-win32-ia32-msvc": "13.3.0",
-        "@next/swc-win32-x64-msvc": "13.3.0",
-        "@swc/helpers": "0.4.14",
+        "@next/env": "13.4.1",
+        "@next/swc-darwin-arm64": "13.4.1",
+        "@next/swc-darwin-x64": "13.4.1",
+        "@next/swc-linux-arm64-gnu": "13.4.1",
+        "@next/swc-linux-arm64-musl": "13.4.1",
+        "@next/swc-linux-x64-gnu": "13.4.1",
+        "@next/swc-linux-x64-musl": "13.4.1",
+        "@next/swc-win32-arm64-msvc": "13.4.1",
+        "@next/swc-win32-ia32-msvc": "13.4.1",
+        "@next/swc-win32-x64-msvc": "13.4.1",
+        "@swc/helpers": "0.5.1",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
-        "styled-jsx": "5.1.1"
+        "styled-jsx": "5.1.1",
+        "zod": "3.21.4"
       },
       "dependencies": {
+        "@swc/helpers": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+          "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.4.0"
+          }
+        },
         "postcss": {
           "version": "8.4.14",
           "dev": true,
@@ -23193,6 +23222,12 @@
     },
     "yocto-queue": {
       "version": "0.1.0",
+      "dev": true
+    },
+    "zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
         "@types/jest-axe": "^3.5.5",
-        "@types/react": "^18.2.0",
+        "@types/react": "^18.2.5",
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
         "babel-jest": "^29.4.2",
@@ -3713,9 +3713,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==",
+      "version": "18.2.5",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.5.tgz",
+      "integrity": "sha512-RuoMedzJ5AOh23Dvws13LU9jpZHIc/k90AgmK7CecAYeWmSr3553L4u5rk4sWAPBuQosfT7HmTfG4Rg5o4nGEA==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -16591,9 +16591,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==",
+      "version": "18.2.5",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.5.tgz",
+      "integrity": "sha512-RuoMedzJ5AOh23Dvws13LU9jpZHIc/k90AgmK7CecAYeWmSr3553L4u5rk4sWAPBuQosfT7HmTfG4Rg5o4nGEA==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -18447,7 +18447,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
         "@types/jest-axe": "^3.5.5",
-        "@types/react": "^18.2.0",
+        "@types/react": "^18.2.5",
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
         "babel-jest": "^29.4.2",


### PR DESCRIPTION
Update dependencies. This covers:

* Bump next from 13.3.0 to 13.4.1 (from PR #3383)
* Bump @types/react from 18.2.0 to 18.2.5 (from PR #3382)
* Bump @next/eslint-plugin-next from 13.3.4 to 13.4.1 (from PR #3381)