### PR TITLE
Python dependency updates, 2023-06-20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.151
+boto3==1.26.155
 codetiming==1.4.0
 cryptography==41.0.1
 Django==3.2.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ django-cors-headers==4.0.0
 django-csp==3.7
 django-debug-toolbar==4.1.0
 django-filter==23.2
-django-redis==5.2.0
+django-redis==5.3.0
 django-ftl==0.14
 django-referrer-policy==1.0
 djangorestframework==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,5 +50,5 @@ types-pyOpenSSL==23.2.0.0
 django-stubs==4.2.1
 djangorestframework-stubs==3.14.1
 boto3-stubs==1.26.151
-botocore-stubs==1.29.151
+botocore-stubs==1.29.155
 mypy-boto3-ses==1.26.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ python-decouple==3.8
 pyOpenSSL==23.2.0
 requests==2.31.0
 sentry-sdk==1.25.1
-whitenoise==6.4.0
+whitenoise==6.5.0
 
 # phones app
 phonenumbers==8.13.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ whitenoise==6.4.0
 
 # phones app
 phonenumbers==8.13.14
-twilio==8.2.2
+twilio==8.3.0
 vobject==0.9.6.1
 
 # tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ sentry-sdk==1.25.1
 whitenoise==6.4.0
 
 # phones app
-phonenumbers==8.13.13
+phonenumbers==8.13.14
 twilio==8.2.2
 vobject==0.9.6.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cryptography==41.0.1
 Django==3.2.19
 dj-database-url==2.0.0
 django-allauth==0.54.0
-django-cors-headers==4.0.0
+django-cors-headers==4.1.0
 django-csp==3.7
 django-debug-toolbar==4.1.0
 django-filter==23.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,6 @@ types-requests==2.31.0.1
 types-pyOpenSSL==23.2.0.0
 django-stubs==4.2.1
 djangorestframework-stubs==3.14.1
-boto3-stubs==1.26.151
+boto3-stubs==1.26.155
 botocore-stubs==1.29.155
 mypy-boto3-ses==1.26.0.post1


### PR DESCRIPTION
Update Python dependencies. This covers:

* Bump phonenumbers from 8.13.13 to 8.13.14 (from PR #3548)
* Bump twilio from 8.2.2 to 8.3.0 (from PR #3549)
* Bump django-redis from 5.2.0 to 5.3.0 (from PR #3550)
* Bump boto3 from 1.26.151 to 1.26.155 (from PR #3551)
* Bump django-cors-headers from 4.0.0 to 4.1.0 (from PR #3552)
* Bump botocore-stubs from 1.29.151 to 1.29.155 (from PR #3553)
* Bump whitenoise from 6.4.0 to 6.5.0 (from PR #3554)
* Bump boto3-stubs from 1.26.151 to 1.26.155 (from PR #3555)