### PR TITLE
MPP-2117: Add type annotations for sending email, allow ASCII encoding

### DIFF
--- a/emails/utils.py
+++ b/emails/utils.py
@@ -7,6 +7,8 @@ from email.mime.text import MIMEText
 from email.mime.application import MIMEApplication
 from email.utils import parseaddr
 from functools import cache
+from io import IOBase
+from typing import cast, Any, Callable, Literal, TypeVar
 import json
 import pathlib
 import re
@@ -32,6 +34,7 @@ from django.template.defaultfilters import linebreaksbr, urlize
 
 from privaterelay.utils import get_countries_info_from_request_and_mapping
 
+from .apps import EmailsConfig
 from .models import (
     DomainAddress,
     RelayAddress,
@@ -101,8 +104,11 @@ def strict_trackers():
     return get_trackers(level=2)
 
 
-def time_if_enabled(name):
-    def timing_decorator(func):
+_TimedFunction = TypeVar("_TimedFunction", bound=Callable[..., Any])
+
+
+def time_if_enabled(name: str) -> Callable[[_TimedFunction], _TimedFunction]:
+    def timing_decorator(func: _TimedFunction) -> _TimedFunction:
         def func_wrapper(*args, **kwargs):
             ctx_manager = (
                 metrics.timer(name)
@@ -112,7 +118,7 @@ def time_if_enabled(name):
             with ctx_manager:
                 return func(*args, **kwargs)
 
-        return func_wrapper
+        return cast(_TimedFunction, func_wrapper)
 
     return timing_decorator
 
@@ -188,27 +194,36 @@ def get_welcome_email(request: HttpRequest, user: User, format: str) -> str:
     )
 
 
+MessageBodyContent = dict[Literal["Charset", "Data"], str]
+MessageBody = dict[Literal["Text", "Html"], MessageBodyContent]
+AttachmentPair = tuple[str, IOBase]
+MailJSON = dict[str, Any]
+
+
 @time_if_enabled("ses_send_raw_email")
 def ses_send_raw_email(
-    from_address,
-    to_address,
-    subject,
-    message_body,
-    attachments,
-    reply_address,
-    mail,
-    address,
-):
+    from_address: str,
+    to_address: str,
+    subject: str,
+    message_body: MessageBody,
+    attachments: list[AttachmentPair],
+    reply_address: str,
+    mail: MailJSON,
+    address: RelayAddress | DomainAddress,
+) -> HttpResponse:
     msg_with_headers = _start_message_with_headers(
         subject, from_address, to_address, reply_address
     )
     msg_with_body = _add_body_to_message(msg_with_headers, message_body)
     msg_with_attachments = _add_attachments_to_message(msg_with_body, attachments)
 
+    emails_config = apps.get_app_config("emails")
+    assert isinstance(emails_config, EmailsConfig)
+    ses_client = emails_config.ses_client
+    assert ses_client
+    assert settings.AWS_SES_CONFIGSET
     try:
