### PR TITLE
MPP-2117: Cleanup email code, refactor email processing tests

### DIFF
--- a/emails/apps.py
+++ b/emails/apps.py
@@ -30,7 +30,9 @@ class EmailsConfig(AppConfig):
             s3_config = Config(
                 region_name=settings.AWS_REGION,
                 retries={
-                    "max_attempts": 1,  # this includes the initial attempt to get the email
+                    # max_attempts includes the initial attempt to get the email
+                    # so this does not retry with backoff, to avoid timeouts
+                    "max_attempts": 1,
                     "mode": "standard",
                 },
             )
@@ -43,7 +45,8 @@ class EmailsConfig(AppConfig):
 
         # badwords file from:
         # https://www.cs.cmu.edu/~biglou/resources/bad-words.txt
-        # Using `.text` extension because of https://github.com/dependabot/dependabot-core/issues/1657
+        # Using `.text` extension because of
+        # https://github.com/dependabot/dependabot-core/issues/1657
         self.badwords = self._load_terms("badwords.text")
         self.blocklist = self._load_terms("blocklist.text")
 

--- a/emails/apps.py
+++ b/emails/apps.py
@@ -61,4 +61,4 @@ class EmailsConfig(AppConfig):
         return terms
 
     def ready(self):
-        import emails.signals
+        import emails.signals  # noqa: F401 (imported but unused warning)

--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -203,8 +203,10 @@ class RemoveTrackers(TestCase):
 
     def expected_content(self, hyperlink, imagelink):
         return (
-            f'<a href="{self.url}{self.url_trackerwarning_data(hyperlink)}">A link</a>\n'
-            + f'<img src="{self.url}{self.url_trackerwarning_data(imagelink)}">An image</img>'
+            f'<a href="{self.url}{self.url_trackerwarning_data(hyperlink)}">'
+            "A link</a>\n"
+            f'<img src="{self.url}{self.url_trackerwarning_data(imagelink)}">'
+            "An image</img>"
         )
 
     def setUp(self):
@@ -291,34 +293,44 @@ class RemoveTrackers(TestCase):
     def test_general_tracker_embedded_in_another_tracker_replaced_only_once_with_relay_content(
         self,
     ):
-        content = "<a href='https://foo.open.tracker.com/foo/bar.html?src=trckr.com'>A link</a>"
+        content = (
+            "<a href='https://foo.open.tracker.com/foo/bar.html?src=trckr.com'>"
+            "A link</a>"
+        )
         changed_content, tracker_details = remove_trackers(
             content, self.from_address, self.datetime_now
         )
         general_removed = tracker_details["tracker_removed"]
         general_count = tracker_details["level_one"]["count"]
 
