### PR TITLE
MPP-3124 - Set static path for favicon

### DIFF
--- a/frontend/src/components/layout/PageMetadata.tsx
+++ b/frontend/src/components/layout/PageMetadata.tsx
@@ -1,6 +1,5 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
-import favicon from "../../../public/favicon.svg";
 import socialMediaImage from "./images/share-relay.jpg";
 import { getRuntimeConfig } from "../../config";
 import { useL10n } from "../../hooks/l10n";
@@ -11,7 +10,7 @@ export const PageMetadata = () => {
 
   return (
     <Head>
-      <link rel="icon" type="image/svg+xml" href={favicon.src}></link>
+      <link rel="icon" type="image/svg+xml" href="/favicon.svg"></link>
       <title>{l10n.getString("meta-title")}</title>
       <meta name="description" content={l10n.getString("meta-description-2")} />
       <meta


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3124 and #3431 
 
# New feature description

Fix for error we get about not finding our favicon: 

<img width="1908" alt="image" src="https://github.com/mozilla/fx-private-relay/assets/3924990/c16aeeee-8ae7-40bc-a6ec-71dca01a483c">

# Screenshot (if applicable)

<img width="583" alt="image" src="https://github.com/mozilla/fx-private-relay/assets/3924990/8fcaf6d1-a53b-4ee5-990b-5a2e8f66e4ce">

# How to test

Review the console for any errors related to the favicon. 


1. Launch the latest version of the Firefox web browser.
2. Clear the browser cache and ensure there are no existing bookmarks for the URL: 127.0.0.1:8000/accounts/profile/
3. Navigate to the URL: 127.0.0.1:8000/accounts/profile/.
4. Verify that the webpage loads correctly and the favicon is displayed correctly in the tab of the browser.
5. Right-click on the bookmark bar and select "Bookmark This Page" to add it to the bookmarks.
6. Locate the bookmark for the URL 127.0.0.1:8000/accounts/profile/ on the bookmark bar.
7. Verify that the bookmark icon displays the correct favicon image, and not the default "no favicon" image. 

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
