### PR TITLE
for MPP-3123: add system-ui, sans-serif fallback fonts

### DIFF
--- a/emails/templates/emails/first_time_user.html
+++ b/emails/templates/emails/first_time_user.html
@@ -36,11 +36,11 @@
       src: local('Metropolis Bold'), local('Metropolis-Bold'), url(https://relay.firefox.com/fonts/Metropolis/Metropolis-Bold.woff2) format('woff');
     }
     body {
-      font-family: 'inter', Arial, sans-serif;
+      font-family: 'inter', system-ui, sans-serif;
       color: #3D3D3D;
     }
     h1 {
-        font-family: 'metropolis bold';
+        font-family: 'metropolis bold', system-ui, sans-serif;
     }
     a {
       color: #0060DF;
@@ -51,7 +51,7 @@
         box-sizing: border-box;
         padding: 15px 25px;
         display: inline-block;
-        font-family: 'metropolis medium';
+        font-family: 'metropolis medium', system-ui, sans-serif;
         text-decoration: none;
         -webkit-text-size-adjust: none;
         text-align: center;
@@ -236,7 +236,7 @@
 
                 <td style="overflow-wrap:break-word;word-break:break-word;padding:10px;" align="left"> 
                   <h1 class="hero-title" style="margin: 0px; color: #ffffff; line-height: 100%; text-align: left; word-wrap: break-word; font-weight: 500px;">{% ftlmsg 'first-time-user-email-welcome' %}</h1>  
-                  <p class="hero-text" style="line-height: 140%; color: #ffffff;font-family: metropolis medium">{% ftlmsg 'first-time-user-email-welcome-subhead' %}</p>
+                  <p class="hero-text" style="line-height: 140%; color: #ffffff;font-family: metropolis medium, system-ui, sans-serif">{% ftlmsg 'first-time-user-email-welcome-subhead' %}</p>
                 </td>
               </tr>
             </tbody>
@@ -248,8 +248,8 @@
               <tr>
                 <td style="overflow-wrap:break-word;word-break:break-word;" align="center">
 
-                  <p style="color: #321C64; font-size: 18px; font-family: metropolis medium;">{% ftlmsg 'first-time-user-email-hero-primary-text' %}</p> 
-                  <p style="color: #321C64; font-size: 18px; font-family: metropolis medium;margin-top: 20px;">{% ftlmsg 'first-time-user-email-hero-secondary-text' %}</p>
+                  <p style="color: #321C64; font-size: 18px; font-family: metropolis medium, system-ui, sans-serif;">{% ftlmsg 'first-time-user-email-hero-primary-text' %}</p> 
+                  <p style="color: #321C64; font-size: 18px; font-family: metropolis medium, system-ui, sans-serif;margin-top: 20px;">{% ftlmsg 'first-time-user-email-hero-secondary-text' %}</p>
 
                   <a href="{{ SITE_ORIGIN }}/accounts/profile/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=hero-cta" target="_blank" class="button" style="margin-top: 30px;" rel="noreferrer">{% ftlmsg 'first-time-user-email-hero-cta' %}</a>
 
@@ -287,7 +287,7 @@
                           <img align="center" border="0" src="{{ SITE_ORIGIN }}/static/images/email-images/first-time-user/email-icon.png" alt="" title="" style=" height: auto; width: 100%;max-width: 32px;" />
 
                       </td>
-                      <td style="overflow-wrap:break-word;word-break:break-word;padding:10px 20px;font-family:inter;font-size:16px;" align="left">
+                      <td style="overflow-wrap:break-word;word-break:break-word;padding:10px 20px;font-family:inter, system-ui, sans-serif;font-size:16px;" align="left">
 
                           <p style="line-height: 140%; text-align: left; word-wrap: break-word; color: #20123A">
                             <strong>{% ftlmsg 'first-time-user-email-how-item-1-header' %}</strong> 
@@ -307,7 +307,7 @@
                           <img align="center" border="0" src="{{ SITE_ORIGIN }}/static/images/email-images/first-time-user/privacy-icon.png" alt="" title="" style=" height: auto; width: 100%;max-width: 32px;" />
 
                       </td>
-                      <td style="overflow-wrap:break-word;word-break:break-word;padding:10px 20px;font-family:inter;font-size:16px;" align="left">
+                      <td style="overflow-wrap:break-word;word-break:break-word;padding:10px 20px;font-family:inter, system-ui, sans-serif;font-size:16px;" align="left">
 
                           <p style="line-height: 140%; text-align: left; word-wrap: break-word; color: #20123A">
                             <strong>{% ftlmsg 'first-time-user-email-how-item-2-header' %}</strong> 
@@ -327,7 +327,7 @@
                           <img align="center" border="0" src="{{ SITE_ORIGIN }}/static/images/email-images/first-time-user/highlights-icon.png" alt="" title="" style=" height: auto; width: 100%;max-width: 32px;" />
 
                       </td>
-                      <td style="overflow-wrap:break-word;word-break:break-word;padding:10px 20px;font-family:inter;font-size:16px;" align="left">
+                      <td style="overflow-wrap:break-word;word-break:break-word;padding:10px 20px;font-family:inter, system-ui, sans-serif;font-size:16px;" align="left">
 
                           <p style="line-height: 140%; text-align: left; word-wrap: break-word; color: #20123A">
                             <strong>{% ftlmsg 'first-time-user-email-how-item-3-header' %}</strong> 
@@ -351,8 +351,8 @@
                 </td>
 
                 <td class="content" align="left">
-                  <p class="title" style="font-size: 18px; font-family: metropolis bold; color: #321C64; ">{% ftlmsg 'first-time-user-email-extra-protection-inbox-phone-title' %}</p>
-                  <p class="text" style="font-size: 14px; font-family: inter; color: #0C0C0D; word-wrap: break-word; margin-top: 10px; ">{% ftlmsg 'first-time-user-email-extra-protection-inbox-phone-subhead' %}</p> 
+                  <p class="title" style="font-size: 18px; font-family: metropolis bold, system-ui, sans-serif; color: #321C64; ">{% ftlmsg 'first-time-user-email-extra-protection-inbox-phone-title' %}</p>
+                  <p class="text" style="font-size: 14px; font-family: inter, system-ui, sans-serif; color: #0C0C0D; word-wrap: break-word; margin-top: 10px; ">{% ftlmsg 'first-time-user-email-extra-protection-inbox-phone-subhead' %}</p> 
                 </td>
 
                 <td class="cta" align="center"> 
@@ -368,8 +368,8 @@
               <tr style="display: block;">
                 <td style="display: block; text-align: center;" align="center">
                   <img src="{{ SITE_ORIGIN }}/static/images/email-images/first-time-user/union-icon.png" alt="" title="" style="display: block;height: auto;width: 100%;margin: 0 auto;max-width: 26px;" />
-                  <h1 style="word-wrap: break-word; font-size: 22px;font-family: metropolis bold; color: #321C64; margin-top: 30px;">{% ftlmsg 'first-time-user-email-questions-title' %}</h1>
-                  <p style="font-size: 16px; font-family: inter; color: #000000;margin-top: 15px;">{% ftlmsg 'first-time-user-email-questions-subhead-html' url='https://support.mozilla.org/products/relay?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=questions-link' attrs=''%}</p>
+                  <h1 style="word-wrap: break-word; font-size: 22px;font-family: metropolis bold, system-ui, sans-serif; color: #321C64; margin-top: 30px;">{% ftlmsg 'first-time-user-email-questions-title' %}</h1>
+                  <p style="font-size: 16px; font-family: inter, system-ui, sans-serif; color: #000000;margin-top: 15px;">{% ftlmsg 'first-time-user-email-questions-subhead-html' url='https://support.mozilla.org/products/relay?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=questions-link' attrs=''%}</p>
                 </td>
               </tr>
             </tbody>
@@ -391,11 +391,11 @@
             <tbody>
               <tr>
                 <td style="overflow-wrap: break-word;word-break: break-word;width: 70%;margin: 0 auto;display: block;" align="center"> 
-                  <p style="line-height: 140%;font-size: 14px; font-family: inter; color: #0C0C0D;">{% ftlmsg 'first-time-user-email-footer-text-1' %}</p>
-                  <p style="line-height: 140%;font-size: 14px; font-family: inter; color: #0C0C0D;">{% ftlmsg 'first-time-user-email-footer-text-2-html' url='https://support.mozilla.org/products/relay?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=footer-support-link' attrs='style="color: #0C0C0D;"' %}</p>
+                  <p style="line-height: 140%;font-size: 14px; font-family: inter, system-ui, sans-serif; color: #0C0C0D;">{% ftlmsg 'first-time-user-email-footer-text-1' %}</p>
+                  <p style="line-height: 140%;font-size: 14px; font-family: inter, system-ui, sans-serif; color: #0C0C0D;">{% ftlmsg 'first-time-user-email-footer-text-2-html' url='https://support.mozilla.org/products/relay?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=footer-support-link' attrs='style="color: #0C0C0D;"' %}</p>
                   <img align="center" border="0" src="{{ SITE_ORIGIN }}/static/images/email-images/first-time-user/mozilla-logo.png" alt="" title="" style="height: auto; width: 100%;max-width: 146px; margin: 30px auto; display: block;" />
-                  <p style="line-height: 140%;font-size: 14px; font-family: inter; color: #0C0C0D;">{% ftlmsg 'first-time-user-email-footer-text-address' %}</p>
-                  <p style="line-height: 140%;font-size: 14px; font-family: inter medium; color: #0C0C0D;margin-top: 15px;"><a style="color: #0C0C0D; text-decoration: none; font-weight: 600;" href="https://www.mozilla.org/about/legal/terms/firefox-relay/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=footer-legal-link" target="_blank" rel="noreferrer">{% ftlmsg 'first-time-user-email-footer-text-legal' %}</a> • <a style="color: #0C0C0D; text-decoration: none; font-weight: 600;" href="https://www.mozilla.org/privacy/firefox-relay/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=footer-privacy-link" target="_blank" rel="noreferrer">{% ftlmsg 'first-time-user-email-footer-text-privacy' %}</a></p>
+                  <p style="line-height: 140%;font-size: 14px; font-family: inter, system-ui, sans-serif; color: #0C0C0D;">{% ftlmsg 'first-time-user-email-footer-text-address' %}</p>
+                  <p style="line-height: 140%;font-size: 14px; font-family: inter medium, system-ui, sans-serif; color: #0C0C0D;margin-top: 15px;"><a style="color: #0C0C0D; text-decoration: none; font-weight: 600;" href="https://www.mozilla.org/about/legal/terms/firefox-relay/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=footer-legal-link" target="_blank" rel="noreferrer">{% ftlmsg 'first-time-user-email-footer-text-legal' %}</a> • <a style="color: #0C0C0D; text-decoration: none; font-weight: 600;" href="https://www.mozilla.org/privacy/firefox-relay/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=footer-privacy-link" target="_blank" rel="noreferrer">{% ftlmsg 'first-time-user-email-footer-text-privacy' %}</a></p>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
This PR fixes the font issue described in #MPP-3123.

How to test:
1. Set up for local end-to-end testing or test on the dev server
2. Sign up for Relay with a new user
3. Check the "Welcome to Relay" email sent to that user in a non-Apple mail client (e.g., Gmail app)
   * [ ] The fonts shouldn't look like "word art"

<img width="819" alt="image" src="https://github.com/mozilla/fx-private-relay/assets/71928/1c8f14f8-7aad-4b91-8f95-f2d3004e4822">


- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).