### PR TITLE
add shobson as CODEOWNER for landing pages to review any changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+frontend/src/pages/faq* @stephaniehobson
+frontend/src/pages/premium* @stephaniehobson
+frontend/src/pages/index*


### PR DESCRIPTION
Relay landing pages are moving to bedrock. https://github.com/mozilla/bedrock/pull/12964

This PR should make @stephaniehobson a CODEOWNER for the landing pages, so she can get a heads-up and review any changes.