### PR TITLE
MPP-3168 The Interstitial page bundle banner overlaps with the text above due to the new Hero Image

### DIFF
--- a/frontend/src/pages/index.module.scss
+++ b/frontend/src/pages/index.module.scss
@@ -63,7 +63,8 @@
 
 .how-it-works-wrapper {
   background-color: $color-white;
-  margin-top: $layout-md;
+  // Magic number: 64px allows us to have an even spacing between sections on pages
+  padding: calc($spacing-xl * 2) $spacing-md;
 }
 
 .how-it-works {
@@ -224,6 +225,8 @@
 
 .faq-wrapper {
   background-color: $color-white;
+  // Magic number: 64px allows us to have an even spacing between sections on pages
+  padding: calc($spacing-xl * 2) $spacing-md;
 }
 
 .faq {
@@ -277,8 +280,8 @@
 .bundle-banner-section {
   width: 100%;
   margin: 0 auto;
-  padding: $spacing-lg $spacing-md;
-  margin-top: $layout-lg;
+  // Magic number: 64px allows us to have an even spacing between sections on pages
+  padding: calc($spacing-xl * 2) $spacing-md;
 
   @media screen and #{$mq-md} {
     width: $content-max;
@@ -289,6 +292,11 @@
 
 .gray-bg {
   background-color: $color-light-gray-10;
+}
+
+.reviews-container {
+  // Magic number: 64px allows us to have an even spacing between sections on pages
+  padding: calc($spacing-xl * 2) $spacing-md;
 }
 
 .testimonials-wrapper {

--- a/frontend/src/pages/index.page.tsx
+++ b/frontend/src/pages/index.page.tsx
@@ -108,7 +108,7 @@ const Home: NextPage = () => {
           Need to wait on design audit to fix white/grey background 
           discrepanies between pages. 
         */}
-        <div className={styles["gray-bg"]}>
+        <div className={`${styles["gray-bg"]} ${styles["reviews-container"]}`}>
           <Reviews />
           {/* Anchor link "pricing" exists within the PlanMatrix component */}
           <div className={styles.plans}>

--- a/frontend/src/pages/premium.module.scss
+++ b/frontend/src/pages/premium.module.scss
@@ -10,6 +10,11 @@
   margin: 0 auto;
   padding: $spacing-lg;
 
+  .hero-image {
+    flex-basis: 0;
+    flex-grow: 1;
+  }
+
   @media screen and #{$mq-md} {
     flex-direction: row;
     align-items: center;
@@ -212,7 +217,7 @@
 .bundle-banner-section {
   width: 100%;
   margin: 0 auto;
-  padding: $spacing-lg $spacing-md;
+  padding: calc($spacing-xl * 2) $spacing-md;
   margin-top: $layout-lg;
 
   @media screen and #{$mq-md} {


### PR DESCRIPTION
 

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3168
 
<!-- When adding a new feature: -->

# New feature description
The image of the Bundle banner overlaps with the text above it. This PR addresses that and the weird layout issue with the hero image when sizing down the device width. Now image resizes properly. 


# Screenshot (if applicable)

![image](https://github.com/mozilla/fx-private-relay/assets/3924990/05fcbd66-e1ce-40dd-aa2d-41067e2e443a)

# How to test

**Prerequisites:** Do NOT be signed in into a Firefox Relay account;

**Steps to reproduce:**

1. Go to the Relay Interstitial page; 
2. Observe the layout of the top of the page;

**Expected result:** The layout has no issues.

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
