### PR TITLE
MPP-3169 - CTA in emails are hard to read 

### DIFF
--- a/emails/templates/emails/first_time_user.html
+++ b/emails/templates/emails/first_time_user.html
@@ -251,7 +251,7 @@
                   <p style="color: #321C64; font-size: 18px; font-family: metropolis medium, system-ui, sans-serif;">{% ftlmsg 'first-time-user-email-hero-primary-text' %}</p> 
                   <p style="color: #321C64; font-size: 18px; font-family: metropolis medium, system-ui, sans-serif;margin-top: 20px;">{% ftlmsg 'first-time-user-email-hero-secondary-text' %}</p>
 
-                  <a href="{{ SITE_ORIGIN }}/accounts/profile/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=hero-cta" target="_blank" class="button" style="margin-top: 30px;" rel="noreferrer">{% ftlmsg 'first-time-user-email-hero-cta' %}</a>
+                  <a href="{{ SITE_ORIGIN }}/accounts/profile/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=hero-cta" target="_blank" class="button" style="margin-top: 30px; color: #FFFFFF;" rel="noreferrer">{% ftlmsg 'first-time-user-email-hero-cta' %}</a>
 
                 </td>
               </tr>
@@ -356,7 +356,7 @@
                 </td>
 
                 <td class="cta" align="center"> 
-                    <a href="{{ SITE_ORIGIN }}/premium/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=premium-cta" target="_blank" class="button" style="padding: 15px 20px;" rel="noreferrer">{% ftlmsg 'first-time-user-email-extra-protection-cta' %}</a> 
+                    <a href="{{ SITE_ORIGIN }}/premium/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=premium-cta" target="_blank" class="button" style="padding: 15px 20px; color: #FFFFFF;" rel="noreferrer">{% ftlmsg 'first-time-user-email-extra-protection-cta' %}</a> 
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3169
 
<!-- When adding a new feature: -->

# New feature description

Using Gmail on Firefox on Mac: CTAs are hard to read because of text color. This PR adds inline styling for CTA buttons to make their text color white. 

# Screenshot (if applicable)

 
![image](https://github.com/mozilla/fx-private-relay/assets/3924990/8b6cdc03-0390-49d6-b259-44cfff005e3d)
![image](https://github.com/mozilla/fx-private-relay/assets/3924990/74b076c3-04be-4021-a5ae-4c052a9deb5f)


# How to test



# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
