### PR TITLE
MPP-3186: Allow clearing `block_list_emails`

### DIFF
--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -227,7 +227,6 @@ def test_patch_relayaddress_free_user_cannot_set_block_list_emails(
     assert ra.block_list_emails is False
 
 
-@pytest.mark.xfail(reason="MPP-3186: Free user can not clear block_list_emails")
 def test_patch_relayaddress_format_premium_user_can_clear_block_list_emails(
     premium_user, prem_api_client
 ) -> None:

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -210,6 +210,51 @@ def test_post_relayaddress_flagged_error(free_user, free_api_client) -> None:
     }
 
 
+def test_patch_relayaddress_free_user_cannot_set_block_list_emails(
+    free_user, free_api_client
+) -> None:
+    """A free user cannot set block_list_emails to True"""
+    ra = baker.make(RelayAddress, user=free_user, enabled=True, block_list_emails=False)
+    response = free_api_client.patch(
+        reverse("relayaddress-detail", args=[ra.id]),
+        {"enabled": False, "block_list_emails": True},
+        format="json",
+    )
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Must be premium to set block_list_emails."}
+    ra.refresh_from_db()
+    assert ra.enabled is True
+    assert ra.block_list_emails is False
+
+
+@pytest.mark.xfail(reason="MPP-3186: Free user can not clear block_list_emails")
+def test_patch_relayaddress_format_premium_user_can_clear_block_list_emails(
+    premium_user, prem_api_client
+) -> None:
+    """A formerly-premium user can set block_list_emails to False"""
+    # Create a Relay Address with promotions blocked
+    ra = baker.make(
+        RelayAddress, user=premium_user, enabled=False, block_list_emails=True
+    )
+
+    # Unsubscribe the premium user
+    fxa_account = premium_user.profile.fxa
+    fxa_account.extra_data["subscriptions"] = []
+    fxa_account.save()
+    assert not premium_user.profile.has_premium
+
+    # Re-enable the Relay Address
+    response = prem_api_client.patch(
+        reverse("relayaddress-detail", args=[ra.id]),
+        {"enabled": True, "block_list_emails": False},
+        format="json",
+    )
+    assert response.status_code == 200
+    ra.refresh_from_db()
+    assert ra.enabled is True
+    assert ra.block_list_emails is False
+
+
 class TermsAcceptedUserViewTest(TestCase):
     def setUp(self):
         self.factory = RequestFactory()

--- a/emails/signals.py
+++ b/emails/signals.py
@@ -22,14 +22,8 @@ def create_user_profile(sender, instance, created, **kwargs):
 
 
 def check_premium_for_block_list_emails(sender, instance, **kwargs):
-    if not instance.user.profile.has_premium:
-        try:
-            obj = sender.objects.get(pk=instance.pk)
-            if obj.block_list_emails != instance.block_list_emails:
-                raise BadRequest("Must be premium to set block_list_emails")
-        except sender.DoesNotExist:
-            if instance.block_list_emails:
-                raise BadRequest("Must be premium to set block_list_emails")
+    if instance.block_list_emails and not instance.user.profile.has_premium:
+        raise BadRequest("Must be premium to set block_list_emails")
 
 
 @receiver(pre_save, sender=Profile)


### PR DESCRIPTION
Currently, a free user is not allowed to:

1. Set `block_list_emails` on a new relay address.
2. Change `block_list_emails` on an existing relay address.

The `block_list_emails` flag is set when a user chooses to block Promotional emails, a premium feature. If a user was a premium user, they may have `block_list_emails` on an existing relay address, and are no longer able to change it.

This PR fixes the root cause of MPP-3186, by changing the rule to:

1. A free user can not set `block_list_emails` on a relay address, only clear it.

How to test:

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).