### PR TITLE
split lang_code to check for available l10n image

### DIFF
--- a/emails/utils.py
+++ b/emails/utils.py
@@ -157,9 +157,9 @@ def _get_hero_img_src(lang_code):
         "sv",
         "zh",
     ]
-    for avail_l10n_image_code in avail_l10n_image_codes:
-        if avail_l10n_image_code.startswith(lang_code):
-            img_locale = avail_l10n_image_code
+    major_lang = lang_code.split("-")[0]
+    if major_lang in avail_l10n_image_codes:
+        img_locale = major_lang
 
     return f"{settings.SITE_ORIGIN}/static/images/email-images/first-time-user/hero-image-{img_locale}.png"
 


### PR DESCRIPTION
This PR fixes #MPP-3123 (specifically [the QA comment about `zh` language image](https://mozilla-hub.atlassian.net/browse/MPP-3123?focusedCommentId=687827)).

How to test:
1. Set your browser to a Chinese language (starting with `zh`)
2. Sign up for a new account (I pushed this branch to, and tested on, the dev server so I could see the image)
   * [x] In the welcome email, the "hero image" should be `hero-image-zh.png` showing Chinese content

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [ ] I've added a unit test to test for potential regressions of this bug.
   * We need the translated messages from pontoon to sync back to our l10n repo before we can test this. (See [this code comment](https://github.com/mozilla/fx-private-relay/blob/97ddcea55a9f1e4622d7c1b4d322ecb98fb3925e/privaterelay/tests/signals_tests.py#L56))
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).