### PR TITLE
fix plan matrix showing string ID instead of content

### DIFF
--- a/frontend/src/components/landing/PlanMatrix.tsx
+++ b/frontend/src/components/landing/PlanMatrix.tsx
@@ -117,11 +117,11 @@ export const PlanMatrix = (props: Props) => {
           </th>
           {isBundleAvailableInCountry(props.runtimeData) ? (
             <th scope="col" className={styles.recommended}>
-              <b>{l10n.getString("plan-matrix-heading-plan-bundle")}</b>
+              <b>{l10n.getString("plan-matrix-heading-plan-bundle-2")}</b>
             </th>
           ) : (
             <th scope="col">
-              {l10n.getString("plan-matrix-heading-plan-bundle")}
+              {l10n.getString("plan-matrix-heading-plan-bundle-2")}
             </th>
           )}
         </tr>
@@ -535,7 +535,7 @@ export const PlanMatrix = (props: Props) => {
               : ""
           }`}
         >
-          <h3>{l10n.getString("plan-matrix-heading-plan-bundle")}</h3>
+          <h3>{l10n.getString("plan-matrix-heading-plan-bundle-2")}</h3>
           <MobileFeatureList list={bundleFeatures} />
           {isBundleAvailableInCountry(props.runtimeData) ? (
             <div className={styles.pricing}>

--- a/frontend/src/pages/index.test.tsx
+++ b/frontend/src/pages/index.test.tsx
@@ -117,7 +117,7 @@ describe("The landing page", () => {
     render(<Home />);
 
     const bundleColumn = screen.getByRole("columnheader", {
-      name: "l10n string: [plan-matrix-heading-plan-bundle], with vars: {}",
+      name: "l10n string: [plan-matrix-heading-plan-bundle-2], with vars: {}",
     });
 
     expect(bundleColumn).toBeInTheDocument();
@@ -154,7 +154,7 @@ describe("The landing page", () => {
     render(<Home />);
 
     const vpnFeatureRow = screen.getByRole("columnheader", {
-      name: "l10n string: [plan-matrix-heading-plan-bundle], with vars: {}",
+      name: "l10n string: [plan-matrix-heading-plan-bundle-2], with vars: {}",
     });
 
     expect(vpnFeatureRow).toBeInTheDocument();


### PR DESCRIPTION
Note: this neds to follow the "[Dirty `main`](https://github.com/mozilla/fx-private-relay/blob/main/docs/release_process.md#dirty-main-flow)" flow to create and deploy a `2023.05.18.01` tag to prod.

This PR fixes #MPP-3147.

How to test:
1. Go to the home page
2. Scroll down to the premium plan matrix (the section that starts with "Choose a level of protection that’s right for you")
   * [ ] The last column should show "Add VPN Protection" instead of the string ID
3. Go to the /premium page
   * [ ] The last column should show "Add VPN Protection" instead of the string ID

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).