### PR TITLE
MPP-3078: Rewrite `_handle_bounce` to log more data

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -938,6 +938,9 @@ def _handle_bounce(message_json):
     """
     Handle an AWS SES bounce notification.
 
+    For more information, see:
+    https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html#bounce-object
+
     Returns:
     * 404 response if any email address does not match a user,
     * 200 response if all match or none are given
@@ -949,17 +952,14 @@ def _handle_bounce(message_json):
     * relay_action: 'no_action', 'auto_block_spam', 'hard_bounce', 'soft_bounce'
 
     Emits an info log "bounce_notification", same data as metric, plus:
-    * bounce_action - 'action' from bounced recipient data, or None
-    * bounce_status - 'status' from bounced recipient data, or None
-    * bounce_diagnostic - 'diagnosticCode' from bounced recipient data, or None
-    * bounce_extra - Extra data from bounce_recipient data, if any
-    * domain - User's domain, if an address was given
+    * bounce_action: 'action' from bounced recipient data, or None
+    * bounce_status: 'status' from bounced recipient data, or None
+    * bounce_diagnostic: 'diagnosticCode' from bounced recipient data, or None
+    * bounce_extra: Extra data from bounce_recipient data, if any
+    * domain: User's real email address domain, if an address was given
 
     Emits a legacy log "bounced recipient domain: {domain}", with data from
     bounced recipient data, without the email address.
-
-    For more information, see:
-    https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html#bounce-object
     """
     bounce = message_json.get("bounce", {})
     bounce_type = bounce.get("bounceType", "none")

--- a/emails/views.py
+++ b/emails/views.py
@@ -935,45 +935,122 @@ def _get_address(address: str) -> RelayAddress | DomainAddress:
 
 
 def _handle_bounce(message_json):
-    incr_if_enabled("email_bounce", 1)
-    bounce = message_json.get("bounce")
-    bounced_recipients = bounce.get("bouncedRecipients")
+    """
+    Handle an AWS SES bounce notification.
+
+    Returns:
+    * 404 response if any email address does not match a user,
+    * 200 response if all match or none are given
+
+    Emits a counter metric "email_bounce" with these tags:
+    * bounce_type: 'permanent', 'transient', 'undetermined', 'none' if omitted
+    * bounce_subtype: 'undetermined', 'general', etc., 'none' if omitted
+    * user: 'found', 'missing', error states 'no_address' and 'no_recipients'
+    * relay_action: 'no_action', 'auto_block_spam', 'hard_bounce', 'soft_bounce'
+
+    Emits an info log "bounce_notification", same data as metric, plus:
+    * bounce_action - 'action' from bounced recipient data, or None
+    * bounce_status - 'status' from bounced recipient data, or None
+    * bounce_diagnostic - 'diagnosticCode' from bounced recipient data, or None
+    * bounce_extra - Extra data from bounce_recipient data, if any
+    * domain - User's domain, if an address was given
+
+    Emits a legacy log "bounced recipient domain: {domain}", with data from
+    bounced recipient data, without the email address.
+
+    For more information, see:
+    https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html#bounce-object
+    """
+    bounce = message_json.get("bounce", {})
+    bounce_type = bounce.get("bounceType", "none")
+    bounce_subtype = bounce.get("bounceSubType", "none")
+    bounced_recipients = bounce.get("bouncedRecipients", [])
+
+    now = datetime.now(timezone.utc)
+    bounce_data = []
     for recipient in bounced_recipients:
         recipient_address = recipient.pop("emailAddress", None)
+        data = {
+            "bounce_type": bounce_type,
+            "bounce_subtype": bounce_subtype,
+            "bounce_action": recipient.pop("action", ""),
+            "bounce_status": recipient.pop("status", ""),
+            "bounce_diagnostic": recipient.pop("diagnosticCode", ""),
+            "user": "no_address",
+            "relay_action": "no_action",
+        }
+        if recipient:
+            data["bounce_extra"] = recipient.copy()
+        bounce_data.append(data)
+
         if recipient_address is None:
             continue
+
         recipient_address = parseaddr(recipient_address)[1]
         recipient_domain = recipient_address.split("@")[1]
-        info_logger.info(
-            f"bounced recipient domain: {recipient_domain}", extra=recipient
-        )
+        data["domain"] = recipient_domain
+
         try:
             user = User.objects.get(email=recipient_address)
             profile = user.profile
+            data["user"] = "found"
         except User.DoesNotExist:
-            incr_if_enabled("email_bounce_relay_user_gone", 1)
             # TODO: handle bounce for a user who no longer exists
             # add to SES account-wide suppression list?
-            return HttpResponse("Address does not exist", status=404)
-        now = datetime.now(timezone.utc)
-        incr_if_enabled(
-            "email_bounce_%s_%s"
-            % (bounce.get("bounceType"), bounce.get("bounceSubType")),
-            1,
-        )
-        # if an email bounced as spam, set to auto block spam for this user
-        # and DON'T set them into bounce pause state
-        if any("spam" in val.lower() for val in recipient.values()):
-            profile.auto_block_spam = True
-            profile.save()
+            data["user"] = "missing"
             continue
