### PR TITLE
Python updates 2023 05 22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ dj-database-url==2.0.0
 django-allauth==0.54.0
 django-cors-headers==4.0.0
 django-csp==3.7
-django-debug-toolbar==4.0.0
+django-debug-toolbar==4.1.0
 django-filter==23.2
 django-redis==5.2.0
 django-ftl==0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,6 @@ types-requests==2.30.0.0
 types-pyOpenSSL==23.1.0.3
 django-stubs==4.2.0
 djangorestframework-stubs==3.14.0
-boto3-stubs==1.26.131
+boto3-stubs==1.26.137
 botocore-stubs==1.29.130
 mypy-boto3-ses==1.26.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.133
+boto3==1.26.137
 codetiming==1.4.0
 cryptography==40.0.2
 Django==3.2.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ whitenoise==6.4.0
 
 # phones app
 phonenumbers==8.13.11
-twilio==8.2.0
+twilio==8.2.1
 vobject==0.9.6.1
 
 # tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyJWT==2.7.0
 python-decouple==3.8
 pyOpenSSL==23.1.1
 requests==2.30.0
-sentry-sdk==1.22.2
+sentry-sdk==1.23.1
 whitenoise==6.4.0
 
 # phones app


### PR DESCRIPTION
Update dependencies. This covers:

* Bump boto3 from 1.26.133 to 1.26.137 (from PR #3443)
* Bump sentry-sdk from 1.22.2 to 1.23.1 (from PR #3442)
* Bump django-debug-toolbar from 4.0.0 to 4.1.0 (from PR #3441)
* Bump twilio from 8.2.0 to 8.2.1 (from PR #3440)
* Bump boto3-stubs from 1.26.131 to 1.26.137 (from PR #3439)