### PR TITLE
Update Python dependencies,  2023-05-30

### DIFF
--- a/.github/workflows/lint-pending-strings.yml
+++ b/.github/workflows/lint-pending-strings.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Set up Python 3
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v4.6.1
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ black==23.3.0
 
 # type hinting
 mypy==1.3.0
-types-requests==2.30.0.0
+types-requests==2.31.0.0
 types-pyOpenSSL==23.1.0.3
 django-stubs==4.2.0
 djangorestframework-stubs==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ twilio==8.2.1
 vobject==0.9.6.1
 
 # tests
-coverage==7.2.5
+coverage==7.2.6
 model-bakery==1.11.0
 pytest-cov==4.1.0
 pytest-django==4.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,5 +50,5 @@ types-pyOpenSSL==23.1.0.3
 django-stubs==4.2.0
 djangorestframework-stubs==3.14.0
 boto3-stubs==1.26.142
-botocore-stubs==1.29.130
+botocore-stubs==1.29.141
 mypy-boto3-ses==1.26.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyJWT==2.7.0
 python-decouple==3.8
 pyOpenSSL==23.1.1
 requests==2.31.0
-sentry-sdk==1.23.1
+sentry-sdk==1.24.0
 whitenoise==6.4.0
 
 # phones app

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ vobject==0.9.6.1
 # tests
 coverage==7.2.5
 model-bakery==1.11.0
-pytest-cov==4.0.0
+pytest-cov==4.1.0
 pytest-django==4.5.2
 responses==0.23.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.137
+boto3==1.26.142
 codetiming==1.4.0
 cryptography==40.0.2
 Django==3.2.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,6 @@ types-requests==2.31.0.0
 types-pyOpenSSL==23.1.0.3
 django-stubs==4.2.0
 djangorestframework-stubs==3.14.0
-boto3-stubs==1.26.137
+boto3-stubs==1.26.142
 botocore-stubs==1.29.130
 mypy-boto3-ses==1.26.0.post1


### PR DESCRIPTION
Update weekly Python dependencies. This covers:

* Bump types-requests from 2.30.0.0 to 2.31.0.0 (from PR #3461)
* Bump boto3-stubs from 1.26.137 to 1.26.142 (from PR #3462)
* Bump sentry-sdk from 1.23.1 to 1.24.0 (from PR #3463)
* Bump pytest-cov from 4.0.0 to 4.1.0 (from PR #3464)
* Bump boto3 from 1.26.137 to 1.26.142 (from PR #3465)
* Bump coverage from 7.2.5 to 7.2.6 (from PR #3466)
* Bump botocore-stubs from 1.29.130 to 1.29.141 (from PR #3467)
* Bump actions/setup-python from 4.6.0 to 4.6.1 (from PR #3468)