-        if bounce.get("bounceType") == "Permanent":
+
+        action = None
+        if "spam" in data["bounce_diagnostic"].lower():
+            # if an email bounced as spam, set to auto block spam for this user
+            # and DON'T set them into bounce pause state
+            action = "auto_block_spam"
+            profile.auto_block_spam = True
+        elif bounce_type == "Permanent":
+            # TODO: handle sub-types: 'General', 'NoEmail', etc.
+            action = "hard_bounce"
             profile.last_hard_bounce = now
-        if bounce.get("bounceType") == "Transient":
+        elif bounce_type == "Transient":
+            # TODO: handle sub-types: 'MessageTooLarge', 'AttachmentRejected', etc.
+            action = "soft_bounce"
             profile.last_soft_bounce = now
-            # TODO: handle sub-types: 'MessageTooLarge', 'AttachmentRejected',
-            # 'ContentRejected'
-        profile.save()
+        if action:
+            data["relay_action"] = action
+            profile.save()
+
+    if not bounce_data:
+        # Data when there are no identified recipients
+        bounce_data = [{"user": "no_recipients", "relay_action": "no_action"}]
+
+    for data in bounce_data:
+        tags = {
+            "bounce_type": bounce_type,
+            "bounce_subtype": bounce_subtype,
+            "user": data["user"],
+            "relay_action": data["relay_action"],
+        }
+        incr_if_enabled(
+            "email_bounce",
+            1,
+            tags=[generate_tag(key, val) for key, val in tags.items()],
+        )
+        info_logger.info("bounce_notification", extra=data)
+
+        # Legacy log, can be removed Q4 2023
+        recipient_domain = data.get("domain")
+        if recipient_domain:
+            legacy_extra = {
+                "action": data.get("bounce_action"),
+                "status": data.get("bounce_status"),
+                "diagnosticCode": data.get("bounce_diagnostic"),
+            }
+            legacy_extra.update(data.get("bounce_extra", {}))
+            info_logger.info(
+                f"bounced recipient domain: {recipient_domain}", extra=legacy_extra
+            )
+
+    if any(data["user"] == "missing" for data in bounce_data):
+        return HttpResponse("Address does not exist", status=404)
     return HttpResponse("OK", status=200)
 
 


### PR DESCRIPTION
When looking at the data for bounces for MPP-3078, the logs are missing the bounce type and subtype from AWS. This is probably a better method for determining what we should do for bounces than parsing the diagnostic code, which is meant for an email admin to read.

This PR rewrites `_handle_bounce` to move metrics and logging to the end of the function, and to augment them with more data.

The counter "email_bounce" now has tags 'bounce_type', 'bounce_subtype', 'user', and 'relay_action'. The type and sub-type are lowercased. The counter will be incremented for each recipient identified by AWS, or once if no recipients. Previously, this was incremented once per bounce notification, with no tags.

The new log "bounce_notification" has the same data, except the type and subtype are not lowercase. It also includes the data from the bounce recipient 'bounce_action', 'bounce_status', and 'bounce_diagnostic'. If there is more undocumented data, it is in 'bounce_extra'. There is also 'domain' for the user's domain.

The log "bounced recipient domain: {domain}" is still emitted, but marked as legacy. It can be removed in Q4 2023, when we have a full backlog of "bounce_notification" logs.

Some unused metrics have been removed:
* The counter "email_bounce_relay_user_gone" is replaced with the counter "email_bounce" with tag "user=missing".
* The counter "email_bounce_Permanent_General" is replaced with the counter "email_bounce" with tag "bounce_type=permanent", "bounce_subtype=general". Other similar tags that embedded the type and subtype in the name are replaced in the same way.

The handler no longer returns a 404 on the first missing user, but continues processing the recipient list. This is not expected to have an impact, since we forward emails to a single recipient.

# To Test
I did not run this against live data, but relied on the existing tests, which did not change.

1. Edit `.env` to enable statsd logs:
        DJANGO_STATSD_ENABLED=True
        STATSD_DEBUG=True
3. Run `pytest emails/tests/views_tests.py::BounceHandlingTest -sv`, to run the bounce tests in verbose mode without capturing output.

Before this change, I got output for the first test like this:

