### PR TITLE
fix MPP-3156: optimize FxaTokenAuthentication.authenticate 

### DIFF
--- a/api/tests/authentication_tests.py
+++ b/api/tests/authentication_tests.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from model_bakery import baker
-from requests.exceptions import Timeout
 import responses
 
 from django.core.cache import cache
@@ -57,7 +56,6 @@ class AuthenticationMiscellaneous(TestCase):
     def test_introspect_token_catches_JSONDecodeError_raises_AuthenticationFailed(self):
         _setup_fxa_response_no_json(200)
         invalid_token = "invalid-123"
-        cache_key = get_cache_key(invalid_token)
 
         try:
             introspect_token(invalid_token)
@@ -162,7 +160,7 @@ class AuthenticationMiscellaneous(TestCase):
 
         # now check that the 2nd call did NOT make another fxa request
         try:
-            fxa_uid = get_fxa_uid_from_oauth_token(invalid_token)
+            get_fxa_uid_from_oauth_token(invalid_token)
         except APIException as e:
             assert str(e.detail) == "Did not receive a 200 response from FXA."
             assert responses.assert_call_count(self.fxa_verify_path, 1) is True
@@ -194,7 +192,7 @@ class AuthenticationMiscellaneous(TestCase):
 
         # now check that the 2nd call did NOT make another fxa request
         try:
-            fxa_uid = get_fxa_uid_from_oauth_token(invalid_token)
+            get_fxa_uid_from_oauth_token(invalid_token)
         except AuthenticationFailed as e:
             assert str(e.detail) == "FXA returned active: False for token."
             assert responses.assert_call_count(self.fxa_verify_path, 1) is True
@@ -222,7 +220,7 @@ class AuthenticationMiscellaneous(TestCase):
 
         # now check that the 2nd call did NOT make another fxa request
         try:
-            fxa_uid = get_fxa_uid_from_oauth_token(user_token)
+            get_fxa_uid_from_oauth_token(user_token)
         except NotFound as e:
             assert str(e.detail) == "FXA did not return an FXA UID."
             assert responses.assert_call_count(self.fxa_verify_path, 1) is True

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -194,7 +194,7 @@ def terms_accepted_user(request):
         raise ParseError("Missing FXA Token after 'Bearer'.")
 
     try:
-        fxa_uid = get_fxa_uid_from_oauth_token(token)
+        fxa_uid = get_fxa_uid_from_oauth_token(token, use_cache=False)
     except AuthenticationFailed as e:
         # AuthenticationFailed exception returns 403 instead of 401 because we are not
         # using the proper config that comes with the authentication_classes


### PR DESCRIPTION
Use cached FXA response for as long as the token is valid,
unless the request is a write request - i.e., POST, PUT, DELETE.

Exception: Also use the cached FXA response for POST
/api/v1/relayaddresses/ requests

This PR fixes #MPP-3156.

How to test:
1. Run `pytest`

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).