### PR TITLE
Python updates 2023 05 08

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ psycopg2==2.9.6
 PyJWT==2.6.0
 python-decouple==3.8
 pyOpenSSL==23.1.1
-requests==2.29.0
+requests==2.30.0
 sentry-sdk==1.22.1
 whitenoise==6.4.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ black==23.3.0
 
 # type hinting
 mypy==1.2.0
-types-requests==2.29.0.0
+types-requests==2.30.0.0
 types-pyOpenSSL==23.1.0.2
 django-stubs==4.2.0
 djangorestframework-stubs==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyJWT==2.6.0
 python-decouple==3.8
 pyOpenSSL==23.1.1
 requests==2.29.0
-sentry-sdk==1.21.1
+sentry-sdk==1.22.1
 whitenoise==6.4.0
 
 # phones app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.123
+boto3==1.26.129
 codetiming==1.4.0
 cryptography==40.0.2
 Django==3.2.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.26.123
 codetiming==1.4.0
 cryptography==40.0.2
-Django==3.2.18
+Django==3.2.19
 dj-database-url==2.0.0
 django-allauth==0.54.0
 django-cors-headers==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ whitenoise==6.4.0
 
 # phones app
 phonenumbers==8.13.11
-twilio==8.1.0
+twilio==8.2.0
 vobject==0.9.6.1
 
 # tests


### PR DESCRIPTION
Update dependencies. This covers:

* Bump types-requests from 2.29.0.0 to 2.30.0.0 (from PR #3393)
* Bump requests from 2.29.0 to 2.30.0 (from PR #3392)
* Bump boto3 from 1.26.123 to 1.26.129 (from PR #3391)
* Bump sentry-sdk from 1.21.1 to 1.22.1 (from PR #3390)
* Bump twilio from 8.1.0 to 8.2.0 (from PR #3389)
* Bump django from 3.2.18 to 3.2.19 (from PR #3388)