### PR TITLE
Python dependency updates, 2023 06 05

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ dockerflow==2022.8.0
 drf-yasg==1.21.5
 google-measurement-protocol==1.1.0
 gunicorn==20.1.0
-jwcrypto==1.4.2
+jwcrypto==1.5.0
 markus[datadog]==4.2.0
 pem==21.2.0
 psycopg2==2.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ black==23.3.0
 # type hinting
 mypy==1.3.0
 types-requests==2.31.0.1
-types-pyOpenSSL==23.1.0.3
+types-pyOpenSSL==23.2.0.0
 django-stubs==4.2.1
 djangorestframework-stubs==3.14.1
 boto3-stubs==1.26.146

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,5 +50,5 @@ types-pyOpenSSL==23.2.0.0
 django-stubs==4.2.1
 djangorestframework-stubs==3.14.1
 boto3-stubs==1.26.146
-botocore-stubs==1.29.142
+botocore-stubs==1.29.146
 mypy-boto3-ses==1.26.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.142
+boto3==1.26.146
 codetiming==1.4.0
 cryptography==41.0.1
 Django==3.2.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ whitenoise==6.4.0
 
 # phones app
 phonenumbers==8.13.13
-twilio==8.2.1
+twilio==8.2.2
 vobject==0.9.6.1
 
 # tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,6 @@ types-requests==2.31.0.1
 types-pyOpenSSL==23.1.0.3
 django-stubs==4.2.0
 djangorestframework-stubs==3.14.0
-boto3-stubs==1.26.142
+boto3-stubs==1.26.146
 botocore-stubs==1.29.142
 mypy-boto3-ses==1.26.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.26.142
 codetiming==1.4.0
-cryptography==40.0.2
+cryptography==41.0.1
 Django==3.2.19
 dj-database-url==2.0.0
 django-allauth==0.54.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ black==23.3.0
 mypy==1.3.0
 types-requests==2.31.0.1
 types-pyOpenSSL==23.1.0.3
-django-stubs==4.2.0
+django-stubs==4.2.1
 djangorestframework-stubs==3.14.0
 boto3-stubs==1.26.146
 botocore-stubs==1.29.142

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ sentry-sdk==1.24.0
 whitenoise==6.4.0
 
 # phones app
-phonenumbers==8.13.11
+phonenumbers==8.13.13
 twilio==8.2.1
 vobject==0.9.6.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyJWT==2.7.0
 python-decouple==3.8
 pyOpenSSL==23.1.1
 requests==2.31.0
-sentry-sdk==1.24.0
+sentry-sdk==1.25.0
 whitenoise==6.4.0
 
 # phones app

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ mypy==1.3.0
 types-requests==2.31.0.1
 types-pyOpenSSL==23.1.0.3
 django-stubs==4.2.1
-djangorestframework-stubs==3.14.0
+djangorestframework-stubs==3.14.1
 boto3-stubs==1.26.146
 botocore-stubs==1.29.142
 mypy-boto3-ses==1.26.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pem==21.2.0
 psycopg2==2.9.6
 PyJWT==2.7.0
 python-decouple==3.8
-pyOpenSSL==23.1.1
+pyOpenSSL==23.2.0
 requests==2.31.0
 sentry-sdk==1.25.0
 whitenoise==6.4.0


### PR DESCRIPTION
Update Python dependencies. There were more than 10 this week, so I manually added the next 2. This covers:

* Bump boto3-stubs from 1.26.142 to 1.26.146 (from PR #3492)
* Bump django-stubs from 4.2.0 to 4.2.1 (from PR #3493)
* Bump phonenumbers from 8.13.11 to 8.13.13 (from PR #3494)
* Bump twilio from 8.2.1 to 8.2.2 (from PR #3495)
* Bump sentry-sdk from 1.24.0 to 1.25.0 (from PR #3496)
* Bump jwcrypto from 1.4.2 to 1.5.0 (from PR #3497)
* Bump djangorestframework-stubs from 3.14.0 to 3.14.1 (from PR #3498)
* Bump types-pyopenssl from 23.1.0.3 to 23.2.0.0 (from PR #3499)
* Bump botocore-stubs from 1.29.142 to 1.29.146 (from PR #3500)
* Bump cryptography from 40.0.2 to 41.0.1 (from PR #3501)
* Bump boto3 from 1.26.142 to 1.26.146 - Auto-generated from AWS specs
* Bump pyOpenSSL from 23.1.1 to 23.2.0 - Needed for cryptography update