### PR TITLE
Fix layout issues with long email local-part or domain

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasDeletionButton.module.scss
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButton.module.scss
@@ -43,6 +43,7 @@
     border-radius: $border-radius-md;
     box-shadow: $box-shadow-sm;
     padding: $spacing-md;
+    overflow-wrap: break-word;
 
     .hero {
       @include text-title-3xs;


### PR DESCRIPTION
This PR fixes #2296.

# How to test

* Get a long email mask on `/accounts/profile/`
* expand using `Show mask details`
* click the `Delete` button

# Checklist

- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

# Screenshots

![screenshot-1-mask-details](https://github.com/mozilla/fx-private-relay/assets/1068037/bcba6cae-3435-481e-a19d-3b3f21e24542)

![screenshot-2-delete-mask](https://github.com/mozilla/fx-private-relay/assets/1068037/4e9fe74a-a23a-4d93-913b-7ea5c6a35185)