### PR TITLE
Update to Prettier 3.0.0, apply new formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,5 @@
 5fe13eb71813d00ba32eebb6adc4021f6e9c4d66
 # Update to Black 23
 870af2ac817aca795d1bb20184a9ad90c82cef4c
+# 2023-07-18 - Update to prettier 3.0.0
+45833a92393e4033b119768d59fb6b21a213e672

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,7 +61,7 @@
     "license-checker": "^25.0.1",
     "lint-staged": "^13.2.3",
     "next": "^13.4.9",
-    "prettier": "2.8.8",
+    "prettier": "3.0.0",
     "react-test-renderer": "^18.2.0",
     "sass": "^1.63.6",
     "stylelint": "^15.10.1",

--- a/frontend/src/apiMocks/handlers.ts
+++ b/frontend/src/apiMocks/handlers.ts
@@ -16,7 +16,7 @@ import {
 } from "./mockData";
 
 export function getHandlers(
-  defaultMockId: null | (typeof mockIds)[number] = null
+  defaultMockId: null | (typeof mockIds)[number] = null,
 ): RestHandler[] {
   const handlers: RestHandler[] = [];
 
@@ -32,28 +32,28 @@ export function getHandlers(
 
   const addGetHandler: (...args: Parameters<typeof rest.get>) => void = (
     path,
-    resolver
+    resolver,
   ) => {
     handlers.push(rest.get(path, resolver));
     handlers.push(rest.get(`http://127.0.0.1:8000${path}`, resolver));
   };
   const addPatchHandler: (...args: Parameters<typeof rest.patch>) => void = (
     path,
-    resolver
+    resolver,
   ) => {
     handlers.push(rest.patch(path, resolver));
     handlers.push(rest.patch(`http://127.0.0.1:8000${path}`, resolver));
   };
   const addPostHandler: (...args: Parameters<typeof rest.post>) => void = (
     path,
-    resolver
+    resolver,
   ) => {
     handlers.push(rest.post(path, resolver));
     handlers.push(rest.post(`http://127.0.0.1:8000${path}`, resolver));
   };
   const addDeleteHandler: (...args: Parameters<typeof rest.delete>) => void = (
     path,
-    resolver
+    resolver,
   ) => {
     handlers.push(rest.delete(path, resolver));
     handlers.push(rest.delete(`http://127.0.0.1:8000${path}`, resolver));
@@ -83,7 +83,7 @@ export function getHandlers(
         ctx.json({
           message: "error-subdomain-not-available",
           subdomain: "not-available",
-        })
+        }),
       );
     }
 
@@ -178,7 +178,7 @@ export function getHandlers(
 
     const ownAddresses = mockedRelayaddresses[mockId];
     const index = ownAddresses.findIndex(
-      (address) => address.id === Number.parseInt(req.params.id as string, 10)
+      (address) => address.id === Number.parseInt(req.params.id as string, 10),
     );
     if (index === -1) {
       return res(ctx.status(404));
@@ -199,7 +199,7 @@ export function getHandlers(
 
     const ownAddresses = mockedRelayaddresses[mockId];
     const index = ownAddresses.findIndex(
-      (address) => address.id === Number.parseInt(req.params.id as string, 10)
+      (address) => address.id === Number.parseInt(req.params.id as string, 10),
     );
     if (index === -1) {
       return res(ctx.status(404));
@@ -259,7 +259,7 @@ export function getHandlers(
 
     const ownAddresses = mockedDomainaddresses[mockId];
     const index = ownAddresses.findIndex(
-      (address) => address.id === Number.parseInt(req.params.id as string, 10)
+      (address) => address.id === Number.parseInt(req.params.id as string, 10),
     );
     if (index === -1) {
       return res(ctx.status(404));
@@ -281,7 +281,7 @@ export function getHandlers(
 
     const ownAddresses = mockedDomainaddresses[mockId];
     const index = ownAddresses.findIndex(
-      (address) => address.id === Number.parseInt(req.params.id as string, 10)
+      (address) => address.id === Number.parseInt(req.params.id as string, 10),
     );
     if (index === -1) {
       return res(ctx.status(404));
@@ -310,7 +310,7 @@ export function getHandlers(
     const body = (await req.json()) as NewNumber | Verification;
 
     const isVerification = (
-      request: NewNumber | Verification
+      request: NewNumber | Verification,
     ): request is Verification => {
       return typeof (request as Verification).verification_code === "string";
     };
@@ -351,7 +351,7 @@ export function getHandlers(
     }
     const relevantRealPhone = mockedRealphones[mockId].find(
       (realPhone) =>
-        realPhone.id === Number.parseInt(req.params.id as string, 10)
+        realPhone.id === Number.parseInt(req.params.id as string, 10),
     );
     return res(ctx.status(200), ctx.json(relevantRealPhone));
   });
@@ -497,8 +497,10 @@ export function getHandlers(
     return res(
       ctx.status(200),
       ctx.json(
-        mockedRelaynumbers[mockId][Number.parseInt(req.params.id as string, 10)]
-      )
+        mockedRelaynumbers[mockId][
+          Number.parseInt(req.params.id as string, 10)
+        ],
+      ),
     );
   });
 
@@ -511,7 +513,7 @@ export function getHandlers(
     const ownRelayNumbers = mockedRelaynumbers[mockId];
     const index = ownRelayNumbers.findIndex(
       (relayNumber) =>
-        relayNumber.id === Number.parseInt(req.params.id as string, 10)
+        relayNumber.id === Number.parseInt(req.params.id as string, 10),
     );
     if (index === -1) {
       return res(ctx.status(404));
@@ -537,7 +539,7 @@ export function getHandlers(
   handlers.push(
     rest.post("https://basket-mock.com/news/subscribe/", (_req, res, ctx) => {
       return res(ctx.status(200), ctx.json({ status: "ok" }));
-    })
+    }),
   );
   handlers.push(
     rest.get("https://accounts.firefox.com/metrics-flow", (_req, res, ctx) => {
@@ -546,9 +548,9 @@ export function getHandlers(
         ctx.json({
           flowId: "mock-flow-id",
           flowBeginTime: Date.now(),
-        })
+        }),
       );
-    })
+    }),
   );
 
   return handlers;

--- a/frontend/src/apiMocks/initialise.ts
+++ b/frontend/src/apiMocks/initialise.ts
@@ -15,7 +15,7 @@ export function initialiseApiMocks() {
           !req.url.pathname.startsWith("/fonts/") &&
           !req.url.pathname.startsWith("/icons/") &&
           !req.url.href.startsWith(
-            "https://profile.accounts.firefox.com/v1/avatar/"
+            "https://profile.accounts.firefox.com/v1/avatar/",
           )
         ) {
           print.warning();

--- a/frontend/src/apiMocks/mockData.ts
+++ b/frontend/src/apiMocks/mockData.ts
@@ -502,7 +502,7 @@ export const mockedInboundContacts: Record<
       relay_number: 150,
       inbound_number: "+18089251571",
       last_inbound_date: new Date(
-        Date.now() - 24 * 60 * 60 * 1000
+        Date.now() - 24 * 60 * 60 * 1000,
       ).toISOString(),
       last_inbound_type: "text",
       num_calls: 45,

--- a/frontend/src/components/CountdownTimer.test.tsx
+++ b/frontend/src/components/CountdownTimer.test.tsx
@@ -40,7 +40,7 @@ describe("getRemainingTimeParts", () => {
 
   it("knows when there are zero days left", () => {
     expect(
-      getRemainingTimeParts(4 * 60 * 60 * 1000 + 3 * 60 * 1000 + 2 * 1000 + 42)
+      getRemainingTimeParts(4 * 60 * 60 * 1000 + 3 * 60 * 1000 + 2 * 1000 + 42),
     ).toStrictEqual({
       remainingDays: 0,
       remainingHours: 4,
@@ -56,8 +56,8 @@ describe("getRemainingTimeParts", () => {
           4 * 60 * 60 * 1000 +
           3 * 60 * 1000 +
           2 * 1000 +
-          42
-      )
+          42,
+      ),
     ).toStrictEqual({
       remainingDays: 5,
       remainingHours: 4,
@@ -69,8 +69,8 @@ describe("getRemainingTimeParts", () => {
   it("can deal with hours reaching zero with multiple days left", () => {
     expect(
       getRemainingTimeParts(
-        5 * 24 * 60 * 60 * 1000 + 3 * 60 * 1000 + 2 * 1000 + 42
-      )
+        5 * 24 * 60 * 60 * 1000 + 3 * 60 * 1000 + 2 * 1000 + 42,
+      ),
     ).toStrictEqual({
       remainingDays: 5,
       remainingHours: 0,
@@ -82,8 +82,8 @@ describe("getRemainingTimeParts", () => {
   it("can deal with minutes reaching zero with multiple days left", () => {
     expect(
       getRemainingTimeParts(
-        5 * 24 * 60 * 60 * 1000 + 4 * 60 * 60 * 1000 + 2 * 1000 + 42
-      )
+        5 * 24 * 60 * 60 * 1000 + 4 * 60 * 60 * 1000 + 2 * 1000 + 42,
+      ),
     ).toStrictEqual({
       remainingDays: 5,
       remainingHours: 4,
@@ -99,8 +99,8 @@ describe("getRemainingTimeParts", () => {
           23 * 60 * 60 * 1000 +
           3 * 60 * 1000 +
           2 * 1000 +
-          42
-      )
+          42,
+      ),
     ).toStrictEqual({
       remainingDays: 5,
       remainingHours: 23,
@@ -116,8 +116,8 @@ describe("getRemainingTimeParts", () => {
           4 * 60 * 60 * 1000 +
           59 * 60 * 1000 +
           2 * 1000 +
-          42
-      )
+          42,
+      ),
     ).toStrictEqual({
       remainingDays: 5,
       remainingHours: 4,
@@ -133,8 +133,8 @@ describe("getRemainingTimeParts", () => {
           4 * 60 * 60 * 1000 +
           3 * 60 * 1000 +
           59 * 1000 +
-          42
-      )
+          42,
+      ),
     ).toStrictEqual({
       remainingDays: 5,
       remainingHours: 4,
@@ -152,9 +152,9 @@ describe("getRemainingTimeParts", () => {
         (timeInMilliseconds) => {
           const remainingTimeParts = getRemainingTimeParts(timeInMilliseconds);
           expect(remainingTimeParts.remainingDays).toBeGreaterThanOrEqual(0);
-        }
+        },
       ),
-      { numRuns: runs }
+      { numRuns: runs },
     );
   });
 
@@ -167,9 +167,9 @@ describe("getRemainingTimeParts", () => {
         (timeInMilliseconds) => {
           const remainingTimeParts = getRemainingTimeParts(timeInMilliseconds);
           expect(remainingTimeParts.remainingHours).toBeLessThan(24);
-        }
+        },
       ),
-      { numRuns: runs }
+      { numRuns: runs },
     );
   });
 
@@ -182,9 +182,9 @@ describe("getRemainingTimeParts", () => {
         (timeInMilliseconds) => {
           const remainingTimeParts = getRemainingTimeParts(timeInMilliseconds);
           expect(remainingTimeParts.remainingHours).toBeGreaterThanOrEqual(0);
-        }
+        },
       ),
-      { numRuns: runs }
+      { numRuns: runs },
     );
   });
 
@@ -197,9 +197,9 @@ describe("getRemainingTimeParts", () => {
         (timeInMilliseconds) => {
           const remainingTimeParts = getRemainingTimeParts(timeInMilliseconds);
           expect(remainingTimeParts.remainingMinutes).toBeLessThan(60);
-        }
+        },
       ),
-      { numRuns: runs }
+      { numRuns: runs },
     );
   });
 
@@ -212,9 +212,9 @@ describe("getRemainingTimeParts", () => {
         (timeInMilliseconds) => {
           const remainingTimeParts = getRemainingTimeParts(timeInMilliseconds);
           expect(remainingTimeParts.remainingMinutes).toBeGreaterThanOrEqual(0);
-        }
+        },
       ),
-      { numRuns: runs }
+      { numRuns: runs },
     );
   });
 
@@ -227,9 +227,9 @@ describe("getRemainingTimeParts", () => {
         (timeInMilliseconds) => {
           const remainingTimeParts = getRemainingTimeParts(timeInMilliseconds);
           expect(remainingTimeParts.remainingSeconds).toBeLessThan(60);
-        }
+        },
       ),
-      { numRuns: runs }
+      { numRuns: runs },
     );
   });
 
@@ -242,9 +242,9 @@ describe("getRemainingTimeParts", () => {
         (timeInMilliseconds) => {
           const remainingTimeParts = getRemainingTimeParts(timeInMilliseconds);
           expect(remainingTimeParts.remainingSeconds).toBeGreaterThanOrEqual(0);
-        }
+        },
       ),
-      { numRuns: runs }
+      { numRuns: runs },
     );
   });
 
@@ -258,7 +258,7 @@ describe("getRemainingTimeParts", () => {
           fc.nat({ max: 23 }),
           fc.nat({ max: 59 }),
           fc.nat({ max: 59 }),
-          fc.nat({ max: 999 })
+          fc.nat({ max: 999 }),
         ),
         ([days, hours, minutes, seconds, milliseconds]) => {
           const remainingTimeParts = getRemainingTimeParts(
@@ -266,15 +266,15 @@ describe("getRemainingTimeParts", () => {
               hours * 60 * 60 * 1000 +
               minutes * 60 * 1000 +
               seconds * 1000 +
-              milliseconds
+              milliseconds,
           );
           expect(remainingTimeParts.remainingDays).toBe(days);
           expect(remainingTimeParts.remainingHours).toBe(hours);
           expect(remainingTimeParts.remainingMinutes).toBe(minutes);
           expect(remainingTimeParts.remainingSeconds).toBe(seconds);
-        }
+        },
       ),
-      { numRuns: runs }
+      { numRuns: runs },
     );
   });
 });

