### PR TITLE
fix MPP-3145: add more Mozilla-formatted locales

### DIFF
--- a/emails/utils.py
+++ b/emails/utils.py
@@ -26,7 +26,7 @@ from waffle.models import Flag
 
 from django.apps import apps
 from django.conf import settings
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, User
 from django.http import HttpResponse
 from django.template.defaultfilters import linebreaksbr, urlize
 
@@ -170,11 +170,11 @@ def _get_hero_img_src(lang_code):
     )
 
 
-def get_welcome_email(request: HttpRequest, format: str) -> str:
+def get_welcome_email(request: HttpRequest, user: User, format: str) -> str:
     bundle_plans = get_countries_info_from_request_and_mapping(
         request, settings.BUNDLE_PLAN_COUNTRY_LANG_MAPPING
     )
-    lang_code = request.LANGUAGE_CODE
+    lang_code = user.profile.language
     hero_img_src = _get_hero_img_src(lang_code)
     return render_to_string(
         f"emails/first_time_user.{format}",

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -703,6 +703,9 @@ LANGUAGE_CODE = "en"
 LANGUAGES = DEFAULT_LANGUAGES + [
     ("zh-tw", "Chinese"),
     ("zh-cn", "Chinese"),
+    ("es-es", "Spanish"),
+    ("pt-pt", "Portuguese"),
+    ("skr", "Saraiki"),
 ]
 
 TIME_ZONE = "UTC"

--- a/privaterelay/signals.py
+++ b/privaterelay/signals.py
@@ -1,12 +1,15 @@
 from django.apps import apps
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.dispatch import receiver
 
 from allauth.account.signals import user_signed_up, user_logged_in
+from django.http.request import HttpRequest
 from mypy_boto3_ses.client import SESClient
 from mypy_boto3_ses.type_defs import ContentTypeDef
 from waffle import flag_is_active
 
+from emails.apps import EmailsConfig
 from emails.utils import get_welcome_email, incr_if_enabled
 
 from .ftl_bundles import main as ftl_bundle
@@ -26,10 +29,14 @@ def _ses_message_props(data: str) -> ContentTypeDef:
 
 
 @receiver(user_signed_up)
-def send_first_email(request, user, **kwargs):
+def send_first_email(request: HttpRequest, user: User, **kwargs):
     if not flag_is_active(request, "welcome_email"):
         return
-    ses_client: SESClient = apps.get_app_config("emails").ses_client
+    app_config = apps.get_app_config("emails")
+    assert isinstance(app_config, EmailsConfig)
+    ses_client = app_config.ses_client
+    assert ses_client
+    assert settings.RELAY_FROM_ADDRESS
     ses_client.send_email(
         Destination={
             "ToAddresses": [user.email],
@@ -40,8 +47,8 @@ def send_first_email(request, user, **kwargs):
                 ftl_bundle.format("first-time-user-email-welcome")
             ),
             "Body": {
-                "Html": _ses_message_props(get_welcome_email(request, "html")),
-                "Text": _ses_message_props(get_welcome_email(request, "txt")),
+                "Html": _ses_message_props(get_welcome_email(request, user, "html")),
+                "Text": _ses_message_props(get_welcome_email(request, user, "txt")),
             },
         },
     )


### PR DESCRIPTION
This PR fixes `es-es` language in #MPP-3145.

How to test:
1. Set your browser to `es-es` language
2. Sign up for Relay **with a NEW FxA**
   * Note: this makes `es-es` the language for the FXA profile and not just the Relay HTTP request
3. Check the inbox for the welcome email
   * [ ] It should be translated into Spanish!

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).