### PR TITLE
for MPP-3021: add sentry profiling

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -915,6 +915,29 @@ SENTRY_ENVIRONMENT = config("SENTRY_ENVIRONMENT", RELAY_CHANNEL)
 if SENTRY_ENVIRONMENT == "prod" and SITE_ORIGIN != "https://relay.firefox.com":
     SENTRY_ENVIRONMENT = "local"
 
+SENTRY_PROD_TRACE_SAMPLE_RATE = config(
+    "SENTRY_PROD_TRACE_SAMPLE_RATE", 0.001, cast=float
+)
+
+
+def sentry_traces_sampler(_) -> float:
+    if SENTRY_ENVIRONMENT == "prod":
+        return SENTRY_PROD_TRACE_SAMPLE_RATE
+    return 1.0
+
+
+# The profiles_sample_rate setting is *relative to* the traces_sample_rate setting. So,
+# this value is multiplied by the traces sample rate. So the profile rates are:
+# local: 1*1 = 100%
+# dev: 1*1 = 100%
+# stage: 0.1*1 = 10% of requests are profiled
+# prod: 0.1*0.001 = 1% of requests are profiled
+def sentry_profile_sampler(_) -> float:
+    if SENTRY_ENVIRONMENT in ["local", "dev"]:
+        return 1.0
+    return 0.1
+
+
 sentry_sdk.init(
     dsn=config("SENTRY_DSN", None),
     integrations=[DjangoIntegration(cache_spans=not DEBUG)],
@@ -922,6 +945,8 @@ sentry_sdk.init(
     include_local_variables=DEBUG,
     release=sentry_release,
     environment=SENTRY_ENVIRONMENT,
+    traces_sample_rate=1.0,
+    profiles_sample_rate=1.0,
 )
 # Duplicates events for unhandled exceptions, but without useful tracebacks
 ignore_logger("request.summary")


### PR DESCRIPTION
This PR fixes #MPP-3021.

How to test:
* [ ] Push the branch to the dev server and check https://mozilla.sentry.io/profiling/ for data


- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).