--- a/frontend/src/components/CountdownTimer.tsx
+++ b/frontend/src/components/CountdownTimer.tsx
@@ -45,24 +45,24 @@ export const CountdownTimer = (props: Props) => {
 
 export function getRemainingTimeParts(remainingMilliseconds: number) {
   const remainingDays = Math.floor(
-    remainingMilliseconds / (1000 * 60 * 60 * 24)
+    remainingMilliseconds / (1000 * 60 * 60 * 24),
   );
   const remainingHours = Math.floor(
     (remainingMilliseconds - remainingDays * (1000 * 60 * 60 * 24)) /
-      (1000 * 60 * 60)
+      (1000 * 60 * 60),
   );
   const remainingMinutes = Math.floor(
     (remainingMilliseconds -
       remainingDays * (1000 * 60 * 60 * 24) -
       remainingHours * (1000 * 60 * 60)) /
-      (1000 * 60)
+      (1000 * 60),
   );
   const remainingSeconds = Math.floor(
     (remainingMilliseconds -
       remainingDays * (1000 * 60 * 60 * 24) -
       remainingHours * (1000 * 60 * 60) -
       remainingMinutes * (1000 * 60)) /
-      1000
+      1000,
   );
 
   return {

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -167,7 +167,7 @@ export const CloseIcon = ({
 
 /** Bento button that inherits the text color of its container */
 export const BentoIcon = (
-  props: SVGProps<SVGSVGElement> & { alt?: string }
+  props: SVGProps<SVGSVGElement> & { alt?: string },
 ) => {
   return (
     <svg
@@ -193,7 +193,7 @@ export const BentoIcon = (
 
 /** Icon to indicate links that open in a new tab, that inherits the text color of its container */
 export const NewTabIcon = (
-  props: SVGProps<SVGSVGElement> & { alt?: string }
+  props: SVGProps<SVGSVGElement> & { alt?: string },
 ) => {
   const l10n = useL10n();
 

--- a/frontend/src/components/InfoModal.tsx
+++ b/frontend/src/components/InfoModal.tsx
@@ -54,7 +54,7 @@ const PickerDialog = (props: PickerDialogProps & AriaOverlayProps) => {
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const cancelButton = useButton(
     { onPress: () => props.onClose() },
-    cancelButtonRef
+    cancelButtonRef,
   );
 
   return (

--- a/frontend/src/components/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip.tsx
@@ -16,7 +16,7 @@ export const InfoTooltip = (props: Props) => {
   const tooltipTrigger = useTooltipTrigger({}, tooltipTriggerState, triggerRef);
   const { tooltipProps } = useTooltip(
     tooltipTrigger.tooltipProps,
-    tooltipTriggerState
+    tooltipTriggerState,
   );
 
   return (

--- a/frontend/src/components/Localized.tsx
+++ b/frontend/src/components/Localized.tsx
@@ -38,7 +38,7 @@ export const Localized = (props: LocalizedProps) => {
       cloneElement(
         props.children,
         {},
-        <>{l10n.getString(props.id, props.vars)}</>
+        <>{l10n.getString(props.id, props.vars)}</>,
       )
     ) : (
       <>{l10n.getString(props.id, props.vars)}</>

--- a/frontend/src/components/dashboard/PremiumOnboarding.module.scss
+++ b/frontend/src/components/dashboard/PremiumOnboarding.module.scss
@@ -277,7 +277,9 @@
         height: 5px;
         background-color: $color-light-gray-20;
         margin-bottom: $spacing-xs;
-        transition: box-shadow 1s ease-out, color 0.2s ease-out;
+        transition:
+          box-shadow 1s ease-out,
+          color 0.2s ease-out;
       }
 
       &.is-completed {

--- a/frontend/src/components/dashboard/PremiumOnboarding.tsx
+++ b/frontend/src/components/dashboard/PremiumOnboarding.tsx
@@ -162,7 +162,7 @@ export const PremiumOnboarding = (props: Props) => {
           }`}
         >
           {l10n.getString(
-            "multi-part-onboarding-premium-extension-button-dashboard"
+            "multi-part-onboarding-premium-extension-button-dashboard",
           )}
         </Button>
         <AddonDescriptionLinkButton
@@ -256,13 +256,13 @@ const StepOne = () => {
         <p>
           <strong>
             {l10n.getString(
-              `multi-part-onboarding-premium-welcome-feature-headline-${props.name}`
+              `multi-part-onboarding-premium-welcome-feature-headline-${props.name}`,
             )}
           </strong>
           <br />
           <span>
             {l10n.getString(
-              `multi-part-onboarding-premium-welcome-feature-body-${props.name}`
+              `multi-part-onboarding-premium-welcome-feature-body-${props.name}`,
             )}
           </span>
         </p>
@@ -278,7 +278,7 @@ const StepOne = () => {
         </h2>
         <p className={styles.lead}>
           {l10n.getString(
-            "multi-part-onboarding-premium-welcome-subheadline-2"
+            "multi-part-onboarding-premium-welcome-subheadline-2",
           )}
         </p>
       </div>
@@ -287,7 +287,7 @@ const StepOne = () => {
         <div>
           <span className={styles["description-caption"]}>
             {l10n.getString(
-              "multi-part-onboarding-premium-welcome-feature-headline"
+              "multi-part-onboarding-premium-welcome-feature-headline",
             )}
           </span>
           <br />
@@ -362,7 +362,7 @@ const StepTwo = (props: Step2Props) => {
           {partialSubdomain !== ""
             ? partialSubdomain
             : l10n.getString(
-                "multi-part-onboarding-premium-email-domain-placeholder"
+                "multi-part-onboarding-premium-email-domain-placeholder",
               )}
         </span>
         .{getRuntimeConfig().mozmailDomain}
@@ -376,7 +376,7 @@ const StepTwo = (props: Step2Props) => {
       <div className={styles["title-container"]}>
         <h2>
           {l10n.getString(
-            "multi-part-onboarding-premium-email-domain-headline"
+            "multi-part-onboarding-premium-email-domain-headline",
           )}
         </h2>
       </div>
@@ -386,12 +386,12 @@ const StepTwo = (props: Step2Props) => {
           <p className={styles["subdomain-description"]}>
             <span className={styles["description-caption"]}>
               {l10n.getString(
-                "multi-part-onboarding-premium-email-domain-feature-headline"
+                "multi-part-onboarding-premium-email-domain-feature-headline",
               )}
             </span>
             <span className={styles["description-bolded-headline"]}>
               {l10n.getString(
-                "multi-part-onboarding-premium-email-domain-headline-create-masks-on-the-go"
+                "multi-part-onboarding-premium-email-domain-headline-create-masks-on-the-go",
               )}
             </span>
             <br />
@@ -433,7 +433,7 @@ const StepThree = () => {
             <br />
             <span className={styles["description-bolded-headline"]}>
               {l10n.getString(
-                "multi-part-onboarding-premium-reply-description"
+                "multi-part-onboarding-premium-reply-description",
               )}
             </span>
             <br />
@@ -449,7 +449,7 @@ const StepThree = () => {
             </div>
             <p className={`${styles["addon-description"]}`}>
               {l10n.getString(
-                "multi-part-onboarding-premium-added-extension-body"
+                "multi-part-onboarding-premium-added-extension-body",
               )}
             </p>
           </div>
@@ -503,7 +503,7 @@ const AddonDescription = () => {
       <div className={`${styles["addon-description"]} is-hidden-with-addon`}>
         <span className={styles["description-caption"]}>
           {l10n.getString(
-            "multi-part-onboarding-premium-add-extension-feature-headline"
+            "multi-part-onboarding-premium-add-extension-feature-headline",
           )}
         </span>
         <AddonDescriptionHeader headerMessageId={headerMessageId} />

--- a/frontend/src/components/dashboard/PremiumPromoBanners.tsx
+++ b/frontend/src/components/dashboard/PremiumPromoBanners.tsx
@@ -65,7 +65,7 @@ const AdvancedIdentityBanner = () => {
     <Banner
       type="promo"
       title={l10n.getString(
-        "banner-ab-premium-promo-advanced-identity-headline"
+        "banner-ab-premium-promo-advanced-identity-headline",
       )}
       illustration={{
         img: phoneImage,
@@ -90,7 +90,7 @@ const ControlReceiverBanner = () => {
     <Banner
       type="promo"
       title={l10n.getString(
-        "banner-ab-premium-promo-control-receiver-headline"
+        "banner-ab-premium-promo-control-receiver-headline",
       )}
       illustration={{
         img: phoneImage,
@@ -115,7 +115,7 @@ const ExtraProtectionBanner = () => {
     <Banner
       type="promo"
       title={l10n.getString(
-        "banner-ab-premium-promo-extra-protection-headline"
+        "banner-ab-premium-promo-extra-protection-headline",
       )}
       illustration={{
         img: phoneImage,

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -61,7 +61,7 @@ export const ProfileBanners = (props: Props) => {
         key="bounce-banner"
         email={props.user.email}
         profile={props.profile}
-      />
+      />,
     );
   }
 
@@ -71,7 +71,7 @@ export const ProfileBanners = (props: Props) => {
         key="bundle-promo"
         runtimeData={props.runtimeData}
         profileData={props.profile}
-      />
+      />,
     );
   }
 
@@ -80,7 +80,7 @@ export const ProfileBanners = (props: Props) => {
       key="subdomain-picker"
       profile={props.profile}
       onCreate={props.onCreateSubdomain}
-    />
+    />,
   );
 
   // Don't show the "Get Firefox" banner if we have an extension available,
@@ -122,7 +122,7 @@ export const ProfileBanners = (props: Props) => {
             <LoyalistPremiumBanner
               key="premium-banner"
               runtimeData={props.runtimeData}
-            />
+            />,
             // <NoPremiumBanner key="premium-banner" runtimeData={props.runtimeData} />
           );
     }
@@ -206,7 +206,7 @@ const NoChromeExtensionBanner = () => {
     <Banner
       type="promo"
       title={l10n.getString(
-        "banner-download-install-chrome-extension-headline"
+        "banner-download-install-chrome-extension-headline",
       )}
       illustration={{
         img: <Image src={AddonIllustration} alt="" width={60} height={60} />,
@@ -286,7 +286,7 @@ const LoyalistPremiumBanner = (props: NoPremiumBannerProps) => {
           monthly_price: getPeriodicalPremiumPrice(
             props.runtimeData,
             "yearly",
-            l10n
+            l10n,
           ),
         })}
       </p>

--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.test.tsx
@@ -19,7 +19,7 @@ describe("getAddressValidationMessage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     expect(getAddressValidationMessage("invalid address", mockL10n)).toBe(
-      "String ID: modal-custom-alias-picker-form-prefix-spaces-warning"
+      "String ID: modal-custom-alias-picker-form-prefix-spaces-warning",
     );
   });
 
@@ -29,7 +29,7 @@ describe("getAddressValidationMessage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     expect(
-      getAddressValidationMessage("invalid address (╯ ͠° ͟ʖ ͡°)╯┻━┻ ", mockL10n)
+      getAddressValidationMessage("invalid address (╯ ͠° ͟ʖ ͡°)╯┻━┻ ", mockL10n),
     ).toBe("String ID: modal-custom-alias-picker-form-prefix-spaces-warning");
   });
 
@@ -39,7 +39,7 @@ describe("getAddressValidationMessage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     expect(getAddressValidationMessage("π", mockL10n)).toBe(
-      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2"
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2",
     );
   });
 
@@ -49,7 +49,7 @@ describe("getAddressValidationMessage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     expect(getAddressValidationMessage("Invalid-address", mockL10n)).toBe(
-      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2"
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2",
     );
   });
 
@@ -59,7 +59,7 @@ describe("getAddressValidationMessage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     expect(getAddressValidationMessage("-invalid-address", mockL10n)).toBe(
-      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2"
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2",
     );
   });
 
@@ -69,7 +69,7 @@ describe("getAddressValidationMessage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     expect(getAddressValidationMessage("invalid-address-", mockL10n)).toBe(
-      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2"
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2",
     );
   });
 
@@ -79,7 +79,7 @@ describe("getAddressValidationMessage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     expect(getAddressValidationMessage(".invalid.address", mockL10n)).toBe(
-      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2"
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2",
     );
   });
 
@@ -89,7 +89,7 @@ describe("getAddressValidationMessage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     expect(getAddressValidationMessage("invalid.address.", mockL10n)).toBe(
-      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2"
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2",
     );
   });
 
@@ -99,7 +99,7 @@ describe("getAddressValidationMessage", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     expect(getAddressValidationMessage("-", mockL10n)).toBe(
-      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2"
+      "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2",
     );
   });
 });

--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.tsx
@@ -43,7 +43,7 @@ export const AddressPickerModal = (props: Props) => {
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const cancelButton = useButton(
     { onPress: () => props.onClose() },
-    cancelButtonRef
+    cancelButtonRef,
   );
   /**
    * We need a Ref to the address picker field so that we can call the browser's
@@ -62,7 +62,7 @@ export const AddressPickerModal = (props: Props) => {
   };
   const onBlur: FocusEventHandler<HTMLInputElement> = () => {
     addressFieldRef.current?.setCustomValidity(
-      getAddressValidationMessage(address, l10n) ?? ""
+      getAddressValidationMessage(address, l10n) ?? "",
     );
     addressFieldRef.current?.reportValidity();
   };
@@ -104,7 +104,7 @@ export const AddressPickerModal = (props: Props) => {
               <div className={styles.prefix}>
                 <label htmlFor="address">
                   {l10n.getString(
-                    "modal-custom-alias-picker-form-prefix-label-2"
+                    "modal-custom-alias-picker-form-prefix-label-2",
                   )}
                 </label>
                 <input
@@ -116,7 +116,7 @@ export const AddressPickerModal = (props: Props) => {
                   onBlur={onBlur}
                   ref={addressFieldRef}
                   placeholder={l10n.getString(
-                    "modal-custom-alias-picker-form-prefix-placeholder"
+                    "modal-custom-alias-picker-form-prefix-placeholder",
                   )}
                   autoCapitalize="none"
                 />
@@ -135,22 +135,22 @@ export const AddressPickerModal = (props: Props) => {
               />
               <label htmlFor="promotionalsBlocking">
                 {l10n.getString(
-                  "popover-custom-alias-explainer-promotional-block-checkbox"
+                  "popover-custom-alias-explainer-promotional-block-checkbox",
                 )}
               </label>
               <InfoTooltip
                 alt={l10n.getString(
-                  "popover-custom-alias-explainer-promotional-block-tooltip-trigger"
+                  "popover-custom-alias-explainer-promotional-block-tooltip-trigger",
                 )}
               >
                 <h3>
                   {l10n.getString(
-                    "popover-custom-alias-explainer-promotional-block-checkbox"
+                    "popover-custom-alias-explainer-promotional-block-checkbox",
                   )}
                 </h3>
                 <p className={styles["promotionals-blocking-description"]}>
                   {l10n.getString(
-                    "popover-custom-alias-explainer-promotional-block-tooltip-2"
+                    "popover-custom-alias-explainer-promotional-block-tooltip-2",
                   )}
                   <Link href="/faq#faq-promotional-email-blocking">
                     {l10n.getString("banner-label-data-notification-body-cta")}
@@ -168,7 +168,7 @@ export const AddressPickerModal = (props: Props) => {
               </button>
               <Button type="submit" disabled={address.length === 0}>
                 {l10n.getString(
-                  "modal-custom-alias-picker-form-submit-label-2"
+                  "modal-custom-alias-picker-form-submit-label-2",
                 )}
               </Button>
             </div>
@@ -213,14 +213,14 @@ const PickerDialog = (props: PickerDialogProps & AriaOverlayProps) => {
 
 export function getAddressValidationMessage(
   address: string,
-  l10n: ReactLocalization
+  l10n: ReactLocalization,
 ): null | string {
   if (address.length === 0) {
     return null;
   }
   if (address.includes(" ")) {
     return l10n.getString(
-      "modal-custom-alias-picker-form-prefix-spaces-warning"
+      "modal-custom-alias-picker-form-prefix-spaces-warning",
     );
   }
   // Regular expression:
@@ -239,7 +239,7 @@ export function getAddressValidationMessage(
   // validation (`valid_address_pattern` in emails/models.py).
   if (!/^[a-z0-9]([a-z0-9-.]{0,61}[a-z0-9])?$/.test(address)) {
     return l10n.getString(
-      "modal-custom-alias-picker-form-prefix-invalid-warning-2"
+      "modal-custom-alias-picker-form-prefix-invalid-warning-2",
     );
   }
   return null;

--- a/frontend/src/components/dashboard/aliases/Alias.module.scss
+++ b/frontend/src/components/dashboard/aliases/Alias.module.scss
@@ -6,7 +6,8 @@ $toggleTransitionDuration: 200ms;
 .alias-card {
   border-radius: $border-radius-md;
   padding: 0;
-  transition: background-color $toggleTransitionDuration ease,
+  transition:
+    background-color $toggleTransitionDuration ease,
     box-shadow $toggleTransitionDuration ease;
   background-size: cover;
   background-position: top;
@@ -372,7 +373,10 @@ $trackerRemovalIndicatorWidth: 20px;
   max-height: 0;
   overflow: hidden;
   border-top: 1px solid transparent;
-  transition: max-height 200ms, border-color 200ms, padding 200ms;
+  transition:
+    max-height 200ms,
+    border-color 200ms,
+    padding 200ms;
   display: flex;
   flex-direction: column;
   gap: $spacing-md;

--- a/frontend/src/components/dashboard/aliases/Alias.tsx
+++ b/frontend/src/components/dashboard/aliases/Alias.tsx
@@ -56,7 +56,7 @@ export const Alias = (props: Props) => {
   const expandButtonProps = useToggleButton(
     {},
     expandButtonState,
-    expandButtonRef
+    expandButtonRef,
   ).buttonProps;
 
   const address = getFullAddress(props.alias);
@@ -197,7 +197,7 @@ export const Alias = (props: Props) => {
               alt={l10n.getString(
                 expandButtonState.isSelected
                   ? "profile-details-collapse"
-                  : "profile-details-expand"
+                  : "profile-details-expand",
               )}
               width={16}
               height={16}
@@ -218,7 +218,7 @@ export const Alias = (props: Props) => {
             onChange={setBlockLevel}
             hasPremium={props.profile.has_premium}
             premiumAvailableInCountry={isPeriodicalPremiumAvailableInCountry(
-              props.runtimeData
+              props.runtimeData,
             )}
           />
         </div>
@@ -292,7 +292,7 @@ const Stats = (props: StatsProps) => {
           <TrackersRemovedTooltip>
             <span className={styles.number}>
               {numberFormatter.format(
-                props.alias.num_level_one_trackers_blocked
+                props.alias.num_level_one_trackers_blocked,
               )}
             </span>
             <span className={styles.label}>
@@ -479,7 +479,7 @@ const TrackerRemovalIndicator = (props: TrackerRemovalIndicatorProps) => {
   const { triggerProps, tooltipProps: triggerTooltipProps } = useTooltipTrigger(
     {},
     tooltipState,
-    triggerRef
+    triggerRef,
   );
   const { tooltipProps } = useTooltip(triggerTooltipProps, tooltipState);
 

--- a/frontend/src/components/dashboard/aliases/AliasDeletionButton.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButton.test.tsx
@@ -16,7 +16,7 @@ jest.mock("../../../components/Localized.tsx", () => mockLocalizedModule);
 describe("<AliasDeletionButton>", () => {
   it("displays a usable button to delete an alias", () => {
     render(
-      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />
+      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />,
     );
 
     const button = screen.getByRole("button", {
@@ -29,7 +29,7 @@ describe("<AliasDeletionButton>", () => {
 
   it("displays a confirmation prompt, with an unchecked checkbox and a disabled button", async () => {
     render(
-      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />
+      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />,
     );
 
     const button = screen.getByRole("button", {
@@ -51,7 +51,7 @@ describe("<AliasDeletionButton>", () => {
 
   it("enables the delete button on the confirmation prompt, once the checkbox is checked", async () => {
     render(
-      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />
+      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />,
     );
 
     const button = screen.getByRole("button", {
@@ -74,7 +74,7 @@ describe("<AliasDeletionButton>", () => {
 
   it("resets the inputs on the confirmation prompt when reopened, after clicking the Cancel button", async () => {
     render(
-      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />
+      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />,
     );
 
     const button = screen.getByRole("button", {
@@ -108,7 +108,7 @@ describe("<AliasDeletionButton>", () => {
 
   it("resets the inputs on the confirmation prompt when reopened, after clicking off the propmt", async () => {
     render(
-      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />
+      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />,
     );
 
     const button = screen.getByRole("button", {

--- a/frontend/src/components/dashboard/aliases/AliasDeletionButton.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButton.tsx
@@ -43,7 +43,7 @@ export const AliasDeletionButton = (props: Props) => {
     {
       onPress: () => modalState.open(),
     },
-    openModalButtonRef
+    openModalButtonRef,
   ).buttonProps;
 
   const modalState = useOverlayTriggerState({
@@ -52,7 +52,7 @@ export const AliasDeletionButton = (props: Props) => {
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const cancelButton = useButton(
     { onPress: () => modalState.close() },
-    cancelButtonRef
+    cancelButtonRef,
   );
 
   const onConfirm: FormEventHandler = (event) => {
@@ -86,7 +86,7 @@ export const AliasDeletionButton = (props: Props) => {
           {l10n.getString(
             isRandomAlias(props.alias)
               ? "modal-delete-warning-upgrade-2"
-              : "modal-delete-domain-address-warning-upgrade-2"
+              : "modal-delete-domain-address-warning-upgrade-2",
           )}
         </p>
         <form onSubmit={onConfirm} className={styles.confirm}>
@@ -142,7 +142,7 @@ type ConfirmationDialogProps = {
   onClose?: () => void;
 };
 const ConfirmationDialog = (
-  props: ConfirmationDialogProps & AriaOverlayProps
+  props: ConfirmationDialogProps & AriaOverlayProps,
 ) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const { overlayProps, underlayProps } = useOverlay(props, wrapperRef);

--- a/frontend/src/components/dashboard/aliases/AliasGenerationButton.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasGenerationButton.test.tsx
@@ -23,14 +23,14 @@ describe("<AliasGenerationButton>", () => {
         profile={getMockProfileData({ has_premium: false })}
         onCreate={jest.fn()}
         runtimeData={getMockRuntimeDataWithoutPremium()}
-      />
+      />,
     );
 
     const button = screen.getByRole("button");
 
     expect(button).toBeEnabled();
     expect(button).toHaveTextContent(
-      "l10n string: [profile-label-generate-new-alias-2], with vars: {}"
+      "l10n string: [profile-label-generate-new-alias-2], with vars: {}",
     );
   });
 
@@ -48,14 +48,14 @@ describe("<AliasGenerationButton>", () => {
         profile={getMockProfileData({ has_premium: true })}
         onCreate={jest.fn()}
         runtimeData={getMockRuntimeDataWithoutPremium()}
-      />
+      />,
     );
 
     const button = screen.getByRole("button");
 
     expect(button).toBeEnabled();
     expect(button).toHaveTextContent(
-      "l10n string: [profile-label-generate-new-alias-2], with vars: {}"
+      "l10n string: [profile-label-generate-new-alias-2], with vars: {}",
     );
   });
 
@@ -72,13 +72,13 @@ describe("<AliasGenerationButton>", () => {
         profile={getMockProfileData({ has_premium: false })}
         onCreate={jest.fn()}
         runtimeData={getMockRuntimeDataWithPeriodicalPremium()}
-      />
+      />,
     );
 
     const button = screen.getByRole("link");
 
     expect(button).toHaveTextContent(
-      "l10n string: [profile-label-upgrade-2], with vars: {}"
+      "l10n string: [profile-label-upgrade-2], with vars: {}",
     );
   });
 
@@ -95,7 +95,7 @@ describe("<AliasGenerationButton>", () => {
         profile={getMockProfileData({ has_premium: false })}
         onCreate={jest.fn()}
         runtimeData={getMockRuntimeDataWithoutPremium()}
-      />
+      />,
     );
 
     const button = screen.getByRole("button");
@@ -119,7 +119,7 @@ describe("<AliasGenerationButton>", () => {
         })}
         onCreate={jest.fn()}
         runtimeData={getMockRuntimeDataWithoutPremium()}
-      />
+      />,
     );
 
     const button = screen.getByRole("button");
@@ -142,14 +142,14 @@ describe("<AliasGenerationButton>", () => {
           profile={getMockProfileData({ has_premium: true, subdomain: null })}
           onCreate={jest.fn()}
           runtimeData={getMockRuntimeDataWithoutPremium()}
-        />
+        />,
       );
 
       const button = screen.getByRole("button");
 
       expect(button).toBeEnabled();
       expect(button).toHaveTextContent(
-        "l10n string: [profile-label-generate-new-alias-2], with vars: {}"
+        "l10n string: [profile-label-generate-new-alias-2], with vars: {}",
       );
     });
 
@@ -180,7 +180,7 @@ describe("<AliasGenerationButton>", () => {
           })}
           onCreate={jest.fn()}
           runtimeData={getMockRuntimeDataWithoutPremium()}
-        />
+        />,
       );
 
       const dropDownButton = screen.getByRole("button");
@@ -190,7 +190,7 @@ describe("<AliasGenerationButton>", () => {
 
       expect(dropDownButton).toBeEnabled();
       expect(dropDownButton).toHaveTextContent(
-        "l10n string: [profile-label-generate-new-alias-2], with vars: {}"
+        "l10n string: [profile-label-generate-new-alias-2], with vars: {}",
       );
       expect(menu).toBeInTheDocument();
       expect(menuItems).toHaveLength(2);

--- a/frontend/src/components/dashboard/aliases/AliasGenerationButton.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasGenerationButton.tsx
@@ -40,7 +40,7 @@ export type Props = {
   onCreate: (
     options:
       | { mask_type: "random" }
-      | { mask_type: "custom"; address: string; blockPromotionals: boolean }
+      | { mask_type: "custom"; address: string; blockPromotionals: boolean },
   ) => void;
 };
 
@@ -109,7 +109,7 @@ type AliasTypeMenuProps = {
   onCreate: (
     options:
       | { mask_type: "random" }
-      | { mask_type: "custom"; address: string; blockPromotionals: boolean }
+      | { mask_type: "custom"; address: string; blockPromotionals: boolean },
   ) => void;
 };
 const AliasTypeMenu = (props: AliasTypeMenuProps) => {
@@ -128,7 +128,7 @@ const AliasTypeMenu = (props: AliasTypeMenuProps) => {
 
   const onPick = (
     address: string,
-    settings: { blockPromotionals: boolean }
+    settings: { blockPromotionals: boolean },
   ) => {
     props.onCreate({
       mask_type: "custom",
@@ -175,7 +175,7 @@ const AliasTypeMenuButton = (props: AliasTypeMenuButtonProps) => {
   const { menuTriggerProps, menuProps } = useMenuTrigger(
     {},
     triggerState,
-    triggerRef
+    triggerRef,
   );
   // `menuProps` has an `autoFocus` property that is not compatible with the
   // `autoFocus` property for HTMLElements, because it can also be of type
@@ -193,7 +193,7 @@ const AliasTypeMenuButton = (props: AliasTypeMenuButtonProps) => {
 
   const triggerButtonProps = useButton(
     menuTriggerProps,
-    triggerRef
+    triggerRef,
   ).buttonProps;
 
   return (
@@ -235,7 +235,7 @@ const AliasTypeMenuPopup = (props: AliasTypeMenuPopupProps) => {
       isOpen: true,
       isDismissable: true,
     },
-    overlayRef
+    overlayRef,
   );
 
   // <FocusScope> ensures that focus is restored back to the
@@ -290,7 +290,7 @@ const AliasTypeMenuItem = (props: AliasTypeMenuItemProps) => {
       onClose: props.onClose,
     },
     props.state,
-    menuItemRef
+    menuItemRef,
   ).menuItemProps;
 
   const [_isFocused, setIsFocused] = useState(false);

--- a/frontend/src/components/dashboard/aliases/AliasList.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.test.tsx
@@ -18,7 +18,7 @@ describe("<AliasList>", () => {
     const updateCallback = jest.fn();
     const storeLocalLabelCallback = jest.fn();
     LocalLabelsMock.setMockLocalLabelsOnce(
-      LocalLabelsMock.getReturnValueWithoutAddon(storeLocalLabelCallback)
+      LocalLabelsMock.getReturnValueWithoutAddon(storeLocalLabelCallback),
     );
     render(
       <AliasList
@@ -28,7 +28,7 @@ describe("<AliasList>", () => {
         onDelete={jest.fn()}
         profile={getMockProfileData({ server_storage: true })}
         user={{ email: "arbitrary@example.com" }}
-      />
+      />,
     );
 
     const labelField = screen.getByRole("textbox");
@@ -45,7 +45,7 @@ describe("<AliasList>", () => {
     const updateCallback = jest.fn();
     const storeLocalLabelCallback = jest.fn();
     LocalLabelsMock.setMockLocalLabelsOnce(
-      LocalLabelsMock.getReturnValueWithAddon([], storeLocalLabelCallback)
+      LocalLabelsMock.getReturnValueWithAddon([], storeLocalLabelCallback),
     );
     render(
       <AliasList
@@ -55,7 +55,7 @@ describe("<AliasList>", () => {
         onDelete={jest.fn()}
         profile={getMockProfileData({ server_storage: false })}
         user={{ email: "arbitrary@example.com" }}
-      />
+      />,
     );
 
     const labelField = screen.getByRole("textbox");
@@ -67,7 +67,7 @@ describe("<AliasList>", () => {
     expect(updateCallback).toHaveBeenCalledWith(expect.anything(), {});
     expect(storeLocalLabelCallback).toHaveBeenCalledWith(
       expect.anything(),
-      "Some label"
+      "Some label",
     );
   });
 
@@ -75,7 +75,7 @@ describe("<AliasList>", () => {
     const updateCallback = jest.fn();
     const storeLocalLabelCallback = jest.fn();
     LocalLabelsMock.setMockLocalLabelsOnce(
-      LocalLabelsMock.getReturnValueWithAddon([], storeLocalLabelCallback)
+      LocalLabelsMock.getReturnValueWithAddon([], storeLocalLabelCallback),
     );
     render(
       <AliasList
@@ -85,7 +85,7 @@ describe("<AliasList>", () => {
         onDelete={jest.fn()}
         profile={getMockProfileData({ server_storage: true })}
         user={{ email: "arbitrary@example.com" }}
-      />
+      />,
     );
 
     const labelField = screen.getByRole("textbox");
@@ -100,7 +100,7 @@ describe("<AliasList>", () => {
 
   it("does not provide the option to edit the label if server-side storage is disabled, and local storage is not available (i.e. the user does not have the add-on)", async () => {
     LocalLabelsMock.setMockLocalLabelsOnce(
-      LocalLabelsMock.getReturnValueWithoutAddon()
+      LocalLabelsMock.getReturnValueWithoutAddon(),
     );
     render(
       <AliasList
@@ -110,7 +110,7 @@ describe("<AliasList>", () => {
         onDelete={jest.fn()}
         profile={getMockProfileData({ server_storage: false })}
         user={{ email: "arbitrary@example.com" }}
-      />
+      />,
     );
 
     const labelField = screen.queryByRole("textbox");
@@ -131,7 +131,7 @@ describe("<AliasList>", () => {
         onDelete={jest.fn()}
         profile={getMockProfileData({ server_storage: true })}
         user={{ email: "arbitrary@example.com" }}
-      />
+      />,
     );
 
     const stringFilterField = screen.getByRole("searchbox");
@@ -143,7 +143,7 @@ describe("<AliasList>", () => {
     await userEvent.type(stringFilterField, "arbitrary other description");
 
     const aliasElementNotMatchingFilter = screen.queryByText(
-      mockAlias.full_address
+      mockAlias.full_address,
     );
     expect(aliasElementNotMatchingFilter).not.toBeInTheDocument();
   });
@@ -153,8 +153,8 @@ describe("<AliasList>", () => {
     LocalLabelsMock.setMockLocalLabels(
       LocalLabelsMock.getReturnValueWithAddon(
         [{ ...mockAlias, description: "some local description" }],
-        jest.fn()
-      )
+        jest.fn(),
+      ),
     );
     render(
       <AliasList
@@ -164,7 +164,7 @@ describe("<AliasList>", () => {
         onDelete={jest.fn()}
         profile={getMockProfileData({ server_storage: false })}
         user={{ email: "arbitrary@example.com" }}
-      />
+      />,
     );
 
     const stringFilterField = screen.getByRole("searchbox");
@@ -176,7 +176,7 @@ describe("<AliasList>", () => {
     await userEvent.type(stringFilterField, "arbitrary other description");
 
     const aliasElementNotMatchingFilter = screen.queryByText(
-      mockAlias.full_address
+      mockAlias.full_address,
     );
     expect(aliasElementNotMatchingFilter).not.toBeInTheDocument();
   });

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -25,7 +25,7 @@ export type Props = {
   onCreate: (
     options:
       | { mask_type: "random" }
-      | { mask_type: "custom"; address: string; blockPromotionals: boolean }
+      | { mask_type: "custom"; address: string; blockPromotionals: boolean },
   ) => void;
   onUpdate: (alias: AliasData, updatedFields: Partial<AliasData>) => void;
   onDelete: (alias: AliasData) => void;
@@ -44,18 +44,18 @@ export const AliasList = (props: Props) => {
   // URL pointing to a mask, scroll to that mask:
   useFlaggedAnchorLinks(
     [],
-    props.aliases.map((alias) => encodeURIComponent(alias.full_address))
+    props.aliases.map((alias) => encodeURIComponent(alias.full_address)),
   );
   const [openAlias, setOpenAlias] = useState<AliasData | undefined>(
     // If the mask was focused on by an anchor link, expand that one on page load:
     props.aliases.find(
       (alias) =>
         alias.full_address ===
-        decodeURIComponent(document.location.hash.substring(1))
-    )
+        decodeURIComponent(document.location.hash.substring(1)),
+    ),
   );
   const [existingAliases, setExistingAliases] = useState<AliasData[]>(
-    props.aliases
+    props.aliases,
   );
 
   useEffect(() => {
@@ -64,7 +64,7 @@ export const AliasList = (props: Props) => {
     } else {
       const existingAliasIds = existingAliases.map((alias) => alias.id);
       const newAliases = props.aliases.filter(
-        (alias) => existingAliasIds.indexOf(alias.id) === -1
+        (alias) => existingAliasIds.indexOf(alias.id) === -1,
       );
       if (newAliases.length !== 0) {
         setOpenAlias(newAliases[0]);
@@ -86,7 +86,8 @@ export const AliasList = (props: Props) => {
     ) {
       const localLabel = localLabels.find(
         (localLabel) =>
-          localLabel.id === alias.id && localLabel.mask_type === alias.mask_type
+          localLabel.id === alias.id &&
+          localLabel.mask_type === alias.mask_type,
       );
       if (localLabel !== undefined) {
         aliasWithLocalLabel.description = localLabel.description;
@@ -99,7 +100,7 @@ export const AliasList = (props: Props) => {
     filterAliases(aliasesWithLocalLabels, {
       ...categoryFilters,
       string: stringFilterInput,
-    })
+    }),
   );
 
   const aliasCards = aliases.map((alias) => {

--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.tsx
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.tsx
@@ -67,7 +67,7 @@ export const BlockLevelSlider = (props: Props) => {
         // However, since you still can't access that value directly on
         // `sliderState`, we'll still need `onlyThumbIndex` anyway, so for
         // consistency, we're still using a single-element array.
-        (value as [number])[onlyThumbIndex]
+        (value as [number])[onlyThumbIndex],
       );
       gaEvent({
         category: "Dashboard Alias Settings",
@@ -86,7 +86,7 @@ export const BlockLevelSlider = (props: Props) => {
   const { groupProps, trackProps, labelProps, outputProps } = useSlider(
     sliderSettings,
     sliderState,
-    trackRef
+    trackRef,
   );
 
   const lockIcon = props.hasPremium ? null : (
@@ -98,7 +98,7 @@ export const BlockLevelSlider = (props: Props) => {
       <br />
       <span className={styles["premium-only-marker"]}>
         {l10n.getString(
-          "profile-promo-email-blocking-option-promotionals-premiumonly-marker"
+          "profile-promo-email-blocking-option-promotionals-premiumonly-marker",
         )}
       </span>
     </>
@@ -122,7 +122,7 @@ export const BlockLevelSlider = (props: Props) => {
               className={getTrackStopClassNames(
                 props.alias,
                 sliderState,
-                "none"
+                "none",
               )}
             >
               <Image src={UmbrellaClosedMobile} alt="" />
@@ -139,7 +139,7 @@ export const BlockLevelSlider = (props: Props) => {
                 className={getTrackStopClassNames(
                   props.alias,
                   sliderState,
-                  "promotional"
+                  "promotional",
                 )}
               >
                 <Image src={UmbrellaSemiMobile} alt="" />
@@ -152,7 +152,7 @@ export const BlockLevelSlider = (props: Props) => {
               className={getTrackStopClassNames(
                 props.alias,
                 sliderState,
-                "all"
+                "all",
               )}
             >
               <Image src={UmbrellaOpenMobile} alt="" />
@@ -193,12 +193,12 @@ export const BlockLevelSlider = (props: Props) => {
       <output {...outputProps} className={styles["value-description"]}>
         <BlockLevelIllustration
           level={getBlockLevelFromSliderValue(
-            sliderState.getThumbValue(onlyThumbIndex)
+            sliderState.getThumbValue(onlyThumbIndex),
           )}
         />
         <BlockLevelDescription
           level={getBlockLevelFromSliderValue(
-            sliderState.getThumbValue(onlyThumbIndex)
+            sliderState.getThumbValue(onlyThumbIndex),
           )}
         />
       </output>
@@ -218,7 +218,7 @@ const Thumb = (props: ThumbProps) => {
       trackRef: props.trackRef,
       inputRef: inputRef,
     },
-    props.sliderState
+    props.sliderState,
   );
 
   const { focusProps, isFocusVisible } = useFocusRing();
@@ -262,7 +262,7 @@ const BlockLevelDescription = (props: { level: BlockLevel }) => {
     return (
       <span className={styles["value-description-content"]}>
         {l10n.getString(
-          "profile-promo-email-blocking-description-promotionals"
+          "profile-promo-email-blocking-description-promotionals",
         )}
         <Link href="/faq#faq-promotional-email-blocking">
           {l10n.getString("banner-label-data-notification-body-cta")}
@@ -309,7 +309,7 @@ const PromotionalTrackStopGhost = (props: PromotionalTrackStopGhostProps) => {
       type: "dialog",
     },
     overlayTriggerState,
-    triggerRef
+    triggerRef,
   );
   const { buttonProps } = useButton(triggerProps, triggerRef);
 
@@ -354,7 +354,7 @@ const PromotionalTooltip = (props: PromotionalTooltipProps) => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const { overlayProps, underlayProps } = useOverlay(
     { isOpen: true, onClose: props.onClose, isDismissable: true },
-    overlayRef
+    overlayRef,
   );
 
   const { modalProps } = useModal();
@@ -373,19 +373,19 @@ const PromotionalTooltip = (props: PromotionalTooltipProps) => {
     {
       onPress: () => props.onClose(),
     },
-    closeButtonRef
+    closeButtonRef,
   ).buttonProps;
 
   const link = props.premiumAvailableInCountry ? (
     <Link href="/premium/">
       {l10n.getString(
-        "profile-promo-email-blocking-description-promotionals-locked-cta"
+        "profile-promo-email-blocking-description-promotionals-locked-cta",
       )}
     </Link>
   ) : (
     <Link href="/premium/waitlist">
       {l10n.getString(
-        "profile-promo-email-blocking-description-promotionals-locked-waitlist-cta"
+        "profile-promo-email-blocking-description-promotionals-locked-waitlist-cta",
       )}
     </Link>
   );
@@ -399,7 +399,7 @@ const PromotionalTooltip = (props: PromotionalTooltipProps) => {
             dialogProps,
             props.overlayProps,
             overlayPositionProps,
-            modalProps
+            modalProps,
           )}
           ref={overlayRef}
           className={styles["upgrade-tooltip"]}
@@ -413,11 +413,11 @@ const PromotionalTooltip = (props: PromotionalTooltipProps) => {
             <b className={styles["locked-message"]} {...titleProps}>
               <LockIcon alt="" className={styles["lock-icon"]} />
               {l10n.getString(
-                "profile-promo-email-blocking-description-promotionals-locked-label"
+                "profile-promo-email-blocking-description-promotionals-locked-label",
               )}
             </b>
             {l10n.getString(
-              "profile-promo-email-blocking-description-promotionals"
+              "profile-promo-email-blocking-description-promotionals",
             )}
             {link}
           </span>
@@ -428,7 +428,7 @@ const PromotionalTooltip = (props: PromotionalTooltipProps) => {
           >
             <CloseIcon
               alt={l10n.getString(
-                "profile-promo-email-blocking-description-promotionals-locked-close"
+                "profile-promo-email-blocking-description-promotionals-locked-close",
               )}
             />
           </button>
@@ -459,7 +459,7 @@ function getBlockLevelFromSliderValue(value: number): BlockLevel {
 }
 function getLabelForBlockLevel(
   blockLevel: BlockLevel,
-  l10n: ReactLocalization
+  l10n: ReactLocalization,
 ): string {
   switch (blockLevel) {
     case "none":
@@ -495,7 +495,7 @@ class SliderValueFormatter implements Intl.NumberFormat {
   // interface, but react-aria should only call the `.format` method:
   formatRangeToParts(
     _startDate: number | bigint,
-    _endDate: number | bigint
+    _endDate: number | bigint,
   ): Intl.NumberRangeFormatPart[] {
     throw new Error("Method not implemented.");
   }
@@ -503,7 +503,7 @@ class SliderValueFormatter implements Intl.NumberFormat {
   format(value: number): string {
     return getLabelForBlockLevel(
       getBlockLevelFromSliderValue(value),
-      this.l10n
+      this.l10n,
     );
   }
 }
@@ -521,7 +521,7 @@ function getBlockLevelGaEventLabel(blockLevel: BlockLevel): string {
 
 const isBlockLevelActive = (
   alias: AliasData,
-  blockLevel: BlockLevel
+  blockLevel: BlockLevel,
 ): boolean => {
   if (
     blockLevel === "none" &&
@@ -545,7 +545,7 @@ const isBlockLevelActive = (
 const getTrackStopClassNames = (
   alias: AliasData,
   sliderState: SliderState,
-  blockLevel: BlockLevel
+  blockLevel: BlockLevel,
 ): string => {
   const isActiveClass = isBlockLevelActive(alias, blockLevel)
     ? styles["is-active"]

--- a/frontend/src/components/dashboard/aliases/CategoryFilter.tsx
+++ b/frontend/src/components/dashboard/aliases/CategoryFilter.tsx
@@ -49,7 +49,7 @@ export const CategoryFilter = (props: Props) => {
   const { triggerProps, overlayProps } = useOverlayTrigger(
     { type: "listbox" },
     menuState,
-    triggerRef
+    triggerRef,
   );
 
   const positionProps = useOverlayPosition({
@@ -107,14 +107,14 @@ type FilterMenuProps = HTMLAttributes<HTMLDivElement> & {
 const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
   function FilterMenuWithForwardedRef(
     { selectedFilters, onClose, isOpen, ...otherProps },
-    overlayRef
+    overlayRef,
   ) {
     const l10n = useL10n();
     const [domainType, setDomainType] = useState<Filters["domainType"]>(
-      selectedFilters.domainType
+      selectedFilters.domainType,
     );
     const [status, setStatus] = useState<Filters["status"]>(
-      selectedFilters.status
+      selectedFilters.status,
     );
     const saveAndClose = () => {
       onClose({ selectedFilters: { domainType, status } });
@@ -134,7 +134,7 @@ const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
         isOpen: isOpen,
         isDismissable: true,
       },
-      overlayRef as RefObject<HTMLDivElement>
+      overlayRef as RefObject<HTMLDivElement>,
     );
 
     const onSubmit: FormEventHandler = (event) => {
@@ -211,7 +211,7 @@ const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
                 id="promoBlockingAliases"
               />
               {l10n.getString(
-                "profile-filter-category-option-promo-blocking-masks"
+                "profile-filter-category-option-promo-blocking-masks",
               )}
             </label>
             <label>
@@ -238,5 +238,5 @@ const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
         </div>
       </FocusScope>
     );
-  }
+  },
 );

--- a/frontend/src/components/dashboard/aliases/LabelEditor.tsx
+++ b/frontend/src/components/dashboard/aliases/LabelEditor.tsx
@@ -45,7 +45,7 @@ export const LabelEditor = (props: Props) => {
   };
   const onBlur: FocusEventHandler<HTMLInputElement> = (_event) => {
     formRef.current?.dispatchEvent(
-      new Event("submit", { bubbles: true, cancelable: true })
+      new Event("submit", { bubbles: true, cancelable: true }),
     );
   };
 

--- a/frontend/src/components/dashboard/aliases/MaskCard.module.scss
+++ b/frontend/src/components/dashboard/aliases/MaskCard.module.scss
@@ -4,7 +4,9 @@
 .card {
   background-color: $color-white;
   border-radius: $border-radius-md;
-  transition: box-shadow 200ms ease-in-out, opacity 200ms ease-in-out;
+  transition:
+    box-shadow 200ms ease-in-out,
+    opacity 200ms ease-in-out;
 
   &.is-enabled {
     box-shadow: $box-shadow-sm;

--- a/frontend/src/components/dashboard/aliases/MaskCard.tsx
+++ b/frontend/src/components/dashboard/aliases/MaskCard.tsx
@@ -67,7 +67,7 @@ export const MaskCard = (props: Props) => {
   const expandButtonProps = useToggleButton(
     {},
     expandButtonState,
-    expandButtonRef
+    expandButtonRef,
   ).buttonProps;
   // Used to link the expandButton to the area-to-be-expanded:
   const detailsElementId = useId();
@@ -143,7 +143,7 @@ export const MaskCard = (props: Props) => {
               ? l10n.getString("profile-promo-email-blocking-label-none")
               : props.mask.block_list_emails === true
               ? l10n.getString(
-                  "profile-promo-email-blocking-label-promotionals"
+                  "profile-promo-email-blocking-label-promotionals",
                 )
               : null}
           </div>
@@ -159,7 +159,7 @@ export const MaskCard = (props: Props) => {
             alt={l10n.getString(
               expandButtonState.isSelected
                 ? "profile-details-collapse"
-                : "profile-details-expand"
+                : "profile-details-expand",
             )}
             width={16}
             height={16}
@@ -201,7 +201,7 @@ export const MaskCard = (props: Props) => {
                   <dt>{l10n.getString("profile-label-trackers-removed")}</dt>
                   <dd>
                     {statNumberFormatter.format(
-                      props.mask.num_level_one_trackers_blocked
+                      props.mask.num_level_one_trackers_blocked,
                     )}
                   </dd>
                 </div>
@@ -244,7 +244,7 @@ export const MaskCard = (props: Props) => {
                   value="promotionals"
                   isDisabled={!props.profile.has_premium}
                   title={l10n.getString(
-                    "profile-promo-email-blocking-description-promotionals-locked-label"
+                    "profile-promo-email-blocking-description-promotionals-locked-label",
                   )}
                   isPromo={true}
                   promoSelectedState={promoIsSelected}
@@ -253,12 +253,12 @@ export const MaskCard = (props: Props) => {
                   {!props.profile.has_premium && (
                     <LockIcon
                       alt={l10n.getString(
-                        "profile-promo-email-blocking-description-promotionals-locked-label"
+                        "profile-promo-email-blocking-description-promotionals-locked-label",
                       )}
                     />
                   )}
                   {l10n.getString(
-                    "profile-promo-email-blocking-option-promotions"
+                    "profile-promo-email-blocking-option-promotions",
                   )}
                 </BlockLevelOption>
                 <BlockLevelOption
@@ -275,16 +275,16 @@ export const MaskCard = (props: Props) => {
                   <strong>
                     <LockIcon
                       alt={l10n.getString(
-                        "profile-promo-email-blocking-description-promotionals-locked-label"
+                        "profile-promo-email-blocking-description-promotionals-locked-label",
                       )}
                     />
                     {l10n.getString(
-                      "profile-promo-email-blocking-description-promotionals-locked-label"
+                      "profile-promo-email-blocking-description-promotionals-locked-label",
                     )}
                   </strong>
                   <p>
                     {l10n.getString(
-                      "profile-promo-email-blocking-description-promotionals"
+                      "profile-promo-email-blocking-description-promotionals",
                     )}
                   </p>
                   <Link
@@ -307,19 +307,19 @@ export const MaskCard = (props: Props) => {
             >
               {blockLevel === "all" &&
                 l10n.getString(
-                  "profile-promo-email-blocking-description-all-2"
+                  "profile-promo-email-blocking-description-all-2",
                 )}
               {blockLevel === "promotionals" && (
                 <>
                   <p>
                     {l10n.getString(
-                      "profile-promo-email-blocking-description-promotionals"
+                      "profile-promo-email-blocking-description-promotionals",
                     )}
                   </p>
                   <p>
                     <Link href="/faq#faq-promotional-email-blocking">
                       {l10n.getString(
-                        "banner-label-data-notification-body-cta"
+                        "banner-label-data-notification-body-cta",
                       )}
                     </Link>
                   </p>
@@ -327,7 +327,7 @@ export const MaskCard = (props: Props) => {
               )}
               {blockLevel === "none" &&
                 l10n.getString(
-                  "profile-promo-email-blocking-description-none-2"
+                  "profile-promo-email-blocking-description-none-2",
                 )}
             </div>
           </div>
@@ -370,12 +370,12 @@ const BlockLevelContext = createContext<RadioGroupState | null>(null);
 const BlockLevelSegmentedControl = (
   props: { children: ReactElement[] } & RadioGroupProps &
     AriaRadioGroupProps &
-    Required<Pick<AriaRadioGroupProps, "label">>
+    Required<Pick<AriaRadioGroupProps, "label">>,
 ) => {
   const state = useRadioGroupState(props);
   const { radioGroupProps, labelProps } = useRadioGroup(
     { orientation: "horizontal", ...props },
-    state
+    state,
   );
 
   return (
@@ -399,7 +399,7 @@ const BlockLevelOption = (
     isPromo?: boolean;
     promoSelectedState?: boolean;
     setPromoSelectedState: (promoSelectedState: boolean) => void;
-  }
+  },
 ) => {
   const state = useContext(BlockLevelContext);
   const inputRef = useRef<HTMLInputElement>(null);

--- a/frontend/src/components/dashboard/subdomain/ConfirmationForm.tsx
+++ b/frontend/src/components/dashboard/subdomain/ConfirmationForm.tsx
@@ -22,7 +22,7 @@ export const SubdomainConfirmationForm = (props: Props) => {
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const cancelButton = useButton(
     { onPress: () => props.onCancel() },
-    cancelButtonRef
+    cancelButtonRef,
   );
 
   const onSubmit: FormEventHandler = (event) => {

--- a/frontend/src/components/dashboard/subdomain/ConfirmationModal.tsx
+++ b/frontend/src/components/dashboard/subdomain/ConfirmationModal.tsx
@@ -103,12 +103,12 @@ const SuccessModal = (props: Props) => {
                 <p>
                   <strong>
                     {l10n.getString(
-                      "modal-email-domain-success-headline-on-the-go"
+                      "modal-email-domain-success-headline-on-the-go",
                     )}
                   </strong>
                   <p>
                     {l10n.getString(
-                      "modal-email-domain-success-body-on-the-go"
+                      "modal-email-domain-success-body-on-the-go",
                     )}
                   </p>
                 </p>
@@ -118,7 +118,7 @@ const SuccessModal = (props: Props) => {
                 <p>
                   <strong>
                     {l10n.getString(
-                      "modal-email-domain-success-headline-any-word"
+                      "modal-email-domain-success-headline-any-word",
                     )}
                   </strong>
                   <p>
@@ -126,7 +126,7 @@ const SuccessModal = (props: Props) => {
                       "modal-email-domain-success-body-any-word",
                       {
                         custom_domain_full: `@${props.subdomain}.mozmail.com`,
-                      }
+                      },
                     )}
                   </p>
                 </p>

--- a/frontend/src/components/dashboard/subdomain/SearchForm.tsx
+++ b/frontend/src/components/dashboard/subdomain/SearchForm.tsx
@@ -26,7 +26,7 @@ export const SubdomainSearchForm = (props: Props) => {
         l10n.getString("error-subdomain-not-available-2", {
           unavailable_subdomain: subdomainInput,
         }),
-        { type: "error" }
+        { type: "error" },
       );
       return;
     }
@@ -51,7 +51,7 @@ export const SubdomainSearchForm = (props: Props) => {
         value={subdomainInput}
         onInput={onInput}
         placeholder={l10n.getString(
-          "banner-set-email-domain-input-placeholder"
+          "banner-set-email-domain-input-placeholder",
         )}
         name="subdomain"
         id="subdomain"
@@ -68,7 +68,7 @@ export const SubdomainSearchForm = (props: Props) => {
 
 async function getAvailability(subdomain: string) {
   const checkResponse = await authenticatedFetch(
-    `/accounts/profile/subdomain?subdomain=${subdomain}`
+    `/accounts/profile/subdomain?subdomain=${subdomain}`,
   );
   if (!checkResponse.ok) {
     return false;

--- a/frontend/src/components/dashboard/subdomain/SubdomainIndicator.tsx
+++ b/frontend/src/components/dashboard/subdomain/SubdomainIndicator.tsx
@@ -28,7 +28,7 @@ export type Props = {
   subdomain: string | null;
   onCreateAlias: (
     address: string,
-    settings: { blockPromotionals: boolean }
+    settings: { blockPromotionals: boolean },
   ) => void;
 };
 
@@ -52,7 +52,7 @@ type ExplainerTriggerProps = {
   subdomain: string;
   onCreateAlias: (
     address: string,
-    settings: { blockPromotionals: boolean }
+    settings: { blockPromotionals: boolean },
   ) => void;
 };
 const ExplainerTrigger = (props: ExplainerTriggerProps) => {
@@ -66,11 +66,11 @@ const ExplainerTrigger = (props: ExplainerTriggerProps) => {
 
   const openButtonProps = useButton(
     { onPress: () => explainerState.open() },
-    openButtonRef
+    openButtonRef,
   ).buttonProps;
   const closeButtonProps = useButton(
     { onPress: () => explainerState.close() },
-    closeButtonRef
+    closeButtonRef,
   ).buttonProps;
   const generateButtonProps = useButton(
     {
@@ -79,7 +79,7 @@ const ExplainerTrigger = (props: ExplainerTriggerProps) => {
         addressPickerState.open();
       },
     },
-    generateButtonRef
+    generateButtonRef,
   ).buttonProps;
 
   const positionProps = useOverlayPosition({
@@ -92,7 +92,7 @@ const ExplainerTrigger = (props: ExplainerTriggerProps) => {
 
   const onPick = (
     address: string,
-    settings: { blockPromotionals: boolean }
+    settings: { blockPromotionals: boolean },
   ) => {
     props.onCreateAlias(address, settings);
     addressPickerState.close();
@@ -121,7 +121,7 @@ const ExplainerTrigger = (props: ExplainerTriggerProps) => {
             </p>
             <p className={styles["button-heading"]}>
               {l10n.getString(
-                "popover-custom-alias-explainer-generate-button-heading-2"
+                "popover-custom-alias-explainer-generate-button-heading-2",
               )}
             </p>
             <button
@@ -130,7 +130,7 @@ const ExplainerTrigger = (props: ExplainerTriggerProps) => {
               className={styles["generate-button"]}
             >
               {l10n.getString(
-                "popover-custom-alias-explainer-generate-button-label-2"
+                "popover-custom-alias-explainer-generate-button-label-2",
               )}
             </button>
             <button
@@ -140,7 +140,7 @@ const ExplainerTrigger = (props: ExplainerTriggerProps) => {
             >
               <CloseIcon
                 alt={l10n.getString(
-                  "popover-custom-alias-explainer-close-button-label"
+                  "popover-custom-alias-explainer-close-button-label",
                 )}
               />
             </button>
@@ -170,14 +170,14 @@ const Explainer = forwardRef<HTMLDivElement, ExplainerProps>(
 
     const { overlayProps } = useOverlay(
       props,
-      overlayRef as RefObject<HTMLDivElement>
+      overlayRef as RefObject<HTMLDivElement>,
     );
 
     const { modalProps } = useModal();
 
     const { dialogProps, titleProps } = useDialog(
       {},
-      overlayRef as RefObject<HTMLDivElement>
+      overlayRef as RefObject<HTMLDivElement>,
     );
 
     // On small screens, this is a dialog at the top of the viewport.
@@ -187,7 +187,7 @@ const Explainer = forwardRef<HTMLDivElement, ExplainerProps>(
       overlayProps,
       positionProps,
       dialogProps,
-      modalProps
+      modalProps,
     );
 
     return (
@@ -208,5 +208,5 @@ const Explainer = forwardRef<HTMLDivElement, ExplainerProps>(
         </div>
       </FocusScope>
     );
-  }
+  },
 );

--- a/frontend/src/components/dashboard/tips/Tips.tsx
+++ b/frontend/src/components/dashboard/tips/Tips.tsx
@@ -86,7 +86,7 @@ export const Tips = (props: Props) => {
 
   // If the user has Premium, show a tip about how to claim a custom subdomain:
   const customAliasDismissal = useLocalDismissal(
-    `tips_customAlias_${props.profile.id}`
+    `tips_customAlias_${props.profile.id}`,
   );
   const customMaskTip = {
     id: "custom-subdomain",
@@ -242,7 +242,7 @@ const TipsCarousel = (props: Parameters<typeof useTabListState>[0]) => {
   const { tabListProps } = useTabList(
     { ...props, orientation: "horizontal" },
     tabListState,
-    tabListRef
+    tabListRef,
   );
 
   const tipSwitcher =
@@ -283,7 +283,7 @@ const PanelDot = (props: PanelDotProps) => {
   const { tabProps } = useTab(
     { key: props.item.key },
     props.tabListState,
-    dotRef
+    dotRef,
   );
   const isSelected = props.tabListState.selectedKey === props.item.key;
   const alt = l10n.getString("tips-switcher-label", {
@@ -340,7 +340,7 @@ const TipPanel = ({
       panelRef.current = element;
       inViewRef(element);
     },
-    [inViewRef]
+    [inViewRef],
   );
 
   const { tabPanelProps } = useTabPanel(
@@ -350,7 +350,7 @@ const TipPanel = ({
     // but because we're using a MutableRefObject (due to useGaViewPing, by
     // virtue of its use of useInView, not accepting an existing Ref), we need
     // to explicitly tell it that that, too, is a Ref:
-    panelRef as RefObject<HTMLDivElement>
+    panelRef as RefObject<HTMLDivElement>,
   );
 
   return (

--- a/frontend/src/components/landing/BundleBanner.tsx
+++ b/frontend/src/components/landing/BundleBanner.tsx
@@ -136,7 +136,7 @@ export const BundleBanner = (props: Props) => {
                 onClick={() =>
                   trackPlanPurchaseStart(
                     { plan: "bundle" },
-                    { label: "bundle-banner-upgrade-promo" }
+                    { label: "bundle-banner-upgrade-promo" },
                   )
                 }
               >

--- a/frontend/src/components/landing/DemoPhone.tsx
+++ b/frontend/src/components/landing/DemoPhone.tsx
@@ -25,7 +25,7 @@ export const DemoPhone = (props: Props) => {
 
   const getScreenshotImage = (
     isPremium: boolean,
-    lang: string
+    lang: string,
   ): StaticImageData => {
     if (lang === "fr") {
       return PremiumScreenshotFr;

--- a/frontend/src/components/landing/FaqAccordion.tsx
+++ b/frontend/src/components/landing/FaqAccordion.tsx
@@ -18,7 +18,7 @@ export type Props = {
  */
 export const FaqAccordionItem = (props: Props) => {
   const [expandedIndex, setExpandedIndex] = useState(
-    props.defaultExpandedIndex ?? 0
+    props.defaultExpandedIndex ?? 0,
   );
   const { autoFocus } = props;
 

--- a/frontend/src/components/landing/HighlightedFeatures.tsx
+++ b/frontend/src/components/landing/HighlightedFeatures.tsx
@@ -40,13 +40,13 @@ export const HighlightedFeatures = () => {
             )}
             <h3 className={styles["highlighted-feature-headline"]}>
               {l10n.getString(
-                `highlighted-features-section-${props.name}-headline`
+                `highlighted-features-section-${props.name}-headline`,
               )}
             </h3>
             <p className={styles["highlighted-feature-body"]}>
               {l10n.getString(
                 `highlighted-features-section-${props.name}-body`,
-                variables
+                variables,
               )}
             </p>
           </>

--- a/frontend/src/components/landing/PlanMatrix.tsx
+++ b/frontend/src/components/landing/PlanMatrix.tsx
@@ -186,11 +186,11 @@ export const PlanMatrix = (props: Props) => {
                   monthly_price: getPeriodicalPremiumPrice(
                     props.runtimeData,
                     "monthly",
-                    l10n
+                    l10n,
                   ),
                   subscribeLink: getPeriodicalPremiumSubscribeLink(
                     props.runtimeData,
-                    "monthly"
+                    "monthly",
                   ),
                   gaViewPing: {
                     category: "Purchase monthly Premium button",
@@ -205,11 +205,11 @@ export const PlanMatrix = (props: Props) => {
                   monthly_price: getPeriodicalPremiumPrice(
                     props.runtimeData,
                     "yearly",
-                    l10n
+                    l10n,
                   ),
                   subscribeLink: getPeriodicalPremiumSubscribeLink(
                     props.runtimeData,
-                    "yearly"
+                    "yearly",
                   ),
                   gaViewPing: {
                     category: "Purchase yearly Premium button",
@@ -253,11 +253,11 @@ export const PlanMatrix = (props: Props) => {
                   monthly_price: getPhonesPrice(
                     props.runtimeData,
                     "monthly",
-                    l10n
+                    l10n,
                   ),
                   subscribeLink: getPhoneSubscribeLink(
                     props.runtimeData,
-                    "monthly"
+                    "monthly",
                   ),
                   gaViewPing: {
                     category: "Purchase monthly Premium+phones button",
@@ -272,11 +272,11 @@ export const PlanMatrix = (props: Props) => {
                   monthly_price: getPhonesPrice(
                     props.runtimeData,
                     "yearly",
-                    l10n
+                    l10n,
                   ),
                   subscribeLink: getPhoneSubscribeLink(
                     props.runtimeData,
-                    "yearly"
+                    "yearly",
                   ),
                   gaViewPing: {
                     category: "Purchase yearly Premium+phones button",
@@ -304,7 +304,7 @@ export const PlanMatrix = (props: Props) => {
                   </Link>
                   <small>
                     {l10n.getString(
-                      "plan-matrix-price-period-monthly-footnote-1"
+                      "plan-matrix-price-period-monthly-footnote-1",
                     )}
                   </small>
                 </div>
@@ -343,7 +343,7 @@ export const PlanMatrix = (props: Props) => {
                     onClick={() =>
                       trackPlanPurchaseStart(
                         { plan: "bundle" },
-                        { label: "plan-matrix-bundle-cta-desktop" }
+                        { label: "plan-matrix-bundle-cta-desktop" },
                       )
                     }
                     className={styles["pick-button"]}
@@ -352,7 +352,7 @@ export const PlanMatrix = (props: Props) => {
                   </a>
                   <small>
                     {l10n.getString(
-                      "plan-matrix-price-period-yearly-footnote-1"
+                      "plan-matrix-price-period-yearly-footnote-1",
                     )}
                   </small>
                 </div>
@@ -373,7 +373,7 @@ export const PlanMatrix = (props: Props) => {
                   </Link>
                   <small>
                     {l10n.getString(
-                      "plan-matrix-price-period-monthly-footnote-1"
+                      "plan-matrix-price-period-monthly-footnote-1",
                     )}
                   </small>
                 </div>
@@ -416,11 +416,11 @@ export const PlanMatrix = (props: Props) => {
                 monthly_price: getPeriodicalPremiumPrice(
                   props.runtimeData,
                   "monthly",
-                  l10n
+                  l10n,
                 ),
                 subscribeLink: getPeriodicalPremiumSubscribeLink(
                   props.runtimeData,
-                  "monthly"
+                  "monthly",
                 ),
                 gaViewPing: {
                   category: "Purchase monthly Premium button",
@@ -435,11 +435,11 @@ export const PlanMatrix = (props: Props) => {
                 monthly_price: getPeriodicalPremiumPrice(
                   props.runtimeData,
                   "yearly",
-                  l10n
+                  l10n,
                 ),
                 subscribeLink: getPeriodicalPremiumSubscribeLink(
                   props.runtimeData,
-                  "yearly"
+                  "yearly",
                 ),
                 gaViewPing: {
                   category: "Purchase yearly Premium button",
@@ -478,11 +478,11 @@ export const PlanMatrix = (props: Props) => {
                 monthly_price: getPhonesPrice(
                   props.runtimeData,
                   "monthly",
-                  l10n
+                  l10n,
                 ),
                 subscribeLink: getPhoneSubscribeLink(
                   props.runtimeData,
-                  "monthly"
+                  "monthly",
                 ),
                 gaViewPing: {
                   category: "Purchase monthly Premium+phones button",
@@ -497,11 +497,11 @@ export const PlanMatrix = (props: Props) => {
                 monthly_price: getPhonesPrice(
                   props.runtimeData,
                   "yearly",
-                  l10n
+                  l10n,
                 ),
                 subscribeLink: getPhoneSubscribeLink(
                   props.runtimeData,
-                  "yearly"
+                  "yearly",
                 ),
                 gaViewPing: {
                   category: "Purchase yearly Premium+phones button",
@@ -568,7 +568,7 @@ export const PlanMatrix = (props: Props) => {
                   onClick={() =>
                     trackPlanPurchaseStart(
                       { plan: "bundle" },
-                      { label: "plan-matrix-bundle-cta-mobile" }
+                      { label: "plan-matrix-bundle-cta-mobile" },
                     )
                   }
                   className={styles["pick-button"]}
@@ -664,7 +664,7 @@ const MobileFeatureList = (props: MobileFeatureListProps) => {
   const lis = Object.entries(props.list)
     .filter(
       ([_feature, availability]) =>
-        typeof availability !== "boolean" || availability
+        typeof availability !== "boolean" || availability,
     )
     .map(([feature, availability]) => {
       const variables =

--- a/frontend/src/components/landing/Reviews.tsx
+++ b/frontend/src/components/landing/Reviews.tsx
@@ -37,14 +37,14 @@ export const Reviews = () => {
 
   const slideLeftButton = useButton(
     { onPress: () => scrollReview(currentReview, userReviews, "right") },
-    slideLeftButtonRef
+    slideLeftButtonRef,
   );
 
   const slideRightButtonRef = useRef<HTMLButtonElement>(null);
 
   const slideRightButton = useButton(
     { onPress: () => scrollReview(currentReview, userReviews, "left") },
-    slideRightButtonRef
+    slideRightButtonRef,
   );
 
   // Get initial user position on touch
@@ -110,7 +110,7 @@ export const Reviews = () => {
   const scrollReview = (
     count: number,
     reviews: UserReview[],
-    direction: Direction
+    direction: Direction,
   ): void => {
     if (direction === "right") {
       setCurrentReview(count < reviews.length - 1 ? count + 1 : 0);
@@ -131,7 +131,7 @@ export const Reviews = () => {
         <StarIcon className={styles.star} key={index} alt="" />
       ) : (
         <StarIcon className={styles["empty-star"]} key={index} alt="" />
-      )
+      ),
     );
 
   // Render a bulleted list if review is an array of strings.
@@ -224,7 +224,7 @@ export const Reviews = () => {
               {...slideRightButton.buttonProps}
               ref={slideRightButtonRef}
               aria-label={l10n.getString(
-                "landing-reviews-show-previous-button"
+                "landing-reviews-show-previous-button",
               )}
               className={`${styles.chevron} ${styles["hidden-mobile"]}`}
             >
@@ -248,7 +248,7 @@ export const Reviews = () => {
               {...slideRightButton.buttonProps}
               ref={slideRightButtonRef}
               aria-label={l10n.getString(
-                "landing-reviews-show-previous-button"
+                "landing-reviews-show-previous-button",
               )}
               className={`${styles.chevron}`}
             >

--- a/frontend/src/components/layout/navigation/AppPicker.tsx
+++ b/frontend/src/components/layout/navigation/AppPicker.tsx
@@ -46,7 +46,7 @@ const getProducts = (referringSiteUrl: string) => ({
   monitor: {
     id: "monitor",
     url: `https://monitor.firefox.com/?utm_source=${encodeURIComponent(
-      referringSiteUrl
+      referringSiteUrl,
     )}&utm_medium=referral&utm_campaign=bento&utm_content=desktop`,
     gaLabel: "fx-monitor",
   },
@@ -58,21 +58,21 @@ const getProducts = (referringSiteUrl: string) => ({
   fxDesktop: {
     id: "fxDesktop",
     url: `https://www.mozilla.org/firefox/new/?utm_source=${encodeURIComponent(
-      referringSiteUrl
+      referringSiteUrl,
     )}&utm_medium=referral&utm_campaign=bento&utm_content=desktop`,
     gaLabel: "fx-desktop",
   },
   fxMobile: {
     id: "fxMobile",
     url: `https://www.mozilla.org/firefox/browsers/mobile/?utm_source=${encodeURIComponent(
-      referringSiteUrl
+      referringSiteUrl,
     )}&utm_medium=referral&utm_campaign=bento&utm_content=desktop`,
     gaLabel: "fx-mobile",
   },
   vpn: {
     id: "vpn",
     url: `https://www.mozilla.org/products/vpn/?utm_source=${encodeURIComponent(
-      referringSiteUrl
+      referringSiteUrl,
     )}&utm_medium=referral&utm_campaign=bento&utm_content=desktop`,
     gaLabel: "vpn",
   },
@@ -92,7 +92,7 @@ export const AppPicker = (props: Props) => {
   const products = getProducts(
     typeof document !== "undefined"
       ? document.location.host
-      : "relay.firefox.com"
+      : "relay.firefox.com",
   );
   const linkRefs: Record<
     keyof typeof products,
@@ -205,7 +205,7 @@ export const AppPicker = (props: Props) => {
         <a
           ref={mozillaLinkRef}
           href={`https://www.mozilla.org/?utm_source=${encodeURIComponent(
-            getRuntimeConfig().frontendOrigin
+            getRuntimeConfig().frontendOrigin,
           )}&utm_medium=referral&utm_campaign=bento&utm_content=desktop`}
           className={`${styles["menu-link"]} ${styles["mozilla-link"]}`}
           target="_blank"
@@ -239,7 +239,7 @@ const AppPickerTrigger = ({
   const { menuTriggerProps, menuProps } = useMenuTrigger(
     {},
     appPickerTriggerState,
-    triggerButtonRef
+    triggerButtonRef,
   );
   // `menuProps` has an `autoFocus` property that is not compatible with the
   // `autoFocus` property for HTMLElements, because it can also be of type
@@ -257,7 +257,7 @@ const AppPickerTrigger = ({
 
   const triggerButtonProps = useButton(
     menuTriggerProps,
-    triggerButtonRef
+    triggerButtonRef,
   ).buttonProps;
 
   useEffect(() => {
@@ -321,7 +321,7 @@ const AppPickerPopup = (props: AppPickerPopupProps) => {
       isOpen: true,
       isDismissable: true,
     },
-    overlayRef
+    overlayRef,
   );
 
   // <FocusScope> ensures that focus is restored back to the
@@ -382,7 +382,7 @@ const AppPickerItem = (props: AppPickerItemProps) => {
       onClose: props.onClose,
     },
     props.state,
-    menuItemRef
+    menuItemRef,
   ).menuItemProps;
 
   const [_isFocused, setIsFocused] = useState(false);

--- a/frontend/src/components/layout/navigation/Navigation.test.tsx
+++ b/frontend/src/components/layout/navigation/Navigation.test.tsx
@@ -18,7 +18,7 @@ jest.mock("next/router", () => mockNextRouter);
 jest.mock("react-intersection-observer", () => mockReactIntersectionObsever);
 jest.mock(
   "../../../hooks/fxaFlowTracker.ts",
-  () => mockUseFxaFlowTrackerModule
+  () => mockUseFxaFlowTrackerModule,
 );
 jest.mock("../../../hooks/l10n.ts", () => mockUseL10nModule);
 jest.mock("../../../config.ts", () => mockConfigModule);
@@ -35,7 +35,7 @@ describe("<Navigation>", () => {
         hasPremium={false}
         isLoggedIn={false}
         theme="free"
-      />
+      />,
     );
 
     const landingLink = screen.getByRole("link", {
@@ -52,7 +52,7 @@ describe("<Navigation>", () => {
         hasPremium={false}
         isLoggedIn={true}
         theme="premium"
-      />
+      />,
     );
 
     const emailDashboardLink = screen.getByRole("link", {
@@ -70,7 +70,7 @@ describe("<Navigation>", () => {
         hasPremium={true}
         isLoggedIn={true}
         theme="premium"
-      />
+      />,
     );
 
     const phoneDashboardLink = screen.queryByRole("link", {
@@ -88,7 +88,7 @@ describe("<Navigation>", () => {
         hasPremium={true}
         isLoggedIn={true}
         theme="premium"
-      />
+      />,
     );
 
     const phoneDashboardLink = screen.getByRole("link", {

--- a/frontend/src/components/layout/navigation/SignInButton.tsx
+++ b/frontend/src/components/layout/navigation/SignInButton.tsx
@@ -17,7 +17,7 @@ export const SignInButton = (props: Props): JSX.Element => {
   });
   const signInUrl = getLoginUrl(
     "relay-sign-in-header",
-    signInFxaFlowTracker.flowData
+    signInFxaFlowTracker.flowData,
   );
 
   return (

--- a/frontend/src/components/layout/navigation/SignUpButton.tsx
+++ b/frontend/src/components/layout/navigation/SignUpButton.tsx
@@ -16,7 +16,7 @@ export const SignUpButton = (props: Props): JSX.Element => {
   });
   const signUpUrl = getLoginUrl(
     "relay-sign-up-header",
-    signUpFxaFlowTracker.flowData
+    signUpFxaFlowTracker.flowData,
   );
 
   return (

--- a/frontend/src/components/layout/navigation/UserMenu.tsx
+++ b/frontend/src/components/layout/navigation/UserMenu.tsx
@@ -221,7 +221,7 @@ const UserMenuTrigger = ({
   const { menuTriggerProps, menuProps } = useMenuTrigger(
     {},
     userMenuTriggerState,
-    triggerButtonRef
+    triggerButtonRef,
   );
   // `menuProps` has an `autoFocus` property that is not compatible with the
   // `autoFocus` property for HTMLElements, because it can also be of type
@@ -239,7 +239,7 @@ const UserMenuTrigger = ({
 
   const triggerButtonProps = useButton(
     menuTriggerProps,
-    triggerButtonRef
+    triggerButtonRef,
   ).buttonProps;
 
   return (
@@ -285,7 +285,7 @@ const UserMenuPopup = (props: UserMenuPopupProps) => {
       isOpen: true,
       isDismissable: true,
     },
-    overlayRef
+    overlayRef,
   );
 
   // <FocusScope> ensures that focus is restored back to the
@@ -340,7 +340,7 @@ const UserMenuItem = (props: UserMenuItemProps) => {
       onClose: props.onClose,
     },
     props.state,
-    menuItemRef
+    menuItemRef,
   ).menuItemProps;
 
   const [_isFocused, setIsFocused] = useState(false);

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewContent.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewContent.tsx
@@ -72,7 +72,7 @@ export type WhatsNewComponentContentProps = {
  * Content of a "What's New" entry with a component as the hero
  */
 export const WhatsNewComponentContent = (
-  props: WhatsNewComponentContentProps
+  props: WhatsNewComponentContentProps,
 ) => {
   return (
     <div className={styles.wrapper}>

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.test.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.test.tsx
@@ -14,7 +14,7 @@ jest.mock("../../../../hooks/l10n.ts", () => mockUseL10nModule);
 
 function getMockEntry(
   id: number,
-  options: { expired?: boolean; dismissed?: boolean } = {}
+  options: { expired?: boolean; dismissed?: boolean } = {},
 ): WhatsNewEntry {
   const subtractTime = options.expired ? 30 * 24 * 60 * 60 * 1000 + 1 : 0;
   const annDate = new Date(Date.now() - subtractTime);
@@ -53,7 +53,7 @@ describe("The 'What's new' dashboard", () => {
         new={newEntries}
         archive={allEntries}
         onClose={jest.fn()}
-      />
+      />,
     );
 
     const menuItems = screen.getAllByRole("menuitem");
@@ -74,7 +74,7 @@ describe("The 'What's new' dashboard", () => {
         new={newEntries}
         archive={allEntries}
         onClose={jest.fn()}
-      />
+      />,
     );
 
     expect(screen.getAllByRole("menuitem")).toHaveLength(2);
@@ -82,7 +82,7 @@ describe("The 'What's new' dashboard", () => {
     const tabs = screen.getAllByRole("tab");
     expect(tabs).toHaveLength(2);
     expect(tabs[1]).toHaveTextContent(
-      "l10n string: [whatsnew-tab-archive-label], with vars: {}"
+      "l10n string: [whatsnew-tab-archive-label], with vars: {}",
     );
 
     await userEvent.click(tabs[1]);
@@ -103,7 +103,7 @@ describe("The 'What's new' dashboard", () => {
         new={newEntries}
         archive={allEntries}
         onClose={jest.fn()}
-      />
+      />,
     );
 
     const menuItems = screen.getAllByRole("menuitem");
@@ -125,7 +125,7 @@ describe("The 'What's new' dashboard", () => {
         new={newEntries}
         archive={allEntries}
         onClose={jest.fn()}
-      />
+      />,
     );
 
     const clearAllButton = screen.getByRole("button", {
@@ -150,7 +150,7 @@ describe("The 'What's new' dashboard", () => {
         new={newEntries}
         archive={allEntries}
         onClose={jest.fn()}
-      />
+      />,
     );
 
     expect(screen.queryByText(allEntries[1].content)).not.toBeInTheDocument();
@@ -174,7 +174,7 @@ describe("The 'What's new' dashboard", () => {
         new={newEntries}
         archive={allEntries}
         onClose={jest.fn()}
-      />
+      />,
     );
 
     expect(screen.queryByText(allEntries[1]?.content)).not.toBeInTheDocument();
@@ -205,11 +205,11 @@ describe("The 'What's new' dashboard", () => {
         new={newEntries}
         archive={allEntries}
         onClose={jest.fn()}
-      />
+      />,
     );
 
     expect(
-      screen.getByText("l10n string: [whatsnew-empty-message], with vars: {}")
+      screen.getByText("l10n string: [whatsnew-empty-message], with vars: {}"),
     ).toBeInTheDocument();
   });
 
@@ -226,7 +226,7 @@ describe("The 'What's new' dashboard", () => {
         new={newEntries}
         archive={allEntries}
         onClose={jest.fn()}
-      />
+      />,
     );
 
     const tabs = screen.getAllByRole("tab");
@@ -259,7 +259,7 @@ describe("The 'What's new' dashboard", () => {
         new={newEntries}
         archive={allEntries}
         onClose={jest.fn()}
-      />
+      />,
     );
 
     const menuItems = screen.getAllByRole("menuitem");
@@ -286,7 +286,7 @@ describe("The 'What's new' dashboard", () => {
         new={newEntries}
         archive={allEntries}
         onClose={jest.fn()}
-      />
+      />,
     );
 
     const menuItems = screen.getAllByRole("menuitem");
@@ -318,7 +318,7 @@ describe("The 'What's new' dashboard", () => {
         new={newEntries}
         archive={allEntries}
         onClose={jest.fn()}
-      />
+      />,
     );
 
     const clearAllButton = screen.getByRole("button", {

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewList.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewList.tsx
@@ -31,12 +31,12 @@ export const WhatsNewList = (props: Props) => {
       aria-label={props["aria-label"]}
       onSelect={(key) => {
         const selectedItem = props.entries.find(
-          (entry) => encodeURI(entry.title) === key
+          (entry) => encodeURI(entry.title) === key,
         );
         /* istanbul ignore if [Types can't represent that a `selectedItem` should always be found, but it should.] */
         if (!selectedItem) {
           console.error(
-            `WhatsNewListMenu.onSelect: [${key}] not found in the contained Items.`
+            `WhatsNewListMenu.onSelect: [${key}] not found in the contained Items.`,
           );
           return;
         }
@@ -64,7 +64,7 @@ const WhatsNewListMenu = (props: WhatsNewListMenuProps) => {
   const { menuProps } = useMenu(
     { selectionMode: "single", ...props },
     menuState,
-    menuRef
+    menuRef,
   );
 
   return (
@@ -100,7 +100,7 @@ const WhatsNewListMenuItem = (props: WhatsNewListMenuItemProps) => {
       onAction: () => props.onSelect(),
     },
     props.state,
-    menuItemRef
+    menuItemRef,
   );
 
   return (

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -145,7 +145,7 @@ export const WhatsNewMenu = (props: Props) => {
             {
               size: 10,
               unit: "MB",
-            }
+            },
           )}
           heading={l10n.getString("whatsnew-feature-size-limit-heading")}
           image={SizeLimitHero}
@@ -161,7 +161,7 @@ export const WhatsNewMenu = (props: Props) => {
       ),
       icon: SizeLimitIcon,
       dismissal: useLocalDismissal(
-        `whatsnew-feature_size-limit_${props.profile.id}`
+        `whatsnew-feature_size-limit_${props.profile.id}`,
       ),
       announcementDate: {
         year: 2022,
@@ -177,7 +177,7 @@ export const WhatsNewMenu = (props: Props) => {
     content: (
       <WhatsNewContent
         description={l10n.getString(
-          "whatsnew-feature-forward-some-description"
+          "whatsnew-feature-forward-some-description",
         )}
         heading={l10n.getString("whatsnew-feature-forward-some-heading")}
         image={ForwardSomeHero}
@@ -185,7 +185,7 @@ export const WhatsNewMenu = (props: Props) => {
     ),
     icon: ForwardSomeIcon,
     dismissal: useLocalDismissal(
-      `whatsnew-feature_sign-back-in_${props.profile.id}`
+      `whatsnew-feature_sign-back-in_${props.profile.id}`,
     ),
     announcementDate: {
       year: 2022,
@@ -203,7 +203,7 @@ export const WhatsNewMenu = (props: Props) => {
     content: (
       <WhatsNewContent
         description={l10n.getString(
-          "whatsnew-feature-sign-back-in-description"
+          "whatsnew-feature-sign-back-in-description",
         )}
         heading={l10n.getString("whatsnew-feature-sign-back-in-heading")}
         image={SignBackInHero}
@@ -211,7 +211,7 @@ export const WhatsNewMenu = (props: Props) => {
     ),
     icon: SignBackInIcon,
     dismissal: useLocalDismissal(
-      `whatsnew-feature_sign-back-in_${props.profile.id}`
+      `whatsnew-feature_sign-back-in_${props.profile.id}`,
     ),
     announcementDate: {
       year: 2022,
@@ -229,7 +229,7 @@ export const WhatsNewMenu = (props: Props) => {
     content: (
       <WhatsNewContent
         description={l10n.getString(
-          "whatsnew-feature-alias-to-mask-description"
+          "whatsnew-feature-alias-to-mask-description",
         )}
         heading={l10n.getString("whatsnew-feature-alias-to-mask-heading")}
         image={aliasToMaskHero}
@@ -237,7 +237,7 @@ export const WhatsNewMenu = (props: Props) => {
     ),
     icon: aliasToMaskIcon,
     dismissal: useLocalDismissal(
-      `whatsnew-feature_alias-to-mask_${props.profile.id}`
+      `whatsnew-feature_alias-to-mask_${props.profile.id}`,
     ),
     announcementDate: {
       year: 2022,
@@ -275,17 +275,17 @@ export const WhatsNewMenu = (props: Props) => {
     content: (
       <WhatsNewContent
         description={l10n.getString(
-          "whatsnew-feature-premium-expansion-description"
+          "whatsnew-feature-premium-expansion-description",
         )}
         heading={l10n.getString(
-          "whatsnew-feature-premium-expansion-sweden-heading"
+          "whatsnew-feature-premium-expansion-sweden-heading",
         )}
         image={PremiumSwedenHero}
       />
     ),
     icon: PremiumSwedenIcon,
     dismissal: useLocalDismissal(
-      `whatsnew-feature_premium-expansion-sweden_${props.profile.id}`
+      `whatsnew-feature_premium-expansion-sweden_${props.profile.id}`,
     ),
     announcementDate: {
       year: 2022,
@@ -307,17 +307,17 @@ export const WhatsNewMenu = (props: Props) => {
     content: (
       <WhatsNewContent
         description={l10n.getString(
-          "whatsnew-feature-premium-expansion-description"
+          "whatsnew-feature-premium-expansion-description",
         )}
         heading={l10n.getString(
-          "whatsnew-feature-premium-expansion-finland-heading"
+          "whatsnew-feature-premium-expansion-finland-heading",
         )}
         image={PremiumFinlandHero}
       />
     ),
     icon: PremiumFinlandIcon,
     dismissal: useLocalDismissal(
-      `whatsnew-feature_premium-expansion-finland_${props.profile.id}`
+      `whatsnew-feature_premium-expansion-finland_${props.profile.id}`,
     ),
     announcementDate: {
       year: 2022,
@@ -339,10 +339,10 @@ export const WhatsNewMenu = (props: Props) => {
     content: (
       <WhatsNewContent
         description={l10n.getString(
-          "whatsnew-feature-premium-expansion-eu-description"
+          "whatsnew-feature-premium-expansion-eu-description",
         )}
         heading={l10n.getString(
-          "whatsnew-feature-premium-expansion-eu-heading"
+          "whatsnew-feature-premium-expansion-eu-heading",
         )}
         image={PremiumEuExpansionHero}
         cta={
@@ -356,7 +356,7 @@ export const WhatsNewMenu = (props: Props) => {
     ),
     icon: PremiumEuExpansionIcon,
     dismissal: useLocalDismissal(
-      `whatsnew-feature_premium-expansion-eu_2023_${props.profile.id}`
+      `whatsnew-feature_premium-expansion-eu_2023_${props.profile.id}`,
     ),
     announcementDate: {
       year: 2023,
@@ -387,7 +387,7 @@ export const WhatsNewMenu = (props: Props) => {
       "si",
       "sk",
     ].includes(
-      props.runtimeData.PERIODICAL_PREMIUM_PLANS.country_code.toLowerCase()
+      props.runtimeData.PERIODICAL_PREMIUM_PLANS.country_code.toLowerCase(),
     )
   ) {
     entries.push(premiumEuExpansion);
@@ -399,7 +399,7 @@ export const WhatsNewMenu = (props: Props) => {
     content: (
       <WhatsNewContent
         description={l10n.getString(
-          "whatsnew-feature-tracker-removal-description-2"
+          "whatsnew-feature-tracker-removal-description-2",
         )}
         heading={l10n.getString("whatsnew-feature-tracker-removal-heading")}
         image={TrackerRemovalHero}
@@ -407,7 +407,7 @@ export const WhatsNewMenu = (props: Props) => {
     ),
     icon: TrackerRemovalIcon,
     dismissal: useLocalDismissal(
-      `whatsnew-feature_tracker-removal_${props.profile.id}`
+      `whatsnew-feature_tracker-removal_${props.profile.id}`,
     ),
     announcementDate: {
       year: 2022,
@@ -435,7 +435,7 @@ export const WhatsNewMenu = (props: Props) => {
       <WhatsNewComponentContent
         description={l10n.getString(
           "whatsnew-feature-offer-countdown-description",
-          { end_date: endDateFormatter.format(introPricingOfferEndDate) }
+          { end_date: endDateFormatter.format(introPricingOfferEndDate) },
         )}
         heading={l10n.getString("whatsnew-feature-offer-countdown-heading")}
         hero={
@@ -447,7 +447,7 @@ export const WhatsNewMenu = (props: Props) => {
     ),
     icon: OfferCountdownIcon,
     dismissal: useLocalDismissal(
-      `whatsnew-feature_offer-countdown_${props.profile.id}`
+      `whatsnew-feature_offer-countdown_${props.profile.id}`,
     ),
     announcementDate: {
       year: 2022,
@@ -560,7 +560,7 @@ export const WhatsNewMenu = (props: Props) => {
     content: (
       <WhatsNewContent
         description={l10n.getString(
-          "whatsnew-feature-firefox-integration-description"
+          "whatsnew-feature-firefox-integration-description",
         )}
         heading={l10n.getString("whatsnew-feature-firefox-integration-heading")}
         image={FirefoxIntegrationHero}
@@ -568,7 +568,7 @@ export const WhatsNewMenu = (props: Props) => {
     ),
     icon: FirefoxIntegrationIcon,
     dismissal: useLocalDismissal(
-      `whatsnew-feature_firefox-integration_${props.profile.id}`
+      `whatsnew-feature_firefox-integration_${props.profile.id}`,
     ),
     // Week after release of Firefox 111 (to ensure it was rolled out to everyone)
     announcementDate: {
@@ -590,7 +590,7 @@ export const WhatsNewMenu = (props: Props) => {
     content: (
       <WhatsNewContent
         description={l10n.getString(
-          "whatsnew-feature-mailing-list-description"
+          "whatsnew-feature-mailing-list-description",
         )}
         heading={l10n.getString("whatsnew-feature-mailing-list-heading")}
         image={MailingListHero}
@@ -607,7 +607,7 @@ export const WhatsNewMenu = (props: Props) => {
     ),
     icon: MailingListIcon,
     dismissal: useLocalDismissal(
-      `whatsnew-feature_mailing-list_${props.profile.id}`
+      `whatsnew-feature_mailing-list_${props.profile.id}`,
     ),
     announcementDate: {
       year: 2023,
@@ -625,8 +625,8 @@ export const WhatsNewMenu = (props: Props) => {
       Date.UTC(
         entry.announcementDate.year,
         entry.announcementDate.month - 1,
-        entry.announcementDate.day
-      )
+        entry.announcementDate.day,
+      ),
     );
     // Filter out entries that are in the future:
     return entryDate.getTime() <= Date.now();
@@ -638,8 +638,8 @@ export const WhatsNewMenu = (props: Props) => {
       Date.UTC(
         entry.announcementDate.year,
         entry.announcementDate.month - 1,
-        entry.announcementDate.day
-      )
+        entry.announcementDate.day,
+      ),
     );
     const ageInMilliSeconds = Date.now() - entryDate.getTime();
     // Automatically move entries to the archive after 30 days:
@@ -650,7 +650,7 @@ export const WhatsNewMenu = (props: Props) => {
   const { triggerProps, overlayProps } = useOverlayTrigger(
     { type: "dialog" },
     triggerState,
-    triggerRef
+    triggerRef,
   );
 
   const positionProps = useOverlayPosition({
@@ -733,21 +733,21 @@ const WhatsNewPopover = forwardRef<HTMLDivElement, PopoverProps>(
         isOpen: isOpen,
         isDismissable: true,
       },
-      ref as RefObject<HTMLDivElement>
+      ref as RefObject<HTMLDivElement>,
     );
 
     const { modalProps } = useModal();
 
     const { dialogProps, titleProps } = useDialog(
       {},
-      ref as RefObject<HTMLDivElement>
+      ref as RefObject<HTMLDivElement>,
     );
 
     const mergedOverlayProps = mergeProps(
       overlayProps,
       dialogProps,
       otherProps,
-      modalProps
+      modalProps,
     );
 
     return (
@@ -769,13 +769,13 @@ const WhatsNewPopover = forwardRef<HTMLDivElement, PopoverProps>(
         </div>
       </FocusScope>
     );
-  }
+  },
 );
 WhatsNewPopover.displayName = "WhatsNewPopover";
 
 const entriesDescByDateSorter: Parameters<Array<WhatsNewEntry>["sort"]>[0] = (
   entryA,
-  entryB
+  entryB,
 ) => {
   const dateANr =
     entryA.announcementDate.year +

--- a/frontend/src/components/layout/topmessage/CsatSurvey.test.tsx
+++ b/frontend/src/components/layout/topmessage/CsatSurvey.test.tsx
@@ -57,14 +57,14 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../hooks/firstSeen.ts") as any).useFirstSeen;
     useFirstSeen.mockReturnValueOnce(
-      new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+      new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
     );
     const getCookie: jest.Mock =
       // TypeScript can't follow paths in `jest.requireMock`:
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../functions/cookies.ts") as any).getCookie;
     getCookie.mockImplementation((key: string) =>
-      key.includes("free-7days") ? Date.now() : undefined
+      key.includes("free-7days") ? Date.now() : undefined,
     );
     const mockProfileData = getMockProfileData({ has_premium: false });
 
@@ -86,7 +86,7 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../hooks/firstSeen.ts") as any).useFirstSeen;
     useFirstSeen.mockReturnValueOnce(
-      new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+      new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
     );
     const mockProfileData = getMockProfileData({ has_premium: false });
 
@@ -108,14 +108,14 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../hooks/firstSeen.ts") as any).useFirstSeen;
     useFirstSeen.mockReturnValueOnce(
-      new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+      new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
     );
     const getCookie: jest.Mock =
       // TypeScript can't follow paths in `jest.requireMock`:
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../functions/cookies.ts") as any).getCookie;
     getCookie.mockImplementation((key: string) =>
-      key.includes("free-7days") ? Date.now() : undefined
+      key.includes("free-7days") ? Date.now() : undefined,
     );
     const mockProfileData = getMockProfileData({ has_premium: false });
 
@@ -137,14 +137,14 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../hooks/firstSeen.ts") as any).useFirstSeen;
     useFirstSeen.mockReturnValueOnce(
-      new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+      new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
     );
     const getCookie: jest.Mock =
       // TypeScript can't follow paths in `jest.requireMock`:
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../functions/cookies.ts") as any).getCookie;
     getCookie.mockImplementation((key: string) =>
-      key.includes("free-30days") ? Date.now() : undefined
+      key.includes("free-30days") ? Date.now() : undefined,
     );
     const mockProfileData = getMockProfileData({ has_premium: false });
 
@@ -166,7 +166,7 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../hooks/firstSeen.ts") as any).useFirstSeen;
     useFirstSeen.mockReturnValueOnce(
-      new Date(Date.now() - 3 * 30 * 24 * 60 * 60 * 1000)
+      new Date(Date.now() - 3 * 30 * 24 * 60 * 60 * 1000),
     );
     const mockProfileData = getMockProfileData({ has_premium: false });
 
@@ -188,14 +188,14 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../hooks/firstSeen.ts") as any).useFirstSeen;
     useFirstSeen.mockReturnValueOnce(
-      new Date(Date.now() - 3 * 30 * 24 * 60 * 60 * 1000)
+      new Date(Date.now() - 3 * 30 * 24 * 60 * 60 * 1000),
     );
     const getCookie: jest.Mock =
       // TypeScript can't follow paths in `jest.requireMock`:
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../functions/cookies.ts") as any).getCookie;
     getCookie.mockImplementation((key: string) =>
-      key.includes("free-30days") ? Date.now() : undefined
+      key.includes("free-30days") ? Date.now() : undefined,
     );
     const mockProfileData = getMockProfileData({ has_premium: false });
 
@@ -217,14 +217,14 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../hooks/firstSeen.ts") as any).useFirstSeen;
     useFirstSeen.mockReturnValueOnce(
-      new Date(Date.now() - 3 * 30 * 24 * 60 * 60 * 1000)
+      new Date(Date.now() - 3 * 30 * 24 * 60 * 60 * 1000),
     );
     const getCookie: jest.Mock =
       // TypeScript can't follow paths in `jest.requireMock`:
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../functions/cookies.ts") as any).getCookie;
     getCookie.mockImplementation((key: string) =>
-      key.includes("free-7days") ? Date.now() : undefined
+      key.includes("free-7days") ? Date.now() : undefined,
     );
     const mockProfileData = getMockProfileData({ has_premium: false });
 
@@ -246,14 +246,14 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../hooks/firstSeen.ts") as any).useFirstSeen;
     useFirstSeen.mockReturnValueOnce(
-      new Date(Date.now() - 3 * 30 * 24 * 60 * 60 * 1000)
+      new Date(Date.now() - 3 * 30 * 24 * 60 * 60 * 1000),
     );
     const getCookie: jest.Mock =
       // TypeScript can't follow paths in `jest.requireMock`:
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../functions/cookies.ts") as any).getCookie;
     getCookie.mockImplementation((key: string) =>
-      key.includes("free-90days") ? Date.now() : undefined
+      key.includes("free-90days") ? Date.now() : undefined,
     );
     const mockProfileData = getMockProfileData({ has_premium: false });
 
@@ -275,7 +275,7 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../hooks/firstSeen.ts") as any).useFirstSeen;
     useFirstSeen.mockReturnValueOnce(
-      new Date(Date.now() - 6 * 30 * 24 * 60 * 60 * 1001)
+      new Date(Date.now() - 6 * 30 * 24 * 60 * 60 * 1001),
     );
     const getCookie: jest.Mock =
       // TypeScript can't follow paths in `jest.requireMock`:
@@ -284,7 +284,7 @@ describe("The CSAT survey", () => {
     getCookie.mockImplementation((key: string) =>
       key.includes("free-90days")
         ? Date.now() - 3 * 30 * 24 * 60 * 60 * 1001
-        : undefined
+        : undefined,
     );
     const mockProfileData = getMockProfileData({ has_premium: false });
 
@@ -352,7 +352,7 @@ describe("The CSAT survey", () => {
     const mockProfileData = getMockProfileData({
       has_premium: true,
       date_subscribed: new Date(
-        Date.now() - 7 * 24 * 60 * 60 * 1000
+        Date.now() - 7 * 24 * 60 * 60 * 1000,
       ).toISOString(),
     });
 
@@ -375,12 +375,12 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../functions/cookies.ts") as any).getCookie;
     getCookie.mockImplementation((key: string) =>
-      key.includes("premium-7days") ? Date.now() : undefined
+      key.includes("premium-7days") ? Date.now() : undefined,
     );
     const mockProfileData = getMockProfileData({
       has_premium: true,
       date_subscribed: new Date(
-        Date.now() - 7 * 24 * 60 * 60 * 1000
+        Date.now() - 7 * 24 * 60 * 60 * 1000,
       ).toISOString(),
     });
 
@@ -401,7 +401,7 @@ describe("The CSAT survey", () => {
     const mockProfileData = getMockProfileData({
       has_premium: true,
       date_subscribed: new Date(
-        Date.now() - 30 * 24 * 60 * 60 * 1000
+        Date.now() - 30 * 24 * 60 * 60 * 1000,
       ).toISOString(),
     });
 
@@ -424,12 +424,12 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../functions/cookies.ts") as any).getCookie;
     getCookie.mockImplementation((key: string) =>
-      key.includes("premium-7days") ? Date.now() : undefined
+      key.includes("premium-7days") ? Date.now() : undefined,
     );
     const mockProfileData = getMockProfileData({
       has_premium: true,
       date_subscribed: new Date(
-        Date.now() - 30 * 24 * 60 * 60 * 1000
+        Date.now() - 30 * 24 * 60 * 60 * 1000,
       ).toISOString(),
     });
 
@@ -452,12 +452,12 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../functions/cookies.ts") as any).getCookie;
     getCookie.mockImplementation((key: string) =>
-      key.includes("free-30days") ? Date.now() : undefined
+      key.includes("free-30days") ? Date.now() : undefined,
     );
     const mockProfileData = getMockProfileData({
       has_premium: true,
       date_subscribed: new Date(
-        Date.now() - 30 * 24 * 60 * 60 * 1000
+        Date.now() - 30 * 24 * 60 * 60 * 1000,
       ).toISOString(),
     });
 
@@ -480,12 +480,12 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../functions/cookies.ts") as any).getCookie;
     getCookie.mockImplementation((key: string) =>
-      key.includes("premium-30days") ? Date.now() : undefined
+      key.includes("premium-30days") ? Date.now() : undefined,
     );
     const mockProfileData = getMockProfileData({
       has_premium: true,
       date_subscribed: new Date(
-        Date.now() - 30 * 24 * 60 * 60 * 1000
+        Date.now() - 30 * 24 * 60 * 60 * 1000,
       ).toISOString(),
     });
 
@@ -506,7 +506,7 @@ describe("The CSAT survey", () => {
     const mockProfileData = getMockProfileData({
       has_premium: true,
       date_subscribed: new Date(
-        Date.now() - 3 * 30 * 24 * 60 * 60 * 1000
+        Date.now() - 3 * 30 * 24 * 60 * 60 * 1000,
       ).toISOString(),
     });
 
@@ -529,12 +529,12 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../functions/cookies.ts") as any).getCookie;
     getCookie.mockImplementation((key: string) =>
-      key.includes("premium-30days") ? Date.now() : undefined
+      key.includes("premium-30days") ? Date.now() : undefined,
     );
     const mockProfileData = getMockProfileData({
       has_premium: true,
       date_subscribed: new Date(
-        Date.now() - 3 * 30 * 24 * 60 * 60 * 1000
+        Date.now() - 3 * 30 * 24 * 60 * 60 * 1000,
       ).toISOString(),
     });
 
@@ -557,12 +557,12 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../functions/cookies.ts") as any).getCookie;
     getCookie.mockImplementation((key: string) =>
-      key.includes("premium-7days") ? Date.now() : undefined
+      key.includes("premium-7days") ? Date.now() : undefined,
     );
     const mockProfileData = getMockProfileData({
       has_premium: true,
       date_subscribed: new Date(
-        Date.now() - 3 * 30 * 24 * 60 * 60 * 1000
+        Date.now() - 3 * 30 * 24 * 60 * 60 * 1000,
       ).toISOString(),
     });
 
@@ -585,12 +585,12 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../functions/cookies.ts") as any).getCookie;
     getCookie.mockImplementation((key: string) =>
-      key.includes("free-90days") ? Date.now() : undefined
+      key.includes("free-90days") ? Date.now() : undefined,
     );
     const mockProfileData = getMockProfileData({
       has_premium: true,
       date_subscribed: new Date(
-        Date.now() - 3 * 30 * 24 * 60 * 60 * 1000
+        Date.now() - 3 * 30 * 24 * 60 * 60 * 1000,
       ).toISOString(),
     });
 
@@ -613,12 +613,12 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../functions/cookies.ts") as any).getCookie;
     getCookie.mockImplementation((key: string) =>
-      key.includes("premium-90days") ? Date.now() : undefined
+      key.includes("premium-90days") ? Date.now() : undefined,
     );
     const mockProfileData = getMockProfileData({
       has_premium: true,
       date_subscribed: new Date(
-        Date.now() - 3 * 30 * 24 * 60 * 60 * 1000
+        Date.now() - 3 * 30 * 24 * 60 * 60 * 1000,
       ).toISOString(),
     });
 
@@ -643,12 +643,12 @@ describe("The CSAT survey", () => {
     getCookie.mockImplementation((key: string) =>
       key.includes("premium-90days")
         ? Date.now() - 3 * 30 * 24 * 60 * 60 * 1001
-        : undefined
+        : undefined,
     );
     const mockProfileData = getMockProfileData({
       has_premium: true,
       date_subscribed: new Date(
-        Date.now() - 6 * 30 * 24 * 60 * 60 * 1001
+        Date.now() - 6 * 30 * 24 * 60 * 60 * 1001,
       ).toISOString(),
     });
 
@@ -670,7 +670,7 @@ describe("The CSAT survey", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (jest.requireMock("../../../hooks/firstSeen.ts") as any).useFirstSeen;
     useFirstSeen.mockReturnValueOnce(
-      new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+      new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
     );
     const mockProfileData = getMockProfileData({
       has_premium: true,

--- a/frontend/src/components/layout/topmessage/CsatSurvey.tsx
+++ b/frontend/src/components/layout/topmessage/CsatSurvey.tsx
@@ -44,26 +44,26 @@ type Props = {
  */
 export const CsatSurvey = (props: Props) => {
   const free7DaysDismissal = useLocalDismissal(
-    "csat-survey-free-7days_" + props.profile.id
+    "csat-survey-free-7days_" + props.profile.id,
   );
   const free30DaysDismissal = useLocalDismissal(
-    "csat-survey-free-30days_" + props.profile.id
+    "csat-survey-free-30days_" + props.profile.id,
   );
   const free90DaysDismissal = useLocalDismissal(
     "csat-survey-free-90days_" + props.profile.id,
     // After the third month, show every three months:
-    { duration: 90 * 24 * 60 * 60 }
+    { duration: 90 * 24 * 60 * 60 },
   );
   const premium7DaysDismissal = useLocalDismissal(
-    "csat-survey-premium-7days_" + props.profile.id
+    "csat-survey-premium-7days_" + props.profile.id,
   );
   const premium30DaysDismissal = useLocalDismissal(
-    "csat-survey-premium-30days_" + props.profile.id
+    "csat-survey-premium-30days_" + props.profile.id,
   );
   const premium90DaysDismissal = useLocalDismissal(
     "csat-survey-premium-90days_" + props.profile.id,
     // After the third month, show every three months:
-    { duration: 90 * 24 * 60 * 60 }
+    { duration: 90 * 24 * 60 * 60 },
   );
   const firstSeen = useFirstSeen();
   const l10n = useL10n();
@@ -183,7 +183,7 @@ export const CsatSurvey = (props: Props) => {
       // Metric 12 in Google Analytics is "CSAT Satisfaction Value",
       // i.e. it tracks where users are Satisfied, Neutral or Dissatisfied:
       metric12: getNumericValueOfSatisfactionCategory(
-        getCategoryOfSatisfaction(satisfaction)
+        getCategoryOfSatisfaction(satisfaction),
       ),
     });
   };
@@ -271,7 +271,7 @@ export const CsatSurvey = (props: Props) => {
 };
 
 function getNumericValueOfSatisfaction(
-  satisfaction: keyof SurveyLinks
+  satisfaction: keyof SurveyLinks,
 ): 1 | 2 | 3 | 4 | 5 {
   switch (satisfaction) {
     case "Very Dissatisfied":
@@ -289,7 +289,7 @@ function getNumericValueOfSatisfaction(
 
 type SatisfactionCategory = "Dissatisfied" | "Neutral" | "Satisfied";
 function getCategoryOfSatisfaction(
-  satisfaction: keyof SurveyLinks
+  satisfaction: keyof SurveyLinks,
 ): SatisfactionCategory {
   switch (satisfaction) {
     case "Very Dissatisfied":
@@ -304,7 +304,7 @@ function getCategoryOfSatisfaction(
 }
 
 function getNumericValueOfSatisfactionCategory(
-  satisfactionCategory: SatisfactionCategory
+  satisfactionCategory: SatisfactionCategory,
 ): -1 | 0 | 1 {
   switch (satisfactionCategory) {
     case "Dissatisfied":

--- a/frontend/src/components/layout/topmessage/NpsSurvey.tsx
+++ b/frontend/src/components/layout/topmessage/NpsSurvey.tsx
@@ -16,7 +16,7 @@ export const NpsSurvey = () => {
   const profileData = useProfiles();
   const dismissal = useLocalDismissal(
     "nps-survey_" + profileData.data?.[0].id,
-    { duration: 30 * 24 * 60 * 60 }
+    { duration: 30 * 24 * 60 * 60 },
   );
   const firstSeen = useFirstSeen();
   const isLoggedIn = useIsLoggedIn();

--- a/frontend/src/components/layout/topmessage/TopMessage.tsx
+++ b/frontend/src/components/layout/topmessage/TopMessage.tsx
@@ -27,7 +27,7 @@ export const TopMessage = (props: Props) => {
     // ...the user is from the US, and...
     ["us"].includes(
       props.runtimeData?.PERIODICAL_PREMIUM_PLANS.country_code ??
-        "not the user's country"
+        "not the user's country",
     ) &&
     // ...the user speaks English:
     getLocale(l10n).split("-")[0] === "en"
@@ -44,7 +44,7 @@ export const TopMessage = (props: Props) => {
     props.profile.has_phone &&
     // ...the user is from the US or Canada, and...
     ["us", "ca"].includes(
-      props.runtimeData?.PHONE_PLANS.country_code ?? "not the user's country"
+      props.runtimeData?.PHONE_PLANS.country_code ?? "not the user's country",
     ) &&
     // ...the user speaks English:
     getLocale(l10n).split("-")[0] === "en"

--- a/frontend/src/components/phones/dashboard/PhoneDashboard.tsx
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.tsx
@@ -96,7 +96,7 @@ export const PhoneDashboard = (props: Props) => {
   const forwardToggleButtonProps = useToggleButton(
     {},
     forwardToggleState,
-    forwardToggleButtonRef
+    forwardToggleButtonRef,
   ).buttonProps;
 
   const copyPhoneNumber: MouseEventHandler<HTMLButtonElement> = () => {
@@ -172,10 +172,10 @@ export const PhoneDashboard = (props: Props) => {
           title={
             forwardToggleState.isSelected
               ? l10n.getString(
-                  "phone-dashboard-forwarding-toggle-disable-tooltip"
+                  "phone-dashboard-forwarding-toggle-disable-tooltip",
                 )
               : l10n.getString(
-                  "phone-dashboard-forwarding-toggle-enable-tooltip"
+                  "phone-dashboard-forwarding-toggle-enable-tooltip",
                 )
           }
         >

--- a/frontend/src/components/phones/dashboard/PhoneWelcomeView.tsx
+++ b/frontend/src/components/phones/dashboard/PhoneWelcomeView.tsx
@@ -120,11 +120,11 @@ export const PhoneWelcomeView = (props: PhoneWelcomePageProps) => {
                     await props.onRequestContactCard();
                     toast(
                       l10n.getString(
-                        "phone-banner-resend-welcome-sms-toast-msg"
+                        "phone-banner-resend-welcome-sms-toast-msg",
                       ),
                       {
                         type: "success",
-                      }
+                      },
                     );
                     props.dismissal.resendSMS.dismiss();
                   }}
@@ -136,7 +136,7 @@ export const PhoneWelcomeView = (props: PhoneWelcomePageProps) => {
             </>
           }
           demoHeading={l10n.getString(
-            "phone-masking-splash-save-contact-example"
+            "phone-masking-splash-save-contact-example",
           )}
           demoInput={
             <>
@@ -158,7 +158,7 @@ export const PhoneWelcomeView = (props: PhoneWelcomePageProps) => {
           body={l10n.getString("phone-masking-splash-replies-body")}
           demoHeading={l10n.getString("phone-masking-splash-replies-example")}
           demoInput={l10n.getString(
-            "phone-masking-splash-replies-example-text"
+            "phone-masking-splash-replies-example-text",
           )}
           demoImage={
             <div className={styles["demo-img"]}>

--- a/frontend/src/components/phones/dashboard/SendersPanelView.tsx
+++ b/frontend/src/components/phones/dashboard/SendersPanelView.tsx
@@ -78,7 +78,7 @@ export const SendersPanelView = (props: Props) => {
         (a, b) =>
           // Sort by last sent date
           parseDate(b.last_inbound_date).getTime() -
-          parseDate(a.last_inbound_date).getTime()
+          parseDate(a.last_inbound_date).getTime(),
       )
       .map((data) => {
         return (

--- a/frontend/src/components/phones/onboarding/PurchasePhonesPlan.tsx
+++ b/frontend/src/components/phones/onboarding/PurchasePhonesPlan.tsx
@@ -86,7 +86,7 @@ const PricingToggle = (props: PricingToggleProps) => {
               { plan: "phones", billing_period: "yearly" },
               {
                 label: "phone-onboarding-purchase-yearly-cta",
-              }
+              },
             )
           }
           // tabIndex tells react-aria that this element is focusable
@@ -113,7 +113,7 @@ const PricingToggle = (props: PricingToggleProps) => {
               { plan: "phones", billing_period: "monthly" },
               {
                 label: "phone-onboarding-purchase-monthly-cta",
-              }
+              },
             )
           }
           // tabIndex tells react-aria that this element is focusable

--- a/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
+++ b/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
@@ -28,10 +28,10 @@ type RealPhoneSetupProps = {
 };
 export const RealPhoneSetup = (props: RealPhoneSetupProps) => {
   const phonesPendingVerification = props.unverifiedRealPhones.filter(
-    hasPendingVerification
+    hasPendingVerification,
   );
   const [isEnteringNumber, setIsEnteringNumber] = useState(
-    phonesPendingVerification.length === 0
+    phonesPendingVerification.length === 0,
   );
 
   if (isEnteringNumber || phonesPendingVerification.length === 0) {
@@ -110,7 +110,7 @@ const RealPhoneForm = (props: RealPhoneFormProps) => {
 
     // submit the request for phone verification
     const res = await props.requestPhoneVerification(
-      phoneNumberWithCountryCode
+      phoneNumberWithCountryCode,
     );
 
     /**
@@ -164,7 +164,7 @@ const RealPhoneForm = (props: RealPhoneFormProps) => {
               styles["phone-input"]
             }`}
             placeholder={l10n.getString(
-              "phone-onboarding-step2-input-placeholder"
+              "phone-onboarding-step2-input-placeholder",
             )}
             type="tel"
             autoComplete="tel"
@@ -197,15 +197,15 @@ const RealPhoneVerification = (props: RealPhoneVerificationProps) => {
   const l10n = useL10n();
   const phoneWithMostRecentlySentVerificationCode =
     getPhoneWithMostRecentlySentVerificationCode(
-      props.phonesPendingVerification
+      props.phonesPendingVerification,
     );
   const [verificationCode, setVerificationCode] = useState("");
 
   const verificationSentDate = parseDate(
-    phoneWithMostRecentlySentVerificationCode.verification_sent_date
+    phoneWithMostRecentlySentVerificationCode.verification_sent_date,
   );
   const [remainingTime, setRemainingTime] = useState(
-    getRemainingTime(verificationSentDate, props.maxMinutesToVerify)
+    getRemainingTime(verificationSentDate, props.maxMinutesToVerify),
   );
   /** `undefined` if verification hasn't been attempted yet */
   const [isVerifiedSuccessfully, setIsVerifiedSuccessfully] =
@@ -220,7 +220,7 @@ const RealPhoneVerification = (props: RealPhoneVerificationProps) => {
 
   const onInvalid: FormEventHandler<HTMLInputElement> = (event) => {
     event.currentTarget.setCustomValidity(
-      l10n.getString("phone-onboarding-step3-input-placeholder")
+      l10n.getString("phone-onboarding-step3-input-placeholder"),
     );
   };
 
@@ -232,7 +232,7 @@ const RealPhoneVerification = (props: RealPhoneVerificationProps) => {
       {
         number: phoneWithMostRecentlySentVerificationCode.number,
         verification_code: verificationCode,
-      }
+      },
     );
 
     setIsVerifiedSuccessfully(response.ok);
@@ -240,13 +240,13 @@ const RealPhoneVerification = (props: RealPhoneVerificationProps) => {
 
   const onSendNewCode = async () => {
     props.requestPhoneVerification(
-      phoneWithMostRecentlySentVerificationCode.number
+      phoneWithMostRecentlySentVerificationCode.number,
     );
   };
 
   useInterval(() => {
     setRemainingTime(
-      getRemainingTime(verificationSentDate, props.maxMinutesToVerify)
+      getRemainingTime(verificationSentDate, props.maxMinutesToVerify),
     );
   }, 1000);
 
@@ -310,7 +310,7 @@ const RealPhoneVerification = (props: RealPhoneVerificationProps) => {
           id="phone-onboarding-step3-body"
           vars={{
             phone_number: formatPhone(
-              phoneWithMostRecentlySentVerificationCode.number
+              phoneWithMostRecentlySentVerificationCode.number,
             ),
             remaining_seconds: secondCountdown,
             remaining_minutes: minuteCountdown,
@@ -367,7 +367,7 @@ const RealPhoneVerification = (props: RealPhoneVerificationProps) => {
 
 function getRemainingTime(
   verificationSentTime: Date,
-  maxMinutesToVerify: number
+  maxMinutesToVerify: number,
 ): number {
   const currentTime = new Date().getTime();
   const elapsedTime = currentTime - verificationSentTime.getTime();
@@ -376,7 +376,7 @@ function getRemainingTime(
 }
 
 function getPhoneWithMostRecentlySentVerificationCode(
-  phones: UnverifiedPhone[]
+  phones: UnverifiedPhone[],
 ) {
   const mostRecentVerifiedPhone = [...phones].sort((a, b) => {
     const sendDateA = parseDate(a.verification_sent_date).getTime();

--- a/frontend/src/components/phones/onboarding/RelayNumberConfirmationModal.tsx
+++ b/frontend/src/components/phones/onboarding/RelayNumberConfirmationModal.tsx
@@ -49,7 +49,7 @@ export const RelayNumberConfirmationModal = (props: Props) => {
             disabled={props.relayNumber.length === 0}
           >
             {l10n.getString(
-              "phone-onboarding-step4-button-confirm-relay-number"
+              "phone-onboarding-step4-button-confirm-relay-number",
             )}
           </Button>
         </div>
@@ -64,7 +64,7 @@ type ConfirmationDialogProps = {
   onClose?: () => void;
 };
 const ConfirmationDialog = (
-  props: ConfirmationDialogProps & AriaOverlayProps
+  props: ConfirmationDialogProps & AriaOverlayProps,
 ) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const { overlayProps, underlayProps } = useOverlay(props, wrapperRef);

--- a/frontend/src/components/phones/onboarding/RelayNumberPicker.tsx
+++ b/frontend/src/components/phones/onboarding/RelayNumberPicker.tsx
@@ -110,7 +110,7 @@ const RelayNumberSelection = (props: RelayNumberSelectionProps) => {
         ...relayNumberSuggestionsData.data.other_areas_options,
         ...relayNumberSuggestionsData.data.same_prefix_options,
         ...relayNumberSuggestionsData.data.random_options,
-      ].map((suggestion) => suggestion.phone_number)
+      ].map((suggestion) => suggestion.phone_number),
     );
   }
 
@@ -146,7 +146,7 @@ const RelayNumberSelection = (props: RelayNumberSelectionProps) => {
     if (data) {
       // add new relay number suggestions
       setRelayNumberSuggestions(
-        data.map((suggestion) => suggestion.phone_number)
+        data.map((suggestion) => suggestion.phone_number),
       );
 
       // reset relay number index
@@ -175,7 +175,7 @@ const RelayNumberSelection = (props: RelayNumberSelectionProps) => {
       setRelayNumberIndex(
         newRelayNumberIndex >= relayNumberSuggestions.length
           ? 0
-          : newRelayNumberIndex
+          : newRelayNumberIndex,
       );
     }
   };
@@ -260,7 +260,7 @@ const RelayNumberSelection = (props: RelayNumberSelectionProps) => {
           }
         >
           {l10n.getString(
-            "phone-onboarding-step4-button-register-phone-number"
+            "phone-onboarding-step4-button-register-phone-number",
           )}
         </Button>
       </form>
@@ -322,12 +322,12 @@ const RelayNumberConfirmation = (props: RelayNumberConfirmationProps) => {
         </h3>
         <p>
           {l10n.getString(
-            "phone-onboarding-step4-code-success-subhead-body-p1"
+            "phone-onboarding-step4-code-success-subhead-body-p1",
           )}
         </p>
         <p>
           {l10n.getString(
-            "phone-onboarding-step4-code-success-subhead-body-p2"
+            "phone-onboarding-step4-code-success-subhead-body-p2",
           )}
         </p>
         <Button onClick={() => props.onComplete()} className={styles.button}>

--- a/frontend/src/components/waitlist/CountryPicker.tsx
+++ b/frontend/src/components/waitlist/CountryPicker.tsx
@@ -34,8 +34,8 @@ export const CountryPicker = (props: Props) => {
     .filter(
       ([code]) =>
         !["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"].some((nr) =>
-          code.includes(nr)
-        )
+          code.includes(nr),
+        ),
     )
     .sort(([_codeA, nameA], [_codeB, nameB]) => nameA.localeCompare(nameB))
     .map(([code, name]) => (

--- a/frontend/src/components/waitlist/WaitlistPage.test.tsx
+++ b/frontend/src/components/waitlist/WaitlistPage.test.tsx
@@ -66,7 +66,7 @@ describe("The waitlist", () => {
           legalese={<>Arbitrary legalese footer.</>}
           newsletterId="arbitrary-newsletter-id"
           supportedLocales={["en"]}
-        />
+        />,
       );
 
       let results;
@@ -89,11 +89,11 @@ describe("The waitlist", () => {
         legalese={<>Arbitrary legalese footer.</>}
         newsletterId="arbitrary-newsletter-id"
         supportedLocales={["en"]}
-      />
+      />,
     );
 
     const emailInput = screen.getByLabelText(
-      "l10n string: [waitlist-control-email-label], with vars: {}"
+      "l10n string: [waitlist-control-email-label], with vars: {}",
     );
     await userEvent.clear(emailInput);
     await userEvent.type(emailInput, "some_email@example.com");
@@ -106,7 +106,7 @@ describe("The waitlist", () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({ body: expect.any(String) })
+      expect.objectContaining({ body: expect.any(String) }),
     );
     const requestBody = (global.fetch as jest.Mock).mock.calls[0][1].body;
     const params = new URLSearchParams(requestBody);
@@ -125,11 +125,11 @@ describe("The waitlist", () => {
         legalese={<>Arbitrary legalese footer.</>}
         newsletterId="arbitrary-newsletter-id"
         supportedLocales={["en"]}
-      />
+      />,
     );
 
     const emailInput = screen.getByLabelText(
-      "l10n string: [waitlist-control-email-label], with vars: {}"
+      "l10n string: [waitlist-control-email-label], with vars: {}",
     );
     await userEvent.clear(emailInput);
     await userEvent.type(emailInput, "arbitrary_email@example.com");
@@ -142,7 +142,7 @@ describe("The waitlist", () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith(
       "https://some-basket-url.com/news/subscribe/",
-      expect.anything()
+      expect.anything(),
     );
     // Restore the original runtime data mocks:
     setMockRuntimeData();

--- a/frontend/src/components/waitlist/WaitlistPage.tsx
+++ b/frontend/src/components/waitlist/WaitlistPage.tsx
@@ -30,12 +30,12 @@ export const WaitlistPage = (props: Props) => {
     props.supportedLocales.find(
       (supportedLocale) =>
         supportedLocale.toLowerCase() ===
-        currentLocale.split("-")[0].toLowerCase()
-    ) ?? "en"
+        currentLocale.split("-")[0].toLowerCase(),
+    ) ?? "en",
   );
   const usersData = useUsers();
   const [email, setEmail] = useState<string | undefined>(
-    usersData.data?.[0]?.email
+    usersData.data?.[0]?.email,
   );
 
   useEffect(() => {
@@ -53,7 +53,7 @@ export const WaitlistPage = (props: Props) => {
     if (!email) {
       // Modern browsers should prevent this from happening, due to the `required` attribute:
       console.error(
-        "WaitlistPage.onSubmit: form submitted while required input field was empty."
+        "WaitlistPage.onSubmit: form submitted while required input field was empty.",
       );
       return;
     }
@@ -108,7 +108,7 @@ export const WaitlistPage = (props: Props) => {
                 required={true}
                 onChange={(event) => setEmail(event.target.value)}
                 placeholder={l10n.getString(
-                  "waitlist-control-email-placeholder"
+                  "waitlist-control-email-placeholder",
                 )}
               />
             </div>
@@ -123,7 +123,7 @@ export const WaitlistPage = (props: Props) => {
                 value={country ?? currentCountry ?? "US"}
                 onChange={(event) =>
                   setCountry(
-                    event.target.selectedOptions.item(0)?.value ?? country
+                    event.target.selectedOptions.item(0)?.value ?? country,
                   )
                 }
                 required={true}
@@ -140,7 +140,7 @@ export const WaitlistPage = (props: Props) => {
                 value={locale}
                 onChange={(event) =>
                   setLocale(
-                    event.target.selectedOptions.item(0)?.value ?? locale
+                    event.target.selectedOptions.item(0)?.value ?? locale,
                   )
                 }
                 supportedLocales={props.supportedLocales}

--- a/frontend/src/functions/cookies.ts
+++ b/frontend/src/functions/cookies.ts
@@ -24,7 +24,7 @@ export type SetCookieOptions = {
 export function setCookie(
   cookieId: string,
   value: string,
-  options: SetCookieOptions = {}
+  options: SetCookieOptions = {},
 ) {
   const maxAgeString =
     typeof options.maxAgeInSeconds === "number"

--- a/frontend/src/functions/filterAliases.test.ts
+++ b/frontend/src/functions/filterAliases.test.ts
@@ -7,7 +7,7 @@ import { filterAliases, Filters } from "./filterAliases";
 
 const getMockedAliasMatching = (
   filters: Partial<Filters>,
-  customSubdomain = "arbitrary_subdomain"
+  customSubdomain = "arbitrary_subdomain",
 ): AliasData => {
   const alias = {
     address: filters.string ?? "arbitrary_string",
@@ -136,7 +136,7 @@ it("can filter out non-random domains", () => {
   ];
 
   expect(
-    filterAliases(aliases, { string: "", domainType: "random" })
+    filterAliases(aliases, { string: "", domainType: "random" }),
   ).toStrictEqual([aliases[0]]);
 });
 
@@ -147,7 +147,7 @@ it("can filter out non-random domains", () => {
   ];
 
   expect(
-    filterAliases(aliases, { string: "", domainType: "custom" })
+    filterAliases(aliases, { string: "", domainType: "custom" }),
   ).toStrictEqual([aliases[1]]);
 });
 
@@ -159,7 +159,7 @@ it("can filter out blocking aliases", () => {
   ];
 
   expect(
-    filterAliases(aliases, { string: "", status: "forwarding" })
+    filterAliases(aliases, { string: "", status: "forwarding" }),
   ).toStrictEqual([aliases[2]]);
 });
 
@@ -171,7 +171,7 @@ it("can filter out aliases that are blocking promotional emails", () => {
   ];
 
   expect(
-    filterAliases(aliases, { string: "", status: "promo-blocking" })
+    filterAliases(aliases, { string: "", status: "promo-blocking" }),
   ).toStrictEqual([aliases[1]]);
 });
 
@@ -183,7 +183,7 @@ it("can filter out forwarding aliases", () => {
   ];
 
   expect(
-    filterAliases(aliases, { string: "", status: "blocking" })
+    filterAliases(aliases, { string: "", status: "blocking" }),
   ).toStrictEqual([aliases[0]]);
 });
 
@@ -201,6 +201,6 @@ it("can combine filters", () => {
   ];
 
   expect(
-    filterAliases(aliases, { string: "some", status: "forwarding" })
+    filterAliases(aliases, { string: "some", status: "forwarding" }),
   ).toStrictEqual([aliases[2]]);
 });

--- a/frontend/src/functions/filterAliases.ts
+++ b/frontend/src/functions/filterAliases.ts
@@ -13,7 +13,7 @@ export type Filters = {
  */
 export const filterAliases = (
   aliases: AliasData[],
-  filters: Filters
+  filters: Filters,
 ): AliasData[] => {
   const stringFilter = filters.string.toLowerCase();
   const matchesStringFilter = (alias: AliasData) => {

--- a/frontend/src/functions/formatPhone.test.ts
+++ b/frontend/src/functions/formatPhone.test.ts
@@ -11,22 +11,22 @@ it("returns only digits if specified", () => {
   const phoneNumberWithoutCountryCode = "2505551234";
 
   expect(formatPhone(phoneNumberWithCountryCode, { digitsOnly: true })).toBe(
-    "2505551234"
+    "2505551234",
   );
   expect(formatPhone(phoneNumberWithoutCountryCode, { digitsOnly: true })).toBe(
-    "2505551234"
+    "2505551234",
   );
   expect(
     formatPhone(phoneNumberWithCountryCode, {
       digitsOnly: true,
       withCountryCode: true,
-    })
+    }),
   ).toBe("+12505551234");
   expect(
     formatPhone(phoneNumberWithoutCountryCode, {
       digitsOnly: true,
       withCountryCode: true,
-    })
+    }),
   ).toBe("+12505551234");
 });
 
@@ -43,10 +43,10 @@ it("returns a formatted number with country code if requested", () => {
   const phoneNumberWithoutCountryCode = "2505551234";
 
   expect(
-    formatPhone(phoneNumberWithCountryCode, { withCountryCode: true })
+    formatPhone(phoneNumberWithCountryCode, { withCountryCode: true }),
   ).toBe("+1 (250) 555 - 1234");
   expect(
-    formatPhone(phoneNumberWithoutCountryCode, { withCountryCode: true })
+    formatPhone(phoneNumberWithoutCountryCode, { withCountryCode: true }),
   ).toBe("+1 (250) 555 - 1234");
 });
 
@@ -55,11 +55,11 @@ it("returns a formatted number", () => {
   const phoneNumberWithoutCountryCode = "(250) 555 - 1234";
 
   expect(
-    formatPhone(phoneNumberWithCountryCode, { withCountryCode: true })
+    formatPhone(phoneNumberWithCountryCode, { withCountryCode: true }),
   ).toBe("+1 (250) 555 - 1234");
   expect(formatPhone(phoneNumberWithCountryCode)).toBe("(250) 555 - 1234");
   expect(
-    formatPhone(phoneNumberWithoutCountryCode, { withCountryCode: true })
+    formatPhone(phoneNumberWithoutCountryCode, { withCountryCode: true }),
   ).toBe("+1 (250) 555 - 1234");
   expect(formatPhone(phoneNumberWithoutCountryCode)).toBe("(250) 555 - 1234");
 });

--- a/frontend/src/functions/formatPhone.ts
+++ b/frontend/src/functions/formatPhone.ts
@@ -5,7 +5,7 @@
  */
 export function formatPhone(
   phoneNumber: string,
-  options?: { withCountryCode?: boolean; digitsOnly?: boolean }
+  options?: { withCountryCode?: boolean; digitsOnly?: boolean },
 ): string {
   // remove country code by default
   // remove all none numeric characters

--- a/frontend/src/functions/getL10n.ts
+++ b/frontend/src/functions/getL10n.ts
@@ -15,7 +15,7 @@ export function getL10n(options: { deterministicLocales: boolean }) {
   const translationsContext = (require as any).context(
     "../../../privaterelay/locales",
     true,
-    /\.ftl$/
+    /\.ftl$/,
   );
   const RESOURCES: Record<string, FluentResource[]> = {};
 
@@ -42,13 +42,13 @@ export function getL10n(options: { deterministicLocales: boolean }) {
       // render either:
       options.deterministicLocales ? [] : (userLocales as string[]),
       Object.keys(RESOURCES),
-      { defaultLocale: "en" }
+      { defaultLocale: "en" },
     );
 
     for (const locale of currentLocales) {
       if (typeof RESOURCES[locale] === "undefined") {
         throw new Error(
-          `Locale [${locale}] not found. You might want to run \`git submodule update --remote\` at the root of this repository?`
+          `Locale [${locale}] not found. You might want to run \`git submodule update --remote\` at the root of this repository?`,
         );
       }
       const bundle = new FluentBundle(locale);
@@ -59,30 +59,30 @@ export function getL10n(options: { deterministicLocales: boolean }) {
         // `require` isn't usually valid JS, so skip type checking for that:
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const pendingTranslations = (require as any)(
-          "../../pendingTranslations.ftl"
+          "../../pendingTranslations.ftl",
         );
         const pendingTranslationsResource = new FluentResource(
-          pendingTranslations
+          pendingTranslations,
         );
         bundle.addResource(pendingTranslationsResource);
         if (process.env.NEXT_PUBLIC_DEBUG === "true") {
           // All string IDs in `pendingTranslations.ftl`:
           const pendingTranslationsIds = pendingTranslationsResource.body.map(
-            (stringData) => stringData.id
+            (stringData) => stringData.id,
           );
           // All string IDs in all English FTL files:
           const mergedEnglishTranslationIds = RESOURCES.en.flatMap(
             (enResource) => {
               return enResource.body.map((stringData) => stringData.id);
-            }
+            },
           );
           const unmergedStrings = pendingTranslationsIds.filter(
-            (id) => !mergedEnglishTranslationIds.includes(id)
+            (id) => !mergedEnglishTranslationIds.includes(id),
           );
           if (unmergedStrings.length > 0) {
             console.warn(
               `The following ${unmergedStrings.length} strings have not yet been merged into the l10n repository, and thus cannot be translated yet:`,
-              unmergedStrings
+              unmergedStrings,
             );
           }
         }
@@ -107,9 +107,9 @@ export function getL10n(options: { deterministicLocales: boolean }) {
   // bundles. You can store it in your app's state.
   const l10n = new ReactLocalization(
     generateBundles(
-      typeof navigator !== "undefined" ? navigator.languages : []
+      typeof navigator !== "undefined" ? navigator.languages : [],
     ),
-    parseMarkup
+    parseMarkup,
   );
   return l10n;
 }

--- a/frontend/src/functions/getPlan.ts
+++ b/frontend/src/functions/getPlan.ts
@@ -4,7 +4,7 @@ import { getLocale } from "./getLocale";
 
 const getPlan = <P extends Partial<PlanData>>(
   productData: ProductData<P>,
-  billingPeriod: keyof P
+  billingPeriod: keyof P,
 ) => {
   const languageCode = navigator.language.split("-")[0].toLowerCase();
   const countryPlans =
@@ -18,7 +18,7 @@ const getPlan = <P extends Partial<PlanData>>(
 export const getPeriodicalPremiumPrice = (
   runtimeData: RuntimeDataWithPeriodicalPremiumAvailable,
   billingPeriod: keyof PlanData,
-  l10n: ReactLocalization
+  l10n: ReactLocalization,
 ) => {
   const plan = getPlan(runtimeData.PERIODICAL_PREMIUM_PLANS, billingPeriod);
   const formatter = new Intl.NumberFormat(getLocale(l10n), {
@@ -32,7 +32,7 @@ export const getPeriodicalPremiumPrice = (
  */
 export const getPeriodicalPremiumSubscribeLink = (
   runtimeData: RuntimeDataWithPeriodicalPremiumAvailable,
-  billingPeriod: keyof PlanData
+  billingPeriod: keyof PlanData,
 ) => {
   const plan = getPlan(runtimeData.PERIODICAL_PREMIUM_PLANS, billingPeriod);
 
@@ -42,7 +42,7 @@ export const getPeriodicalPremiumSubscribeLink = (
 export const getPhonesPrice = (
   runtimeData: RuntimeDataWithPhonesAvailable,
   billingPeriod: keyof PlanData,
-  l10n: ReactLocalization
+  l10n: ReactLocalization,
 ) => {
   const plan = getPlan(runtimeData.PHONE_PLANS, billingPeriod);
   const formatter = new Intl.NumberFormat(getLocale(l10n), {
@@ -53,7 +53,7 @@ export const getPhonesPrice = (
 };
 export const getPhoneSubscribeLink = (
   runtimeData: RuntimeDataWithPhonesAvailable,
-  billingPeriod: keyof PlanData
+  billingPeriod: keyof PlanData,
 ) => {
   const plan = getPlan(runtimeData.PHONE_PLANS, billingPeriod);
   return `${runtimeData.FXA_ORIGIN}/subscriptions/products/${runtimeData.PHONE_PRODUCT_ID}?plan=${plan.id}`;
@@ -61,7 +61,7 @@ export const getPhoneSubscribeLink = (
 
 export const getBundlePrice = (
   runtimeData: RuntimeDataWithBundleAvailable,
-  l10n: ReactLocalization
+  l10n: ReactLocalization,
 ) => {
   const plan = getPlan(runtimeData.BUNDLE_PLANS, "yearly");
   const formatter = new Intl.NumberFormat(getLocale(l10n), {
@@ -71,7 +71,7 @@ export const getBundlePrice = (
   return formatter.format(plan.price);
 };
 export const getBundleSubscribeLink = (
-  runtimeData: RuntimeDataWithBundleAvailable
+  runtimeData: RuntimeDataWithBundleAvailable,
 ) => {
   const plan = getPlan(runtimeData.BUNDLE_PLANS, "yearly");
   return `${runtimeData.FXA_ORIGIN}/subscriptions/products/${runtimeData.BUNDLE_PRODUCT_ID}?plan=${plan.id}`;
@@ -93,19 +93,19 @@ export type RuntimeDataWithBundleAvailable =
   RuntimeDataWithPlanAvailable<"BUNDLE_PLANS">;
 
 export function isPeriodicalPremiumAvailableInCountry(
-  runtimeData: RuntimeData | undefined
+  runtimeData: RuntimeData | undefined,
 ): runtimeData is RuntimeDataWithPeriodicalPremiumAvailable {
   return runtimeData?.PERIODICAL_PREMIUM_PLANS?.available_in_country === true;
 }
 
 export function isPhonesAvailableInCountry(
-  runtimeData: RuntimeData | undefined
+  runtimeData: RuntimeData | undefined,
 ): runtimeData is RuntimeDataWithPhonesAvailable {
   return runtimeData?.PHONE_PLANS?.available_in_country === true;
 }
 
 export function isBundleAvailableInCountry(
-  runtimeData: RuntimeData | undefined
+  runtimeData: RuntimeData | undefined,
 ): runtimeData is RuntimeDataWithBundleAvailable {
   return runtimeData?.BUNDLE_PLANS?.available_in_country === true;
 }

--- a/frontend/src/functions/makeToast.ts
+++ b/frontend/src/functions/makeToast.ts
@@ -16,7 +16,9 @@ export function makeToast(l10n: ReactLocalization, usersData?: UserData) {
   if (checkUserSignIn && typeof usersData !== "undefined") {
     clearCookie("user-sign-in");
     return toast.success(
-      l10n.getString("success-signed-in-message", { username: usersData.email })
+      l10n.getString("success-signed-in-message", {
+        username: usersData.email,
+      }),
     );
   }
 }

--- a/frontend/src/functions/renderDate.ts
+++ b/frontend/src/functions/renderDate.ts
@@ -7,7 +7,7 @@ import { parseDate } from "./parseDate";
  */
 export const renderDate = (
   iso8601DateString: string,
-  l10n: ReactLocalization
+  l10n: ReactLocalization,
 ): string => {
   const formatter = new Intl.DateTimeFormat(getLocale(l10n), {
     dateStyle: "medium",

--- a/frontend/src/functions/trackPurchase.ts
+++ b/frontend/src/functions/trackPurchase.ts
@@ -46,7 +46,7 @@ export const getCookieId = (plan: Plan): string => {
  */
 export const trackPlanPurchaseStart = (
   plan: Plan,
-  args?: PurchaseTrackingArgs
+  args?: PurchaseTrackingArgs,
 ) => {
   gaEvent({
     ...args,

--- a/frontend/src/functions/waffle.ts
+++ b/frontend/src/functions/waffle.ts
@@ -6,7 +6,7 @@ export type RuntimeDataWithWaffle = RuntimeData & {
 
 export function isFlagActive(
   runtimeData: RuntimeData | undefined,
-  flagName: FlagNames
+  flagName: FlagNames,
 ): runtimeData is RuntimeDataWithWaffle {
   if (runtimeData?.WAFFLE_FLAGS) {
     for (const flag of runtimeData.WAFFLE_FLAGS) {

--- a/frontend/src/hooks/addon.ts
+++ b/frontend/src/hooks/addon.ts
@@ -40,7 +40,7 @@ const defaultAddonData: AddonData = {
 function useMutationObserver(
   elementRef: RefObject<HTMLElement>,
   options: MutationObserverInit,
-  callback: MutationCallback
+  callback: MutationCallback,
 ) {
   const [observer, setObserver] = useState<MutationObserver>();
 
@@ -95,7 +95,7 @@ const parseAddonData = (addonElement: HTMLElement): AddonData => {
   let addonData: AddonData = {
     sendEvent: (type, data = {}) => {
       addonElement.dispatchEvent(
-        new CustomEvent("website", { detail: { ...data, type: type } })
+        new CustomEvent("website", { detail: { ...data, type: type } }),
       );
     },
   };
@@ -125,12 +125,12 @@ const parseAddonData = (addonElement: HTMLElement): AddonData => {
  * @returns The data that should be set as the element's props, to ensure they're aligned with its in-DOM attributes.
  */
 export function useAddonElementWatcher(
-  addonElementRef: RefObject<HTMLElement>
+  addonElementRef: RefObject<HTMLElement>,
 ): AddonData {
   const [addonData, setAddonData] = useState<AddonData>(
     addonElementRef.current !== null
       ? parseAddonData(addonElementRef.current)
-      : defaultAddonData
+      : defaultAddonData,
   );
   useEffect(() => {
     if (addonElementRef.current === null) {
@@ -159,7 +159,7 @@ export function useAddonElementWatcher(
         return newAddonData;
       });
     },
-    [setAddonData]
+    [setAddonData],
   );
 
   useMutationObserver(addonElementRef, { attributes: true }, mutationListener);

--- a/frontend/src/hooks/api/aliases.ts
+++ b/frontend/src/hooks/api/aliases.ts
@@ -41,11 +41,11 @@ export type AliasData = RandomAliasData | CustomAliasData;
 export type AliasCreateFn = (
   options:
     | { mask_type: "random" }
-    | { mask_type: "custom"; address: string; blockPromotionals: boolean }
+    | { mask_type: "custom"; address: string; blockPromotionals: boolean },
 ) => Promise<Response>;
 export type AliasUpdateFn = (
   alias: Pick<CommonAliasData, "id" | "mask_type">,
-  updatedFields: Partial<AliasData>
+  updatedFields: Partial<AliasData>,
 ) => Promise<Response>;
 export type AliasDeleteFn = (alias: AliasData) => Promise<Response>;
 
@@ -147,7 +147,7 @@ export function isRandomAlias(alias: AliasData): alias is RandomAliasData {
 
 export function getAllAliases(
   randomAliases: RandomAliasData[],
-  customAliases: CustomAliasData[]
+  customAliases: CustomAliasData[],
 ): AliasData[] {
   return (randomAliases as AliasData[]).concat(customAliases);
 }
@@ -171,7 +171,7 @@ export function getFullAddress(alias: AliasData) {
  */
 export function isBlockingLevelOneTrackers(
   alias: AliasData,
-  profile: ProfileData
+  profile: ProfileData,
 ): boolean {
   if (typeof alias.block_level_one_trackers === "boolean") {
     return alias.block_level_one_trackers;

--- a/frontend/src/hooks/api/api.ts
+++ b/frontend/src/hooks/api/api.ts
@@ -7,7 +7,7 @@ import { getCsrfToken } from "../../functions/cookies";
  */
 export const authenticatedFetch = async (
   path: string,
-  init?: Parameters<typeof fetch>[1]
+  init?: Parameters<typeof fetch>[1],
 ) => {
   let authToken;
   if (
@@ -24,7 +24,7 @@ export const authenticatedFetch = async (
   const headers = new Headers(init?.headers ?? undefined);
   headers.set(
     "Content-Type",
-    headers.get("Content-Type") ?? "application/json"
+    headers.get("Content-Type") ?? "application/json",
   );
   headers.set("Accept", headers.get("Accept") ?? "application/json");
   if (typeof authToken === "string") {
@@ -47,7 +47,7 @@ export const authenticatedFetch = async (
 
 export const apiFetch = async (
   route: string,
-  init?: Parameters<typeof fetch>[1]
+  init?: Parameters<typeof fetch>[1],
 ) => {
   const path = `/api/v1${route}`;
   return authenticatedFetch(path, init);
@@ -67,14 +67,14 @@ const fetcher: Fetcher = async (route: string, init?: RequestInit) => {
  */
 export function useApiV1<Data = unknown>(
   route: string | null,
-  swrOptions: Partial<SWRConfiguration> = {}
+  swrOptions: Partial<SWRConfiguration> = {},
 ): SWRResponse<Data, FetchError> {
   const onErrorRetry: typeof SWRConfig.defaultValue.onErrorRetry = (
     error: unknown | FetchError,
     key,
     config,
     revalidate,
-    revalidateOpts
+    revalidateOpts,
   ) => {
     if (error instanceof FetchError && error.response.ok === false) {
       // When the request got rejected by the back-end, do not retry:
@@ -86,7 +86,7 @@ export function useApiV1<Data = unknown>(
       key,
       config,
       revalidate,
-      revalidateOpts
+      revalidateOpts,
     );
   };
   // TODO: Also use the sessionId cookie in the key,

--- a/frontend/src/hooks/api/inboundContact.ts
+++ b/frontend/src/hooks/api/inboundContact.ts
@@ -19,12 +19,12 @@ export type InboundContact = {
 export type InboundContactData = Array<InboundContact>;
 
 export type InboundContactNumber = (
-  inbound_number: string
+  inbound_number: string,
 ) => Promise<Response>;
 
 export type UpdateForwardingToPhone = (
   enabled: boolean,
-  id: number
+  id: number,
 ) => Promise<Response>;
 
 export function useInboundContact(): SWRResponse<
@@ -38,7 +38,7 @@ export function useInboundContact(): SWRResponse<
 
   const setForwardingState: UpdateForwardingToPhone = async (
     blocked: boolean,
-    id: number
+    id: number,
   ) => {
     const response = await apiFetch(`/inboundcontact/${id}/`, {
       method: "PATCH",

--- a/frontend/src/hooks/api/profile.ts
+++ b/frontend/src/hooks/api/profile.ts
@@ -27,10 +27,10 @@ export type ProfilesData = [ProfileData];
 
 export type ProfileUpdateFn = (
   id: ProfileData["id"],
-  data: Omit<Partial<ProfileData>, "subdomain">
+  data: Omit<Partial<ProfileData>, "subdomain">,
 ) => Promise<Response>;
 export type SetSubdomainFn = (
-  subdomain: Exclude<ProfileData["subdomain"], null>
+  subdomain: Exclude<ProfileData["subdomain"], null>,
 ) => Promise<Response>;
 
 /**
@@ -52,7 +52,7 @@ export function useProfiles(): SWRResponse<ProfilesData, unknown> & {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       config: any,
       revalidate: Parameters<typeof SWRConfig.defaultValue.onErrorRetry>[3],
-      revalidateOpts: Parameters<typeof SWRConfig.defaultValue.onErrorRetry>[4]
+      revalidateOpts: Parameters<typeof SWRConfig.defaultValue.onErrorRetry>[4],
     ) => {
       if (error instanceof FetchError && error.response.status === 401) {
         // When the user is not logged in, this API returns a 401.
@@ -64,7 +64,7 @@ export function useProfiles(): SWRResponse<ProfilesData, unknown> & {
         key,
         config,
         revalidate,
-        revalidateOpts
+        revalidateOpts,
       );
     },
   }) as SWRResponse<ProfilesData, FetchError>;
@@ -108,14 +108,14 @@ export function useProfiles(): SWRResponse<ProfilesData, unknown> & {
  */
 const profileFetcher = async (
   url: string,
-  requestInit: RequestInit
+  requestInit: RequestInit,
 ): Promise<ProfilesData> => {
   const isToldByFxaToRefresh =
     document.location.search.indexOf("fxa_refresh=1") !== -1;
 
   if (isToldByFxaToRefresh) {
     const refreshResponse = await authenticatedFetch(
-      "/accounts/profile/refresh"
+      "/accounts/profile/refresh",
     );
     await refreshResponse.json();
   }

--- a/frontend/src/hooks/api/realPhone.ts
+++ b/frontend/src/hooks/api/realPhone.ts
@@ -38,7 +38,7 @@ export function isNotVerified(phone: RealPhone): phone is UnverifiedPhone {
 }
 
 export function hasPendingVerification(
-  phone: RealPhone
+  phone: RealPhone,
 ): phone is UnverifiedPhone {
   // Short circuit logic if there's no verification sent yet,
   // or if the phone number has already been verified:
@@ -51,7 +51,7 @@ export function hasPendingVerification(
   }
 
   const verificationSentDate = parseDate(
-    phone.verification_sent_date
+    phone.verification_sent_date,
   ).getTime();
   const currentDateMinus5Mins = new Date().getTime() - 5 * 60 * 1000;
 
@@ -61,7 +61,7 @@ export function hasPendingVerification(
 export type RealPhonesData = [RealPhoneData];
 
 export type PhoneNumberRequestVerificationFn = (
-  phoneNumber: string
+  phoneNumber: string,
 ) => Promise<Response>;
 
 export type ResendWelcomeSMSFn = () => Promise<Response>;
@@ -72,7 +72,7 @@ export type RealPhoneVerification = Pick<
 >;
 export type PhoneNumberSubmitVerificationFn = (
   id: number,
-  obj: RealPhoneVerification
+  obj: RealPhoneVerification,
 ) => Promise<Response>;
 
 export type RequestPhoneRemovalFn = (id: number) => Promise<Response>;
@@ -94,7 +94,7 @@ export function useRealPhonesData(): SWRResponse<RealPhoneData, unknown> & {
    */
   const submitPhoneVerification: PhoneNumberSubmitVerificationFn = async (
     id,
-    obj
+    obj,
   ) => {
     const response = await apiFetch(`/realphone/${id}/`, {
       method: "PATCH",
@@ -108,7 +108,7 @@ export function useRealPhonesData(): SWRResponse<RealPhoneData, unknown> & {
    * Request a one-time password to validate a real phone number.
    */
   const requestPhoneVerification: PhoneNumberRequestVerificationFn = async (
-    phoneNumber
+    phoneNumber,
   ) => {
     // TODO: Validate number as E.164
     // https://blog.kevinchisholm.com/javascript/javascript-e164-phone-number-validation/

--- a/frontend/src/hooks/api/relayNumber.ts
+++ b/frontend/src/hooks/api/relayNumber.ts
@@ -20,12 +20,12 @@ export type RelayNumber = {
 export type RelayNumberData = Array<RelayNumber>;
 
 export type PhoneNumberRegisterRelayNumberFn = (
-  phoneNumber: string
+  phoneNumber: string,
 ) => Promise<Response>;
 
 export type UpdateForwardingToPhone = (
   enabled: boolean,
-  id: number
+  id: number,
 ) => Promise<Response>;
 
 export type UseRelayNumberOptions = Partial<{
@@ -42,13 +42,13 @@ export type UseRelayNumberOptions = Partial<{
  * Get relay (masked) phone number records for the authenticated user with our API using [SWR](https://swr.vercel.app).
  */
 export function useRelayNumber(
-  options: UseRelayNumberOptions = {}
+  options: UseRelayNumberOptions = {},
 ): SWRResponse<RelayNumberData, unknown> & {
   registerRelayNumber: PhoneNumberRegisterRelayNumberFn;
   setForwardingState: UpdateForwardingToPhone;
 } {
   const relayNumber: SWRResponse<RelayNumberData, unknown> = useApiV1(
-    options.disable === true ? null : "/relaynumber/"
+    options.disable === true ? null : "/relaynumber/",
   );
 
   // TODO: Add post function to same API url
@@ -56,7 +56,7 @@ export function useRelayNumber(
    * Register selected Relay number
    */
   const registerRelayNumber: PhoneNumberRegisterRelayNumberFn = async (
-    phoneNumber
+    phoneNumber,
   ) => {
     // TODO: Validate number as E.164
     // https://blog.kevinchisholm.com/javascript/javascript-e164-phone-number-validation/
@@ -72,7 +72,7 @@ export function useRelayNumber(
    */
   const setForwardingState: UpdateForwardingToPhone = async (
     enabled: boolean,
-    id: number
+    id: number,
   ) => {
     const response = await apiFetch(`/relaynumber/${id}/`, {
       method: "PATCH",

--- a/frontend/src/hooks/api/runtimeData.ts
+++ b/frontend/src/hooks/api/runtimeData.ts
@@ -57,7 +57,7 @@ export function useRuntimeData() {
       revalidateIfStale: false,
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
-    }
+    },
   );
   return runtimeData;
 }

--- a/frontend/src/hooks/api/user.ts
+++ b/frontend/src/hooks/api/user.ts
@@ -17,7 +17,7 @@ export function useUsers() {
       key,
       config,
       revalidate,
-      revalidateOpts
+      revalidateOpts,
     ) => {
       if (error instanceof FetchError && error.response.status === 401) {
         // When the user is not logged in, this API returns a 401.
@@ -29,7 +29,7 @@ export function useUsers() {
         key,
         config,
         revalidate,
-        revalidateOpts
+        revalidateOpts,
       );
     },
   });

--- a/frontend/src/hooks/firstSeen.ts
+++ b/frontend/src/hooks/firstSeen.ts
@@ -30,7 +30,7 @@ export function useFirstSeen(): Date | null {
     currentTimestamp.toString(),
     {
       maxAgeInSeconds: 10 * 365 * 24 * 60 * 60,
-    }
+    },
   );
   return new Date(currentTimestamp);
 }

--- a/frontend/src/hooks/flaggedAnchorLinks.ts
+++ b/frontend/src/hooks/flaggedAnchorLinks.ts
@@ -19,7 +19,7 @@ import { DependencyList, useEffect } from "react";
  */
 export function useFlaggedAnchorLinks(
   dependencies: DependencyList,
-  allowedTargetElementIds?: string[]
+  allowedTargetElementIds?: string[],
 ) {
   useEffect(() => {
     if (document.location.hash.length <= 1) {
@@ -32,7 +32,7 @@ export function useFlaggedAnchorLinks(
       return;
     }
     const targetElement = document.getElementById(
-      document.location.hash.substring(1)
+      document.location.hash.substring(1),
     );
     targetElement?.scrollIntoView();
     // The hooks linter can't statically analyse a dynamic dependency list,

--- a/frontend/src/hooks/fxaFlowTracker.test.ts
+++ b/frontend/src/hooks/fxaFlowTracker.test.ts
@@ -14,9 +14,9 @@ describe("getLoginUrl", () => {
       getLoginUrl("some_entrypoint", {
         flowBeginTime: "1990-11-12T13:37:42.000Z",
         flowId: "some_flow_id",
-      })
+      }),
     ).toBe(
-      "https://mock-login.com/?form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=1990-11-12T13%3A37%3A42.000Z"
+      "https://mock-login.com/?form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=1990-11-12T13%3A37%3A42.000Z",
     );
   });
 
@@ -30,9 +30,9 @@ describe("getLoginUrl", () => {
       getLoginUrl("some_entrypoint", {
         flowBeginTime: "1990-11-12T13:37:42.000Z",
         flowId: "some_flow_id",
-      })
+      }),
     ).toBe(
-      "https://mock-login.com/?some_query=param&form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=1990-11-12T13%3A37%3A42.000Z"
+      "https://mock-login.com/?some_query=param&form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=1990-11-12T13%3A37%3A42.000Z",
     );
   });
 
@@ -46,9 +46,9 @@ describe("getLoginUrl", () => {
       getLoginUrl("some_entrypoint", {
         flowBeginTime: "1990-11-12T13:37:42.000Z",
         flowId: "some_flow_id",
-      })
+      }),
     ).toBe(
-      "/login?form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=1990-11-12T13%3A37%3A42.000Z"
+      "/login?form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=1990-11-12T13%3A37%3A42.000Z",
     );
   });
 });

--- a/frontend/src/hooks/fxaFlowTracker.ts
+++ b/frontend/src/hooks/fxaFlowTracker.ts
@@ -20,7 +20,7 @@ export type FlowData = {
  */
 export function useFxaFlowTracker(
   args: FxaFlowTrackerArgs | null,
-  options?: IntersectionOptions
+  options?: IntersectionOptions,
 ) {
   const runtimeData = useRuntimeData();
   const { ref } = useInView({
@@ -38,8 +38,8 @@ export function useFxaFlowTracker(
 
       fetch(
         `${fxaOrigin}/metrics-flow?form_type=other&entrypoint=${encodeURIComponent(
-          args.entrypoint
-        )}&utm_source=${encodeURIComponent(document.location.host)}`
+          args.entrypoint,
+        )}&utm_source=${encodeURIComponent(document.location.host)}`,
       )
         .then(async (response) => {
           if (!response.ok) {
@@ -85,7 +85,7 @@ export function getLoginUrl(entrypoint: string, flowData?: FlowData): string {
     loginUrl,
     typeof document !== "undefined"
       ? document.location.origin
-      : "https://relay.firefox.com"
+      : "https://relay.firefox.com",
   );
   urlObject.searchParams.append("form_type", "button");
   urlObject.searchParams.append("entrypoint", entrypoint);
@@ -93,7 +93,7 @@ export function getLoginUrl(entrypoint: string, flowData?: FlowData): string {
     urlObject.searchParams.append("flowId", flowData.flowId);
     urlObject.searchParams.append(
       "flowBeginTime",
-      flowData.flowBeginTime.toString()
+      flowData.flowBeginTime.toString(),
     );
   }
 

--- a/frontend/src/hooks/gaViewPing.ts
+++ b/frontend/src/hooks/gaViewPing.ts
@@ -12,7 +12,7 @@ export type GaViewPingArgs = Omit<EventArgs, "action" | "nonInteraction">;
  */
 export function useGaViewPing(
   args: GaViewPingArgs | null,
-  options?: IntersectionOptions
+  options?: IntersectionOptions,
 ) {
   const { ref } = useInView({
     threshold: 1,

--- a/frontend/src/hooks/l10n.ts
+++ b/frontend/src/hooks/l10n.ts
@@ -17,7 +17,7 @@ import { createElement, Fragment, useEffect, useState } from "react";
 type GetFragment = (
   id: Parameters<ReactLocalization["getString"]>[0],
   args?: Parameters<ReactLocalization["getElement"]>[2],
-  fallback?: Parameters<ReactLocalization["getString"]>[2]
+  fallback?: Parameters<ReactLocalization["getString"]>[2],
 ) => ReturnType<ReactLocalization["getElement"]>;
 
 type ExtendedReactLocalization = ReactLocalization & {

--- a/frontend/src/hooks/localDismissal.test.ts
+++ b/frontend/src/hooks/localDismissal.test.ts
@@ -20,7 +20,7 @@ describe("useLocalDismissal", () => {
     mockCookiesModule.getCookie.mockReturnValue(undefined);
     const { result, rerender } = renderHook(
       (key: string) => useLocalDismissal(key),
-      { initialProps: "key1" }
+      { initialProps: "key1" },
     );
 
     const dismissal = result.current;
@@ -40,7 +40,7 @@ describe("useLocalDismissal", () => {
     // `duration`) ago:
     mockCookiesModule.getCookie.mockReturnValue((Date.now() - 1001).toString());
     const { result } = renderHook(() =>
-      useLocalDismissal("arbitrary_key", { duration: 1 })
+      useLocalDismissal("arbitrary_key", { duration: 1 }),
     );
 
     const dismissal = result.current;
@@ -70,14 +70,14 @@ describe("useLocalDismissal", () => {
     expect(mockCookiesModule.setCookie).toHaveBeenCalledWith(
       "some_key_dismissed",
       expect.any(String),
-      { maxAgeInSeconds: 100 * 365 * 24 * 60 * 60 }
+      { maxAgeInSeconds: 100 * 365 * 24 * 60 * 60 },
     );
   });
 
   it("sets the cookie's expiration time to the given value", () => {
     mockCookiesModule.getCookie.mockReturnValue(undefined);
     const { result } = renderHook(() =>
-      useLocalDismissal("some_key", { duration: 1337 })
+      useLocalDismissal("some_key", { duration: 1337 }),
     );
 
     act(() => {
@@ -87,7 +87,7 @@ describe("useLocalDismissal", () => {
     expect(mockCookiesModule.setCookie).toHaveBeenCalledWith(
       "some_key_dismissed",
       expect.any(String),
-      { maxAgeInSeconds: 1337 }
+      { maxAgeInSeconds: 1337 },
     );
   });
 
@@ -114,14 +114,14 @@ describe("useLocalDismissal", () => {
     expect(mockCookiesModule.setCookie).toHaveBeenCalledWith(
       "some_key_dismissed",
       expect.any(String),
-      { maxAgeInSeconds: 100 * 365 * 24 * 60 * 60 }
+      { maxAgeInSeconds: 100 * 365 * 24 * 60 * 60 },
     );
   });
 
   it("sets the cookie's expiration time to the given value, also for `soft` dismissals", () => {
     mockCookiesModule.getCookie.mockReturnValue(undefined);
     const { result } = renderHook(() =>
-      useLocalDismissal("some_key", { duration: 1337 })
+      useLocalDismissal("some_key", { duration: 1337 }),
     );
 
     act(() => {
@@ -131,7 +131,7 @@ describe("useLocalDismissal", () => {
     expect(mockCookiesModule.setCookie).toHaveBeenCalledWith(
       "some_key_dismissed",
       expect.any(String),
-      { maxAgeInSeconds: 1337 }
+      { maxAgeInSeconds: 1337 },
     );
   });
 });

--- a/frontend/src/hooks/localDismissal.ts
+++ b/frontend/src/hooks/localDismissal.ts
@@ -25,12 +25,12 @@ export type DismissalOptions = {
  */
 export function useLocalDismissal(
   key: string,
-  options: DismissalOptions = {}
+  options: DismissalOptions = {},
 ): DismissalData {
   const cookieId = key + "_dismissed";
 
   const [isDismissed, setIsDismissed] = useState(
-    hasDismissedCookie(cookieId, options.duration)
+    hasDismissedCookie(cookieId, options.duration),
   );
 
   // Whenever `key` (and therefore `cookieId`) changes, re-check the appropriate

--- a/frontend/src/hooks/localLabels.ts
+++ b/frontend/src/hooks/localLabels.ts
@@ -33,7 +33,7 @@ export type NotEnabled = [null, SetLocalLabel];
 export function useLocalLabels(): LocalLabelHook | NotEnabled {
   const addonData = useAddonData();
   const [localLabels, setLocalLabels] = useState<LocalLabel[]>(
-    addonData.localLabels ?? []
+    addonData.localLabels ?? [],
   );
 
   if (addonData.present !== true) {
@@ -46,10 +46,10 @@ export function useLocalLabels(): LocalLabelHook | NotEnabled {
     // Replace existing labels for this alias:
     const oldLocalLabel = localLabels.find(
       (localLabel) =>
-        localLabel.id === alias.id && localLabel.mask_type === maskType
+        localLabel.id === alias.id && localLabel.mask_type === maskType,
     );
     const newLocalLabels = localLabels.filter(
-      (localLabel) => localLabel !== oldLocalLabel
+      (localLabel) => localLabel !== oldLocalLabel,
     );
 
     newLocalLabels.push({

--- a/frontend/src/hooks/mediaQuery.ts
+++ b/frontend/src/hooks/mediaQuery.ts
@@ -3,7 +3,7 @@ import variables from "./mediaQuery.module.scss";
 
 function useMediaQueryImp(mediaQuery: string): boolean {
   const [mediaQueryList, setMediaQueryList] = useState(
-    window.matchMedia(mediaQuery)
+    window.matchMedia(mediaQuery),
   );
   useEffect(() => {
     setMediaQueryList(window.matchMedia(mediaQuery));
@@ -12,7 +12,7 @@ function useMediaQueryImp(mediaQuery: string): boolean {
   const [matches, setMatches] = useState(mediaQueryList.matches);
   useEffect(() => {
     const changeListener: Parameters<MediaQueryList["addEventListener"]>[1] = (
-      _changedList
+      _changedList,
     ) => {
       setMatches(mediaQueryList.matches);
     };
@@ -37,7 +37,7 @@ export const useMediaQuery =
  * @returns Whether the current viewport width matches that media query.
  */
 export function useMinViewportWidth(
-  width: "xs" | "sm" | "md" | "lg" | "xl"
+  width: "xs" | "sm" | "md" | "lg" | "xl",
 ): boolean {
   let mediaQuery = "";
   if (width === "xl") {

--- a/frontend/src/pages/_app.page.tsx
+++ b/frontend/src/pages/_app.page.tsx
@@ -44,7 +44,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   const addonData = useAddonElementWatcher(addonDataElementRef);
   const [l10n, setL10n] = useState<ReactLocalization>(
-    getL10n({ deterministicLocales: true })
+    getL10n({ deterministicLocales: true }),
   );
 
   useEffect(() => {
@@ -71,7 +71,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     });
     const cookies = document.cookie.split("; ");
     const gaEventCookies = cookies.filter((item) =>
-      item.trim().startsWith("server_ga_event:")
+      item.trim().startsWith("server_ga_event:"),
     );
     gaEventCookies.forEach((item) => {
       const serverEventLabel = item.split("=")[1];

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -103,7 +103,7 @@ const Profile: NextPage = () => {
         l10n.getString("error-subdomain-not-available-2", {
           unavailable_subdomain: customSubdomain,
         }),
-        { type: "error" }
+        { type: "error" },
       );
     }
     addonData.sendEvent("subdomainClaimed", { subdomain: customSubdomain });
@@ -111,7 +111,7 @@ const Profile: NextPage = () => {
 
   const allAliases = getAllAliases(
     aliasData.randomAliasData.data,
-    aliasData.customAliasData.data
+    aliasData.customAliasData.data,
   );
 
   if (
@@ -151,13 +151,13 @@ const Profile: NextPage = () => {
   const createAlias = async (
     options:
       | { mask_type: "random" }
-      | { mask_type: "custom"; address: string; blockPromotionals: boolean }
+      | { mask_type: "custom"; address: string; blockPromotionals: boolean },
   ) => {
     try {
       const response = await aliasData.create(options);
       if (!response.ok) {
         throw new Error(
-          "Immediately caught to land in the same code path as failed requests."
+          "Immediately caught to land in the same code path as failed requests.",
         );
       }
       addonData.sendEvent("aliasListUpdate");
@@ -168,13 +168,13 @@ const Profile: NextPage = () => {
 
   const updateAlias = async (
     alias: AliasData,
-    updatedFields: Partial<AliasData>
+    updatedFields: Partial<AliasData>,
   ) => {
     try {
       const response = await aliasData.update(alias, updatedFields);
       if (!response.ok) {
         throw new Error(
-          "Immediately caught to land in the same code path as failed requests."
+          "Immediately caught to land in the same code path as failed requests.",
         );
       }
     } catch (error) {
@@ -182,7 +182,7 @@ const Profile: NextPage = () => {
         l10n.getString("error-mask-update-failed", {
           alias: getFullAddress(alias),
         }),
-        { type: "error" }
+        { type: "error" },
       );
     }
   };
@@ -192,7 +192,7 @@ const Profile: NextPage = () => {
       const response = await aliasData.delete(alias);
       if (!response.ok) {
         throw new Error(
-          "Immediately caught to land in the same code path as failed requests."
+          "Immediately caught to land in the same code path as failed requests.",
         );
       }
       addonData.sendEvent("aliasListUpdate");
@@ -201,7 +201,7 @@ const Profile: NextPage = () => {
         l10n.getString("error-mask-delete-failed", {
           alias: getFullAddress(alias),
         }),
-        { type: "error" }
+        { type: "error" },
       );
     }
   };
@@ -215,7 +215,7 @@ const Profile: NextPage = () => {
             subdomain={profile.subdomain}
             onCreateAlias={(
               address: string,
-              settings: { blockPromotionals: boolean }
+              settings: { blockPromotionals: boolean },
             ) =>
               createAlias({
                 mask_type: "custom",
@@ -345,12 +345,12 @@ const Profile: NextPage = () => {
                   <StatExplainer>
                     <p>
                       {l10n.getString(
-                        "profile-stat-label-trackers-learn-more-part1"
+                        "profile-stat-label-trackers-learn-more-part1",
                       )}
                     </p>
                     <p>
                       {l10n.getString(
-                        "profile-stat-label-trackers-learn-more-part2-2"
+                        "profile-stat-label-trackers-learn-more-part2-2",
                       )}
                     </p>
                   </StatExplainer>
@@ -485,13 +485,13 @@ const StatExplainer = (props: { children: React.ReactNode }) => {
   const { triggerProps } = useOverlayTrigger(
     { type: "dialog" },
     explainerState,
-    openButtonRef
+    openButtonRef,
   );
 
   const openButtonProps = useButton(triggerProps, openButtonRef).buttonProps;
   const closeButtonProps = useButton(
     { onPress: explainerState.close },
-    closeButtonRef
+    closeButtonRef,
   ).buttonProps;
 
   const positionProps = useOverlayPosition({
@@ -551,7 +551,7 @@ const StatExplainerTooltip = forwardRef<
 >(function StatExplainerTooltipWithForwardedRef(props, overlayRef) {
   const { overlayProps } = useOverlay(
     props.overlayProps,
-    overlayRef as RefObject<HTMLDivElement>
+    overlayRef as RefObject<HTMLDivElement>,
   );
 
   return (

--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -53,7 +53,7 @@ jest.mock("../../hooks/api/api.ts", () => ({
     Promise.resolve({
       ok: true,
       json: () => Promise.resolve({ available: true }),
-    })
+    }),
   ),
 }));
 jest.mock("../../hooks/gaViewPing.ts");
@@ -213,7 +213,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const domainSearchField = screen.getByLabelText(
-      "l10n string: [banner-set-email-domain-input-placeholder-label], with vars: {}"
+      "l10n string: [banner-set-email-domain-input-placeholder-label], with vars: {}",
     );
 
     expect(domainSearchField).toBeInTheDocument();
@@ -224,7 +224,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const domainSearchField = screen.queryByLabelText(
-      "l10n string: [banner-set-email-domain-input-placeholder-label], with vars: {}"
+      "l10n string: [banner-set-email-domain-input-placeholder-label], with vars: {}",
     );
 
     expect(domainSearchField).not.toBeInTheDocument();
@@ -238,7 +238,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const domainSearchField = screen.queryByLabelText(
-      "l10n string: [banner-set-email-domain-input-placeholder-label], with vars: {}"
+      "l10n string: [banner-set-email-domain-input-placeholder-label], with vars: {}",
     );
 
     expect(domainSearchField).not.toBeInTheDocument();
@@ -249,7 +249,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const domainSearchField = screen.getByLabelText(
-      "l10n string: [banner-set-email-domain-input-placeholder-label], with vars: {}"
+      "l10n string: [banner-set-email-domain-input-placeholder-label], with vars: {}",
     );
 
     await userEvent.type(domainSearchField, "SpoNGeBoB");
@@ -456,7 +456,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const searchFilter = screen.getAllByLabelText(
-      "l10n string: [profile-filter-search-placeholder-2], with vars: {}"
+      "l10n string: [profile-filter-search-placeholder-2], with vars: {}",
     );
 
     expect(searchFilter[0]).toBeInTheDocument();
@@ -468,7 +468,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const searchFilter = screen.getAllByLabelText(
-      "l10n string: [profile-filter-search-placeholder-2], with vars: {}"
+      "l10n string: [profile-filter-search-placeholder-2], with vars: {}",
     );
 
     expect(searchFilter[0]).toBeInTheDocument();
@@ -493,7 +493,7 @@ describe("The dashboard", () => {
 
     // The alias filter servers as a proxy here for the aliases being shown:
     const searchFilter = screen.queryByLabelText(
-      "l10n string: [profile-filter-search-placeholder-2], with vars: {}"
+      "l10n string: [profile-filter-search-placeholder-2], with vars: {}",
     );
 
     expect(searchFilter).not.toBeInTheDocument();
@@ -522,7 +522,7 @@ describe("The dashboard", () => {
     // used by the add-on) is fine here:
     // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
     const addonDataElements = container.getElementsByTagName(
-      "firefox-private-relay-addon-data"
+      "firefox-private-relay-addon-data",
     );
 
     expect(addonDataElements).toHaveLength(1);
@@ -539,7 +539,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const subdomainSearchField = screen.getByLabelText(
-      "l10n string: [banner-set-email-domain-input-placeholder-label], with vars: {}"
+      "l10n string: [banner-set-email-domain-input-placeholder-label], with vars: {}",
     );
 
     expect(subdomainSearchField).toBeInTheDocument();
@@ -561,7 +561,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const subdomainSearchField = screen.getByLabelText(
-      "l10n string: [banner-set-email-domain-input-placeholder-label], with vars: {}"
+      "l10n string: [banner-set-email-domain-input-placeholder-label], with vars: {}",
     );
 
     await userEvent.type(subdomainSearchField, "sPoNGeBob");
@@ -590,7 +590,7 @@ describe("The dashboard", () => {
     render(<Profile />);
 
     const subdomainSearchField = screen.queryByLabelText(
-      "l10n string: [banner-set-email-domain-input-placeholder], with vars: {}"
+      "l10n string: [banner-set-email-domain-input-placeholder], with vars: {}",
     );
 
     expect(subdomainSearchField).not.toBeInTheDocument();
@@ -600,7 +600,7 @@ describe("The dashboard", () => {
     const updateFn: ProfileUpdateFn = jest.fn();
     setMockProfileDataOnce(
       { id: 42, has_premium: true, onboarding_state: 1 },
-      { updater: updateFn }
+      { updater: updateFn },
     );
     render(<Profile />);
 
@@ -616,7 +616,7 @@ describe("The dashboard", () => {
     const updateFn: ProfileUpdateFn = jest.fn();
     setMockProfileDataOnce(
       { id: 42, has_premium: true, onboarding_state: 2 },
-      { updater: updateFn }
+      { updater: updateFn },
     );
     render(<Profile />);
 
@@ -632,7 +632,7 @@ describe("The dashboard", () => {
     const updateFn: AliasUpdateFn = jest.fn();
     setMockAliasesDataOnce(
       { random: [{ enabled: true, id: 42 }], custom: [] },
-      { updater: updateFn }
+      { updater: updateFn },
     );
     render(<Profile />);
 
@@ -655,13 +655,13 @@ describe("The dashboard", () => {
     expect(console.error).toHaveBeenCalledWith(
       "Warning: Received NaN for the `%s` attribute. If this is expected, cast the value to a string.%s",
       "value",
-      expect.any(String)
+      expect.any(String),
     );
     console.error = originalConsoleError;
 
     expect(updateFn).toHaveBeenCalledWith(
       expect.objectContaining({ id: 42, mask_type: "random" }),
-      { enabled: false }
+      { enabled: false },
     );
   });
 
@@ -783,7 +783,7 @@ describe("The dashboard", () => {
     await userEvent.click(categoryFilterButton);
 
     const categoryFilterCheckboxCustomMask = screen.getByLabelText(
-      "l10n string: [profile-filter-category-option-custom-masks], with vars: {}"
+      "l10n string: [profile-filter-category-option-custom-masks], with vars: {}",
     );
     await userEvent.click(categoryFilterCheckboxCustomMask);
 
@@ -821,7 +821,7 @@ describe("The dashboard", () => {
     await userEvent.click(categoryFilterButton);
 
     const categoryFilterCheckboxRandomMask = screen.getByLabelText(
-      "l10n string: [profile-filter-category-option-random-masks], with vars: {}"
+      "l10n string: [profile-filter-category-option-random-masks], with vars: {}",
     );
     await userEvent.click(categoryFilterCheckboxRandomMask);
 
@@ -856,7 +856,7 @@ describe("The dashboard", () => {
     await userEvent.click(categoryFilterButton);
 
     const categoryFilterCheckboxCustomMask = screen.getByLabelText(
-      "l10n string: [profile-filter-category-option-custom-masks], with vars: {}"
+      "l10n string: [profile-filter-category-option-custom-masks], with vars: {}",
     );
     await userEvent.click(categoryFilterCheckboxCustomMask);
 
@@ -893,7 +893,7 @@ describe("The dashboard", () => {
     // used by the add-on) is fine here:
     // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
     const addonDataElements = container.getElementsByTagName(
-      "firefox-private-relay-addon-data"
+      "firefox-private-relay-addon-data",
     );
 
     expect(addonDataElements).toHaveLength(1);
@@ -928,7 +928,7 @@ describe("The dashboard", () => {
     await userEvent.click(aliasDeleteButton);
 
     const confirmationCheckbox = screen.getByLabelText(
-      "l10n string: [modal-delete-confirmation-2], with vars: {}"
+      "l10n string: [modal-delete-confirmation-2], with vars: {}",
     );
     await userEvent.click(confirmationCheckbox);
 
@@ -969,7 +969,7 @@ describe("The dashboard", () => {
         name: "l10n string: [tips-header-title], with vars: {}",
       });
       const customMaskTip = screen.getByText(
-        "l10n string: [tips-custom-alias-heading-2], with vars: {}"
+        "l10n string: [tips-custom-alias-heading-2], with vars: {}",
       );
 
       expect(tipsHeader).toBeInTheDocument();
@@ -982,7 +982,7 @@ describe("The dashboard", () => {
       render(<Profile />);
 
       const customMaskTip = screen.queryByText(
-        "l10n string: [tips-custom-alias-heading-2], with vars: {}"
+        "l10n string: [tips-custom-alias-heading-2], with vars: {}",
       );
 
       expect(customMaskTip).not.toBeInTheDocument();
@@ -1052,7 +1052,7 @@ describe("The dashboard", () => {
       });
       const generateCustomAliasMenuItem = screen.getByRole("menuitem", {
         name: `l10n string: [profile-label-generate-new-alias-menu-custom-2], with vars: ${JSON.stringify(
-          { subdomain: "some_subdomain" }
+          { subdomain: "some_subdomain" },
         )}`,
       });
 

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -40,13 +40,13 @@ const Settings: NextPage = () => {
   const aliasData = useAliases();
   const addonData = useAddonData();
   const [labelCollectionEnabled, setLabelCollectionEnabled] = useState(
-    profileData.data?.[0].server_storage
+    profileData.data?.[0].server_storage,
   );
   const [trackerRemovalEnabled, setTrackerRemovalEnabled] = useState(
-    profileData.data?.[0].remove_level_one_email_trackers
+    profileData.data?.[0].remove_level_one_email_trackers,
   );
   const [phoneCallerSMSLogEnabled, setPhoneCallerSMSLogEnabled] = useState(
-    profileData.data?.[0].store_phone_log
+    profileData.data?.[0].store_phone_log,
   );
   const [phoneCallerSMSLogEnabledLabel, setPhoneCallerSMSLogEnabledLabel] =
     useState(false);
@@ -114,7 +114,7 @@ const Settings: NextPage = () => {
           const localLabel = localLabels?.find(
             (localLabel) =>
               localLabel.mask_type === alias.mask_type &&
-              localLabel.id === alias.id
+              localLabel.id === alias.id,
           );
           if (typeof localLabel !== "undefined") {
             aliasData.update(alias, {
@@ -284,7 +284,7 @@ const Settings: NextPage = () => {
     ) : null;
 
   const phoneCallerSMSLogSetting = isPhonesAvailableInCountry(
-    runtimeData.data
+    runtimeData.data,
   ) ? (
     <div className={styles.field}>
       <h2 className={styles["field-heading"]}>

--- a/frontend/src/pages/accounts/settings.test.tsx
+++ b/frontend/src/pages/accounts/settings.test.tsx
@@ -69,8 +69,8 @@ describe("The settings screen", () => {
 
     await userEvent.click(
       screen.getByLabelText(
-        "l10n string: [setting-label-collection-description-3], with vars: {}"
-      )
+        "l10n string: [setting-label-collection-description-3], with vars: {}",
+      ),
     );
 
     const toggleWarning = screen.getByRole("alert");
@@ -95,14 +95,14 @@ describe("The settings screen", () => {
 
     await userEvent.click(
       screen.getByLabelText(
-        "l10n string: [setting-label-collection-description-3], with vars: {}"
-      )
+        "l10n string: [setting-label-collection-description-3], with vars: {}",
+      ),
     );
 
     await userEvent.click(
       screen.getByRole("button", {
         name: "l10n string: [settings-button-save-label], with vars: {}",
-      })
+      }),
     );
 
     expect(addonNotifier).toHaveBeenCalledWith("serverStorageChange");
@@ -116,14 +116,14 @@ describe("The settings screen", () => {
 
     await userEvent.click(
       screen.getByLabelText(
-        "l10n string: [setting-label-collection-description-3], with vars: {}"
-      )
+        "l10n string: [setting-label-collection-description-3], with vars: {}",
+      ),
     );
 
     await userEvent.click(
       screen.getByRole("button", {
         name: "l10n string: [settings-button-save-label], with vars: {}",
-      })
+      }),
     );
 
     expect(addonNotifier).toHaveBeenCalledWith("serverStorageChange");

--- a/frontend/src/pages/contains-tracker-warning.page.tsx
+++ b/frontend/src/pages/contains-tracker-warning.page.tsx
@@ -67,7 +67,7 @@ const ContainsTracker: NextPage = () => {
           <OutboundLink
             to={trackerData.original_link}
             eventLabel={l10n.getString(
-              "contains-tracker-warning-view-link-cta"
+              "contains-tracker-warning-view-link-cta",
             )}
             target="_blank"
             rel="noopener noreferrer"
@@ -109,38 +109,38 @@ const ContainsTracker: NextPage = () => {
                     a: (
                       <p>
                         {l10n.getString(
-                          "faq-question-define-tracker-answer-partone"
+                          "faq-question-define-tracker-answer-partone",
                         )}
                         <br />
                         <br />
                         {l10n.getString(
-                          "faq-question-define-tracker-answer-parttwo"
+                          "faq-question-define-tracker-answer-parttwo",
                         )}
                       </p>
                     ),
                   },
                   {
                     q: l10n.getString(
-                      "faq-question-disable-trackerremoval-question"
+                      "faq-question-disable-trackerremoval-question",
                     ),
                     a: l10n.getString(
-                      "faq-question-disable-trackerremoval-answer"
+                      "faq-question-disable-trackerremoval-answer",
                     ),
                   },
                   {
                     q: l10n.getString(
-                      "faq-question-bulk-trackerremoval-question"
+                      "faq-question-bulk-trackerremoval-question",
                     ),
                     a: l10n.getString(
-                      "faq-question-bulk-trackerremoval-answer"
+                      "faq-question-bulk-trackerremoval-answer",
                     ),
                   },
                   {
                     q: l10n.getString(
-                      "faq-question-trackerremoval-breakage-question"
+                      "faq-question-trackerremoval-breakage-question",
                     ),
                     a: l10n.getString(
-                      "faq-question-trackerremoval-breakage-answer-2"
+                      "faq-question-trackerremoval-breakage-answer-2",
                     ),
                   },
                 ]}

--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -36,7 +36,7 @@ const Faq: NextPage = () => {
       <QAndA
         id={"phone-masking-faq-question-change-phone-mask"}
         question={l10n.getString(
-          "phone-masking-faq-question-change-phone-mask"
+          "phone-masking-faq-question-change-phone-mask",
         )}
       >
         <p>{l10n.getString("phone-masking-faq-answer-change-phone-mask")}</p>
@@ -159,13 +159,13 @@ const Faq: NextPage = () => {
 
   const trackerBlockingFaqs = isFlagActive(
     runtimeData.data,
-    "tracker_removal"
+    "tracker_removal",
   ) ? (
     <>
       <QAndA
         id="faq-disable-trackerremoval"
         question={l10n.getString(
-          "faq-question-disable-trackerremoval-question"
+          "faq-question-disable-trackerremoval-question",
         )}
       >
         <p>{l10n.getString("faq-question-disable-trackerremoval-answer")}</p>
@@ -179,7 +179,7 @@ const Faq: NextPage = () => {
       <QAndA
         id="faq-trackerremoval-breakage"
         question={l10n.getString(
-          "faq-question-trackerremoval-breakage-question"
+          "faq-question-trackerremoval-breakage-question",
         )}
       >
         <p>{l10n.getString("faq-question-trackerremoval-breakage-answer-2")}</p>
@@ -205,7 +205,7 @@ const Faq: NextPage = () => {
               <QAndA
                 id="faq-missing-emails"
                 question={l10n.getString(
-                  "faq-question-missing-emails-question-2"
+                  "faq-question-missing-emails-question-2",
                 )}
               >
                 <p>
@@ -214,12 +214,12 @@ const Faq: NextPage = () => {
                 <ul>
                   <li>
                     {l10n.getString(
-                      "faq-question-missing-emails-answer-reason-spam"
+                      "faq-question-missing-emails-answer-reason-spam",
                     )}
                   </li>
                   <li>
                     {l10n.getString(
-                      "faq-question-missing-emails-answer-reason-blocked-2"
+                      "faq-question-missing-emails-answer-reason-blocked-2",
                     )}
                   </li>
                   <li>
@@ -228,22 +228,22 @@ const Faq: NextPage = () => {
                       {
                         size: getRuntimeConfig().emailSizeLimitNumber,
                         unit: getRuntimeConfig().emailSizeLimitUnit,
-                      }
+                      },
                     )}
                   </li>
                   <li>
                     {l10n.getString(
-                      "faq-question-missing-emails-answer-reason-not-accepted-2"
+                      "faq-question-missing-emails-answer-reason-not-accepted-2",
                     )}
                   </li>
                   <li>
                     {l10n.getString(
-                      "faq-question-missing-emails-answer-reason-turned-off-2"
+                      "faq-question-missing-emails-answer-reason-turned-off-2",
                     )}
                   </li>
                   <li>
                     {l10n.getString(
-                      "faq-question-missing-emails-answer-reason-delay"
+                      "faq-question-missing-emails-answer-reason-delay",
                     )}
                   </li>
                 </ul>
@@ -322,19 +322,19 @@ const Faq: NextPage = () => {
               <QAndA
                 id="faq-subdomain-question"
                 question={l10n.getString(
-                  "faq-question-subdomain-characters-question"
+                  "faq-question-subdomain-characters-question",
                 )}
               >
                 <p>
                   {l10n.getString(
-                    "faq-question-subdomain-characters-answer-v2"
+                    "faq-question-subdomain-characters-answer-v2",
                   )}
                 </p>
               </QAndA>
               <QAndA
                 id="faq-browser-support"
                 question={l10n.getString(
-                  "faq-question-browser-support-question"
+                  "faq-question-browser-support-question",
                 )}
               >
                 <p>{l10n.getString("faq-question-browser-support-answer-2")}</p>
@@ -365,7 +365,7 @@ const Faq: NextPage = () => {
               <QAndA
                 id="faq-unsubscribe-domain"
                 question={l10n.getString(
-                  "faq-question-unsubscribe-domain-question-2"
+                  "faq-question-unsubscribe-domain-question-2",
                 )}
               >
                 <p>
@@ -421,7 +421,7 @@ const Faq: NextPage = () => {
               <QAndA
                 id="faq-acceptable-use"
                 question={l10n.getString(
-                  "faq-question-acceptable-use-question"
+                  "faq-question-acceptable-use-question",
                 )}
               >
                 <Localized
@@ -445,17 +445,17 @@ const Faq: NextPage = () => {
                 <ul>
                   <li>
                     {l10n.getString(
-                      "faq-question-acceptable-use-answer-measure-account"
+                      "faq-question-acceptable-use-answer-measure-account",
                     )}
                   </li>
                   <li>
                     {l10n.getString(
-                      "faq-question-acceptable-use-answer-measure-unlimited-payment-2"
+                      "faq-question-acceptable-use-answer-measure-unlimited-payment-2",
                     )}
                   </li>
                   <li>
                     {l10n.getString(
-                      "faq-question-acceptable-use-answer-measure-rate-limit-2"
+                      "faq-question-acceptable-use-answer-measure-rate-limit-2",
                     )}
                   </li>
                 </ul>
@@ -481,19 +481,19 @@ const Faq: NextPage = () => {
               <QAndA
                 id="faq-promotional-email-blocking"
                 question={l10n.getString(
-                  "faq-question-promotional-email-blocking-question"
+                  "faq-question-promotional-email-blocking-question",
                 )}
               >
                 <p>
                   {l10n.getString(
-                    "faq-question-promotional-email-blocking-answer"
+                    "faq-question-promotional-email-blocking-answer",
                   )}
                 </p>
               </QAndA>
               <QAndA
                 id="faq-detect-promotional"
                 question={l10n.getString(
-                  "faq-question-detect-promotional-question"
+                  "faq-question-detect-promotional-question",
                 )}
               >
                 <p>

--- a/frontend/src/pages/flags.page.tsx
+++ b/frontend/src/pages/flags.page.tsx
@@ -67,7 +67,7 @@ const Flags: NextPage = () => {
           and therefore cannot be {enable ? "enabled" : "disabled"} for
           everyone.
         </>,
-        { type: "error" }
+        { type: "error" },
       );
       return;
     }
@@ -80,7 +80,7 @@ const Flags: NextPage = () => {
           Flag <output>{flagInput}</output> {enable ? "enabled" : "disabled"}{" "}
           successfully
         </>,
-        { type: "success" }
+        { type: "success" },
       );
       // Don't make it too easy to update multiple flags in a row
       // (to avoid making mistakes):
@@ -92,7 +92,7 @@ const Flags: NextPage = () => {
           Something went wrong {enable ? "enabling" : "disabling"} flag{" "}
           <output>{flagInput}</output>
         </>,
-        { type: "error" }
+        { type: "error" },
       );
     }
     return;

--- a/frontend/src/pages/index.page.tsx
+++ b/frontend/src/pages/index.page.tsx
@@ -140,7 +140,7 @@ const Home: NextPage = () => {
                     a: isFlagActive(runtimeData.data, "eu_country_expansion")
                       ? l10n.getString("faq-question-availability-answer-v4")
                       : l10n.getString(
-                          "faq-question-landing-page-availability"
+                          "faq-question-landing-page-availability",
                         ),
                   },
                   {
@@ -153,12 +153,12 @@ const Home: NextPage = () => {
                       <>
                         <p>
                           {l10n.getString(
-                            "faq-question-use-cases-answer-part1-2"
+                            "faq-question-use-cases-answer-part1-2",
                           )}
                         </p>
                         <p>
                           {l10n.getString(
-                            "faq-question-use-cases-answer-part2-2"
+                            "faq-question-use-cases-answer-part2-2",
                           )}
                         </p>
                       </>

--- a/frontend/src/pages/mock/login.page.tsx
+++ b/frontend/src/pages/mock/login.page.tsx
@@ -139,7 +139,7 @@ function byUseDate(a: UsedToken, b: UsedToken) {
 function isFirstInstance(
   value: UsedToken,
   index: number,
-  fullArray: UsedToken[]
+  fullArray: UsedToken[],
 ): boolean {
   return fullArray.findIndex((token) => token.token === value.token) === index;
 }

--- a/frontend/src/pages/phone.page.tsx
+++ b/frontend/src/pages/phone.page.tsx
@@ -27,11 +27,11 @@ const Phone: NextPage = () => {
   const relayNumberData = useRelayNumber();
   const [isInOnboarding, setIsInOnboarding] = useState<boolean>();
   const welcomeScreenDismissal = useLocalDismissal(
-    `phone-welcome-screen-${profile?.id}`
+    `phone-welcome-screen-${profile?.id}`,
   );
 
   const resendWelcomeSMSDismissal = useLocalDismissal(
-    `resend-sms-banner-${profile?.id}`
+    `resend-sms-banner-${profile?.id}`,
   );
 
   const realPhoneData = useRealPhonesData();

--- a/frontend/src/pages/tracker-report.page.tsx
+++ b/frontend/src/pages/tracker-report.page.tsx
@@ -59,7 +59,7 @@ const TrackerReport: NextPage = () => {
   }
 
   const trackers = Object.entries(reportData.trackers ?? {}).sort(
-    ([_trackerA, countA], [_trackerB, countB]) => countB - countA
+    ([_trackerA, countA], [_trackerB, countB]) => countB - countA,
   );
   const trackerListing =
     trackers.length === 0 ? (
@@ -126,7 +126,7 @@ const TrackerReport: NextPage = () => {
                   {l10n.getString("trackerreport-trackers-value", {
                     count: Object.values(reportData.trackers ?? {}).reduce(
                       (acc, count) => acc + count,
-                      0
+                      0,
                     ),
                   })}
                 </dd>
@@ -151,12 +151,12 @@ const TrackerReport: NextPage = () => {
               </h2>
               <p>
                 {l10n.getString(
-                  "trackerreport-trackers-explainer-content-part1"
+                  "trackerreport-trackers-explainer-content-part1",
                 )}
               </p>
               <p>
                 {l10n.getString(
-                  "trackerreport-trackers-explainer-content-part2"
+                  "trackerreport-trackers-explainer-content-part2",
                 )}
               </p>
               <div className={styles["breakage-warning"]}>
@@ -187,12 +187,12 @@ const TrackerReport: NextPage = () => {
                       <>
                         <p>
                           {l10n.getString(
-                            "faq-question-define-tracker-answer-partone"
+                            "faq-question-define-tracker-answer-partone",
                           )}
                         </p>
                         <p>
                           {l10n.getString(
-                            "faq-question-define-tracker-answer-parttwo"
+                            "faq-question-define-tracker-answer-parttwo",
                           )}
                         </p>
                       </>
@@ -200,26 +200,26 @@ const TrackerReport: NextPage = () => {
                   },
                   {
                     q: l10n.getString(
-                      "faq-question-disable-trackerremoval-question"
+                      "faq-question-disable-trackerremoval-question",
                     ),
                     a: l10n.getString(
-                      "faq-question-disable-trackerremoval-answer"
+                      "faq-question-disable-trackerremoval-answer",
                     ),
                   },
                   {
                     q: l10n.getString(
-                      "faq-question-bulk-trackerremoval-question"
+                      "faq-question-bulk-trackerremoval-question",
                     ),
                     a: l10n.getString(
-                      "faq-question-bulk-trackerremoval-answer"
+                      "faq-question-bulk-trackerremoval-answer",
                     ),
                   },
                   {
                     q: l10n.getString(
-                      "faq-question-trackerremoval-breakage-question"
+                      "faq-question-trackerremoval-breakage-question",
                     ),
                     a: l10n.getString(
-                      "faq-question-trackerremoval-breakage-answer-2"
+                      "faq-question-trackerremoval-breakage-answer-2",
                     ),
                   },
                 ]}
@@ -263,7 +263,7 @@ function containsReportData(parsed: any): parsed is ReportData {
     ["undefined", "object"].includes(typeof parsed.trackers) &&
     Object.entries(parsed.trackers ?? {}).every(
       ([tracker, count]: [unknown, unknown]) =>
-        typeof tracker === "string" && Number.isInteger(count)
+        typeof tracker === "string" && Number.isInteger(count),
     )
   );
 }

--- a/frontend/src/pages/vpn-relay-welcome.page.tsx
+++ b/frontend/src/pages/vpn-relay-welcome.page.tsx
@@ -76,7 +76,7 @@ const VpnRelayWelcome: NextPage = () => {
               <p>{l10n.getString("vpn-relay-go-vpn-body")}</p>
               <LinkButton
                 href={`https://vpn.mozilla.org/vpn/download/?utm_source=${encodeURIComponent(
-                  referringSiteUrl
+                  referringSiteUrl,
                 )}&utm_medium=referral&utm_campaign=vpn-relay-welcome&utm_content=download-button`}
                 target="_blank"
                 className={styles["get-addon-button"]}

--- a/frontend/src/styles/fonts/inter-ui.scss
+++ b/frontend/src/styles/fonts/inter-ui.scss
@@ -3,7 +3,8 @@
   font-style: normal;
   font-weight: 100;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-Thin.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-Thin.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-Thin.woff?v=3.18") format("woff");
 }
 @font-face {
@@ -11,7 +12,8 @@
   font-style: italic;
   font-weight: 100;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-ThinItalic.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-ThinItalic.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-ThinItalic.woff?v=3.18") format("woff");
 }
 
@@ -20,7 +22,8 @@
   font-style: normal;
   font-weight: 200;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-ExtraLight.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-ExtraLight.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-ExtraLight.woff?v=3.18") format("woff");
 }
 @font-face {
@@ -28,7 +31,8 @@
   font-style: italic;
   font-weight: 200;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-ExtraLightItalic.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-ExtraLightItalic.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-ExtraLightItalic.woff?v=3.18") format("woff");
 }
 
@@ -37,7 +41,8 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-Light.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-Light.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-Light.woff?v=3.18") format("woff");
 }
 @font-face {
@@ -45,7 +50,8 @@
   font-style: italic;
   font-weight: 300;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-LightItalic.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-LightItalic.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-LightItalic.woff?v=3.18") format("woff");
 }
 
@@ -54,7 +60,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-Regular.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-Regular.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-Regular.woff?v=3.18") format("woff");
 }
 @font-face {
@@ -62,7 +69,8 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-Italic.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-Italic.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-Italic.woff?v=3.18") format("woff");
 }
 
@@ -71,7 +79,8 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-Medium.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-Medium.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-Medium.woff?v=3.18") format("woff");
 }
 @font-face {
@@ -79,7 +88,8 @@
   font-style: italic;
   font-weight: 500;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-MediumItalic.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-MediumItalic.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-MediumItalic.woff?v=3.18") format("woff");
 }
 
@@ -88,7 +98,8 @@
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-SemiBold.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-SemiBold.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-SemiBold.woff?v=3.18") format("woff");
 }
 @font-face {
@@ -96,7 +107,8 @@
   font-style: italic;
   font-weight: 600;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-SemiBoldItalic.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-SemiBoldItalic.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-SemiBoldItalic.woff?v=3.18") format("woff");
 }
 
@@ -105,7 +117,8 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-Bold.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-Bold.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-Bold.woff?v=3.18") format("woff");
 }
 @font-face {
@@ -113,7 +126,8 @@
   font-style: italic;
   font-weight: 700;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-BoldItalic.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-BoldItalic.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-BoldItalic.woff?v=3.18") format("woff");
 }
 
@@ -122,7 +136,8 @@
   font-style: normal;
   font-weight: 800;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-ExtraBold.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-ExtraBold.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-ExtraBold.woff?v=3.18") format("woff");
 }
 @font-face {
@@ -130,7 +145,8 @@
   font-style: italic;
   font-weight: 800;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-ExtraBoldItalic.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-ExtraBoldItalic.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-ExtraBoldItalic.woff?v=3.18") format("woff");
 }
 
@@ -139,7 +155,8 @@
   font-style: normal;
   font-weight: 900;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-Black.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-Black.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-Black.woff?v=3.18") format("woff");
 }
 @font-face {
@@ -147,7 +164,8 @@
   font-style: italic;
   font-weight: 900;
   font-display: swap;
-  src: url("/fonts/Inter/Inter-BlackItalic.woff2?v=3.18") format("woff2"),
+  src:
+    url("/fonts/Inter/Inter-BlackItalic.woff2?v=3.18") format("woff2"),
     url("/fonts/Inter/Inter-BlackItalic.woff?v=3.18") format("woff");
 }
 

--- a/frontend/src/styles/fonts/metropolis.scss
+++ b/frontend/src/styles/fonts/metropolis.scss
@@ -2,7 +2,8 @@
   font-family: "Metropolis";
   font-style: normal;
   font-weight: 700;
-  src: local("Metropolis-Bold"),
+  src:
+    local("Metropolis-Bold"),
     url("/fonts/Metropolis/Metropolis-Bold.woff2") format("woff2");
   font-display: swap;
 }
@@ -11,7 +12,8 @@
   font-family: "Metropolis";
   font-style: normal;
   font-weight: 600;
-  src: local("Metropolis-SemiBold"),
+  src:
+    local("Metropolis-SemiBold"),
     url("/fonts/Metropolis/Metropolis-SemiBold.woff2") format("woff2");
   font-display: swap;
 }
@@ -20,7 +22,8 @@
   font-family: "Metropolis";
   font-style: normal;
   font-weight: 500;
-  src: local("Metropolis-Medium"),
+  src:
+    local("Metropolis-Medium"),
     url("/fonts/Metropolis/Metropolis-Medium.woff2") format("woff2");
   font-display: swap;
 }
@@ -29,7 +32,8 @@
   font-family: "Metropolis";
   font-style: normal;
   font-weight: 300;
-  src: local("Metropolis-Light"),
+  src:
+    local("Metropolis-Light"),
     url("/fonts/Metropolis/Metropolis-Light.woff2") format("woff2");
   font-display: swap;
 }

--- a/frontend/src/styles/fonts/zilla-slab.scss
+++ b/frontend/src/styles/fonts/zilla-slab.scss
@@ -2,7 +2,8 @@
   font-family: "Zilla Slab";
   font-style: normal;
   font-weight: 700;
-  src: local("Zilla Slab-Bold"),
+  src:
+    local("Zilla Slab-Bold"),
     url("/fonts/Zilla_Slab/ZillaSlab-Bold.woff2") format("woff2");
   font-display: swap;
 }
@@ -11,7 +12,8 @@
   font-family: "Zilla Slab";
   font-style: normal;
   font-weight: 600;
-  src: local("Zilla Slab-SemiBold"),
+  src:
+    local("Zilla Slab-SemiBold"),
     url("/fonts/Zilla_Slab/ZillaSlab-SemiBold.woff2") format("woff2");
   font-display: swap;
 }
@@ -20,7 +22,8 @@
   font-family: "Zilla Slab";
   font-style: normal;
   font-weight: 500;
-  src: local("Zilla Slab-Medium"),
+  src:
+    local("Zilla Slab-Medium"),
     url("/fonts/Zilla_Slab/ZillaSlab-Medium.woff2") format("woff2");
   font-display: swap;
 }
@@ -29,7 +32,8 @@
   font-family: "Zilla Slab";
   font-style: normal;
   font-weight: 300;
-  src: local("Zilla Slab-Light"),
+  src:
+    local("Zilla Slab-Light"),
     url("/fonts/Zilla_Slab/ZillaSlab-Light.woff2") format("woff2");
   font-display: swap;
 }

--- a/frontend/src/styles/tokens.scss
+++ b/frontend/src/styles/tokens.scss
@@ -8,7 +8,9 @@ $firefoxGradient: linear-gradient(
 );
 
 // For use with box-shadow:
-$buttonFocusOutline: 0 0 0 1px #0a84ff, 0 0 0 1px #0a84ff,
+$buttonFocusOutline:
+  0 0 0 1px #0a84ff,
+  0 0 0 1px #0a84ff,
   0 0 0 4px rgba(10, 132, 255, 0.3);
 
 // Overwrite the Protocol colours with Nebula colours:

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "license-checker": "^25.0.1",
         "lint-staged": "^13.2.3",
         "next": "^13.4.9",
-        "prettier": "2.8.8",
+        "prettier": "3.0.0",
         "react-test-renderer": "^18.2.0",
         "sass": "^1.63.6",
         "stylelint": "^15.10.1",
@@ -11958,15 +11958,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -19086,7 +19086,7 @@
         "lint-staged": "^13.2.3",
         "msw": "^1.2.2",
         "next": "^13.4.9",
-        "prettier": "2.8.8",
+        "prettier": "3.0.0",
         "react": "18.2.0",
         "react-aria": "^3.26.0",
         "react-dom": "18.2.0",
@@ -22570,9 +22570,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
       "dev": true
     },
     "pretty-format": {


### PR DESCRIPTION
This includes the upgrade to prettier 3.0.0 on PR #3663, and applies the new rules with `npx prettier --write ./src`. The changes are:

* [trailing-commas](https://prettier.io/docs/en/options.html#trailing-commas) changed from `es5` to `all`, affecting `.ts` and `.tsx` files
* Multi-line `.scss` rules had the first line inline, and now it is indented with the rest of the lines.