-        # Provide the contents of the email.
-        emails_config = apps.get_app_config("emails")
-        ses_response = emails_config.ses_client.send_raw_email(
+        ses_response = ses_client.send_raw_email(
             Source=from_address,
             Destinations=[to_address],
             RawMessage={
@@ -226,7 +241,9 @@ def ses_send_raw_email(
     return HttpResponse("Sent email to final recipient.", status=200)
 
 
-def _start_message_with_headers(subject, from_address, to_address, reply_address):
+def _start_message_with_headers(
+    subject: str, from_address: str, to_address: str, reply_address: str
+) -> MIMEMultipart:
     # Create a multipart/mixed parent container.
     msg = MIMEMultipart("mixed")
     # Add subject, from and to lines.
@@ -237,7 +254,9 @@ def _start_message_with_headers(subject, from_address, to_address, reply_address
     return msg
 
 
-def _add_body_to_message(msg, message_body):
+def _add_body_to_message(
+    msg: MIMEMultipart, message_body: MessageBody
+) -> MIMEMultipart:
     charset = "UTF-8"
     # Create a multipart/alternative child container.
     msg_body = MIMEMultipart("alternative")
@@ -247,11 +266,11 @@ def _add_body_to_message(msg, message_body):
     # outside the ASCII range.
     if "Text" in message_body:
         body_text = message_body["Text"]["Data"]
-        textpart = MIMEText(body_text.encode(charset), "plain", charset)
+        textpart = MIMEText(body_text.encode(charset), "plain", charset)  # type: ignore
         msg_body.attach(textpart)
     if "Html" in message_body:
         body_html = message_body["Html"]["Data"]
-        htmlpart = MIMEText(body_html.encode(charset), "html", charset)
+        htmlpart = MIMEText(body_html.encode(charset), "html", charset)  # type: ignore
         msg_body.attach(htmlpart)
 
     # Attach the multipart/alternative child container to the multipart/mixed
@@ -260,7 +279,9 @@ def _add_body_to_message(msg, message_body):
     return msg
 
 
-def _add_attachments_to_message(msg, attachments):
+def _add_attachments_to_message(
+    msg: MIMEMultipart, attachments: list[AttachmentPair]
+) -> MIMEMultipart:
     # attach attachments
     for actual_att_name, attachment in attachments:
         # Define the attachment part and encode it using MIMEApplication.
@@ -276,7 +297,7 @@ def _add_attachments_to_message(msg, attachments):
     return msg
 
 
-def _store_reply_record(mail, ses_response, address):
+def _store_reply_record(mail: MailJSON, ses_response, address) -> MailJSON:
     # After relaying email, store a Reply record for it
     reply_metadata = {}
     for header in mail["headers"]:
@@ -286,7 +307,10 @@ def _store_reply_record(mail, ses_response, address):
     (lookup_key, encryption_key) = derive_reply_keys(message_id_bytes)
     lookup = b64_lookup_key(lookup_key)
     encrypted_metadata = encrypt_reply_metadata(encryption_key, reply_metadata)
-    reply_create_args = {"lookup": lookup, "encrypted_metadata": encrypted_metadata}
+    reply_create_args: dict[str, Any] = {
+        "lookup": lookup,
+        "encrypted_metadata": encrypted_metadata,
+    }
     if type(address) == DomainAddress:
         reply_create_args["domain_address"] = address
     elif type(address) == RelayAddress:
@@ -296,8 +320,14 @@ def _store_reply_record(mail, ses_response, address):
 
 
 def ses_relay_email(
-    from_address, to_address, subject, message_body, attachments, mail, address
-):
+    from_address: str,
+    to_address: str,
+    subject: str,
+    message_body: MessageBody,
+    attachments: list[AttachmentPair],
+    mail: MailJSON,
+    address: RelayAddress | DomainAddress,
+) -> HttpResponse:
     reply_address = "replies@%s" % get_domains_from_settings().get(
         "RELAY_FIREFOX_DOMAIN"
     )
@@ -351,16 +381,16 @@ def generate_relay_From(original_from_address, user_profile=None):
     return formatted_from_address
 
 
-def get_message_id_bytes(message_id_str):
+def get_message_id_bytes(message_id_str: str) -> bytes:
     message_id = message_id_str.split("@", 1)[0].rsplit("<", 1)[-1].strip()
     return message_id.encode()
 
 
-def b64_lookup_key(lookup_key):
+def b64_lookup_key(lookup_key: bytes) -> str:
     return base64.urlsafe_b64encode(lookup_key).decode("ascii")
 
 
-def derive_reply_keys(message_id):
+def derive_reply_keys(message_id: bytes) -> tuple[bytes, bytes]:
     """Derive the lookup key and encrytion key from an aliased message id."""
     algorithm = hashes.SHA256()
     hkdf = HKDFExpand(algorithm=algorithm, length=16, info=b"replay replies lookup key")
@@ -372,7 +402,7 @@ def derive_reply_keys(message_id):
     return (lookup_key, encryption_key)
 
 
-def encrypt_reply_metadata(key, payload):
+def encrypt_reply_metadata(key: bytes, payload: dict[str, str]) -> str:
     """Encrypt the given payload into a JWE, using the given key."""
     # This is a bit dumb, we have to base64-encode the key in order to load it :-/
     k = jwcrypto.jwk.JWK(
@@ -381,7 +411,7 @@ def encrypt_reply_metadata(key, payload):
     e = jwcrypto.jwe.JWE(
         json.dumps(payload), json.dumps({"alg": "dir", "enc": "A256GCM"}), recipient=k
     )
-    return e.serialize(compact=True)
+    return cast(str, e.serialize(compact=True))
 
 
 def decrypt_reply_metadata(key, jwe):

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -257,20 +257,20 @@ def _start_message_with_headers(
 def _add_body_to_message(
     msg: MIMEMultipart, message_body: MessageBody
 ) -> MIMEMultipart:
-    charset = "UTF-8"
     # Create a multipart/alternative child container.
     msg_body = MIMEMultipart("alternative")
 
-    # Encode the text and HTML content and set the character encoding.
-    # This step is necessary if you're sending a message with characters
-    # outside the ASCII range.
     if "Text" in message_body:
         body_text = message_body["Text"]["Data"]
-        textpart = MIMEText(body_text.encode(charset), "plain", charset)  # type: ignore
+        # Let MIMEText determine if us-ascii encoding will work
+        textpart = MIMEText(body_text, "plain")
         msg_body.attach(textpart)
     if "Html" in message_body:
         body_html = message_body["Html"]["Data"]
-        htmlpart = MIMEText(body_html.encode(charset), "html", charset)  # type: ignore
+        # Our translated strings contain U+2068 (First Strong Isolate) and
+        # U+2069 (Pop Directional Isolate), us-ascii will not work
+        # so save time by suggesting utf-8 encoding
+        htmlpart = MIMEText(body_html, "html", "utf-8")
         msg_body.attach(htmlpart)
 
     # Attach the multipart/alternative child container to the multipart/mixed

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -161,7 +161,7 @@ if DJANGO_ALLOWED_SUBNET:
 ADMIN_ENABLED = config("ADMIN_ENABLED", False, cast=bool)
 
 
-AWS_REGION = config("AWS_REGION", None)
+AWS_REGION: str | None = config("AWS_REGION", None)
 AWS_ACCESS_KEY_ID = config("AWS_ACCESS_KEY_ID", None)
 AWS_SECRET_ACCESS_KEY = config("AWS_SECRET_ACCESS_KEY", None)
 AWS_SNS_TOPIC = set(config("AWS_SNS_TOPIC", "", cast=Csv()))
@@ -335,7 +335,7 @@ TEMPLATES = [
 
 RELAY_FIREFOX_DOMAIN = config("RELAY_FIREFOX_DOMAIN", "relay.firefox.com", cast=str)
 MOZMAIL_DOMAIN = config("MOZMAIL_DOMAIN", "mozmail.com", cast=str)
-MAX_NUM_FREE_ALIASES = config("MAX_NUM_FREE_ALIASES", 5, cast=int)
+MAX_NUM_FREE_ALIASES: int = config("MAX_NUM_FREE_ALIASES", 5, cast=int)
 PERIODICAL_PREMIUM_PROD_ID = config("PERIODICAL_PREMIUM_PROD_ID", "", cast=str)
 PREMIUM_PLAN_ID_US_MONTHLY = config(
     "PREMIUM_PLAN_ID_US_MONTHLY", "price_1LXUcnJNcmPzuWtRpbNOajYS", cast=str
@@ -788,7 +788,7 @@ FXA_SETTINGS_URL = config("FXA_SETTINGS_URL", f"{FXA_BASE_ORIGIN}/settings")
 FXA_SUBSCRIPTIONS_URL = config(
     "FXA_SUBSCRIPTIONS_URL", f"{FXA_BASE_ORIGIN}/subscriptions"
 )
-# check https://mozilla.github.io/ecosystem-platform/api#tag/Subscriptions/operation/getOauthMozillasubscriptionsCustomerBillingandsubscriptions
+# check https://mozilla.github.io/ecosystem-platform/api#tag/Subscriptions/operation/getOauthMozillasubscriptionsCustomerBillingandsubscriptions  # noqa: E501 (line too long)
 FXA_ACCOUNTS_ENDPOINT = config(
     "FXA_ACCOUNTS_ENDPOINT",
     "https://api.accounts.firefox.com/v1",


### PR DESCRIPTION
This PR adds type annotations to `ses_relay_email` and all the `utils` functions it calls.

## How to Test
* Get the code in an email-relaying environment
* Send an HTML message to a mask, the wrapped message is delivered
* Send a plain text, ASCII only message to a mask. The wrapped message is delivered. The "original" email has the text version in ASCII ("us-ascii")
* Send a plain text message with non-ASCII unicode to a mask. The wrapped message is delivered. The "original" email has the text version in base64-encoded UTF-8.

## Details

When adding annotations, `mypy` flagged this code:

```python
charset = "UTF-8"
...
textpart = MIMEText(body_text.encode(charset), "plain", charset)
```

with the error:

```
Argument 1 to "MIMEText" has incompatible type "bytes"; expected "str"  [arg-type] 
```

Looking in the Python code, `MIMEText` does expect a `str` and passes it to [email.Message.set_payload](https://github.com/python/cpython/blob/ede89af605b1c0442353435ad22195c16274f65d/Lib/email/message.py#L330C1-L348), which detects bytes and decodes it back to a string with `payload.decode('ascii', 'surrogateescape')` (see [PEP 383](https://peps.python.org/pep-0383/)), and then re-encodes it as UTF-8. This is extra work at best and will introduce encoding errors at worst.

Instead, pass the content as a `str`. For text content, let [MIMEText](https://github.com/python/cpython/blob/3698fda06eefb3c01e78c4c07f46fcdd0559e0f6/Lib/email/mime/text.py#L12-L40) detect the encoding (`us-ascii` with a `utf-8` fallback), which will be smaller and look better for ASCII messages. For HTML content, our translations always output unicode ([U+2068](https://www.compart.com/en/unicode/U+2068) and [U+2069](https://www.compart.com/en/unicode/U+2069)), so pass `utf-8` and skip encoding detection.
