### PR TITLE
Python updates 2023 05 15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cryptography==40.0.2
 Django==3.2.19
 dj-database-url==2.0.0
 django-allauth==0.54.0
-django-cors-headers==3.14.0
+django-cors-headers==4.0.0
 django-csp==3.7
 django-debug-toolbar==4.0.0
 django-filter==23.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.129
+boto3==1.26.133
 codetiming==1.4.0
 cryptography==40.0.2
 Django==3.2.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,6 @@ black==23.3.0
 # type hinting
 mypy==1.2.0
 types-requests==2.30.0.0
-types-pyOpenSSL==23.1.0.2
+types-pyOpenSSL==23.1.0.3
 django-stubs==4.2.0
 djangorestframework-stubs==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ responses==0.23.1
 black==23.3.0
 
 # type hinting
-mypy==1.2.0
+mypy==1.3.0
 types-requests==2.30.0.0
 types-pyOpenSSL==23.1.0.3
 django-stubs==4.2.0


### PR DESCRIPTION
Update dependencies. This covers:

* Bump mypy from 1.2.0 to 1.3.0 (from PR #3415)
* Bump django-cors-headers from 3.14.0 to 4.0.0 (from PR #3414)
* Bump boto3 from 1.26.129 to 1.26.133 (from PR #3412)
* Bump types-pyopenssl from 23.1.0.2 to 23.1.0.3 (from PR #3411)