### PR TITLE
Remove multiple scrollbars on Chrome

### DIFF
--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -29,9 +29,33 @@ body,
 #overlayProvider {
   font-family: $font-stack-base;
 
+  // It looks like a Chrome/Blink bug results in the entire page moving up when
+  // the user toggles the Forwarding control (e.g. from blocking all to blocking
+  // promotional emails), and the bottom of the page being just whitespace.
+  // The reason this looks to be a chrome bug is that adding `position: fixed`
+  // and then removing it again to the `#__next` element fixes the issue,
+  // even though that ends us up with the original styles.
+  // Removing `height: 100%` and `overflow: hidden` causes the following issues:
+  // - The footer isn't pushed to the bottom of the viewport anymore if the
+  //   page isn't tall enough (e.g. settings page on desktop). See
+  //   https://github.com/mozilla/fx-private-relay/issues/3223
+  // - The mobile menu doesn't stay fixed to the top of the viewport. See
+  //   https://github.com/mozilla/fx-private-relay/issues/3407
+  // Since the Blink bug is most impactful on mobile (where the erroneous
+  // whitespace covers the entire viewport), we accept the above bugs there.
+  // See also:
+  // - https://github.com/mozilla/fx-private-relay/pull/3222
+  // - https://github.com/mozilla/fx-private-relay/issues/3223
+  // - https://github.com/mozilla/fx-private-relay/issues/3406
   @media screen and #{$mq-lg} {
-    // Ensures that the footer stays at the bottom
     height: 100%;
+    // In <Layout> all content is wrapped in a `.non-header-wrapper` that has its
+    // own `overflow` applied, to allow the header and mobile menu to remain fixed
+    // in place. However, in Blink- and WebKit-based browsers, this resulted in
+    // empty space at the bottom of the page, below the footer.
+    // Since the user can scroll in `.non-header-wrapper`, everything outside that
+    // that still overflows these elements can safely be hidden:
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
This was originally added in
66265f8e9623fa188a3d53fcb18dbbedf8ebc032, then removed in https://github.com/mozilla/fx-private-relay/pull/3222, and then was supposed to be restored (but only on large screens) in https://github.com/mozilla/fx-private-relay/pull/3268 - but that didn't happen. Thus, I've added it back here.
I also added a comment with more links to what happened in the first place, to hopefully aid investigation into a proper fix down the road.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3105.

How to test: open the website in Chrome - there should just be a single scrollbar visible. Also, on a small screen in Chrome, you should be able to toggle forwarding status without the page obviously breaking. On larger screens, unfortunately, toggling it will still result in the bottom half of the page being covered in whitespace, which we still don't have a fix for. Possibly, the suggestions in https://github.com/mozilla/fx-private-relay/issues/3406#issuecomment-1544027172 can fix that issue.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual issue.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
