### PR TITLE
for MPP-2867: remove FxAToRequest middleware

### DIFF
--- a/privaterelay/fxa_utils.py
+++ b/privaterelay/fxa_utils.py
@@ -68,8 +68,7 @@ def _get_oauth2_session(social_account: SocialAccount) -> OAuth2Session:
     }
 
     # TODO: find out why the auto_refresh and token_updater is not working
-    # and instead we are manually refreshing the token at
-    # FxAToRequest and get_subscription_data_from_fxa
+    # and instead we are manually refreshing the token at get_subscription_data_from_fxa
     client = OAuth2Session(
         client_id,
         scope=settings.SOCIALACCOUNT_PROVIDERS["fxa"]["SCOPE"],

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -308,7 +308,6 @@ MIDDLEWARE += [
     "django_referrer_policy.middleware.ReferrerPolicyMiddleware",
     "dockerflow.django.middleware.DockerflowMiddleware",
     "waffle.middleware.WaffleMiddleware",
-    "privaterelay.middleware.FxAToRequest",
     "privaterelay.middleware.AddDetectedCountryToRequestAndResponseHeaders",
     "privaterelay.middleware.StoreFirstVisit",
 ]


### PR DESCRIPTION
This PR supports #MPP-2867.

When our API automatically created a Relay user for Firefox, it created a `SocialAccount` object without any `SocialToken` objects, because it did not go thru the regular OAuth2 flow. This breaks the (old) `FxAToRequest` middleware that tried to use the `SocialToken` to retrieve FXA data and attach it to the request object as an `fxa_account` attribute.

But, we don't have any code that uses the `fxa_account` attribute. (I searched both this code-base and the add-on codebase for `fxa_account` and didn't find a single reference to it.) So, we can remove the `FxAToRequest` middleware completely.

We also checked that after Firefox creates a user without `SocialToken` objects, the django-allauth code automatically gets and stores proper `SocialToken` objects on the correct `SocialAccount` as soon as the user signs in tru the web-based OAuth flow.

How to test:

1. Run `pytest`
   * [ ] Everything still passes
2. Run this branch of code and run thru regular functionality: signing up/in still works, creating/deleting masks still works, changing settings still works, etc.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).