-        assert (
-            changed_content
-            == f"<a href='{self.url}{self.url_trackerwarning_data(self.hyperlink_tracker_in_tracker)}'>A link</a>"
+        expected_content = (
+            f"<a href='{self.url}"
+            f"{self.url_trackerwarning_data(self.hyperlink_tracker_in_tracker)}'>"
+            "A link</a>"
         )
+        assert changed_content == expected_content
         assert general_removed == 1
         assert general_count == 1
 
     def test_general_tracker_also_in_text_tracker_replaced_only_once_with_relay_content(
         self,
     ):
-        content = "<a href='https://foo.open.tracker.com/foo/bar.html?src=trckr.com'>trckr.com</a>"
+        content = (
+            "<a href='https://foo.open.tracker.com/foo/bar.html?src=trckr.com'>"
+            "trckr.com</a>"
+        )
         changed_content, tracker_details = remove_trackers(
             content, self.from_address, self.datetime_now
         )
         general_removed = tracker_details["tracker_removed"]
         general_count = tracker_details["level_one"]["count"]
 
-        assert (
-            changed_content
-            == f"<a href='{self.url}{self.url_trackerwarning_data(self.hyperlink_tracker_in_tracker)}'>trckr.com</a>"
+        expected_content = (
+            f"<a href='{self.url}"
+            "{self.url_trackerwarning_data(self.hyperlink_tracker_in_tracker)}'>"
+            "trckr.com</a>"
         )
+        assert changed_content == expected_content
         assert general_removed == 1
         assert general_count == 1
 

--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -290,9 +290,11 @@ class RemoveTrackers(TestCase):
             general_count == general_removed
         )  # count uses the same regex pattern as removing trackers
 
-    def test_general_tracker_embedded_in_another_tracker_replaced_only_once_with_relay_content(
-        self,
-    ):
+    def test_general_tracker_embedded_in_another_tracker_replaced_only_once(self):
+        """
+        Test that a general tracker embedded in the URL of another tracker is
+        replaced only once with the relay content.
+        """
         content = (
             "<a href='https://foo.open.tracker.com/foo/bar.html?src=trckr.com'>"
             "A link</a>"
@@ -312,9 +314,11 @@ class RemoveTrackers(TestCase):
         assert general_removed == 1
         assert general_count == 1
 
-    def test_general_tracker_also_in_text_tracker_replaced_only_once_with_relay_content(
-        self,
-    ):
+    def test_general_tracker_also_in_text_tracker_replaced_only_once(self):
+        """
+        Test that a general tracker embedded in another tracker, and also in the text
+        of the link, is replaced only once with the relay content.
+        """
         content = (
             "<a href='https://foo.open.tracker.com/foo/bar.html?src=trckr.com'>"
             "trckr.com</a>"

--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -327,7 +327,7 @@ class RemoveTrackers(TestCase):
 
         expected_content = (
             f"<a href='{self.url}"
-            "{self.url_trackerwarning_data(self.hyperlink_tracker_in_tracker)}'>"
+            f"{self.url_trackerwarning_data(self.hyperlink_tracker_in_tracker)}'>"
             "trckr.com</a>"
         )
         assert changed_content == expected_content

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -143,7 +143,7 @@ class SNSNotificationTest(TestCase):
         raise Exception("Never found message body!")
 
     @override_settings(RELAY_FROM_ADDRESS="reply@relay.example.com")
-    def test_single_recipient_sns_notification(self):
+    def test_single_recipient_sns_notification(self) -> None:
         _sns_notification(EMAIL_SNS_BODIES["single_recipient"])
 
         self.mock_send_raw_email.assert_called_once()
@@ -169,7 +169,7 @@ class SNSNotificationTest(TestCase):
         assert self.ra.num_forwarded == 1
         assert (datetime.now(tz=timezone.utc) - self.ra.last_used_at).seconds < 2.0
 
-    def test_list_email_sns_notification(self):
+    def test_list_email_sns_notification(self) -> None:
         """By default, list emails should still forward."""
         _sns_notification(EMAIL_SNS_BODIES["single_recipient_list"])
 
@@ -178,7 +178,7 @@ class SNSNotificationTest(TestCase):
         assert self.ra.num_forwarded == 1
         assert (datetime.now(tz=timezone.utc) - self.ra.last_used_at).seconds < 2.0
 
-    def test_block_list_email_sns_notification(self):
+    def test_block_list_email_sns_notification(self) -> None:
         """When an alias is blocking list emails, list emails should not forward."""
         self.ra.user = self.premium_user
         self.ra.save()
@@ -192,7 +192,7 @@ class SNSNotificationTest(TestCase):
         assert self.ra.num_forwarded == 0
         assert self.ra.num_blocked == 1
 
-    def test_spamVerdict_FAIL_default_still_relays(self):
+    def test_spamVerdict_FAIL_default_still_relays(self) -> None:
         """For a default user, spam email will still relay."""
         _sns_notification(EMAIL_SNS_BODIES["spamVerdict_FAIL"])
 
@@ -200,7 +200,7 @@ class SNSNotificationTest(TestCase):
         self.ra.refresh_from_db()
         assert self.ra.num_forwarded == 1
 
-    def test_spamVerdict_FAIL_auto_block_doesnt_relay(self):
+    def test_spamVerdict_FAIL_auto_block_doesnt_relay(self) -> None:
         """When a user has auto_block_spam=True, spam will not relay."""
         self.profile.auto_block_spam = True
         self.profile.save()
@@ -211,15 +211,16 @@ class SNSNotificationTest(TestCase):
         self.ra.refresh_from_db()
         assert self.ra.num_forwarded == 0
 
-    def test_domain_recipient(self):
+    def test_domain_recipient(self) -> None:
         _sns_notification(EMAIL_SNS_BODIES["domain_recipient"])
 
         self.mock_send_raw_email.assert_called_once()
         da = DomainAddress.objects.get(user=self.premium_user, address="wildcard")
         assert da.num_forwarded == 1
+        assert da.last_used_at
         assert (datetime.now(tz=timezone.utc) - da.last_used_at).seconds < 2.0
 
-    def test_successful_email_relay_message_removed_from_s3(self):
+    def test_successful_email_relay_message_removed_from_s3(self) -> None:
         _sns_notification(EMAIL_SNS_BODIES["single_recipient"])
 
         self.mock_send_raw_email.assert_called_once()
@@ -228,7 +229,7 @@ class SNSNotificationTest(TestCase):
         assert self.ra.num_forwarded == 1
         assert (datetime.now(tz=timezone.utc) - self.ra.last_used_at).seconds < 2.0
 
-    def test_unsuccessful_email_relay_message_not_removed_from_s3(self):
+    def test_unsuccessful_email_relay_message_not_removed_from_s3(self) -> None:
         self.mock_send_raw_email.side_effect = ClientError(
             error_response={"Error": {"Code": "the code", "Message": "the message"}},
             operation_name="SES.send_raw_email",

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -102,7 +102,6 @@ FAIL_TEST_IF_CALLED = Exception("This function should not have been called.")
 
 class SNSNotificationTest(TestCase):
     def setUp(self):
-        # FIXME: this should make an object so that the test passes
         self.user = baker.make(User)
         self.profile = self.user.profile
         self.sa = baker.make(SocialAccount, user=self.user, provider="fxa")

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -162,7 +162,7 @@ class SNSNotificationTest(TestCase):
         assert self.ra.last_used_at.date() == datetime.today().date()
 
     def test_list_email_sns_notification(self):
-        # by default, list emails should still forward
+        """By default, list emails should still forward."""
         _sns_notification(EMAIL_SNS_BODIES["single_recipient_list"])
 
         self.mock_ses_relay_email.assert_called_once()
@@ -171,7 +171,7 @@ class SNSNotificationTest(TestCase):
         assert self.ra.last_used_at.date() == datetime.today().date()
 
     def test_block_list_email_sns_notification(self):
-        # when an alias is blocking list emails, list emails should not forward
+        """When an alias is blocking list emails, list emails should not forward."""
         self.ra.user = self.premium_user
         self.ra.save()
         self.ra.block_list_emails = True
@@ -185,7 +185,7 @@ class SNSNotificationTest(TestCase):
         assert self.ra.num_blocked == 1
 
     def test_spamVerdict_FAIL_default_still_relays(self):
-        # for a default user, spam email will still relay
+        """For a default user, spam email will still relay."""
         _sns_notification(EMAIL_SNS_BODIES["spamVerdict_FAIL"])
 
         self.mock_ses_relay_email.assert_called_once()
@@ -193,7 +193,7 @@ class SNSNotificationTest(TestCase):
         assert self.ra.num_forwarded == 1
 
     def test_spamVerdict_FAIL_auto_block_doesnt_relay(self):
-        # when user has auto_block_spam=True, spam will not relay
+        """When a user has auto_block_spam=True, spam will not relay."""
         self.profile.auto_block_spam = True
         self.profile.save()
 

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -167,7 +167,7 @@ class SNSNotificationTest(TestCase):
 
         self.ra.refresh_from_db()
         assert self.ra.num_forwarded == 1
-        assert self.ra.last_used_at.date() == datetime.today().date()
+        assert (datetime.now(tz=timezone.utc) - self.ra.last_used_at).seconds < 2.0
 
     def test_list_email_sns_notification(self):
         """By default, list emails should still forward."""
@@ -176,7 +176,7 @@ class SNSNotificationTest(TestCase):
         self.mock_send_raw_email.assert_called_once()
         self.ra.refresh_from_db()
         assert self.ra.num_forwarded == 1
-        assert self.ra.last_used_at.date() == datetime.today().date()
+        assert (datetime.now(tz=timezone.utc) - self.ra.last_used_at).seconds < 2.0
 
     def test_block_list_email_sns_notification(self):
         """When an alias is blocking list emails, list emails should not forward."""
@@ -217,7 +217,7 @@ class SNSNotificationTest(TestCase):
         self.mock_send_raw_email.assert_called_once()
         da = DomainAddress.objects.get(user=self.premium_user, address="wildcard")
         assert da.num_forwarded == 1
-        assert da.last_used_at.date() == datetime.today().date()
+        assert (datetime.now(tz=timezone.utc) - da.last_used_at).seconds < 2.0
 
     def test_successful_email_relay_message_removed_from_s3(self):
         _sns_notification(EMAIL_SNS_BODIES["single_recipient"])
@@ -226,7 +226,7 @@ class SNSNotificationTest(TestCase):
         self.mock_remove_message_from_s3.assert_called_once()
         self.ra.refresh_from_db()
         assert self.ra.num_forwarded == 1
-        assert self.ra.last_used_at.date() == datetime.today().date()
+        assert (datetime.now(tz=timezone.utc) - self.ra.last_used_at).seconds < 2.0
 
     def test_unsuccessful_email_relay_message_not_removed_from_s3(self):
         self.mock_send_raw_email.side_effect = ClientError(

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -115,20 +115,20 @@ class SNSNotificationTest(TestCase):
         self.premium_profile.subdomain = "subdomain"
         self.premium_profile.save()
 
-        patcher = patch("emails.views.remove_message_from_s3")
-        self.mock_remove_message_from_s3 = patcher.start()
-        self.addCleanup(patcher.stop)
+        remove_s3_patcher = patch("emails.views.remove_message_from_s3")
+        self.mock_remove_message_from_s3 = remove_s3_patcher.start()
+        self.addCleanup(remove_s3_patcher.stop)
 
         self.mock_send_raw_email = Mock(
             spec_set=[], return_value={"MessageId": str(uuid4())}
         )
-        patcher2 = patch(
+        send_raw_email_patcher = patch(
             "emails.apps.EmailsConfig.ses_client",
             spec_set=["send_raw_email"],
             send_raw_email=self.mock_send_raw_email,
         )
-        patcher2.start()
-        self.addCleanup(patcher2.stop)
+        send_raw_email_patcher.start()
+        self.addCleanup(send_raw_email_patcher.stop)
 
     def get_headers_from_raw_message(self, raw_message: str) -> dict[str, str]:
         """Get headers from a raw email message (RFC 5322)"""

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -47,7 +47,10 @@ info_logger = logging.getLogger("eventsinfo")
 study_logger = logging.getLogger("studymetrics")
 metrics = markus.get_metrics("fx-private-relay")
 
-shavar_prod_lists_url = "https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json"
+shavar_prod_lists_url = (
+    "https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/"
+    "master/disconnect-blacklist.json"
+)
 EMAILS_FOLDER_PATH = pathlib.Path(__file__).parent
 TRACKER_FOLDER_PATH = EMAILS_FOLDER_PATH / "tracker_lists"
 
@@ -161,7 +164,10 @@ def _get_hero_img_src(lang_code):
     if major_lang in avail_l10n_image_codes:
         img_locale = major_lang
 
-    return f"{settings.SITE_ORIGIN}/static/images/email-images/first-time-user/hero-image-{img_locale}.png"
+    return (
+        settings.SITE_ORIGIN
+        + f"/static/images/email-images/first-time-user/hero-image-{img_locale}.png"
+    )
 
 
 def get_welcome_email(request: HttpRequest, format: str) -> str:

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -411,7 +411,7 @@ def _get_bucket_and_key_from_s3_json(message_json):
         if "S3" in message_json_receipt["action"]["type"]:
             bucket = message_json_receipt["action"]["bucketName"]
             object_key = message_json_receipt["action"]["objectKey"]
-    except (KeyError, TypeError) as e:
+    except (KeyError, TypeError):
         logger.error(
             "sns_inbound_message_receipt_malformed",
             extra={"receipt_action": message_json_receipt["action"]},


### PR DESCRIPTION
This PR is the preliminary work needed for MPP-2117, which will alter the headers of emails relayed to Relay users (but not their replies). This PR should not change any functionality of production code. 

## Changes

* Fix select flake8 issues in email code:
    - Wrap strings that exceed 88 columns
    - Rewrite comments that exceed 88 columns
    - Ignore unused `emails.signals` import, which is imported for side-effects
    - Reduce function names that exceed 88 columns, and turn into a docstring
    - Convert first descriptive test comment into docstring
* Change the `SNSNotificationTest` mock from `emails.views.ses_relay_email` to `ses_client.send_raw_email`, to allow checking the headers of the sent message for both incoming and outgoing messages. Add assertion for the headers of relayed emails.
* Tighten the `last_used_at` test from "same day" to "last 2 seconds"
* Enable `mypy` type checking for `SNSNotificationTest`
* Add `SNSNotificationTest.test_reply` to test reply headers

## How to Test

* Tests pass in CircleCI
* Changes in non-test code are cosmetic, no functionality changes