### PR TITLE
MPP-3234 Typing and unittests for phone sync reset limits

### DIFF
--- a/privaterelay/management/commands/sync_phone_related_dates_on_profile.py
+++ b/privaterelay/management/commands/sync_phone_related_dates_on_profile.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta, timezone
-
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandParser
 
 from privaterelay.fxa_utils import get_phone_subscription_dates
 from privaterelay.management.utils import (
@@ -68,14 +67,13 @@ def sync_phone_related_dates_on_profile(group: str) -> int:
 class Command(BaseCommand):
     help = "Sync date_subscribed_phone, date_phone_limits_reset, date_phone_subscription_end fields on Profile by syncing with Firefox Accounts data"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "--group",
             default="subscription",
             choices=["subscription", "free", "both"],
             help="Choose phone subscription users, free phone users, or both. Defaults to subscription users.",
         )
-        return super().add_arguments(parser)
 
     def handle(self, *args, **options):
         group = options["group"]

--- a/privaterelay/tests/mgmt_sync_phone_related_dates_on_profile_tests.py
+++ b/privaterelay/tests/mgmt_sync_phone_related_dates_on_profile_tests.py
@@ -28,6 +28,7 @@ from privaterelay.management.commands.sync_phone_related_dates_on_profile import
 
 
 MOCK_BASE = "privaterelay.management.commands.sync_phone_related_dates_on_profile"
+SYNC_COMMAND = "sync_phone_related_dates_on_profile"
 
 
 @pytest.fixture()
@@ -234,10 +235,41 @@ def test_yearly_phone_subscriber_with_subscription_date_older_than_31_days_profi
 
 
 @pytest.mark.django_db
-def test_command_sync_phone(capsys):
-    call_command("sync_phone_related_dates_on_profile", "--group", "free")
+@patch(f"{MOCK_BASE}.get_phone_subscription_dates")
+def test_command_with_one_update(
+    mocked_dates,
+    patch_datetime_now,
+    phone_user,
+    capsys,
+):
+    profile = Profile.objects.get(user=phone_user)
+    date_subscribed_phone = datetime.now(timezone.utc)
+    profile.date_subscribed_phone = date_subscribed_phone
+    profile.save()
+    mocked_dates.return_value = (
+        date_subscribed_phone,
+        date_subscribed_phone,
+        date_subscribed_phone + timedelta(365),
+    )
+    call_command(SYNC_COMMAND, "--group", "subscription")
+    out, err = capsys.readouterr()
+    num_profiles_updated = int(out.split(" ")[0])
+
+    profile.refresh_from_db()
+    assert profile.date_phone_subscription_reset == date_subscribed_phone
+    assert profile.date_subscribed_phone == date_subscribed_phone
+    assert profile.date_phone_subscription_start == date_subscribed_phone
+    assert profile.date_phone_subscription_end == date_subscribed_phone + timedelta(365)
+    assert num_profiles_updated == 1
+
+
+@pytest.mark.django_db
+def test_command_sync_phone(
+    capsys,
+):
+    call_command(SYNC_COMMAND, "--group", "free")
     out, err = capsys.readouterr()
 
-    updated_accounts = int(out.split(" ")[0])
+    num_profiles_updated = int(out.split(" ")[0])
 
-    assert updated_accounts == 0
+    assert num_profiles_updated == 0

--- a/privaterelay/tests/mgmt_sync_phone_related_dates_on_profile_tests.py
+++ b/privaterelay/tests/mgmt_sync_phone_related_dates_on_profile_tests.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from django.conf import settings
+from django.core.management import call_command
 
 from allauth.socialaccount.models import SocialAccount
 from model_bakery import baker
@@ -22,6 +23,7 @@ if settings.PHONES_ENABLED:
 
 from privaterelay.management.commands.sync_phone_related_dates_on_profile import (
     sync_phone_related_dates_on_profile,
+    CommandParser,
 )
 
 
@@ -229,3 +231,13 @@ def test_yearly_phone_subscriber_with_subscription_date_older_than_31_days_profi
     assert profile.date_phone_subscription_start == date_subscribed_phone
     assert profile.date_phone_subscription_end == date_subscribed_phone + timedelta(365)
     assert num_profiles_updated == 1
+
+
+@pytest.mark.django_db
+def test_command_sync_phone(capsys):
+    call_command("sync_phone_related_dates_on_profile", "--group", "free")
+    out, err = capsys.readouterr()
+
+    updated_accounts = int(out.split(" ")[0])
+
+    assert updated_accounts == 0

--- a/privaterelay/tests/mgmt_sync_phone_related_dates_on_profile_tests.py
+++ b/privaterelay/tests/mgmt_sync_phone_related_dates_on_profile_tests.py
@@ -23,7 +23,6 @@ if settings.PHONES_ENABLED:
 
 from privaterelay.management.commands.sync_phone_related_dates_on_profile import (
     sync_phone_related_dates_on_profile,
-    CommandParser,
 )
 
 


### PR DESCRIPTION
# Description
When looking at the coverage of the phone limit reset commands in mgmt_sync_phone_related_dates_on_profile_tests, by running pytest --cov-report term-missing --cov=privaterelay privaterelay/tests, it was 90% (MPP-3223). After the additions, they are now at 100%. Some typing was also added to the function headers.

# How to test
* Set PHONES_ENABLED to true in your .env
* Run  `pytest --cov-report term-missing --cov=privaterelay privaterelay/tests` (or `pytest --cov-report html --cov=privaterelay privaterelay/tests` and open htmlcov/index.html)


# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [ ] ~~Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.~~
- [ ] ~~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] ~~l10n changes have been submitted to the l10n repository, if any.~~