```
emails/tests/views_tests.py::BounceHandlingTest::test_sns_message_with_hard_bounce Creating test database for alias 'default'...
{"Timestamp": 1683735414647800064, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "MacBook-Pro-2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 7708, "Fields": {"msg": "METRICS|2023-05-10 16:16:54|incr|fx.private.relay.sns_inbound_Notification_Received|1|"}}
{"Timestamp": 1683735414648381952, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "MacBook-Pro-2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 7708, "Fields": {"msg": "METRICS|2023-05-10 16:16:54|incr|fx.private.relay.email_bounce|1|"}}
{"Timestamp": 1683735414648477952, "Type": "eventsinfo", "Logger": "fx-private-relay", "Hostname": "MacBook-Pro-2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 7708, "Fields": {"action": "failed", "status": "5.1.1", "diagnosticCode": "Amazon SES did not send the message to this address because it is on the suppression list for your account. For more information about removing addresses from the suppression list, see the Amazon SES Developer Guide at https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-email-suppression-list.html", "msg": "bounced recipient domain: test.com"}}
{"Timestamp": 1683735414649171968, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "MacBook-Pro-2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 7708, "Fields": {"msg": "METRICS|2023-05-10 16:16:54|incr|fx.private.relay.email_bounce_Permanent_OnAccountSuppressionList|1|"}}
{"Timestamp": 1683735414649914112, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "MacBook-Pro-2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 7708, "Fields": {"msg": "METRICS|2023-05-10 16:16:54|timing|fx.private.relay.s3_remove_message_from|0.000666000232740771|"}}
PASSED
...
```

```
emails/tests/views_tests.py::BounceHandlingTest::test_sns_message_with_hard_bounce Creating test database for alias 'default'...
{"Timestamp": 1683734579199550976, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "MacBook-Pro-2.local", "EnvVersion": "2.0", "Severity": 6, "Pid": 7052, "Fields": {"msg": "METRICS|2023-05-10 16:02:59|incr|fx.private.relay.sns_inbound_Notification_Received|1|"}}
{"Timestamp": 1683734579201264128, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "MacBook-Pro-2.local", "EnvVersion": "2.0", "Severity": 6, "Pid": 7052, "Fields": {"msg": "METRICS|2023-05-10 16:02:59|incr|fx.private.relay.email_bounce|1|#bounce_type:permanent,bounce_subtype:onaccountsuppressionlist,user:found,relay_action:hard_bounce"}}
{"Timestamp": 1683734579201334016, "Type": "eventsinfo", "Logger": "fx-private-relay", "Hostname": "MacBook-Pro-2.local", "EnvVersion": "2.0", "Severity": 6, "Pid": 7052, "Fields": {"bounce_type": "Permanent", "bounce_subtype": "OnAccountSuppressionList", "bounce_action": "failed", "bounce_status": "5.1.1", "bounce_diagnostic": "Amazon SES did not send the message to this address because it is on the suppression list for your account. For more information about removing addresses from the suppression list, see the Amazon SES Developer Guide at https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-email-suppression-list.html", "user": "found", "relay_action": "hard_bounce", "domain": "test.com", "msg": "bounce_notification"}}
{"Timestamp": 1683734579201404928, "Type": "eventsinfo", "Logger": "fx-private-relay", "Hostname": "MacBook-Pro-2.local", "EnvVersion": "2.0", "Severity": 6, "Pid": 7052, "Fields": {"action": "failed", "status": "5.1.1", "diagnosticCode": "Amazon SES did not send the message to this address because it is on the suppression list for your account. For more information about removing addresses from the suppression list, see the Amazon SES Developer Guide at https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-email-suppression-list.html", "msg": "bounced recipient domain: test.com"}}
{"Timestamp": 1683734579201613056, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "MacBook-Pro-2.local", "EnvVersion": "2.0", "Severity": 6, "Pid": 7052, "Fields": {"msg": "METRICS|2023-05-10 16:02:59|timing|fx.private.relay.s3_remove_message_from|0.0005840001904289238|"}}
PASSED
...
```

The changes:
* Counter `fx.private.relay.sns_inbound_Notification_Received` is the same
* Counter `fx.private.relay.email_bounce` now has tags:
    - `bounce_type:permanent`
    - `bounce_subtype:onaccountsuppressionlist`
    - `user:found`
    - `relay_action:hard_bounce`
* New `eventsinfo` log with data:
    ```json
    {
      "bounce_type": "Permanent",
      "bounce_subtype": "OnAccountSuppressionList",
      "bounce_action": "failed",
      "bounce_status": "5.1.1",
      "bounce_diagnostic": "Amazon SES did not send the message to this address because it is on the suppression list for your account. For more information about removing addresses from the suppression list, see the Amazon SES Developer Guide at https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-email-suppression-list.html",
      "user": "found",
      "relay_action": "hard_bounce",
      "domain": "test.com",
      "msg": "bounce_notification"
    }
    ```
* Same `eventsinfo` log with data:
    ```json
    {
      "action": "failed",
      "status": "5.1.1",
      "diagnosticCode": "Amazon SES did not send the message to this address because it is on the suppression list for your account. For more information about removing addresses from the suppression list, see the Amazon SES Developer Guide at https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-email-suppression-list.html",
      "msg": "bounced recipient domain: test.com"
    }
    ```
* metric `fx.private.relay.email_bounce_Permanent_OnAccountSuppressionList` removed, data is in tags for `email_bounce`
* timing metric `fx.private.relay.s3_remove_message_from` is the same

