### PR TITLE
Upgrade Python dependencies, 2023-06-26, part 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,5 +53,5 @@ types-pyOpenSSL==23.2.0.1
 django-stubs==4.2.1
 djangorestframework-stubs==3.14.1
 boto3-stubs==1.26.160
-botocore-stubs==1.29.160
+botocore-stubs==1.29.161
 mypy-boto3-ses==1.26.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,6 @@ types-requests==2.31.0.1
 types-pyOpenSSL==23.2.0.1
 django-stubs==4.2.1
 djangorestframework-stubs==3.14.1
-boto3-stubs==1.26.160
+boto3-stubs==1.26.161
 botocore-stubs==1.29.161
 mypy-boto3-ses==1.26.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.160
+boto3==1.26.161
 codetiming==1.4.0
 cryptography==41.0.1
 Django==3.2.19


### PR DESCRIPTION
Update Python dependencies, part 2. This covers:

* Bump botocore-stubs from 1.29.160 to 1.29.161 (from PR #3598)
* Bump boto3 from 1.26.160 to 1.26.161 (from PR #3599)
* Bump boto3-stubs from 1.26.160 to 1.26.161