### PR TITLE
MPP-3064 - Email tracker link 

### DIFF
--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -145,7 +145,7 @@
             {% comment %}
               Create this as a link if we have a report link to show 
             {% endcomment %}
-            {% if tracker_report_link %}
+            {% if num_level_one_email_trackers_removed > 0 and tracker_report_link %}
             <a class="container-link" href="{{ tracker_report_link  }}" style="color: #FFFFFF;"> 
               {% ftlmsg 'relay-email-trackers-removed' number=num_level_one_email_trackers_removed %}
             </a>

--- a/frontend/src/pages/tracker-report.page.tsx
+++ b/frontend/src/pages/tracker-report.page.tsx
@@ -48,7 +48,13 @@ const TrackerReport: NextPage = () => {
       </div>
     );
   }
-  if (reportData === null) {
+
+  // check if reportData is null and check if trackers are set.
+  if (
+    reportData === null ||
+    !reportData.trackers ||
+    Object.keys(reportData.trackers).length === 0
+  ) {
     return (
       <div className={styles["load-error"]}>
         {l10n.getString("trackerreport-load-error")}

--- a/frontend/src/pages/tracker-report.page.tsx
+++ b/frontend/src/pages/tracker-report.page.tsx
@@ -23,7 +23,7 @@ import { useL10n } from "../hooks/l10n";
 type ReportData = {
   sender: string;
   received_at: number;
-  trackers: Record<string, number>;
+  trackers?: Record<string, number>;
 };
 
 const TrackerReport: NextPage = () => {
@@ -50,11 +50,7 @@ const TrackerReport: NextPage = () => {
   }
 
   // check if reportData is null and check if trackers are set.
-  if (
-    reportData === null ||
-    !reportData.trackers ||
-    Object.keys(reportData.trackers).length === 0
-  ) {
+  if (reportData === null) {
     return (
       <div className={styles["load-error"]}>
         {l10n.getString("trackerreport-load-error")}
@@ -62,7 +58,7 @@ const TrackerReport: NextPage = () => {
     );
   }
 
-  const trackers = Object.entries(reportData.trackers).sort(
+  const trackers = Object.entries(reportData.trackers ?? {}).sort(
     ([_trackerA, countA], [_trackerB, countB]) => countB - countA
   );
   const trackerListing =
@@ -128,8 +124,9 @@ const TrackerReport: NextPage = () => {
                 <dt>{l10n.getString("trackerreport-meta-count-heading")}</dt>
                 <dd>
                   {l10n.getString("trackerreport-trackers-value", {
-                    count: Object.values(reportData.trackers).reduce(
-                      (acc, count) => acc + count
+                    count: Object.values(reportData.trackers ?? {}).reduce(
+                      (acc, count) => acc + count,
+                      0
                     ),
                   })}
                 </dd>
@@ -246,8 +243,8 @@ function containsReportData(parsed: any): parsed is ReportData {
     parsed !== null &&
     typeof parsed.sender === "string" &&
     Number.isInteger(parsed.received_at) &&
-    typeof parsed.trackers === "object" &&
-    Object.entries(parsed.trackers).every(
+    ["undefined", "object"].includes(typeof parsed.trackers) &&
+    Object.entries(parsed.trackers ?? {}).every(
       ([tracker, count]: [unknown, unknown]) =>
         typeof tracker === "string" && Number.isInteger(count)
     )


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3064

Clicking tracker reports in forwarded emails directs to a white screen noting a console error. 
 
<!-- When adding a new feature: -->

# New feature description

Suggested fix: @Vinnl the email should not include a link to the tracker report if no trackers were detected. And now that we've already sent these emails to folks, we probably also want to update the tracker report page to deal with 0 detected trackers.

This is a two part fix. Update the email template (wrapper) and update the tracker report page. 

We updated the email template to only render an anchor tag if trackers were detected, additional check added, (link and number of). We also added a check in the tracker report page, to make sure we render the appropriate error message if trackers are not found in the `reportData` object as assumed previously. 

# Screenshot (if applicable)

Not applicable.

# How to test

Use this URL: https://deploy-preview-3410--fx-relay-demo.netlify.app/tracker-report/#%7B%22sender%22:%20%22Microsoft@engage.microsoft.co[%E2%80%A6]t%22:%201683402542065,%20%22trackers%22:%20%7B%7D%7D 

On PRD, this URL would give you an application error page / white screen. Here, it should give you an error message, same as if we were missing `reportData`. 


# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
