### PR TITLE
MPP-3192 - Refactor email sending functions

### DIFF
--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -24,12 +24,12 @@ import pytest
 
 from privaterelay.ftl_bundles import main
 from emails.models import (
-    address_hash,
     DeletedAddress,
     DomainAddress,
     Profile,
     RelayAddress,
     Reply,
+    address_hash,
     get_domains_from_settings,
 )
 from emails.utils import (
@@ -40,18 +40,18 @@ from emails.utils import (
     get_message_id_bytes,
 )
 from emails.views import (
+    ReplyHeadersNotFound,
+    _build_reply_requires_premium_email,
     _get_address,
     _get_attachment,
     _get_keys_from_headers,
     _record_receipt_verdicts,
-    _build_reply_requires_premium_email,
     _set_forwarded_first_reply,
     _sns_message,
     _sns_notification,
     reply_requires_premium_test,
     validate_sns_arn_and_type,
     wrapped_email_test,
-    ReplyHeadersNotFound,
 )
 
 from .models_tests import (

--- a/emails/types.py
+++ b/emails/types.py
@@ -1,0 +1,14 @@
+"""Types for email functions"""
+from typing import Any, Literal
+from io import IOBase
+
+# Relay container for email content
+MessageBodyContent = dict[Literal["Charset", "Data"], str]
+MessageBody = dict[Literal["Text", "Html"], MessageBodyContent]
+
+# Attachment path and data stream
+AttachmentPair = tuple[str, IOBase]
+
+# AWS "mail" element in Received notification
+# See https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html
+AWS_MailJSON = dict[str, Any]

--- a/emails/types.py
+++ b/emails/types.py
@@ -18,6 +18,9 @@ OutgoingHeaderName = Literal[
 ]
 OutgoingHeaders = dict[OutgoingHeaderName, str]
 
+# Generic AWS message over SNS - Notification, Bounce, Complaint, ...
+AWS_SNSMessageJSON = dict[str, Any]
+
 # AWS "mail" element in Received notification
 # See https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html
 AWS_MailJSON = dict[str, Any]

--- a/emails/types.py
+++ b/emails/types.py
@@ -9,6 +9,15 @@ MessageBody = dict[Literal["Text", "Html"], MessageBodyContent]
 # Attachment path and data stream
 AttachmentPair = tuple[str, IOBase]
 
+# Headers for outgoing emails
+OutgoingHeaderName = Literal[
+    "From",
+    "Reply-To",
+    "Subject",
+    "To",
+]
+OutgoingHeaders = dict[OutgoingHeaderName, str]
+
 # AWS "mail" element in Received notification
 # See https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html
 AWS_MailJSON = dict[str, Any]

--- a/emails/types.py
+++ b/emails/types.py
@@ -12,6 +12,8 @@ AttachmentPair = tuple[str, IOBase]
 # Headers for outgoing emails
 OutgoingHeaderName = Literal[
     "From",
+    "In-Reply-To",
+    "References",
     "Reply-To",
     "Subject",
     "To",

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -312,24 +312,17 @@ def _store_reply_record(mail: AWS_MailJSON, ses_response, address) -> AWS_MailJS
 
 
 def ses_relay_email(
-    from_address: str,
-    to_address: str,
-    subject: str,
+    source_address: str,
+    destination_address: str,
+    headers: OutgoingHeaders,
     message_body: MessageBody,
     attachments: list[AttachmentPair],
     mail: AWS_MailJSON,
     address: RelayAddress | DomainAddress,
 ) -> HttpResponse:
-    reply_address = get_reply_to_address()
-    headers: OutgoingHeaders = {
-        "Subject": subject,
-        "From": from_address,
-        "To": to_address,
-        "Reply-To": reply_address,
-    }
     response = ses_send_raw_email(
-        from_address,
-        to_address,
+        source_address,
+        destination_address,
         headers,
         message_body,
         attachments,

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -196,14 +196,10 @@ def get_welcome_email(request: HttpRequest, user: User, format: str) -> str:
 def ses_send_raw_email(
     source_address: str,
     destination_address: str,
-    headers: OutgoingHeaders,
-    message_body: MessageBody,
-    attachments: list[AttachmentPair],
+    message: MIMEMultipart,
     mail: AWS_MailJSON,
     address: RelayAddress | DomainAddress,
 ) -> HttpResponse:
-    message = create_message(headers, message_body, attachments)
-
     emails_config = apps.get_app_config("emails")
     assert isinstance(emails_config, EmailsConfig)
     ses_client = emails_config.ses_client
@@ -320,12 +316,11 @@ def ses_relay_email(
     mail: AWS_MailJSON,
     address: RelayAddress | DomainAddress,
 ) -> HttpResponse:
+    message = create_message(headers, message_body, attachments)
     response = ses_send_raw_email(
         source_address,
         destination_address,
-        headers,
-        message_body,
-        attachments,
+        message,
         mail,
         address,
     )

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -40,7 +40,7 @@ from .models import (
     Reply,
     get_domains_from_settings,
 )
-from .types import AttachmentPair, AWS_MailJSON, MessageBody
+from .types import AttachmentPair, AWS_MailJSON, MessageBody, OutgoingHeaders
 
 
 logger = logging.getLogger("events")
@@ -203,9 +203,13 @@ def ses_send_raw_email(
     mail: AWS_MailJSON,
     address: RelayAddress | DomainAddress,
 ) -> HttpResponse:
-    msg_with_headers = _start_message_with_headers(
-        subject, from_address, to_address, reply_address
-    )
+    headers: OutgoingHeaders = {
+        "Subject": subject,
+        "From": from_address,
+        "To": to_address,
+        "Reply-To": reply_address,
+    }
+    msg_with_headers = _start_message_with_headers(headers)
     msg_with_body = _add_body_to_message(msg_with_headers, message_body)
     msg_with_attachments = _add_attachments_to_message(msg_with_body, attachments)
 
@@ -233,16 +237,12 @@ def ses_send_raw_email(
     return HttpResponse("Sent email to final recipient.", status=200)
 
 
-def _start_message_with_headers(
-    subject: str, from_address: str, to_address: str, reply_address: str
-) -> MIMEMultipart:
+def _start_message_with_headers(headers: OutgoingHeaders) -> MIMEMultipart:
     # Create a multipart/mixed parent container.
     msg = MIMEMultipart("mixed")
-    # Add subject, from and to lines.
-    msg["Subject"] = subject
-    msg["From"] = from_address
-    msg["To"] = to_address
-    msg["Reply-To"] = reply_address
+    # Add headers
+    for name, value in headers.items():
+        msg[name] = value
     return msg
 
 

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -221,10 +221,12 @@ def ses_send_raw_email(
 def create_message(
     headers: OutgoingHeaders,
     message_body: MessageBody,
-    attachments: list[AttachmentPair],
+    attachments: list[AttachmentPair] | None = None,
 ) -> MIMEMultipart:
     msg_with_headers = _start_message_with_headers(headers)
     msg_with_body = _add_body_to_message(msg_with_headers, message_body)
+    if not attachments:
+        return msg_with_body
     msg_with_attachments = _add_attachments_to_message(msg_with_body, attachments)
     return msg_with_attachments
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -39,32 +39,32 @@ from django.views.decorators.csrf import csrf_exempt
 from .apps import EmailsConfig
 
 from .models import (
-    address_hash,
     CannotMakeAddressException,
-    get_domain_numerical,
-    get_domains_from_settings,
     DeletedAddress,
     DomainAddress,
     Profile,
     RelayAddress,
     Reply,
+    address_hash,
+    get_domain_numerical,
+    get_domains_from_settings,
 )
 from .utils import (
     _get_bucket_and_key_from_s3_json,
     b64_lookup_key,
-    remove_trackers,
     count_all_trackers,
-    get_message_content_from_s3,
-    incr_if_enabled,
-    histogram_if_enabled,
-    ses_relay_email,
-    urlize_and_linebreaks,
-    derive_reply_keys,
     decrypt_reply_metadata,
-    remove_message_from_s3,
-    ses_send_raw_email,
-    get_message_id_bytes,
+    derive_reply_keys,
     generate_relay_From,
+    get_message_content_from_s3,
+    get_message_id_bytes,
+    histogram_if_enabled,
+    incr_if_enabled,
+    remove_message_from_s3,
+    remove_trackers,
+    ses_relay_email,
+    ses_send_raw_email,
+    urlize_and_linebreaks,
 )
 from .sns import verify_from_sns, SUPPORTED_SNS_TYPES
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -720,7 +720,7 @@ def _build_reply_requires_premium_email(
     # If we haven't forwarded a first reply for this user yet, _reply_allowed
     # will forward.  So, tell the user we forwarded it.
     forwarded = not reply_record.address.user.profile.forwarded_first_reply
-    sender: str | None = None
+    sender: str | None = ""
     if decrypted_metadata is not None:
         sender = decrypted_metadata.get("reply-to") or decrypted_metadata.get("from")
     ctx = {
@@ -857,7 +857,7 @@ def _handle_reply(
             logger.error("s3_object_does_not_exist", extra=e.response["Error"])
             return HttpResponse("Email not in S3", status=404)
         logger.error("s3_client_error_get_email", extra=e.response["Error"])
-        # we are returning a 5XX so that SNS can retry the email processing
+        # we are returning a 500 so that SNS can retry the email processing
         return HttpResponse("Cannot fetch the message content from S3", status=503)
 
     message_body: MessageBody = {}

--- a/emails/views.py
+++ b/emails/views.py
@@ -857,7 +857,7 @@ def _handle_reply(
             logger.error("s3_object_does_not_exist", extra=e.response["Error"])
             return HttpResponse("Email not in S3", status=404)
         logger.error("s3_client_error_get_email", extra=e.response["Error"])
-        # we are returning a 500 so that SNS can retry the email processing
+        # we are returning a 5XX so that SNS can retry the email processing
         return HttpResponse("Cannot fetch the message content from S3", status=503)
 
     message_body: MessageBody = {}

--- a/emails/views.py
+++ b/emails/views.py
@@ -421,7 +421,7 @@ def _get_relay_recipient_from_message_json(message_json):
     return _get_recipient_with_relay_domain(recipients)
 
 
-def _sns_message(message_json):
+def _sns_message(message_json: AWS_SNSMessageJSON) -> HttpResponse:
     incr_if_enabled("sns_inbound_Notification_Received", 1)
     notification_type = message_json.get("notificationType")
     event_type = message_json.get("eventType")
@@ -562,7 +562,7 @@ def _sns_message(message_json):
     # and apply default link styles
     display_email = re.sub("([@.:])", r"<span>\1</span>", to_address)
 
-    message_body = {}
+    message_body: MessageBody = {}
     tracker_report_link = ""
     removed_count = 0
     # frontend expects a timestamp in milliseconds
@@ -983,7 +983,7 @@ def _get_address(address: str) -> RelayAddress | DomainAddress:
         raise e
 
 
-def _handle_bounce(message_json):
+def _handle_bounce(message_json: AWS_SNSMessageJSON) -> HttpResponse:
     """
     Handle an AWS SES bounce notification.
 
@@ -1103,7 +1103,7 @@ def _handle_bounce(message_json):
     return HttpResponse("OK", status=200)
 
 
-def _handle_complaint(message_json):
+def _handle_complaint(message_json: AWS_SNSMessageJSON) -> HttpResponse:
     """
     Handle an AWS SES complaint notification.
 


### PR DESCRIPTION
For MPP-2117, refactor the email sending functions to take a dictionary of email headers (`OutgoingHeaders`), and to move email assembly to its own function. The code has the same behavior and there are no test changes (except for import order).

Function changes:

* `ses_relay_email` - the function now creates the email message, sends it, creates a `Reply` record, and creates the `HttpResponse`. This was previously done by `ses_send_raw_email`. This more flexible function can be used by `_send_reply_requires_premium_email`, rather than `ses_send_raw_email`. Parameter changes:
   - `from_address` becomes `source_address`, to match `ses_client.send_raw_email`'s `Source` parameter
   - `to_address` becomes `destination_address`, to match `ses_client.send_raw_email`'s `Destinations` parameter
   - new `headers` dict has the email headers, at least `Subject`, `From`, and `To`, but can include `Reply-To`, `In-Reply-To`, and `References` (static checks w/ mypy). These headers can now vary from the params sent to `ses_client.send_raw_email`
   - drop `subject` (in `headers`)
* `ses_send_raw_email` - the function is now focused on calling `ses_client.send_raw_email`. Parameter changes:
   - `from_address` becomes `source_address`, to match `ses_client.send_raw_email`'s `Source` parameter
   - `to_address` becomes `destination_address`, to match `ses_client.send_raw_email`'s `Destinations` parameter
   - new `message` is a `MIMEMultipart` email message
   - drop `subject`, `message_body`, `attachements`, and `reply_address`, part of the `message` param
   - drop `mail` and `address`, functionality moved to `ses_relay_email`
* `_store_reply_record` now takes a `message_id`, rather than the entire SES response to get the `MessageId`.
* new `create_message` function takes `headers`, a `message_body` dict, and optional `attachments` and returns a `MIMEMultipart` email message. This more flexible function can be used by `_build_reply_requires_premium_email`.  
* new `get_reply_to_address` can return the premium (default) or free reply address. This _might_ be the same address these days...

How to test:

* `pytest` passes