### PR TITLE
fix MPP-3110: add DeletedAddress records during _handle_fxa_delete()

### DIFF
--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -23,6 +23,15 @@ import jwt
 import pytest
 import responses
 
+from emails.models import (
+    DeletedAddress,
+    DomainAddress,
+    Profile,
+    RelayAddress,
+    address_hash,
+)
+from emails.tests.models_tests import unlimited_subscription
+
 from ..apps import PrivateRelayConfig
 from ..fxa_utils import NoSocialToken
 from ..views import _update_all_data, fxa_verifying_keys
@@ -200,6 +209,8 @@ class FxaRpEventsSetupData:
     mock_fxa_verifying_keys: Mock
     mock_responses: responses.RequestsMock
     profile_response: FxaProfileResponse
+    ra: RelayAddress
+    da: DomainAddress
 
 
 @pytest.fixture
@@ -216,9 +227,11 @@ def setup_fxa_rp_events(
 
     # Create user subscribed to emails and phones
     user = baker.make(User, email="test@example.com")
-    user.profile.server_storage = True
-    user.profile.date_subscribed = timezone.now()
-    user.profile.save()
+    profile = user.profile
+    assert isinstance(profile, Profile)
+    profile.server_storage = True
+    profile.date_subscribed = timezone.now()
+    profile.save()
 
     # Create FxA app, account, token, etc.
     fxa_app: SocialApp = baker.make(SocialApp, provider="fxa")
@@ -231,7 +244,7 @@ def setup_fxa_rp_events(
         "uid": str(uuid4()),
         "avatar": "https://profile.stage.mozaws.net/v1/avatar/t",
         "avatarDefault": False,
-        "subscriptions": ["test-unlimited", "test-phone"],
+        "subscriptions": [unlimited_subscription(), "test-phone"],
     }
     fxa_acct: SocialAccount = baker.make(
         SocialAccount,
@@ -247,6 +260,10 @@ def setup_fxa_rp_events(
         expires_at=timezone.now() + timedelta(days=2),
     )
     baker.make(EmailAddress, user=user, email=user.email)
+
+    ra = baker.make(RelayAddress, user=user)
+    profile.add_subdomain("premiumuser")
+    da = baker.make(DomainAddress, user=user, address="premium")
 
     # Setup mock fxa_verifying_key
     fxa_public_key = mock_fxa_signing_key.public_key()
@@ -296,6 +313,8 @@ def setup_fxa_rp_events(
             mock_fxa_verifying_keys=mock_fxa_verifying_keys,
             mock_responses=mock_responses,
             profile_response=profile_response,
+            ra=ra,
+            da=da,
         )
 
 
@@ -483,6 +502,18 @@ def test_fxa_rp_events_delete_user(
     )
     auth_header = f"Bearer {event_jwt}"
 
+    ra = setup_fxa_rp_events.ra
+    da = setup_fxa_rp_events.da
+    assert isinstance(ra, RelayAddress)
+    assert RelayAddress.objects.filter(id=ra.id).exists()
+    assert DomainAddress.objects.filter(id=da.id).exists()
+    assert not DeletedAddress.objects.filter(
+        address_hash=address_hash(ra.address)
+    ).exists()
+    assert not DeletedAddress.objects.filter(
+        address_hash=address_hash(da.address)
+    ).exists()
+
     with MetricsMock() as mm:
         response = client.get("/fxa-rp-events", HTTP_AUTHORIZATION=auth_header)
     assert mm.get_records() == []
@@ -492,3 +523,11 @@ def test_fxa_rp_events_delete_user(
     ]
     assert response.status_code == 200
     assert not User.objects.filter(id=setup_fxa_rp_events.user.id).exists()
+    assert not RelayAddress.objects.filter(id=ra.id).exists()
+    assert not DomainAddress.objects.filter(id=da.id).exists()
+    ra_address_hash = address_hash(ra.address)
+    assert DeletedAddress.objects.filter(address_hash=ra_address_hash).exists()
+    da_address_hash = address_hash(
+        da.address, da.user.profile.subdomain, da.domain_value
+    )
+    assert DeletedAddress.objects.filter(address_hash=da_address_hash).exists()


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #MPP-3110.

How to test:
1. Run `pytest`
   * [x] All tests should pass
2. (Post-merge, on the dev server) Sign in as a Relay user
3. Create a random mask addresses
   * [x] Make a note of the localpart (e.g., 78x0f0aes)
4. Go to the [FXA stage settings](https://accounts.stage.mozaws.net/settings) for the Relay user
5. At the bottom, click "Delete Account"
6. Check all boxes and click "Continue"
7. Enter the account password and click "Delete"
8. Wait a bit(?)
9. Run `heroku python manage.py shell`
   * `from emails.models import address_hash, DeletedAddress`
   * `assert DeletedAddress.objects.filter(address_hash=address_hash("78x0f0aes")).exists()`
      * [x] Should run without an error


- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).