### PR TITLE
Translation fixes

### DIFF
--- a/emails/templates/emails/first_time_user.html
+++ b/emails/templates/emails/first_time_user.html
@@ -294,7 +294,7 @@
                           </p>
 
                           <p style="line-height: 140%; text-align: left; word-wrap: break-word;">
-                            {% ftlmsg 'first-time-user-email-how-item-1-subhead-html' url='https://addons.mozilla.org/firefox/addon/private-relay/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=addon-cta' %}
+                            {% ftlmsg 'first-time-user-email-how-item-1-subhead-html' url='https://addons.mozilla.org/firefox/addon/private-relay/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=addon-cta' attrs='' %}
                           </p>
 
                       </td>
@@ -334,7 +334,7 @@
                           </p>
 
                           <p style="line-height: 140%; text-align: left; word-wrap: break-word;">
-                            {% ftlmsg 'first-time-user-email-how-item-3-subhead-html' url=SITE_ORIGIN|add:'/accounts/profile/' %}
+                            {% ftlmsg 'first-time-user-email-how-item-3-subhead-html' url=SITE_ORIGIN|add:'/accounts/profile/' attrs='' %}
                           </p>
 
                       </td>

--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -123,20 +123,18 @@
           <img width="30" src="{{ SITE_ORIGIN }}/static/images/email-images/relay-icon.png" style="margin-right: 5px; display: inline-block; vertical-align: top;" alt="relay icon"/>   
            
           <p style="margin-top: 0; margin-bottom: 5px; display: inline-block;"> 
-            {% with display_email|striptags|urlencode as mask_url %}
             <span class="forwarded-from-email" style="display: block; color: #FFFFFF;"> 
-            {% ftlmsg 'relay-email-forwarded-from' %} 
-            <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile/#{{ mask_url }}" style="margin-right: 30px;color: #FFFFFF;"> {{ display_email|striptags }} </a>
+            {% with display_email|striptags|urlencode as mask_url %}
+            {% ftlmsg 'relay-email-forwarded-from-html' url=SITE_ORIGIN|add:'/accounts/profile/#'|add:mask_url attrs='class="container-link" style="margin-right: 30px;color: #FFFFFF;"' email_address=display_email|striptags %}
             {% endwith %}
-            </span> 
+            </span>
 
-          <span style="margin-top: 0; margin-bottom: 5px; display: block;color: #FFFFFF;">{% ftlmsg 'relay-email-by-line' %} <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile" style="margin-right: 30px;color: #FFFFFF;">
-            {% if has_premium %} 
-              {% ftlmsg 'relay-email-premium-by-line-link' %} 
+          <span style="margin-top: 0; margin-bottom: 5px; display: block;color: #FFFFFF;">
+            {% if has_premium %}
+              {% ftlmsg 'relay-email-premium-byline-html' url=SITE_ORIGIN|add:'/accounts/profile/' attrs='class="container-link" style="margin-right: 30px;color: #FFFFFF;"' %}
             {% else %}
-              {% ftlmsg 'relay-email-by-line-link' %}
+              {% ftlmsg 'relay-email-byline-html' url=SITE_ORIGIN|add:'/accounts/profile/' attrs='class="container-link" style="margin-right: 30px;color: #FFFFFF;"' %}
             {% endif %}
-          </a>
           </span>
           </p>  
             

--- a/privaterelay/ftl_bundles.py
+++ b/privaterelay/ftl_bundles.py
@@ -33,6 +33,7 @@ main = Bundle(
         "misc.ftl",  # Error messages
         "pending.ftl",  # The backend pending translations, ./en/pending.ftl
         "phones.ftl",  # SMS errors
+        "faq.ftl",  # email-size-limit
     ],
     finder=RelayMessageFinder(),
 )

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -3,18 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # This is the Django equivalent of frontend/pendingTranslations.ftl
-
-# $sender (string) - the sender's email address
-relay-email-replies-not-included-in-free-account-message = We’ve sent this reply to { $sender }. But moving forward, your replies will not be sent. Replying to forwarded emails from your masked email is only available with { -brand-name-firefox-relay-premium }.
-relay-email-replies-not-included-in-free-account-header = Replies are not included with your free account
-relay-email-upgrade-to-reply-to-future-emails = Upgrade now to reply to future emails
+#
 relay-email-upgrade-for-more-protection = Upgrade for more protection
-relay-email-upgrade-to-premium = Upgrade to { -brand-name-firefox-relay-premium }
-relay-email-manage-your-masks = Manage your masks
 relay-email-manage-this-mask = Manage this mask
-relay-email-relay-dashboard = { -brand-name-relay } dashboard
 relay-email-your-dashboard = Your dashboard
-relay-email-block-sender = Block sender
 # The by line for the premium email header that reads "by Firefox Relay Premium"
 relay-email-by-line = by
 # This is used by relay-email-premium-by-line to create a sentence like "by Firefox Relay Premium"

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -28,11 +28,15 @@ first-time-user-email-hero-cta = View your dashboard
 
 first-time-user-email-how-title = How { -brand-name-relay } works 
 first-time-user-email-how-item-1-header = Use a { -brand-name-relay } mask instead of your real email, everywhere
