### PR TITLE
fix MPP-3086 (again): move getCookie out of useEffect

### DIFF
--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -5,7 +5,6 @@ import {
   HTMLAttributes,
   ReactNode,
   RefObject,
-  useEffect,
   useRef,
 } from "react";
 import {
@@ -67,13 +66,11 @@ const Profile: NextPage = () => {
     category: "Purchase Button",
     label: "profile-bottom-promo",
   });
-  useEffect(() => {
-    const hash = getCookie("profile-location-hash");
-    if (hash) {
-      document.location.hash = hash;
-      clearCookie("profile-location-hash");
-    }
-  });
+  const hash = getCookie("profile-location-hash");
+  if (hash) {
+    document.location.hash = hash;
+    clearCookie("profile-location-hash");
+  }
 
   usePurchaseTracker(profileData.data?.[0]);
 


### PR DESCRIPTION
This PR fixes #MPP-3086 (again).

How to test:
Same as https://github.com/mozilla/fx-private-relay/pull/3455

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).