### PR TITLE
MPP-3193 - Add resender_headers flag, alternate email headers

### DIFF
--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -147,7 +147,7 @@ class FormattingToolsTest(TestCase):
         }
 
 
-def _utf8b(value: str) -> str:
+def _encode_as_base64_utf8_str(value: str) -> str:
     """Encode a string in UTF-8 binary (base64), like an email header"""
     b64 = b64encode(value.encode()).decode()
     return f"=?utf-8?b?{b64}?="
@@ -164,7 +164,7 @@ GENERATE_FROM_TEST_CASES: dict[str, _GENERATE_FROM_TEST_CASE_DEF] = {
     "with_umlaut": {
         "in_from": '"foö bär" <foo@bar.com>',
         "in_to": "mask@relay.example.com",
-        "out_from": _utf8b("foö bär <foo@bar.com> [via Relay]")
+        "out_from": _encode_as_base64_utf8_str("foö bär <foo@bar.com> [via Relay]")
         + " <mask@relay.example.com>",
     },
     "realistic_address": {
@@ -196,7 +196,9 @@ GENERATE_FROM_TEST_CASES: dict[str, _GENERATE_FROM_TEST_CASE_DEF] = {
         "in_from": f"l{'ö' * 90}ng <long-umlat@long.example.com>",
         "in_to": "umlat123@relay.example.com",
         "out_from": (
-            _utf8b(f"l{'ö' * 69}… <long-umlat@long.example.com> [via Relay]")
+            _encode_as_base64_utf8_str(
+                f"l{'ö' * 69}… <long-umlat@long.example.com> [via Relay]"
+            )
             + " <umlat123@relay.example.com>"
         ),
     },

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -20,6 +20,7 @@ from botocore.exceptions import ClientError
 from markus.main import MetricsRecord
 from markus.testing import MetricsMock
 from model_bakery import baker
+from waffle.testutils import override_flag
 import pytest
 
 from privaterelay.ftl_bundles import main
@@ -40,6 +41,7 @@ from emails.utils import (
     get_message_id_bytes,
 )
 from emails.views import (
+    RESENDER_HEADERS_FLAG_NAME,
     ReplyHeadersNotFound,
     _build_reply_requires_premium_email,
     _get_address,
@@ -181,6 +183,28 @@ class SNSNotificationTest(TestCase):
         assert self.ra.num_forwarded == 1
         assert (datetime.now(tz=timezone.utc) - self.ra.last_used_at).seconds < 2.0
 
+    @override_flag(RESENDER_HEADERS_FLAG_NAME, active=True)
+    def test_single_recipient_sns_notification_resender_headers(self) -> None:
+        _sns_notification(EMAIL_SNS_BODIES["single_recipient"])
+
+        sender, recipient, headers = self.get_details_from_mock_send_raw_email()
+        assert sender == "replies@default.com"
+        assert recipient == "user@example.com"
+        content_type = headers.pop("Content-Type")
+        assert content_type.startswith('multipart/mixed; boundary="========')
+        assert headers == {
+            "Subject": "localized email header + footer",
+            "MIME-Version": "1.0",
+            "From": '"fxastage@protonmail.com [via Relay]" <ebsbdsan7@test.com>',
+            "To": "user@example.com",
+            "Reply-To": "replies@default.com",
+            "Resent-From": "fxastage@protonmail.com",
+        }
+
+        self.ra.refresh_from_db()
+        assert self.ra.num_forwarded == 1
+        assert (datetime.now(tz=timezone.utc) - self.ra.last_used_at).seconds < 2.0
+
     def test_list_email_sns_notification(self) -> None:
         """By default, list emails should still forward."""
         _sns_notification(EMAIL_SNS_BODIES["single_recipient_list"])
@@ -198,6 +222,28 @@ class SNSNotificationTest(TestCase):
             "From": sender,
             "To": recipient,
             "Reply-To": "replies@default.com",
+        }
+
+        self.ra.refresh_from_db()
+        assert self.ra.num_forwarded == 1
+        assert (datetime.now(tz=timezone.utc) - self.ra.last_used_at).seconds < 2.0
+
+    @override_flag(RESENDER_HEADERS_FLAG_NAME, active=True)
+    def test_list_email_sns_notification_resender_headers(self) -> None:
+        """By default, list emails should still forward."""
+        _sns_notification(EMAIL_SNS_BODIES["single_recipient_list"])
+
+        sender, recipient, headers = self.get_details_from_mock_send_raw_email()
+        assert sender == "replies@default.com"
+        assert recipient == "user@example.com"
+        assert headers == {
+            "Content-Type": headers["Content-Type"],
+            "Subject": "localized email header + footer",
+            "MIME-Version": "1.0",
+            "From": '"fxastage@protonmail.com [via Relay]" <ebsbdsan7@test.com>',
+            "To": "user@example.com",
+            "Reply-To": "replies@default.com",
+            "Resent-From": "fxastage@protonmail.com",
         }
 
         self.ra.refresh_from_db()
@@ -260,6 +306,30 @@ class SNSNotificationTest(TestCase):
         assert da.last_used_at
         assert (datetime.now(tz=timezone.utc) - da.last_used_at).seconds < 2.0
 
+    @override_flag(RESENDER_HEADERS_FLAG_NAME, active=True)
+    def test_domain_recipient_resender_headers(self) -> None:
+        _sns_notification(EMAIL_SNS_BODIES["domain_recipient"])
+
+        sender, recipient, headers = self.get_details_from_mock_send_raw_email()
+        assert sender == "replies@default.com"
+        assert recipient == "premium@email.com"
+        assert headers == {
+            "Content-Type": headers["Content-Type"],
+            "Subject": "localized email header + footer",
+            "MIME-Version": "1.0",
+            "From": (
+                '"fxastage@protonmail.com [via Relay]" <wildcard@subdomain.test.com>'
+            ),
+            "To": "premium@email.com",
+            "Reply-To": "replies@default.com",
+            "Resent-From": "fxastage@protonmail.com",
+        }
+
+        da = DomainAddress.objects.get(user=self.premium_user, address="wildcard")
+        assert da.num_forwarded == 1
+        assert da.last_used_at
+        assert (datetime.now(tz=timezone.utc) - da.last_used_at).seconds < 2.0
+
     def test_successful_email_relay_message_removed_from_s3(self) -> None:
         _sns_notification(EMAIL_SNS_BODIES["single_recipient"])
 
@@ -281,7 +351,7 @@ class SNSNotificationTest(TestCase):
         assert self.ra.last_used_at is None
 
     @patch("emails.views._get_text_html_attachments")
-    def test_reply(self, mock_get_content) -> None:
+    def test_reply(self, mock_get_content, resender_headers=False) -> None:
         """The headers of a reply refer to the Relay mask."""
 
         # Create a premium user matching the s3_stored_replies sender
@@ -311,7 +381,9 @@ class SNSNotificationTest(TestCase):
         mock_get_content.return_value = ("this is a text reply", None, [], None)
 
         # Successfully reply to a previous sender
-        response = _sns_notification(EMAIL_SNS_BODIES["s3_stored_replies"])
+        # Headers are the same before and after the resender change
+        with override_flag(RESENDER_HEADERS_FLAG_NAME, active=resender_headers):
+            response = _sns_notification(EMAIL_SNS_BODIES["s3_stored_replies"])
         assert response.status_code == 200
 
         self.mock_remove_message_from_s3.assert_called_once()
@@ -334,6 +406,9 @@ class SNSNotificationTest(TestCase):
         last_used_at = relay_address.last_used_at
         assert last_used_at
         assert (datetime.now(tz=timezone.utc) - last_used_at).seconds < 2.0
+
+    def test_reply_resender_headers(self) -> None:
+        self.test_reply(resender_headers=True)
 
 
 class BounceHandlingTest(TestCase):

--- a/emails/types.py
+++ b/emails/types.py
@@ -15,6 +15,7 @@ OutgoingHeaderName = Literal[
     "In-Reply-To",
     "References",
     "Reply-To",
+    "Resent-From",
     "Subject",
     "To",
 ]

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -5,7 +5,7 @@ from email.headerregistry import Address
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.application import MIMEApplication
-from email.utils import parseaddr
+from email.utils import formataddr, parseaddr
 from functools import cache
 from typing import cast, Any, Callable, TypeVar
 import json
@@ -13,6 +13,7 @@ import pathlib
 import re
 from django.http.request import HttpRequest
 from django.template.loader import render_to_string
+from django.utils.text import Truncator
 import requests
 
 from botocore.exceptions import ClientError
@@ -366,6 +367,52 @@ def generate_relay_From(
         Address(display_name.encode(maxlinelen=998), addr_spec=relay_from_address)
     )
     return formatted_from_address
+
+
+def truncate(max_length: int, value: str) -> str:
+    """
+    Truncate a string to a maximum length.
+
+    If the value is all ASCII, the truncation suffix will be ...
+    If the value is non-ASCII, the truncation suffix will be … (Unicode ellipsis)
+    """
+    if len(value) <= max_length:
+        return value
+    ellipsis = "..."  # ASCII Ellipsis
+    try:
+        value.encode("ascii")
+    except UnicodeEncodeError:
+        ellipsis = "…"
+    return Truncator(value).chars(max_length, truncate=ellipsis)
+
+
+def generate_from_header(original_from_address: str, relay_mask: str) -> str:
+    """
+    Return a From: header str using the original sender and a display name that
+    refers to Relay.
+
+    This format was introduced in June 2023 with MPP-2117.
+    """
+    oneline_from_address = (
+        original_from_address.replace("\u2028", "").replace("\r", "").replace("\n", "")
+    )
+    display_name, original_address = parseaddr(oneline_from_address)
+    parsed_address = Address(addr_spec=original_address)
+
+    # Truncate the to 71 characters, so the sender portion fits on the first
+    # line of a multi-line "From:" header, if it is ASCII. A utf-8 encoded
+    # header will be 226 chars, still below the 998 limit of RFC 5322 2.1.1.
+    max_length = 71
+
+    if display_name:
+        short_name = truncate(max_length, display_name)
+        short_address = truncate(max_length, parsed_address.addr_spec)
+        sender = f"{short_name} <{short_address}>"
+    else:
+        # Use the email address if the display name was not originally set
+        display_name = parsed_address.addr_spec
+        sender = truncate(max_length, display_name)
+    return formataddr((f"{sender} [via Relay]", relay_mask))
 
 
 def get_message_id_bytes(message_id_str: str) -> bytes:

--- a/emails/views.py
+++ b/emails/views.py
@@ -53,6 +53,7 @@ from .utils import (
     create_message,
     decrypt_reply_metadata,
     derive_reply_keys,
+    generate_from_header,
     generate_relay_From,
     get_message_content_from_s3,
     get_message_id_bytes,
@@ -70,6 +71,7 @@ from .sns import verify_from_sns, SUPPORTED_SNS_TYPES
 from privaterelay.ftl_bundles import main as ftl_bundle
 from privaterelay.utils import flag_is_active_in_task
 
+RESENDER_HEADERS_FLAG_NAME = "resender_headers"
 
 logger = logging.getLogger("events")
 info_logger = logging.getLogger("eventsinfo")
@@ -612,16 +614,27 @@ def _sns_message(message_json: AWS_SNSMessageJSON) -> HttpResponse:
         wrapped_text = relay_header_text + text_content
         message_body["Text"] = {"Charset": "UTF-8", "Data": wrapped_text}
 
+    use_resender_headers = flag_is_active_in_task(
+        RESENDER_HEADERS_FLAG_NAME, user_profile.user
+    )
     destination_address = user_profile.user.email
-    formatted_from_address = generate_relay_From(from_address, user_profile)
-    source_address = formatted_from_address
     reply_address = get_reply_to_address()
+    if use_resender_headers:
+        from_header = generate_from_header(from_address, to_address)
+        source_address = reply_address
+    else:
+        from_header = generate_relay_From(from_address, user_profile)
+        source_address = from_header
+
     headers: OutgoingHeaders = {
         "Subject": subject,
-        "From": formatted_from_address,
+        "From": from_header,
         "To": destination_address,
         "Reply-To": reply_address,
     }
+    if use_resender_headers:
+        headers["Resent-From"] = from_address
+
     response = ses_relay_email(
         source_address,
         destination_address,

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -1049,7 +1049,11 @@ SPECTACULAR_SETTINGS = {
     "SWAGGER_UI_FAVICON_HREF": "SIDECAR",
     "REDOC_DIST": "SIDECAR",
     "TITLE": "Firefox Relay API",
-    "DESCRIPTION": "Keep your email safe from hackers and trackers. This API is built with Django REST Framework and powers the Relay website UI, add-on, Firefox browser, and 3rd-party app integrations.",
+    "DESCRIPTION": (
+        "Keep your email safe from hackers and trackers. This API is built with"
+        " Django REST Framework and powers the Relay website UI, add-on,"
+        " Firefox browser, and 3rd-party app integrations."
+    ),
     "VERSION": "1.0",
     "SERVE_INCLUDE_SCHEMA": False,
 }


### PR DESCRIPTION
This PR is for MPP-3193 / MPP-2177, and is similar to closed PR #3522. 

When the new `resender_headers` flag is active, change some details of relaying emails:

* The `From:` header:
    - current behavior - address is the reply address, such as `"\"john@example.com [via Relay]\"" <replies@relay.firefox.com>`. The header is truncated to 998 characters, to fit in the maximum header width for many email servers.
    - with flag - address is the relay mask, such as `"john@example.com [via Relay]" <rAnd0m^mAsk@mozmail.com>`. This will allow filtering on the mask, and will be especially useful for users who use a different mask for each website. The display name and email of the original sender are truncated to 71 characters, to try to fit in an 80 column header in ASCII. If unicode characters are present, the header will be as much as 266 characters, still below the maximum header size.
* A new `Resent-From:` header:
    - current behavior - this header is not used
    - with flag - the original sender, such as `john@example.com`. Some email client may allow filtering on this header.
* The SMTP-level sender:
    - current behavior - same as `From:` header, such as `"\"john@example.com [via Relay]\"" <replies@relay.firefox.com>`
    - with flag - just the reply email address, without a display name, such as `replies@relay.firefox.com`

The flag does not change where responses go - the `Reply-To:` header has the same value and is picked over the `From:`. The headers of relayed responses do not change, and continue to not expose the user's true email.

Changes from PR #3522:

* `From:` header - in PR #3522, it was the original sender's address. This caused (valid!) DMARC failures for senders like protonmail.com, who said they didn't send the email. By changing to the relay mask, the DMARC and other validation will pass. The display name creation code is also slightly different.
* `Reply-To:` header - always use the premium reply address. This is the strategy used by the current code. It is possible that there is no longer a difference between the premium and free reply addresses in production.
* `Resent-From:` header - Changed to the original sender's `From:` header. I _think_ our code drops the sender's display name, and just uses the email address.
* `Resent-Sender:` header - Dropped, since it was always the same value as the `Reply-To` header.

# How to test

* Deploy code to dev, or enable email locally
* **Before adding the flag** remind yourself how it works:
    - Send an email to a relay random mask
        - [x] The email arrives
        - [x] The email "from" has the reply address
        - [x] *Optional* View original message, note headers - `From:`, `To:`, and `Reply-To:`
        - [x] "Reply" or "Reply All" goes to the reply address, **not** the original sender
        - [x] A reply is delivered to the original sender
    - Send an email to a relay premium mask
        - [x] The email arrives
        - [x] The email "from" has the reply address
        - [x] *Optional* View original message, note headers - `From:`, `To:`, and `Reply-To:`
        - [x] "Reply" or "Reply All" goes to the reply address, **not** the original sender
        - [x] A reply is delivered to the original sender     
* Add the `resender_headers` flag for the test user (or everyone)
    - View `/api/v1/runtime_data`
        - [x] `WAFFLE_FLAGS` has `["resender_headers", true]`
    - Send an email to a relay random mask with the flag
        - [x] The email arrives
        - [x] The email "from" has the **relay mask address** (a change)
        - [x] *Optional* View original message, note headers - `From:` (*changed*), `To:` (*same*), `Reply-To:` (*same*), `Resent-From` (*new, original sender*)
        - [x] "Reply" or "Reply All" goes to the reply address, **not** the original sender
        - [x] A reply is delivered to the original sender
    - Send an email to a relay premium mask
        - [x] The email arrives
        - [x] The email "from" has the reply address
        - [x] *Optional* View original message, note headers - `From:` (*changed*), `To:` (*same*), `Reply-To:` (*same*), `Resent-From` (*new, original sender*)
        - [x] "Reply" or "Reply All" goes to the reply address, **not** the original sender
        - [x] A reply is delivered to the original sender     
    
# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- ~[ ] I've added or updated relevant docs in the docs/ directory~
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- ~[ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- ~[ ] l10n changes have been submitted to the l10n repository, if any.~