+# $url - URL of add-on
+# $attrs - Inline attributes for the link
 first-time-user-email-how-item-1-subhead-html = Create masks directly on { -brand-name-firefox }, with the <a href="{ $url }" { $attrs }>{ -brand-name-relay } add-on</a>, or on your { -brand-name-relay } dashboard.
 first-time-user-email-how-item-1-subhead-text = Create masks directly on { -brand-name-firefox }, with the { -brand-name-relay } add-on, or on your { -brand-name-relay } dashboard.
 first-time-user-email-how-item-2-header = We’ll forward all emails to your inbox 
 first-time-user-email-how-item-2-subhead =  Senders will never see your real address, and you can block emails any time.
 first-time-user-email-how-item-3-header = Manage your masks from your { -brand-name-relay } dashboard
+# $url - URL of the dashboard
+# $attrs - Inline attributes for the link
 first-time-user-email-how-item-3-subhead-html =  <a href="{ $url }" { $attrs }>Sign in</a> to create new masks, label your masks, and delete masks that get spam.
 first-time-user-email-how-item-3-subhead-text =  Sign in to create new masks, label your masks, and delete masks that get spam.
 
@@ -43,12 +47,15 @@ first-time-user-email-extra-protection-inbox-phone-subhead = Upgrade to { -brand
 first-time-user-email-extra-protection-cta = Get { -brand-name-relay-premium }
 
 first-time-user-email-questions-title = Questions about { -brand-name-firefox-relay }? 
+# $url - URL of the support team website
+# $attrs - In-line attributes for the link
 first-time-user-email-questions-subhead-html = Our <a href="{ $url }" { $attrs }>support team</a> is here to help.
 first-time-user-email-questions-subhead-text = Our support team is here to help.
 first-time-user-email-footer-text-1 = You’re receiving this automated email as a subscriber of { -brand-name-firefox-relay } that used { -brand-name-relay } for the first time. If you received it in error, no action is required.
+# $url - URL of the support team website
+# $attrs - In-line attributes for the link
 first-time-user-email-footer-text-2-html = For more information, please visit <a href="{ $url }" { $attrs }>{ -brand-name-mozilla } Support</a>.
 first-time-user-email-footer-text-2-text = For more information, please visit { -brand-name-mozilla } Support.
 first-time-user-email-footer-text-address = 2 Harrison St. #175, San Francisco, California 94105 USA
 first-time-user-email-footer-text-legal = Legal
 first-time-user-email-footer-text-privacy = Terms & Privacy
-

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -25,16 +25,7 @@ relay-email-forwarded-from = Forwarded from
 # $number - the number of email trackers removed
 relay-email-trackers-removed = { $number } email trackers removed
 
-## Email sent to free users who try to reply
-
-# Variables
-#   $sender (string) - the original sender's email address
-other-reply-not-forwarded = Your reply was NOT sent to { $sender }.
-# Variables
-#   $sender (string) - the original sender's email address
-other-reply-not-forwarded-2 = Your reply was not sent to { $sender }.
-
-## Email sent to first time free users 
+## Email sent to first time free users
 
 first-time-user-email-welcome = Welcome to { -brand-name-firefox-relay }
 first-time-user-email-preheader = Email masking to protect your identity

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -7,13 +7,20 @@
 relay-email-upgrade-for-more-protection = Upgrade for more protection
 relay-email-manage-this-mask = Manage this mask
 relay-email-your-dashboard = Your dashboard
-# The by line for the premium email header that reads "by Firefox Relay Premium"
-relay-email-by-line = by
-# This is used by relay-email-premium-by-line to create a sentence like "by Firefox Relay Premium"
-relay-email-premium-by-line-link = { -brand-name-firefox-relay-premium }
-# This is used by relay-email-by-line to create a sentence like "by Firefox Relay"
-relay-email-by-line-link = { -brand-name-firefox-relay }
-relay-email-forwarded-from = Forwarded from
+
+# The byline for the premium email header that reads "by Firefox Relay Premium"
+# $url - The URL of the Relay dashboard
+# $attrs - Inline attributes for the <a> link
+relay-email-premium-byline-html = by <a href="{ $url }" { $attrs }>{ -brand-name-firefox-relay-premium }</a>
+
+# The byline for the email header that reads "by Firefox Relay"
+# $url - The URL of the Relay dashboard
+# $attrs - Inline attributes for the <a> link
+relay-email-byline-html = by <a href="{ $url }" { $attrs }>{ -brand-name-firefox-relay }</a>
+
+# The link to manage this Relay mask
+relay-email-forwarded-from-html = Forwarded from <a href="{ $url }" { $attrs }>{ $email_address }</a>
+
 # $number - the number of email trackers removed
 relay-email-trackers-removed = { $number } email trackers removed
 


### PR DESCRIPTION
Several changes:

* Use `Bundle.reload()` to force Fluent files to reload before tests that use Fluent. This allows failing a test for Fluent errors, used to find many of the issues fixed in this PR.
* Load `faq.ftl` on the backend, which includes the `email-size-limit` used in "misc.ftl"
* Remove `other-reply-not-forwarded-2`, already merged to the l10n repo
* Remove strings unused in the current wrapper email template
* Add translator notes for variables like `{ $url }` and `{ $attrs }`
* Add `attrs=""` for strings that use `{ $attrs }`
* In the wrapper email template, convert partial strings, such as `"by" <a> "Firefox Relay"</a>` to HTML fragments, such as `"by <a> Firefox Relay </a>"`, to allow translators to match their language's sentence construction.

After this change is merged, we can more easily submit upstream to the l10n repo.

# How to test

Locally, view:

* http://127.0.0.1:8000/emails/wrapped_email_test
* http://127.0.0.1:8000/emails/reply_requires_premium_test
* http://127.0.0.1:8000/emails/first_time_user_test

They should be the same before and after this PR. No Fluent errors are printed to the console.