### PR TITLE
Python dependency updates 2023-06-20 part 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,5 +50,5 @@ types-pyOpenSSL==23.2.0.0
 django-stubs==4.2.1
 djangorestframework-stubs==3.14.1
 boto3-stubs==1.26.156
-botocore-stubs==1.29.155
+botocore-stubs==1.29.156
 mypy-boto3-ses==1.26.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,6 @@ types-requests==2.31.0.1
 types-pyOpenSSL==23.2.0.0
 django-stubs==4.2.1
 djangorestframework-stubs==3.14.1
-boto3-stubs==1.26.155
+boto3-stubs==1.26.156
 botocore-stubs==1.29.155
 mypy-boto3-ses==1.26.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.155
+boto3==1.26.156
 codetiming==1.4.0
 cryptography==41.0.1
 Django==3.2.19


### PR DESCRIPTION
Update Python dependencies, part 2. This covers:

* Bump boto3 from 1.26.155 to 1.26.156 (from PR #3569)
* Bump boto3-stubs from 1.26.155 to 1.26.156 (from PR #3568)
* Bump botocore-stubs from 1.29.155 to 1.29.156 (from PR #3567)
