### PR TITLE
fix MPP-3086: save location hash in cookie and restore after FXA

### DIFF
--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -5,6 +5,7 @@ import {
   HTMLAttributes,
   ReactNode,
   RefObject,
+  useEffect,
   useRef,
 } from "react";
 import {
@@ -53,6 +54,7 @@ import { PremiumPromoBanners } from "../../components/dashboard/PremiumPromoBann
 import { useL10n } from "../../hooks/l10n";
 import { Localized } from "../../components/Localized";
 import { InfoModal } from "../../components/InfoModal";
+import { clearCookie, getCookie, setCookie } from "../../functions/cookies";
 
 const Profile: NextPage = () => {
   const runtimeData = useRuntimeData();
@@ -65,12 +67,22 @@ const Profile: NextPage = () => {
     category: "Purchase Button",
     label: "profile-bottom-promo",
   });
+  useEffect(() => {
+    const hash = getCookie("profile-location-hash");
+    if (hash) {
+      document.location.hash = hash;
+      clearCookie("profile-location-hash");
+    }
+  });
 
   usePurchaseTracker(profileData.data?.[0]);
 
   const modalState = useOverlayTriggerState({});
 
   if (!userData.isValidating && userData.error) {
+    if (document.location.hash) {
+      setCookie("profile-location-hash", document.location.hash);
+    }
     document.location.assign(getRuntimeConfig().fxaLoginUrl);
   }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #MPP-3086.

How to test:
1. Make an email alias
2. Sign out of Relay
3. Go to the dashboard with a link directly to the alias (e.g., https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/accounts/profile/#1bsahsinl@mozmail.dev.fxprivaterelay.nonprod.cloudops.mozgcp.net)
4. Go thru the FXA sign-in flow
   * [ ] When you land back on the dashboard, it should focus on the mask that's in the url

- [ ] ~l10n changes have been submitted to the l10n repository, if any.~
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] ~I've added or updated relevant docs in the docs/ directory.~
- [ ] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).