### PR TITLE
Update Python dependencies, 2023-06-26

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ PyJWT==2.7.0
 python-decouple==3.8
 pyOpenSSL==23.2.0
 requests==2.31.0
-sentry-sdk==1.25.1
+sentry-sdk==1.26.0
 whitenoise==6.5.0
 
 # phones app

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ black==23.3.0
 # type hinting
 mypy==1.3.0
 types-requests==2.31.0.1
-types-pyOpenSSL==23.2.0.0
+types-pyOpenSSL==23.2.0.1
 django-stubs==4.2.1
 djangorestframework-stubs==3.14.1
 boto3-stubs==1.26.160

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ django-waffle==3.0.0
 dockerflow==2022.8.0
 # TODO: remove after https://github.com/mozilla/fx-private-relay/pull/3575 is merged
 drf-yasg==1.21.5
-drf-spectacular==0.26.2
+drf-spectacular==0.26.3
 drf-spectacular-sidecar==2023.6.1
 google-measurement-protocol==1.1.0
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ sentry-sdk==1.26.0
 whitenoise==6.5.0
 
 # phones app
-phonenumbers==8.13.14
+phonenumbers==8.13.15
 twilio==8.3.0
 vobject==0.9.6.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,5 +53,5 @@ types-pyOpenSSL==23.2.0.1
 django-stubs==4.2.1
 djangorestframework-stubs==3.14.1
 boto3-stubs==1.26.160
-botocore-stubs==1.29.156
+botocore-stubs==1.29.160
 mypy-boto3-ses==1.26.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,6 @@ types-requests==2.31.0.1
 types-pyOpenSSL==23.2.0.0
 django-stubs==4.2.1
 djangorestframework-stubs==3.14.1
-boto3-stubs==1.26.156
+boto3-stubs==1.26.160
 botocore-stubs==1.29.156
 mypy-boto3-ses==1.26.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ responses==0.23.1
 black==23.3.0
 
 # type hinting
-mypy==1.3.0
+mypy==1.4.1
 types-requests==2.31.0.1
 types-pyOpenSSL==23.2.0.1
 django-stubs==4.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ google-measurement-protocol==1.1.0
 gunicorn==20.1.0
 jwcrypto==1.5.0
 markus[datadog]==4.2.0
-pem==21.2.0
+pem==23.1.0
 psycopg2==2.9.6
 PyJWT==2.7.0
 python-decouple==3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.156
+boto3==1.26.160
 codetiming==1.4.0
 cryptography==41.0.1
 Django==3.2.19


### PR DESCRIPTION
Update dependencies. This covers:

* Bump drf-spectacular from 0.26.2 to 0.26.3 (from PR #3580)
* Bump pem from 21.2.0 to 23.1.0 (from PR #3581)
* Bump phonenumbers from 8.13.14 to 8.13.15 (from PR #3582)
* Bump boto3 from 1.26.156 to 1.26.160 (from PR #3583)
* Bump botocore-stubs from 1.29.156 to 1.29.160 (from PR #3584)
* Bump sentry-sdk from 1.25.1 to 1.26.0 (from PR #3585)
* Bump mypy from 1.3.0 to 1.4.1 (from PR #3586)
* Bump types-pyopenssl from 23.2.0.0 to 23.2.0.1 (from PR #3587)
* Bump boto3-stubs from 1.26.156 to 1.26.160 (from PR #3588)