### PR TITLE
MPP-3191 - Fix phones in non-prod environments

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -307,7 +307,7 @@ class Profile(models.Model):
         if not self.fxa:
             return False
         if settings.RELAY_CHANNEL != "prod" and not settings.IN_PYTEST:
-            if not flag_is_active_in_task("phone", self.user):
+            if not flag_is_active_in_task("phones", self.user):
                 return False
         if flag_is_active_in_task("free_phones", self.user):
             return True


### PR DESCRIPTION
Flag name was misspelled when converting to `flag_is_active_in_task` in PR #3542. Due to the way this is implemented, it can not be tested.

# How to test:

- ~[ ] l10n changes have been submitted to the l10n repository, if any.~
- ~[ ] I've added a unit test to test for potential regressions of this bug.~
- ~[ ] I've added or updated relevant docs in the docs/ directory.~
- ~[ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).