### PR TITLE
Load faq.ftl on backend

### DIFF
--- a/privaterelay/ftl_bundles.py
+++ b/privaterelay/ftl_bundles.py
@@ -33,6 +33,7 @@ main = Bundle(
         "misc.ftl",  # Error messages
         "pending.ftl",  # The backend pending translations, ./en/pending.ftl
         "phones.ftl",  # SMS errors
+        "faq.ftl",  # email-size-limit
     ],
     finder=RelayMessageFinder(),
 )


### PR DESCRIPTION
`faq.ftl` defines `"email-size-limit"`:

https://github.com/mozilla-l10n/fx-private-relay-l10n/blob/a7827d03270c0f56da585028c1dae7224069c3b0/en/faq.ftl#L13

used in `"forwarded-email-header-attachment"`:

https://github.com/mozilla-l10n/fx-private-relay-l10n/blob/a7827d03270c0f56da585028c1dae7224069c3b0/en/misc.ftl#L207-L209

If the backend doesn't load this file, this error is logged:

```
FTL exception for locale [en], message 'forwarded-email-header-attachment', args {}: FluentReferenceError('/Users/john/src/fx-private-relay/privaterelay/locales/en/misc.ftl:209:134: Unknown message: email-size-limit')
```
