### PR TITLE
Windows instruction additions in Step 2 of the readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ state.json
 har/
 allure-results/
 allure-report/
-locales/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ state.json
 har/
 allure-results/
 allure-report/
+locales/

--- a/README.md
+++ b/README.md
@@ -37,17 +37,22 @@ Please refer to our [coding standards](docs/coding-standards.md) for code styles
 
 2. Create and activate a virtual environment:
 
-   Unix based systems: 
+   Unix based systems:
+
    ```sh
    virtualenv env
    source env/bin/activate
    ```
-   Windows: 
+
+   Windows:
+
    ```sh
    python -m venv env
-   source env/Scripts/activate
+   .\env\Scripts\activate
    ```
-   
+
+   Note: If you're running on Windows and get an error message stating that executing scripts are disabled on your computer, go into the Windows powershell and type `Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted`, then try again.
+
 3. Install Python and Node requirements:
 
    ```sh

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Please refer to our [coding standards](docs/coding-standards.md) for code styles
 
    ```sh
    python -m venv env
-   source env/bin/activate
+   source env/Scripts/activate
    ```
 
-   If you are not using Git Bash on Windows, instead of typing `source env/bin/activate`, type `.\env\Scripts\activate`.
+   If you are not using Git Bash on Windows, instead of typing `source env/Scripts/activate`, type `.\env\Scripts\activate`.
 
    Note: If you're running on Windows and get an error message stating that executing scripts are disabled on your computer, go into the Windows powershell and type `Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted`, then try again.
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ Please refer to our [coding standards](docs/coding-standards.md) for code styles
 
    ```sh
    python -m venv env
-   .\env\Scripts\activate
+   source env/bin/activate
    ```
+
+   If you are not using Git Bash on Windows, instead of typing `source env/bin/activate`, type `.\env\Scripts\activate`.
 
    Note: If you're running on Windows and get an error message stating that executing scripts are disabled on your computer, go into the Windows powershell and type `Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted`, then try again.
 


### PR DESCRIPTION
Added a change to the local installation instructions for Windows in Step 2 because 'source' is not a command in Windows. Also added a note for an issue I ran into.