### PR TITLE
pyjwt 2.6.0 to 2.7.0, with type fixes

### DIFF
--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -326,13 +326,7 @@ def get_fxa_event_jwt(
         "jti": str(uuid4()),
         "events": {event_key: event_data},
     }
-    return jwt.encode(
-        payload,
-        # expects str, but RSAPublicKey allowed
-        # https://github.com/jpadilla/pyjwt/issues/660
-        signing_key,  # type: ignore
-        algorithm="RS256",
-    )
+    return jwt.encode(payload, signing_key, algorithm="RS256")
 
 
 def test_fxa_rp_events_password_change(

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -1,20 +1,10 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from functools import lru_cache
 from hashlib import sha256
 from typing import Any, Iterable, Optional, TypedDict
 import json
 import logging
 import os
-from rest_framework.decorators import api_view, schema
-
-# from silk.profiling.profiler import silk_profile
-
-from google_measurement_protocol import event, report
-import jwt
-from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
-from requests_oauthlib import OAuth2Session
-import sentry_sdk
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from django.apps import apps
 from django.conf import settings
@@ -24,15 +14,23 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
+from rest_framework.decorators import api_view, schema
 
-from allauth.socialaccount.models import SocialAccount, SocialApp, SocialToken
+from allauth.socialaccount.models import SocialAccount, SocialApp
 from allauth.socialaccount.providers.fxa.views import FirefoxAccountsOAuth2Adapter
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from google_measurement_protocol import event, report
+from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
+import jwt
+import sentry_sdk
+
+# from silk.profiling.profiler import silk_profile
 
 from emails.models import CannotMakeSubdomainException, valid_available_subdomain
 from emails.utils import incr_if_enabled
+from privaterelay.fxa_utils import _get_oauth2_session, NoSocialToken
 
 from .apps import PrivateRelayConfig
-from privaterelay.fxa_utils import _get_oauth2_session, NoSocialToken
 
 
 FXA_PROFILE_CHANGE_EVENT = "https://schemas.accounts.firefox.com/event/profile-change"

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -14,6 +14,7 @@ import jwt
 from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
 from requests_oauthlib import OAuth2Session
 import sentry_sdk
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from django.apps import apps
 from django.conf import settings
@@ -237,6 +238,7 @@ def _verify_jwt_with_fxa_key(
     for verifying_key in verifying_keys:
         if verifying_key["alg"] == "RS256":
             public_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(verifying_key))
+            assert isinstance(public_key, RSAPublicKey)
             try:
                 security_event = jwt.decode(
                     req_jwt,

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ jwcrypto==1.4.2
 markus[datadog]==4.2.0
 pem==21.2.0
 psycopg2==2.9.6
-PyJWT==2.6.0
+PyJWT==2.7.0
 python-decouple==3.8
 pyOpenSSL==23.1.1
 requests==2.30.0


### PR DESCRIPTION
* Update to pyjwt 2.7.0, from PR #3413, which includes expanded and more accurate type hints. 
* Update our code for the new hints
* Arrange imports and remove some unused imports
