### PR TITLE
Improve scrolling experience across browsers

### DIFF
--- a/frontend/src/components/layout/Layout.module.scss
+++ b/frontend/src/components/layout/Layout.module.scss
@@ -4,7 +4,7 @@
 .wrapper {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  flex: 1 0;
 
   // See https://fkhadra.github.io/react-toastify/how-to-style#override-css-variables
   --toastify-toast-width: 95%;
@@ -140,7 +140,7 @@ $toastify-toast-close-button: var(--toast-close-button);
   min-width: 20px;
 }
 
-.header {
+.header-outer {
   position: sticky;
   left: 0;
   top: 0;
@@ -152,6 +152,11 @@ $toastify-toast-close-button: var(--toast-close-button);
   // Thus, upping the z-index stack the header, and menus
   // expanding from it, on top again:
   z-index: 1;
+}
+
+.header-inner {
+  position: relative;
+  z-index: 2;
   display: grid;
   grid-template-columns: 1fr;
   grid-template-areas:
@@ -258,17 +263,6 @@ $toastify-toast-close-button: var(--toast-close-button);
 }
 
 .non-header-wrapper {
-  // This `overflow` ensures that the `position: sticky` on `.mobile-menu`
-  // in <MobileNavigation> is sticky relative to this wrapper, i.e. will always
-  // stay below the header bar.
-  // For more info, see
-  // https://developer.mozilla.org/en-US/docs/Web/CSS/position#sticky,
-  // and specifically:
-  // > Note that a sticky element "sticks" to its nearest ancestor that has a
-  // > "scrolling mechanism" (created when overflow is hidden, scroll, auto, or
-  // > overlay), even if that ancestor isn't the nearest actually scrolling
-  // > ancestor.
-  overflow: auto;
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -117,15 +117,15 @@ export const Layout = (props: Props) => {
   );
 
   const PlainPageHeader = (
-    <header
-      className={`${styles.header} ${styles["is-grey"]} ${styles["plain-page"]}`}
+    <div
+      className={`${styles["header-inner"]} ${styles["is-grey"]} ${styles["plain-page"]}`}
     >
       <div className={`${styles["logo-wrapper"]} ${styles["plain-page"]}`}>
         <Link href={homePath} className={styles.logo}>
           {RelayHeaderLogo}
         </Link>
       </div>
-    </header>
+    </div>
   );
 
   return (
@@ -137,33 +137,43 @@ export const Layout = (props: Props) => {
           profile={profiles.data?.[0]}
           runtimeData={props.runtimeData}
         />
-        {props.theme === "plain" ? (
-          PlainPageHeader
-        ) : (
-          <header className={`${styles.header} ${darkClass}`}>
-            <div className={styles["logo-wrapper"]}>
-              <Link href={homePath} className={styles.logo}>
-                <>
-                  {router.pathname === "/vpn-relay-welcome" ? (
-                    <Image src={vpnRelayLogo} alt="" height={32} />
-                  ) : (
-                    RelayHeaderLogo
-                  )}
-                </>
-              </Link>
+        <header className={styles["header-outer"]}>
+          {props.theme === "plain" ? (
+            PlainPageHeader
+          ) : (
+            <div className={`${styles["header-inner"]} ${darkClass}`}>
+              <div className={styles["logo-wrapper"]}>
+                <Link href={homePath} className={styles.logo}>
+                  <>
+                    {router.pathname === "/vpn-relay-welcome" ? (
+                      <Image src={vpnRelayLogo} alt="" height={32} />
+                    ) : (
+                      RelayHeaderLogo
+                    )}
+                  </>
+                </Link>
+              </div>
+              <div className={styles["nav-wrapper"]}>
+                <Navigation
+                  mobileMenuExpanded={mobileMenuExpanded}
+                  theme={isDark ? "free" : "premium"}
+                  handleToggle={handleToggle}
+                  hasPremium={hasPremium}
+                  isLoggedIn={isLoggedIn}
+                  profile={profiles.data?.[0]}
+                />
+              </div>
             </div>
-            <div className={styles["nav-wrapper"]}>
-              <Navigation
-                mobileMenuExpanded={mobileMenuExpanded}
-                theme={isDark ? "free" : "premium"}
-                handleToggle={handleToggle}
-                hasPremium={hasPremium}
-                isLoggedIn={isLoggedIn}
-                profile={profiles.data?.[0]}
-              />
-            </div>
-          </header>
-        )}
+          )}
+          <MobileNavigation
+            mobileMenuExpanded={mobileMenuExpanded}
+            hasPremium={hasPremium}
+            isPhonesAvailable={isPhonesAvailableInCountry(props.runtimeData)}
+            isLoggedIn={isLoggedIn}
+            userEmail={usersData?.email}
+            userAvatar={profiles.data?.[0].avatar}
+          />
+        </header>
 
         <ToastContainer
           icon={false}
@@ -178,14 +188,6 @@ export const Layout = (props: Props) => {
         />
 
         <div className={styles["non-header-wrapper"]}>
-          <MobileNavigation
-            mobileMenuExpanded={mobileMenuExpanded}
-            hasPremium={hasPremium}
-            isPhonesAvailable={isPhonesAvailableInCountry(props.runtimeData)}
-            isLoggedIn={isLoggedIn}
-            userEmail={usersData?.email}
-            userAvatar={profiles.data?.[0].avatar}
-          />
           <div
             className={`${styles.content} ${
               router.pathname === "/phone" ? styles["gray-bg"] : null

--- a/frontend/src/components/layout/navigation/MobileNavigation.module.scss
+++ b/frontend/src/components/layout/navigation/MobileNavigation.module.scss
@@ -3,14 +3,12 @@
 
 .mobile-menu {
   width: 100%;
-  position: sticky;
-  top: 0;
+  position: relative;
   // z-index of 1 (so it overlaps content)
   // allows menu to slide under main navigation header
   z-index: 1;
   // `height: 0` prevents the menu from taking up space when it's not expanded:
   height: 0;
-  flex-direction: column;
 }
 
 #mobile-menu {

--- a/frontend/src/components/layout/navigation/MobileNavigation.module.scss
+++ b/frontend/src/components/layout/navigation/MobileNavigation.module.scss
@@ -3,12 +3,12 @@
 
 .mobile-menu {
   width: 100%;
-  position: relative;
+  position: absolute;
   // z-index of 1 (so it overlaps content)
   // allows menu to slide under main navigation header
   z-index: 1;
-  // `height: 0` prevents the menu from taking up space when it's not expanded:
-  height: 0;
+  max-height: calc(100vh - 100%);
+  overflow-y: auto;
 }
 
 #mobile-menu {

--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -28,35 +28,12 @@ body,
 #__next,
 #overlayProvider {
   font-family: $font-stack-base;
+  height: 100%;
+}
 
-  // It looks like a Chrome/Blink bug results in the entire page moving up when
-  // the user toggles the Forwarding control (e.g. from blocking all to blocking
-  // promotional emails), and the bottom of the page being just whitespace.
-  // The reason this looks to be a chrome bug is that adding `position: fixed`
-  // and then removing it again to the `#__next` element fixes the issue,
-  // even though that ends us up with the original styles.
-  // Removing `height: 100%` and `overflow: hidden` causes the following issues:
-  // - The footer isn't pushed to the bottom of the viewport anymore if the
-  //   page isn't tall enough (e.g. settings page on desktop). See
-  //   https://github.com/mozilla/fx-private-relay/issues/3223
-  // - The mobile menu doesn't stay fixed to the top of the viewport. See
-  //   https://github.com/mozilla/fx-private-relay/issues/3407
-  // Since the Blink bug is most impactful on mobile (where the erroneous
-  // whitespace covers the entire viewport), we accept the above bugs there.
-  // See also:
-  // - https://github.com/mozilla/fx-private-relay/pull/3222
-  // - https://github.com/mozilla/fx-private-relay/issues/3223
-  // - https://github.com/mozilla/fx-private-relay/issues/3406
-  @media screen and #{$mq-lg} {
-    height: 100%;
-    // In <Layout> all content is wrapped in a `.non-header-wrapper` that has its
-    // own `overflow` applied, to allow the header and mobile menu to remain fixed
-    // in place. However, in Blink- and WebKit-based browsers, this resulted in
-    // empty space at the bottom of the page, below the footer.
-    // Since the user can scroll in `.non-header-wrapper`, everything outside that
-    // that still overflows these elements can safely be hidden:
-    overflow: hidden;
-  }
+#overlayProvider {
+  display: flex;
+  flex-direction: column;
 }
 
 html {


### PR DESCRIPTION
**Note**: _This is a copy of PR #3426, on mozilla/fx-private-relay so tests will run_

This PR fixes #3407, fixes #3406, fixes #3223, fixes #3079.

Updates layout structure and styling to avoid the issues above. It also moves the menu for small/mobile screens inside the header so that it is able to scroll smoothly with the header.

How to test:

1. Go to Private Relay website (on iOS / Windows / Android browser).
2. Scroll through each page (including tracker report)
3. Observe the following:
   1. Short pages have the footer reach the bottom of the screen
   2. Mobile menu remains directly under the header during scrolling
   3. There are not multiple scroll bars on the page
   4. No blank areas while scrolling on mobile

- [ ] ~l10n changes have been submitted to the l10n repository, if any.~ (N/A)
- [ ] ~I've added a unit test to test for potential regressions of this bug.~ (N/A)
- [ ] ~I've added or updated relevant docs in the docs/ directory.~ (N/A)
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
