### PR TITLE
MPP-2085 - Change premium plan map ID config to include new countries. 

### DIFF
--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -24,7 +24,7 @@ from allauth.socialaccount.helpers import complete_social_login  # type: ignore
 from allauth.socialaccount.providers.fxa.provider import FirefoxAccountsProvider  # type: ignore
 from allauth.socialaccount.providers.fxa.views import FirefoxAccountsOAuth2Adapter
 from django_filters import rest_framework as filters
-from waffle import get_waffle_flag_model
+from waffle import flag_is_active, get_waffle_flag_model
 from waffle.models import Switch, Sample
 from rest_framework import (
     decorators,
@@ -243,7 +243,8 @@ def runtime_data(request):
     switch_values = [(s.name, s.is_active()) for s in switches]
     samples = Sample.get_all()
     sample_values = [(s.name, s.is_active()) for s in samples]
-    premium_mapping = get_premium_country_language_mapping()
+    eu_country_expansion = flag_is_active(request, "eu_country_expansion")
+    premium_mapping = get_premium_country_language_mapping(eu_country_expansion)
     return response.Response(
         {
             "FXA_ORIGIN": settings.FXA_BASE_ORIGIN,

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -38,6 +38,7 @@ from emails.utils import incr_if_enabled
 
 from privaterelay.utils import (
     get_countries_info_from_request_and_mapping,
+    get_premium_country_language_mapping,
 )
 
 from emails.models import (
@@ -242,6 +243,7 @@ def runtime_data(request):
     switch_values = [(s.name, s.is_active()) for s in switches]
     samples = Sample.get_all()
     sample_values = [(s.name, s.is_active()) for s in samples]
+    premium_mapping = get_premium_country_language_mapping()
     return response.Response(
         {
             "FXA_ORIGIN": settings.FXA_BASE_ORIGIN,
@@ -250,7 +252,7 @@ def runtime_data(request):
             "BUNDLE_PRODUCT_ID": settings.BUNDLE_PROD_ID,
             "PHONE_PRODUCT_ID": settings.PHONE_PROD_ID,
             "PERIODICAL_PREMIUM_PLANS": get_countries_info_from_request_and_mapping(
-                request, settings.PERIODICAL_PREMIUM_PLAN_COUNTRY_LANG_MAPPING
+                request, premium_mapping
             ),
             "PHONE_PLANS": get_countries_info_from_request_and_mapping(
                 request, settings.PHONE_PLAN_COUNTRY_LANG_MAPPING

--- a/emails/models.py
+++ b/emails/models.py
@@ -172,7 +172,10 @@ class Profile(models.Model):
     def fxa_locale_in_premium_country(self):
         if self.fxa and self.fxa.extra_data.get("locale"):
             accept_langs = parse_accept_lang_header(self.fxa.extra_data.get("locale"))
-            premium_countries = get_premium_countries()
+            eu_country_expansion = flag_is_active_in_task(
+                "eu_country_expansion", self.user
+            )
+            premium_countries = get_premium_countries(eu_country_expansion)
             if (
                 len(accept_langs) >= 1
                 and len(accept_langs[0][0].split("-")) >= 2

--- a/emails/models.py
+++ b/emails/models.py
@@ -22,7 +22,7 @@ from django.utils.translation.trans_real import (
 from rest_framework.authtoken.models import Token
 
 from api.exceptions import ErrorContextType, RelayAPIException
-from privaterelay.utils import flag_is_active_in_task
+from privaterelay.utils import flag_is_active_in_task, get_premium_countries
 
 
 emails_config = apps.get_app_config("emails")
@@ -172,11 +172,11 @@ class Profile(models.Model):
     def fxa_locale_in_premium_country(self):
         if self.fxa and self.fxa.extra_data.get("locale"):
             accept_langs = parse_accept_lang_header(self.fxa.extra_data.get("locale"))
+            premium_countries = get_premium_countries()
             if (
                 len(accept_langs) >= 1
                 and len(accept_langs[0][0].split("-")) >= 2
-                and accept_langs[0][0].split("-")[1]
-                in settings.PERIODICAL_PREMIUM_PLAN_COUNTRY_LANG_MAPPING.keys()
+                and accept_langs[0][0].split("-")[1] in premium_countries
             ):
                 return True
             # If a language but no country is known, check if there's a country
@@ -186,8 +186,7 @@ class Profile(models.Model):
             if (
                 len(accept_langs) >= 1
                 and len(accept_langs[0][0].split("-")) == 1
-                and accept_langs[0][0].split("-")[0]
-                in settings.PERIODICAL_PREMIUM_PLAN_COUNTRY_LANG_MAPPING.keys()
+                and accept_langs[0][0].split("-")[0] in premium_countries
             ):
                 return True
         return False

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -13,6 +13,7 @@ from django.test import (
 )
 
 from allauth.socialaccount.models import SocialAccount
+from waffle.testutils import override_flag
 import pytest
 
 from model_bakery import baker
@@ -828,6 +829,26 @@ class ProfileTest(TestCase):
         assert self.profile.fxa_locale_in_premium_country is False
 
     def test_locale_in_premium_country_returns_False_if_no_fxa_account(self):
+        assert self.profile.fxa_locale_in_premium_country is False
+
+    @override_flag("eu_country_expansion", active=True)
+    def test_locale_in_premium_country_with_eu_expansion_flag(self):
+        baker.make(
+            SocialAccount,
+            user=self.profile.user,
+            provider="fxa",
+            extra_data={"locale": "et-ee,et;q=0.8"},
+        )
+        assert self.profile.fxa_locale_in_premium_country is True
+
+    @override_flag("eu_country_expansion", active=False)
+    def test_locale_in_premium_country_without_eu_expansion_flag(self):
+        baker.make(
+            SocialAccount,
+            user=self.profile.user,
+            provider="fxa",
+            extra_data={"locale": "et-ee,et;q=0.8"},
+        )
         assert self.profile.fxa_locale_in_premium_country is False
 
     def test_user_joined_before_premium_release_returns_True(self):

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -507,6 +507,126 @@ PERIODICAL_PREMIUM_PLAN_ID_MATRIX = {
                 "currency": "EUR",
             },
         },
+        "si": {
+            "monthly": {
+                "id": "price_1NHALmJNcmPzuWtR2nIoAzEt",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1NHAL9JNcmPzuWtRSZ3BWQs0",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "sk": {
+            "monthly": {
+                "id": "price_1NHAJsJNcmPzuWtR71WX0Pz9",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1NHAKYJNcmPzuWtRtETl30gb",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "pt": {
+            "monthly": {
+                "id": "price_1NHAI1JNcmPzuWtRx8jXjkrQ",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1NHAHWJNcmPzuWtRCRMnWyvK",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "lu": {
+            "monthly": {
+                "id": "price_1NHAFZJNcmPzuWtRm5A7w5qJ",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1NHAF8JNcmPzuWtRG1FiPK0N",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "lt": {
+            "monthly": {
+                "id": "price_1NHACcJNcmPzuWtR5ZJeVtJA",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1NHADOJNcmPzuWtR2PSMBMLr",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "lv": {
+            "monthly": {
+                "id": "price_1NHAASJNcmPzuWtRpcliwx0R",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1NHA9lJNcmPzuWtRLf7DV6GA",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "gr": {
+            "monthly": {
+                "id": "price_1NHA5CJNcmPzuWtR1JSmxqFA",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1NHA4lJNcmPzuWtRniS23IuE",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "ee": {
+            "monthly": {
+                "id": "price_1NHA1tJNcmPzuWtRvSeyiVYH",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1NHA2TJNcmPzuWtR10yknZHf",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "mt": {
+            "monthly": {
+                "id": "price_1NH9yxJNcmPzuWtRChanpIQU",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1NH9y3JNcmPzuWtRIJkQos9q",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "cy": {
+            "monthly": {
+                "id": "price_1NH9saJNcmPzuWtRpffF5I59",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1NH9rKJNcmPzuWtRzDiXCeEG",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
     },
     "usd": {
         "en": {
@@ -535,6 +655,7 @@ PERIODICAL_PREMIUM_PLAN_ID_MATRIX = {
         },
     },
 }
+
 PERIODICAL_PREMIUM_PLAN_COUNTRY_LANG_MAPPING = {
     # Austria
     "at": {
@@ -584,23 +705,69 @@ PERIODICAL_PREMIUM_PLAN_COUNTRY_LANG_MAPPING = {
     "fi": {
         "fi": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["euro"]["fi"],
     },
+    # United States
     "us": {
         "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["usd"]["en"],
     },
+    # United Kingdom
     "gb": {
         "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["usd"]["gb"],
     },
+    # Canada
     "ca": {
         "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["usd"]["en"],
     },
+    # New Zealand
     "nz": {
         "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["usd"]["gb"],
     },
+    # Malaysia
     "my": {
         "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["usd"]["gb"],
     },
+    # Singapore
     "sg": {
         "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["usd"]["gb"],
+    },
+    # Cyprus
+    "cy": {
+        "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["euro"]["cy"],
+    },
+    # Estonia
+    "ee": {
+        "et": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["euro"]["ee"],
+    },
+    # Greece
+    "gr": {
+        "el": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["euro"]["gr"],
+    },
+    # Latvia
+    "lv": {
+        "lv": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["euro"]["lv"],
+    },
+    # Lithuania
+    "lt": {
+        "lt": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["euro"]["lt"],
+    },
+    # Luxembourg
+    "lu": {
+        "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["euro"]["lu"],
+    },
+    # Malta
+    "mt": {
+        "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["euro"]["mt"],
+    },
+    # Portugal
+    "pt": {
+        "pt": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["euro"]["pt"],
+    },
+    # Slovakia
+    "sk": {
+        "sk": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["euro"]["sk"],
+    },
+    # Slovenia
+    "si": {
+        "sl": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["euro"]["si"],
     },
 }
 

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -615,6 +615,9 @@ PERIODICAL_PREMIUM_PLAN_ID_MATRIX = {
                 "currency": "EUR",
             },
         },
+        # TODO: clarify this entry
+        # "cy" the language code means Welsh
+        # "cy" means "Cyprus" in our usage, which is probably Greek or Turkish
         "cy": {
             "monthly": {
                 "id": "price_1NH9saJNcmPzuWtRpffF5I59",
@@ -729,8 +732,11 @@ PERIODICAL_PREMIUM_PLAN_COUNTRY_LANG_MAPPING = {
     "sg": {
         "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["usd"]["gb"],
     },
+}
+EU_EXPANSION_PREMIUM_PLAN_COUNTRY_LANG_MAPPING = {
     # Cyprus
     "cy": {
+        # TODO: Welsh (cy) seems wrong. Maybe el (greek) and tr (turkish)?
         "en": PERIODICAL_PREMIUM_PLAN_ID_MATRIX["euro"]["cy"],
     },
     # Estonia

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -17,41 +17,45 @@ import pytest
 from ..utils import (
     flag_is_active_in_task,
     get_premium_country_lang,
+    get_premium_country_language_mapping,
 )
 
 
 class GetPremiumCountryLangTest(TestCase):
+    def setUp(self):
+        self.mapping = get_premium_country_language_mapping()
+
     def test_get_premium_country_lang(self):
-        cc, lang = get_premium_country_lang("en-au,")
+        cc, lang = get_premium_country_lang("en-au,", self.mapping)
         assert cc == "au"
         assert lang == "en"
 
-        cc, lang = get_premium_country_lang("en-us,")
+        cc, lang = get_premium_country_lang("en-us,", self.mapping)
         assert cc == "us"
         assert lang == "en"
 
-        cc, lang = get_premium_country_lang("de-be,")
+        cc, lang = get_premium_country_lang("de-be,", self.mapping)
         assert cc == "be"
         assert lang == "de"
 
-        cc, lang = get_premium_country_lang("de-be,", "at")
+        cc, lang = get_premium_country_lang("de-be,", self.mapping, "at")
         assert cc == "at"
         assert lang == "de"
 
     def test_en_fallback(self) -> None:
-        cc, lang = get_premium_country_lang("en,")
+        cc, lang = get_premium_country_lang("en,", self.mapping)
         assert cc == "us"
         assert lang == "en"
 
     def test_first_lang_fallback_two_parts(self) -> None:
         accept_lang = "sgn-us,"  # American Sign Language
-        cc, lang = get_premium_country_lang(accept_lang)
+        cc, lang = get_premium_country_lang(accept_lang, self.mapping)
         assert cc == "us"
         assert lang == "en"
 
     def test_first_lang_fallback_three_parts(self) -> None:
         accept_lang = "sgn-ch-de,"  # Swiss German Sign Language
-        cc, lang = get_premium_country_lang(accept_lang)
+        cc, lang = get_premium_country_lang(accept_lang, self.mapping)
         assert cc == "ch"
         assert lang == "fr"
 

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -23,7 +23,7 @@ from ..utils import (
 
 class GetPremiumCountryLangTest(TestCase):
     def setUp(self):
-        self.mapping = get_premium_country_language_mapping()
+        self.mapping = get_premium_country_language_mapping(None)
 
     def test_get_premium_country_lang(self):
         cc, lang = get_premium_country_lang("en-au,", self.mapping)
@@ -58,6 +58,18 @@ class GetPremiumCountryLangTest(TestCase):
         cc, lang = get_premium_country_lang(accept_lang, self.mapping)
         assert cc == "ch"
         assert lang == "fr"
+
+    def test_eu_country_expansion_active(self) -> None:
+        mapping = get_premium_country_language_mapping(eu_country_expansion=True)
+        cc, lang = get_premium_country_lang("et-ee", mapping)
+        assert cc == "ee"
+        assert lang == "et"
+
+    def test_eu_country_expansion_inactive(self) -> None:
+        mapping = get_premium_country_language_mapping(eu_country_expansion=False)
+        cc, lang = get_premium_country_lang("et-ee", mapping)
+        assert cc == "ee"
+        assert lang == "en"
 
 
 #

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -49,7 +49,6 @@ class GetPremiumCountryLangTest(TestCase):
         assert cc == "us"
         assert lang == "en"
 
-    @pytest.mark.xfail(strict=True, reason="bug in handling 3-part languages")
     def test_first_lang_fallback_three_parts(self) -> None:
         accept_lang = "sgn-ch-de,"  # Swiss German Sign Language
         cc, lang = get_premium_country_lang(accept_lang)

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -38,6 +38,24 @@ class GetPremiumCountryLangTest(TestCase):
         assert cc == "at"
         assert lang == "de"
 
+    def test_en_fallback(self) -> None:
+        cc, lang = get_premium_country_lang("en,")
+        assert cc == "us"
+        assert lang == "en"
+
+    def test_first_lang_fallback_two_parts(self) -> None:
+        accept_lang = "sgn-us,"  # American Sign Language
+        cc, lang = get_premium_country_lang(accept_lang)
+        assert cc == "us"
+        assert lang == "en"
+
+    @pytest.mark.xfail(strict=True, reason="bug in handling 3-part languages")
+    def test_first_lang_fallback_three_parts(self) -> None:
+        accept_lang = "sgn-ch-de,"  # Swiss German Sign Language
+        cc, lang = get_premium_country_lang(accept_lang)
+        assert cc == "ch"
+        assert lang == "fr"
+
 
 #
 # flag_is_active_in_task tests

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -42,7 +42,7 @@ def get_premium_country_lang(accept_lang, cc=None):
     lang_parts = lang.split("-") if lang and "-" in lang else [lang]
     lang = lang_parts[0].lower()
     if cc is None:
-        cc = lang_parts[1] if len(lang_parts) == 2 else lang_parts[0]
+        cc = lang_parts[1] if len(lang_parts) >= 2 else lang_parts[0]
         cc = cc.lower()
         # if the language was just "en", default to US
         if cc == "en":

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -16,7 +16,7 @@ from waffle.utils import (
 
 
 def get_countries_info_from_request_and_mapping(request, mapping):
-    country_code = _get_cc_from_request(request)
+    country_code = _get_cc_from_request(request, mapping)
     countries = mapping.keys()
     available_in_country = country_code in countries
     return {
@@ -27,17 +27,19 @@ def get_countries_info_from_request_and_mapping(request, mapping):
     }
 
 
-def _get_cc_from_request(request):
+def _get_cc_from_request(request, premium_mapping):
     if "X-Client-Region" in request.headers:
         return request.headers["X-Client-Region"].lower()
     if "Accept-Language" in request.headers:
-        return get_premium_country_lang(request.headers["Accept-Language"])[0]
+        return get_premium_country_lang(
+            request.headers["Accept-Language"], premium_mapping
+        )[0]
     if settings.DEBUG:
         return "us"
     return "us"
 
 
-def get_premium_country_lang(accept_lang, cc=None):
+def get_premium_country_lang(accept_lang, mapping, cc=None):
     lang = accept_lang.split(",")[0]
     lang_parts = lang.split("-") if lang and "-" in lang else [lang]
     lang = lang_parts[0].lower()
@@ -48,12 +50,21 @@ def get_premium_country_lang(accept_lang, cc=None):
         if cc == "en":
             cc = "us"
 
-    if cc in settings.PERIODICAL_PREMIUM_PLAN_COUNTRY_LANG_MAPPING.keys():
-        languages = settings.PERIODICAL_PREMIUM_PLAN_COUNTRY_LANG_MAPPING[cc]
+    if languages := mapping.get(cc):
         if lang in languages.keys():
             return cc, lang
         return cc, list(languages.keys())[0]
     return cc, "en"
+
+
+def get_premium_country_language_mapping():
+    mapping = settings.PERIODICAL_PREMIUM_PLAN_COUNTRY_LANG_MAPPING.copy()
+    return mapping
+
+
+def get_premium_countries():
+    mapping = get_premium_country_language_mapping()
+    return set(mapping.keys())
 
 
 def enable_or_404(

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -57,13 +57,15 @@ def get_premium_country_lang(accept_lang, mapping, cc=None):
     return cc, "en"
 
 
-def get_premium_country_language_mapping():
+def get_premium_country_language_mapping(eu_country_expansion):
     mapping = settings.PERIODICAL_PREMIUM_PLAN_COUNTRY_LANG_MAPPING.copy()
+    if eu_country_expansion:
+        mapping.update(settings.EU_EXPANSION_PREMIUM_PLAN_COUNTRY_LANG_MAPPING)
     return mapping
 
 
-def get_premium_countries():
-    mapping = get_premium_country_language_mapping()
+def get_premium_countries(eu_country_expansion):
+    mapping = get_premium_country_language_mapping(eu_country_expansion)
     return set(mapping.keys())
 
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-2085
 
<!-- When adding a new feature: -->

# New feature description

 Change premium plan map ID config to include new countries. 

- Users in Cyprus, Estonia, Greece, Latvia, Lithuania, Luxembourg, Malta, Portugal, Slovakia, Slovenia can subscribe to Relay Premium 
- localized for Estonian (et), Greek (el), Latvian (lv), Lithuanian (lt), Portuguese (pt), Slovak (sk), Slovenian (sl) (these are the languages that pontoons supports) 
- Euro for currency 
- Allows for premium upsells CTAs in emails, relay website and add-on. 
 
# Screenshot (if applicable)
 

# How to test



# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
