### PR TITLE
MPP-3264: Re-implement guessing the country from the Accept-Langugage header

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -23,7 +23,11 @@ from rest_framework.authtoken.models import Token
 
 from api.exceptions import ErrorContextType, RelayAPIException
 from privaterelay.plans import get_premium_countries
-from privaterelay.utils import flag_is_active_in_task, guess_country_from_accept_lang
+from privaterelay.utils import (
+    AcceptLanguageError,
+    flag_is_active_in_task,
+    guess_country_from_accept_lang,
+)
 
 
 emails_config = apps.get_app_config("emails")
@@ -172,7 +176,10 @@ class Profile(models.Model):
     @property
     def fxa_locale_in_premium_country(self) -> bool:
         if self.fxa and self.fxa.extra_data.get("locale"):
-            country = guess_country_from_accept_lang(self.fxa.extra_data["locale"])
+            try:
+                country = guess_country_from_accept_lang(self.fxa.extra_data["locale"])
+            except AcceptLanguageError:
+                return False
             eu_country_expansion = flag_is_active_in_task(
                 "eu_country_expansion", self.user
             )

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -724,8 +724,12 @@ class ProfileFxaLocaleInPremiumCountryTest(ProfileTestCase):
         self.set_fxa_locale("de-DE,en-xx;q=0.9,en;q=0.8")
         assert self.profile.fxa_locale_in_premium_country is True
 
-    def test_when_premium_unavailable_returns_False(self) -> None:
+    def test_en_implies_premium_available(self) -> None:
         self.set_fxa_locale("en;q=0.8")
+        assert self.profile.fxa_locale_in_premium_country is True
+
+    def test_when_premium_unavailable_returns_False(self) -> None:
+        self.set_fxa_locale("en-IN, en;q=0.8")
         assert self.profile.fxa_locale_in_premium_country is False
 
     def test_when_premium_available_by_language_code_returns_True(self) -> None:

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -736,9 +736,9 @@ class ProfileFxaLocaleInPremiumCountryTest(ProfileTestCase):
         self.set_fxa_locale("de;q=0.8")
         assert self.profile.fxa_locale_in_premium_country is True
 
-    def test_when_invalid_language_code_returns_True(self) -> None:
-        self.set_fxa_locale("xx;q=0.8")  # Invalid code, treated as 'us'
-        assert self.profile.fxa_locale_in_premium_country is True
+    def test_invalid_language_code_returns_False(self) -> None:
+        self.set_fxa_locale("xx;q=0.8")
+        assert self.profile.fxa_locale_in_premium_country is False
 
     def test_when_premium_unavailable_by_language_code_returns_False(self) -> None:
         self.set_fxa_locale("zh;q=0.8")

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -736,8 +736,12 @@ class ProfileFxaLocaleInPremiumCountryTest(ProfileTestCase):
         self.set_fxa_locale("de;q=0.8")
         assert self.profile.fxa_locale_in_premium_country is True
 
+    def test_when_invalid_language_code_returns_True(self) -> None:
+        self.set_fxa_locale("xx;q=0.8")  # Invalid code, treated as 'us'
+        assert self.profile.fxa_locale_in_premium_country is True
+
     def test_when_premium_unavailable_by_language_code_returns_False(self) -> None:
-        self.set_fxa_locale("xx;q=0.8")
+        self.set_fxa_locale("zh;q=0.8")
         assert self.profile.fxa_locale_in_premium_country is False
 
     def test_no_fxa_account_returns_False(self) -> None:

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -14,7 +14,6 @@ from waffle.testutils import override_flag
 from waffle.utils import get_cache as get_waffle_cache
 import pytest
 
-from ..plans import get_premium_country_language_mapping
 from ..utils import (
     flag_is_active_in_task,
     get_premium_country_lang,
@@ -22,50 +21,24 @@ from ..utils import (
 
 
 class GetPremiumCountryLangTest(TestCase):
-    def setUp(self):
-        self.mapping = get_premium_country_language_mapping(None)
-
-    def test_get_premium_country_lang(self):
-        cc, lang = get_premium_country_lang("en-au,", self.mapping)
-        assert cc == "au"
-        assert lang == "en"
-
-        cc, lang = get_premium_country_lang("en-us,", self.mapping)
-        assert cc == "us"
-        assert lang == "en"
-
-        cc, lang = get_premium_country_lang("de-be,", self.mapping)
-        assert cc == "be"
-        assert lang == "de"
+    def test_get_premium_country_lang(self) -> None:
+        assert get_premium_country_lang("en-au,") == "au"
+        assert get_premium_country_lang("en-us,") == "us"
+        assert get_premium_country_lang("de-be,") == "be"
 
     def test_en_fallback(self) -> None:
-        cc, lang = get_premium_country_lang("en,", self.mapping)
-        assert cc == "us"
-        assert lang == "en"
+        assert get_premium_country_lang("en,") == "us"
 
     def test_first_lang_fallback_two_parts(self) -> None:
         accept_lang = "sgn-us,"  # American Sign Language
-        cc, lang = get_premium_country_lang(accept_lang, self.mapping)
-        assert cc == "us"
-        assert lang == "en"
+        assert get_premium_country_lang(accept_lang) == "us"
 
     def test_first_lang_fallback_three_parts(self) -> None:
         accept_lang = "sgn-ch-de,"  # Swiss German Sign Language
-        cc, lang = get_premium_country_lang(accept_lang, self.mapping)
-        assert cc == "ch"
-        assert lang == "fr"
+        assert get_premium_country_lang(accept_lang) == "ch"
 
-    def test_eu_country_expansion_active(self) -> None:
-        mapping = get_premium_country_language_mapping(eu_country_expansion=True)
-        cc, lang = get_premium_country_lang("et-ee", mapping)
-        assert cc == "ee"
-        assert lang == "et"
-
-    def test_eu_country_expansion_inactive(self) -> None:
-        mapping = get_premium_country_language_mapping(eu_country_expansion=False)
-        cc, lang = get_premium_country_lang("et-ee", mapping)
-        assert cc == "ee"
-        assert lang == "en"
+    def test_eu_country_expansion(self) -> None:
+        assert get_premium_country_lang("et-ee") == "ee"
 
 
 #

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -13,9 +13,11 @@ from waffle.testutils import override_flag
 from waffle.utils import get_cache as get_waffle_cache
 import pytest
 
+from ..plans import get_premium_country_language_mapping
 from ..utils import (
     AcceptLanguageError,
     flag_is_active_in_task,
+    get_countries_info_from_request_and_mapping,
     guess_country_from_accept_lang,
 )
 
@@ -263,6 +265,18 @@ def test_guess_country_from_accept_lang(accept_lang, expected_country_code) -> N
 def test_guess_country_from_accept_lang_fails(accept_lang) -> None:
     with pytest.raises(AcceptLanguageError):
         guess_country_from_accept_lang(accept_lang)
+
+
+def test_get_countries_info_bad_accept_language(rf) -> None:
+    request = rf.get("/api/v1/runtime_data", HTTP_ACCEPT_LANGUAGE="xx")
+    mapping = get_premium_country_language_mapping(None)
+    result = get_countries_info_from_request_and_mapping(request, mapping)
+    assert result == {
+        "country_code": "",
+        "countries": sorted(mapping.keys()),
+        "available_in_country": False,
+        "plan_country_lang_mapping": mapping,
+    }
 
 
 #

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -38,10 +38,6 @@ class GetPremiumCountryLangTest(TestCase):
         assert cc == "be"
         assert lang == "de"
 
-        cc, lang = get_premium_country_lang("de-be,", self.mapping, "at")
-        assert cc == "at"
-        assert lang == "de"
-
     def test_en_fallback(self) -> None:
         cc, lang = get_premium_country_lang("en,", self.mapping)
         assert cc == "us"

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -32,7 +32,7 @@ from ..utils import (
         # Good headers, from Django test test_parse_spec_http_header
         ("de", "de"),
         ("en-AU", "au"),
-        ("es-419", "es"),
+        ("es-419", "mx"),
         ("*;q=1.00", "us"),
         ("en-AU;q=0.123", "au"),
         ("en-au;q=0.5", "au"),
@@ -194,6 +194,56 @@ from ..utils import (
         ("zam, es-MX, es, en-US, en", "mx"),  # Miahuatlán Zapotec
         ("zh-CN, zh, zh-TW, zh-HK, en-US, en", "cn"),  # Chinese (China)
         ("zh-tw, zh, en-us, en", "tw"),  # Chinese (Taiwan)
+        # Test cases from RFC 5646, "Tags for Identifying Languages", Appendix A
+        # RFC 5646 - Simple language subtag
+        ("de", "de"),  # German -> Germany
+        ("fr", "fr"),  # French -> France
+        ("ja", "jp"),  # Japanese -> Japan
+        ("i-enochian", "us"),  # Enochian (grandfathered) -> US
+        # RFC 5646 - Language subtag plus Script subtag
+        ("zh-Hant", "cn"),  # Chinese in Traditional Chinese script -> China
+        ("zh-Hans", "cn"),  # Chinese in Simplified Chinese script -> China
+        ("sr-Cyrl", "rs"),  # Serbian in Cyrillic script -> Serbia
+        ("sr-Latn", "rs"),  # Serbian in Latin script -> Serbia
+        # RFC 5646 - Extended language subtags with primary language subtag counterparts
+        ("zh-cmn-Hans-CN", "cn"),  # Chinese, Mandarin, Simplified script, in China
+        ("cmn-Hans-CN", "cn"),  # Mandarin Chinese, Simplified script, as used in China
+        ("zh-yue-HK", "hk"),  # Chinese, Cantonese, as used in Hong Kong SAR
+        ("yue-HK", "hk"),  # Cantonese Chinese, as used in Hong Kong SAR
+        # RFC 5646 - Language-Script-Region
+        ("zh-Hans-CN", "cn"),  # Chinese in Simplified script in mainland China -> China
+        ("sr-Latn-RS", "rs"),  # Serbian in Latin script in Serbia
+        ("zh-Hans-TW", "tw"),  # Chinese in Simplified script in Taiwan (added)
+        # RFC 5646 - Language-Variant
+        ("sl-rozaj", "si"),  # Resian dialect of Slovenian -> Slovenia
+        ("sl-rozaj-biske", "si"),  # San Giorgio dialect of Resian dialect of Slovenian
+        ("sl-nedis", "si"),  # Nadiza dialect of Slovenian -> Slovenia
+        # RFC 5646 - Language-Region-Variant
+        ("de-CH-1901", "ch"),  # German as used in Switzerland using the 1901 variant
+        ("sl-IT-nedis", "it"),  # Slovenian as used in Italy, Nadiza dialect
+        # RFC 5646 - Language-Script-Region-Variant
+        ("hy-Latn-IT-arevela", "it"),  # Eastern Armenian in Latin script, in Italy
+        # RFC 5646 - Language-Region
+        ("de-DE", "de"),  # German for Germany
+        ("en-US", "us"),  # English as used in the United States
+        ("es-419", "mx"),  # Spanish in Latin America and Caribbean region (UN code)
+        # RFC 5646 - Private use subtags
+        ("de-CH-x-phonebk", "ch"),  # Swiss German with private use subtag
+        ("az-Arab-x-AZE-derbend", "az"),  # another private use subtag
+        # RFC 5646 - Private use registry values
+        ("x-whatever", "us"),  # private use using the singleton 'x'
+        ("qaa-Qaaa-QM-x-southern", "us"),  # all private tags
+        ("de-Qaaa", "de"),  # German, with a private script
+        ("sr-Latn-QM", "rs"),  # Serbian, Latin-script, private region
+        ("sr-Qaaa-CS", "cs"),  # Serbian, private script, for Serbia and Montenegro
+        # RFC 5646 - Examples of possible tags that use extensions
+        ("en-US-u-islamCal", "us"),
+        ("zh-CN-a-myext-x-private", "cn"),
+        ("en-a-myext-b-another", "us"),
+        # RFC 5646 - Invalid tags
+        ("de-419-DE", "de"),  # two region tags
+        ("a-DE", "us"),  # single-character subtag in primary position
+        ("ar-a-aaa-b-bbb-a-ccc", "eg"),  # two extensions with same 1 char prefix 'a'
     ),
 )
 def test_guess_country_from_accept_lang(accept_lang, expected_country_code) -> None:

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -37,7 +37,7 @@ from ..utils import (
         ("en-AU;q=0.123", "au"),
         ("en-au;q=0.5", "au"),
         ("en-au;q=1.0", "au"),
-        ("da, en-gb;q=0.25, en;q=0.5", "da"),
+        ("da, en-gb;q=0.25, en;q=0.5", "dk"),
         ("de,en-au;q=0.75,en-us;q=0.5,en;q=0.25,es;q=0.125,fa;q=0.125", "de"),
         ("*", "us"),
         ("de;q=0.", "de"),
@@ -58,6 +58,142 @@ from ..utils import (
         ("12-345", "us"),
         ("", "us"),
         ("en;q=1e0", "us"),
+        # Default Accept-Language headers from Firefox
+        # https://pontoon.mozilla.org/de/firefox/toolkit/chrome/global/intl.properties/?string=81017
+        ("ace, id, en-US, en", "id"),  # Acehnese -> Indonesia
+        ("ach, en-GB, en-US, en", "ug"),  # Acholi -> Uganda
+        ("af, en-ZA, en-GB, en-US, en", "za"),  # Afrikaans -> South Africa
+        ("ar, en-us, en", "eg"),  # Arabic -> Egypt
+        ("arn,es-CL,es-AR,es-MX,es-ES,es,en-US,en", "cl"),  # Mapudungun -> Chile
+        ("an, es-ES, es, ca, en-US, en", "es"),  # Aragonese -> Spain
+        ("as, en-us, en", "in"),  # Assamese -> India
+        ("ast, es-ES, es, en-US, en", "es"),  # Asturian -> Spain
+        ("az-AZ, az, en-US, en", "az"),  # Azerbaijani -> Azerbaijan
+        ("be, en-US, en", "by"),  # Belerusian -> Belarus
+        ("bg, en-US, en", "bg"),  # Bulgarian -> Bulgaria
+        ("bn, en-US, en", "bd"),  # Bengali -> Bangladesh
+        ("bn-in, bn, en-us, en", "in"),  # Bengali (India) -> India
+        ("bo-CN,bo-IN,bo,en-US, en", "cn"),  # Tibetan -> China
+        ("br, fr-FR, fr, en-US, en", "fr"),  # Breton -> France
+        ("brx,as,en-US,en", "in"),  # Bodo -> India
+        ("bs-ba, bs, en-us, en", "ba"),  # Bosnian -> Bosnia and Herzegovina
+        ("ca, en-us, en", "fr"),  # Catalan -> France
+        ("ca-valencia, ca, en-us, en", "es"),  # Catalan (Valencian) -> Spain
+        ("cak, kaq, es, en-us, en", "mx"),  # Kaqchikel -> Mexico
+        ("ckb,en-US,en", "iq"),  # Central Kurdish -> Iraq
+        ("cs, sk, en-US, en", "cz"),  # Czech -> Czech Republic
+        ("cv, en-US, en", "ru"),  # Chuvash -> Russia
+        ("cy-GB, cy, en-US, en", "gb"),  # Welsh -> United Kingdom
+        ("da, en-us, en", "dk"),  # Danish -> Denmark
+        ("de, en-US, en", "de"),  # German -> Germany
+        ("dsb, hsb, de, en-US, en", "de"),  # Lower Sorbian -> Germany
+        ("el-GR, el, en-US, en", "gr"),  # Greek -> Greece
+        ("en-CA, en-US, en", "ca"),  # English (Canadian) -> Canada
+        ("en-GB, en", "gb"),  # English (Great Britain) -> United Kingdom
+        ("eo, en-US, en", "sm"),  # Esperanto -> San Marino
+        ("es-AR, es, en-US, en", "ar"),  # Spanish (Argentina) -> Argentina
+        ("es-CL, es, en-US, en", "cl"),  # Spanish (Chile) -> Chile
+        ("es-ES, es, en-US, en", "es"),  # Spanish (Spain) -> Spain
+        ("es-MX, es, en-US, en", "mx"),  # Spanish (Mexico) -> Mexico
+        ("et, et-ee, en-us, en", "ee"),  # Estonian -> Estonia
+        ("eu, en-us, en", "es"),  # Basque -> Spain
+        ("fa-ir, fa, en-us, en", "ir"),  # Persian -> Iran
+        ("ff, fr-FR, fr, en-GB, en-US, en", "sn"),  # Fulah -> Senegal
+        ("fi-fi, fi, en-us, en", "fi"),  # Finnish -> Finland
+        ("fr, fr-fr, en-us, en", "fr"),  # French -> France
+        ("frp, fr-FR, fr, en-US, en", "fr"),  # Arpitan -> France
+        ("fur-IT, fur, it-IT, it, en-US, en", "it"),  # Friulian -> Italy
+        ("fy-nl, fy, nl, en-us, en ", "nl"),  # Frisian -> Netherlands
+        ("ga-ie, ga, en-ie, en-gb, en-us, en", "ie"),  # Irish -> Ireland
+        ("gd-gb, gd, en-gb, en-us, en", "gb"),  # Gaelic, Scottish -> United Kingdom
+        ("gl-gl, gl, en-us, en", "es"),  # Galician -> Spain
+        ("gn, es, en-US, en", "py"),  # Guarani -> Paraguay
+        ("gu-in, gu, en-us, en", "in"),  # Gujarati -> India
+        ("gv,en-GB,en-US,en", "im"),  # Manx -> Isle of Man
+        ("he, he-IL, en-US, en", "il"),  # Hebrew -> Israel
+        ("hi-in, hi, en-us, en", "in"),  # Hindi -> India
+        ("hr, hr-HR, en-US, en", "hr"),  # Croatian -> Croatia
+        ("hsb, dsb, de, en-US, en", "de"),  # Upper Sorbian -> Germany
+        ("hu-hu, hu, en-US, en", "hu"),  # Hungarian -> Hungary
+        ("hy-AM,hy,en-us,en", "am"),  # Armenian -> Armenia
+        ("hye,hy,en-US,en", "am"),  # Armenian Eastern Classic Orthography -> Armenia
+        ("ia, en-US, en", "fr"),  # Interlingua -> France
+        ("id, en-us, en", "id"),  # Indonesian -> Indonesia
+        ("ilo-PH, ilo, en-US, en", "ph"),  # Iloko -> Philippines
+        ("is, en-us, en", "is"),  # Icelandic -> Iceland
+        ("it-IT, it, en-US, en", "it"),  # Italian -> Italy
+        ("ixl, es-MX, es, en-US, en", "mx"),  # Ixil -> Mexico
+        ("ja, en-US, en", "jp"),  # Japanese -> Japan
+        ("jiv, es, en-US, en", "mx"),  # Shuar -> Mexico
+        ("ka-GE,ka,en-US,en", "ge"),  # Georgian -> Georgia
+        ("kab-DZ,kab,fr-FR,fr,en-US,en", "dz"),  # Kayble -> Algeria
+        ("kk, ru, ru-RU, en-US, en", "kz"),  # Kazakh -> Kazakhstan
+        ("km, en-US, en", "kh"),  # Khmer -> Cambodia
+        ("kn-IN, kn, en-us, en", "in"),  # Kannada -> India
+        ("ko-KR, ko, en-US, en", "kr"),  # Korean -> South Korea
+        ("ks,en-US,en", "in"),  # Kashmiri -> India
+        ("lb, de-DE, de, en-US, en", "lu"),  # Luxembourgish -> Luxembourg
+        ("lg, en-gb, en-us, en", "ug"),  # Luganda -> Uganda
+        ("lij, it, en-US, en", "it"),  # Ligurian -> Italy
+        ("lo, en-US, en", "la"),  # Lao -> Laos
+        ("lt, en-us, en, ru, pl", "lt"),  # Lithuanian -> Lithuania
+        ("ltg, lv, en-US, en", "lv"),  # Latgalian -> Latvia
+        ("lus,en-US,en", "us"),  # Mizo -> United States
+        ("lv, en-us, en", "lv"),  # Latvian -> Latvia
+        ("mai, hi-IN, en", "in"),  # Maithili -> India
+        ("meh,es-MX,es,en-US,en", "mx"),  # Mixteco Yucuhiti -> Mexico
+        ("mix,es-MX,es,en-US,en", "mx"),  # Mixtepec Mixtec -> Mexico
+        ("mk-mk, mk, en-us, en", "mk"),  # Macedonian -> North Macedonia
+        ("ml-in, ml, en-US, en", "in"),  # Malayalam -> India
+        ("mr-IN, mr, en-US, en", "in"),  # Marathi -> India
+        ("ms,en-us, en", "my"),  # Malay -> Malaysia
+        ("my, en-GB, en", "mm"),  # Burmese -> Myanmar
+        ("nb-no, nb, no-no, no, nn-no, nn, en-us, en", "no"),  # No. Bokmål -> Norway
+        ("ne-NP, ne, en-US, en", "np"),  # Nepali -> Nepal
+        ("nl, en-US, en", "nl"),  # Dutch -> Netherlands
+        ("nn-no, nn, no-no, no, nb-no, nb, en-us, en", "no"),  # No. Nynorsk -> Norway
+        ("oc, ca, fr, es, it, en-US, en", "fr"),  # Occitan -> France
+        ("or, en-US, en", "in"),  # Odia -> India
+        ("pa, pa-in, en-us, en", "in"),  # Punjabi -> India
+        ("pl, en-US, en", "pl"),  # Polish -> Poland
+        ("ppl,es-MX,es,en-US,en", "mx"),  # Náhuat Pipil -> Mexico
+        ("pt-BR, pt, en-US, en", "br"),  # Portuguese (Brazil) -> Brazil
+        ("pt-PT, pt, en, en-US", "pt"),  # Portuguese (Portugal) -> Portugal
+        ("quc,es-MX,es,en-US,en", "gt"),  # K'iche' -> Guatemala
+        ("rm, rm-ch, de-CH, de, en-us, en", "ch"),  # Romansh -> Switzerland
+        ("ro-RO, ro, en-US, en-GB, en", "ro"),  # Romanian -> Romania
+        ("ru-RU, ru, en-US, en", "ru"),  # Russian -> Russia
+        ("sat, en-US, en", "in"),  # Santali (Ol Chiki) -> India
+        ("sc, it-IT, it, en-US, en", "it"),  # Sardinian -> Italy
+        ("scn, it-IT, it, en-US, en", "it"),  # Sicilian -> Italy
+        ("sco,en-GB,en", "gb"),  # Scots -> United Kingdom
+        ("si-LK, si, en-US, en", "lk"),  # Sinhala -> Sri Lanka
+        ("sk, cs, en-US, en", "sk"),  # Slovak -> Slovakia
+        ("skr,en-US,en", "pk"),  # Saraiki -> Pakistan
+        ("sl, en-gb, en", "si"),  # Slovenian -> Slovenia
+        ("son, son-ml, fr, en-us, en", "ml"),  # Songhay -> Mali
+        ("sq, sq-AL, en-us, en", "al"),  # Albanian -> Albania
+        ("sr-RS, sr, en-US, en", "rs"),  # Serbian -> Serbia
+        ("sv-SE, sv, en-US, en", "se"),  # Swedish -> Sweeden
+        ("sw, en-US, en", "tz"),  # Swahili -> Tanzania
+        ("szl,pl-PL,pl,en,de", "pl"),  # Silesian -> Poland
+        ("ta-IN, ta, en-US, en", "in"),  # Tamil -> India
+        ("te-in, te, en-us, en", "in"),  # Telugu -> India
+        ("tg, en-US, en", "tj"),  # Tajik -> Tajikistan
+        ("th, en-US, en", "th"),  # Thai -> Thailand
+        ("tl-PH, tl, en-US, en", "ph"),  # Tagalog -> Philippines
+        ("tr-TR, tr, en-US, en", "tr"),  # Turkish OR Crimean Tatar -> Turkey
+        ("trs,es-MX,es,en-US,en", "mx"),  # Triqui -> Mexico
+        ("uk-UA, uk, en-US, en", "ua"),  # Ukrainian -> Ukraine
+        ("ur-PK, ur, en-US, en", "pk"),  # Urdu -> Pakistan
+        ("uz, ru, en, en-US", "uz"),  # Uzbek -> Uzbekistan
+        ("vi-vn, vi, en-us, en", "vn"),  # Vietnamese -> Vietnam
+        ("wo, en-US, en", "sn"),  # Wolof -> Senegal
+        ("xcl,hy,en-US,en", "am"),  # Armenian Classic -> Armenia
+        ("xh-ZA, xh, en-US, en", "za"),  # Xhosa
+        ("zam, es-MX, es, en-US, en", "mx"),  # Miahuatlán Zapotec
+        ("zh-CN, zh, zh-TW, zh-HK, en-US, en", "cn"),  # Chinese (China)
+        ("zh-tw, zh, en-us, en", "tw"),  # Chinese (Taiwan)
     ),
 )
 def test_guess_country_from_accept_lang(accept_lang, expected_country_code) -> None:

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -15,7 +15,7 @@ import pytest
 
 from ..utils import (
     flag_is_active_in_task,
-    get_premium_country_lang,
+    guess_country_from_accept_lang,
 )
 
 
@@ -31,8 +31,8 @@ from ..utils import (
         ("et-ee", "ee"),
     ),
 )
-def test_get_premium_country_lang(accept_lang, expected_country_code) -> None:
-    assert get_premium_country_lang(accept_lang) == expected_country_code
+def test_guess_country_from_accept_lang(accept_lang, expected_country_code) -> None:
+    assert guess_country_from_accept_lang(accept_lang) == expected_country_code
 
 
 #

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -29,6 +29,35 @@ from ..utils import (
         ("sgn-us", "us"),  # American Sign Language
         ("sgn-ch-de", "ch"),  # Swiss German Sign Language
         ("et-ee", "ee"),
+        # Good headers, from Django test test_parse_spec_http_header
+        ("de", "de"),
+        ("en-AU", "au"),
+        ("es-419", "es"),
+        ("*;q=1.00", "us"),
+        ("en-AU;q=0.123", "au"),
+        ("en-au;q=0.5", "au"),
+        ("en-au;q=1.0", "au"),
+        ("da, en-gb;q=0.25, en;q=0.5", "da"),
+        ("de,en-au;q=0.75,en-us;q=0.5,en;q=0.25,es;q=0.125,fa;q=0.125", "de"),
+        ("*", "us"),
+        ("de;q=0.", "de"),
+        ("en; q=1,", "us"),
+        ("en; q=1.0, * ; q=0.5", "us"),
+        # Bad headers, from Django test test_parse_spec_http_header
+        ("en-gb;q=1.0000", "us"),
+        ("en;q=0.1234", "us"),
+        ("en;q=.2", "us"),
+        ("abcdefghi-au", "us"),
+        ("**", "us"),
+        ("en,,gb", "us"),
+        ("en-au;q=0.1.0", "us"),
+        (("X" * 97) + "Z,en", "us"),
+        ("da, en-gb;q=0.8, en;q=0.7,#", "us"),
+        ("de;q=2.0", "us"),
+        ("de;q=0.a", "us"),
+        ("12-345", "us"),
+        ("", "us"),
+        ("en;q=1e0", "us"),
     ),
 )
 def test_guess_country_from_accept_lang(accept_lang, expected_country_code) -> None:

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -4,7 +4,6 @@ import logging
 
 from django.contrib.auth.models import AbstractBaseUser, Group, User
 from django.core.cache.backends.base import BaseCache
-from django.test import TestCase
 
 from _pytest.fixtures import SubRequest
 from _pytest.logging import LogCaptureFixture
@@ -20,25 +19,20 @@ from ..utils import (
 )
 
 
-class GetPremiumCountryLangTest(TestCase):
-    def test_get_premium_country_lang(self) -> None:
-        assert get_premium_country_lang("en-au,") == "au"
-        assert get_premium_country_lang("en-us,") == "us"
-        assert get_premium_country_lang("de-be,") == "be"
-
-    def test_en_fallback(self) -> None:
-        assert get_premium_country_lang("en,") == "us"
-
-    def test_first_lang_fallback_two_parts(self) -> None:
-        accept_lang = "sgn-us,"  # American Sign Language
-        assert get_premium_country_lang(accept_lang) == "us"
-
-    def test_first_lang_fallback_three_parts(self) -> None:
-        accept_lang = "sgn-ch-de,"  # Swiss German Sign Language
-        assert get_premium_country_lang(accept_lang) == "ch"
-
-    def test_eu_country_expansion(self) -> None:
-        assert get_premium_country_lang("et-ee") == "ee"
+@pytest.mark.parametrize(
+    "accept_lang,expected_country_code",
+    (
+        ("en-au,", "au"),
+        ("en-us,", "us"),
+        ("de-be,", "be"),
+        ("en", "us"),
+        ("sgn-us", "us"),  # American Sign Language
+        ("sgn-ch-de", "ch"),  # Swiss German Sign Language
+        ("et-ee", "ee"),
+    ),
+)
+def test_get_premium_country_lang(accept_lang, expected_country_code) -> None:
+    assert get_premium_country_lang(accept_lang) == expected_country_code
 
 
 #

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -31,7 +31,7 @@ def _get_cc_from_request(request):
     if "X-Client-Region" in request.headers:
         return request.headers["X-Client-Region"].lower()
     if "Accept-Language" in request.headers:
-        return get_premium_country_lang(request.headers["Accept-Language"])
+        return guess_country_from_accept_lang(request.headers["Accept-Language"])
     return "us"
 
 
@@ -43,7 +43,18 @@ _PRIMARY_LANGUAGE_TO_COUNTRY = {
 }
 
 
-def get_premium_country_lang(accept_lang):
+def guess_country_from_accept_lang(accept_lang: str) -> str:
+    """
+    Guess the user's country from the Accept-Language header
+
+    The header may come directly from a web request, or may be the header
+    captured by Firefox Accounts (FxA) at signup.
+
+    See RFC 9110, "HTTP Semantics", section 12.5.4, "Accept-Language"
+    See RFC 4646, "Tags for Identifying Languages", and examples in Appendix B
+
+    TODO: handle headers with quality portion ("en; q=1")
+    """
     rawlang = accept_lang.split(",")[0]
     if rawlang and "-" in rawlang:
         subtags = rawlang.split("-")

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -230,11 +230,17 @@ def guess_country_from_accept_lang(accept_lang: str) -> str:
 
     subtags = top_lang_tag.split("-")
     lang = subtags[0].lower()
+    if lang == "i":
+        raise AcceptLanguageError("Irregular language tag", accept_lang)
+    if lang == "x":
+        raise AcceptLanguageError("Private-use language tag", accept_lang)
+    if lang == "*":
+        raise AcceptLanguageError("Wildcard language tag", accept_lang)
     if len(lang) < 2:
-        raise AcceptLanguageError("Grandfathered tag, invalid tag, or '*'", accept_lang)
+        raise AcceptLanguageError("Invalid one-character primary language", accept_lang)
     if len(lang) == 3 and lang[0] == "q" and lang[1] <= "t":
         raise AcceptLanguageError(
-            "Language reserved for private use (RFC 5646 2.2.1)", accept_lang
+            "Private-use language tag (RFC 5646 2.2.1)", accept_lang
         )
 
     for maybe_region_raw in subtags[1:]:

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -37,11 +37,147 @@ def _get_cc_from_request(request):
     return "us"
 
 
-# Map a primary language to the most probably country
-# For many west European countries, the language has the same code as the country.
-# For example, German (de) has the same code as Germany (de)
+# Map a primary language to the most probable country
+# Top country derived from CLDR42 Supplemental Data, Language-Territory Information
+# with the exception of Spanish (es), which is mapped to Spain (es) instead of
+# Mexico (mx), which has the most speakers, but usually specifies es-MX.
 _PRIMARY_LANGUAGE_TO_COUNTRY = {
-    "en": "us",  # English -> United States
+    "ace": "id",  # # Acehnese -> Indonesia
+    "ach": "ug",  # Acholi -> Uganda
+    "af": "za",  # Afrikaans -> South Africa
+    "an": "es",  # Aragonese -> Spain
+    "ar": "eg",  # Arabic -> Egypt
+    "arn": "cl",  # Mapudungun -> Chile
+    "as": "in",  # Assamese -> India
+    "ast": "es",  # Asturian -> Spain
+    "az": "az",  # Azerbaijani -> Azerbaijan
+    "be": "by",  # Belerusian -> Belarus
+    "bg": "bg",  # Bulgarian -> Bulgaria
+    "bn": "bd",  # Bengali -> Bangladesh
+    "bo": "cn",  # Tibetan -> China
+    "br": "fr",  # Breton -> France
+    "brx": "in",  # Bodo -> India
+    "bs": "ba",  # Bosnian -> Bosnia and Herzegovina
+    "ca": "fr",  # Catalan -> France
+    "cak": "mx",  # Kaqchikel -> Mexico
+    "ckb": "iq",  # Central Kurdish -> Iraq
+    "cs": "cz",  # Czech -> Czech Republic
+    "cv": "ru",  # Chuvash -> Russia
+    "cy": "gb",  # Welsh -> United Kingdom
+    "da": "dk",  # Danish -> Denmark
+    "de": "de",  # German -> Germany
+    "dsb": "de",  # Lower Sorbian -> Germany
+    "el": "gr",  # Greek -> Greece
+    "en": "us",  # English -> Canada
+    "eo": "sm",  # Esperanto -> San Marino
+    "es": "es",  # Spanish -> Spain (instead of Mexico, top by population)
+    "et": "ee",  # Estonian -> Estonia
+    "eu": "es",  # Basque -> Spain
+    "fa": "ir",  # Persian -> Iran
+    "ff": "sn",  # Fulah -> Senegal
+    "fi": "fi",  # Finnish -> Finland
+    "fr": "fr",  # French -> France
+    "frp": "fr",  # Arpitan -> France
+    "fur": "it",  # Friulian -> Italy
+    "fy": "nl",  # Frisian -> Netherlands
+    "ga": "ie",  # Irish -> Ireland
+    "gd": "gb",  # Scottish Gaelic -> United Kingdom
+    "gl": "es",  # Galician -> Spain
+    "gn": "py",  # Guarani -> Paraguay
+    "gu": "in",  # Gujarati -> India
+    "gv": "im",  # Manx -> Isle of Man
+    "he": "il",  # Hebrew -> Israel
+    "hi": "in",  # Hindi -> India
+    "hr": "hr",  # Croatian -> Croatia
+    "hsb": "de",  # Upper Sorbian -> Germany
+    "hu": "hu",  # Hungarian -> Hungary
+    "hy": "am",  # Armenian -> Armenia
+    "hye": "am",  # Armenian Eastern Classic Orthography -> Armenia
+    "ia": "fr",  # Interlingua -> France
+    "id": "id",  # Indonesian -> Indonesia
+    "ilo": "ph",  # Iloko -> Philippines
+    "is": "is",  # Icelandic -> Iceland
+    "it": "it",  # Italian -> Italy
+    "ixl": "mx",  # Ixil -> Mexico
+    "ja": "jp",  # Japanese -> Japan
+    "jiv": "mx",  # Shuar -> Mexico
+    "ka": "ge",  # Georgian -> Georgia
+    "kab": "dz",  # Kayble -> Algeria
+    "kk": "kz",  # Kazakh -> Kazakhstan
+    "km": "kh",  # Khmer -> Cambodia
+    "kn": "in",  # Kannada -> India
+    "ko": "kr",  # Korean -> South Korea
+    "ks": "in",  # Kashmiri -> India
+    "lb": "lu",  # Luxembourgish -> Luxembourg
+    "lg": "ug",  # Luganda -> Uganda
+    "lij": "it",  # Ligurian -> Italy
+    "lo": "la",  # Lao -> Laos
+    "lt": "lt",  # Lithuanian -> Lithuania
+    "ltg": "lv",  # Latgalian -> Latvia
+    "lus": "us",  # Mizo -> United States
+    "lv": "lv",  # Latvian -> Latvia
+    "mai": "in",  # Maithili -> India
+    "meh": "mx",  # Mixteco Yucuhiti -> Mexico
+    "mix": "mx",  # Mixtepec Mixtec -> Mexico
+    "mk": "mk",  # Macedonian -> North Macedonia
+    "ml": "in",  # Malayalam -> India
+    "mr": "in",  # Marathi -> India
+    "ms": "my",  # Malay -> Malaysia
+    "my": "mm",  # Burmese -> Myanmar
+    "nb": "no",  # Norwegian Bokmål -> Norway
+    "ne": "np",  # Nepali -> Nepal
+    "nl": "nl",  # Dutch -> Netherlands
+    "nn": "no",  # Norwegian Nynorsk -> Norway
+    "oc": "fr",  # Occitan -> France
+    "or": "in",  # Odia -> India
+    "pa": "in",  # Punjabi -> India
+    "pl": "pl",  # Polish -> Poland
+    "ppl": "mx",  # Náhuat Pipil -> Mexico
+    "pt": "br",  # Portuguese -> Brazil
+    "quc": "gt",  # K'iche' -> Guatemala
+    "rm": "ch",  # Romansh -> Switzerland
+    "ro": "ro",  # Romanian -> Romania
+    "ru": "ru",  # Russian -> Russia
+    "sat": "in",  # Santali (Ol Chiki) -> India
+    "sc": "it",  # Sardinian -> Italy
+    "scn": "it",  # Sicilian -> Italy
+    "sco": "gb",  # Scots -> United Kingdom
+    "si": "lk",  # Sinhala -> Sri Lanka
+    "sk": "sk",  # Slovak -> Slovakia
+    "skr": "pk",  # Saraiki -> Pakistan
+    "sl": "si",  # Slovenian -> Slovenia
+    "son": "ml",  # Songhay -> Mali
+    "sq": "al",  # Albanian -> Albania
+    "sr": "rs",  # Serbian -> Serbia
+    "sv": "se",  # Swedish -> Sweeden
+    "sw": "tz",  # Swahili -> Tanzania
+    "szl": "pl",  # Silesian -> Poland
+    "ta": "in",  # Tamil -> India
+    "te": "in",  # Telugu -> India
+    "tg": "tj",  # Tajik -> Tajikistan
+    "th": "th",  # Thai -> Thailand
+    "tl": "ph",  # Tagalog -> Philippines
+    "tr": "tr",  # Turkish or Crimean Tatar -> Turkey
+    "trs": "mx",  # Triqui -> Mexico
+    "uk": "ua",  # Ukrainian -> Ukraine
+    "ur": "pk",  # Urdu -> Pakistan
+    "uz": "uz",  # Uzbek -> Uzbekistan
+    "vi": "vn",  # Vietnamese -> Vietnam
+    "wo": "sn",  # Wolof -> Senegal
+    "xcl": "am",  # Armenian Classic -> Armenia
+    "xh": "za",  # Xhosa -> South Africa
+    "zam": "mx",  # Miahuatlán Zapotec -> Mexico
+    "zh": "cn",  # Chinese -> China
+}
+
+# Special cases for language tags
+_LANGUAGE_TAG_TO_COUNTRY_OVERRIDE = {
+    # Would be Catalan in Valencian script -> France
+    # Change to Valencian -> Spain
+    ("ca", "valencia"): "es",
+    # Would be Galician (Greenland) -> Greenland
+    # Change to Galician (Galicia region of Spain) -> Spain
+    ("gl", "gl"): "es",
 }
 
 
@@ -58,7 +194,7 @@ def guess_country_from_accept_lang(accept_lang: str) -> str:
     See RFC 9110, "HTTP Semantics", section 12.5.4, "Accept-Language"
     See RFC 4646, "Tags for Identifying Languages", and examples in Appendix B
     """
-    lang_q_pairs = parse_accept_lang_header(accept_lang)
+    lang_q_pairs = parse_accept_lang_header(accept_lang.strip())
     if not lang_q_pairs:
         return "us"
     top_lang_tag = lang_q_pairs[0][0]
@@ -66,15 +202,23 @@ def guess_country_from_accept_lang(accept_lang: str) -> str:
         return "us"
 
     subtags = top_lang_tag.split("-")
+    lang = subtags[0].lower()
+
     if len(subtags) >= 2:
         # Try the region subtag of a Language-Region tag as the country
         cc = subtags[1].lower()
+
+        # Look for a special case
+        try:
+            return _LANGUAGE_TAG_TO_COUNTRY_OVERRIDE[(lang, cc)]
+        except KeyError:
+            pass
+
         # Subtag is an ISO 3166 country code when it is 2 alpha characters
         if len(cc) == 2 and all(c in ascii_lowercase for c in cc):
             return cc
 
     # Guess the country from a simple language tag
-    lang = subtags[0].lower()
     cc = _PRIMARY_LANGUAGE_TO_COUNTRY.get(lang, lang)
     return cc
 

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -16,7 +16,7 @@ from waffle.utils import (
 
 
 def get_countries_info_from_request_and_mapping(request, mapping):
-    country_code = _get_cc_from_request(request, mapping)
+    country_code = _get_cc_from_request(request)
     countries = mapping.keys()
     available_in_country = country_code in countries
     return {
@@ -27,19 +27,15 @@ def get_countries_info_from_request_and_mapping(request, mapping):
     }
 
 
-def _get_cc_from_request(request, premium_mapping):
+def _get_cc_from_request(request):
     if "X-Client-Region" in request.headers:
         return request.headers["X-Client-Region"].lower()
     if "Accept-Language" in request.headers:
-        return get_premium_country_lang(
-            request.headers["Accept-Language"], premium_mapping
-        )[0]
-    if settings.DEBUG:
-        return "us"
+        return get_premium_country_lang(request.headers["Accept-Language"])
     return "us"
 
 
-def get_premium_country_lang(accept_lang, mapping):
+def get_premium_country_lang(accept_lang):
     lang = accept_lang.split(",")[0]
     lang_parts = lang.split("-") if lang and "-" in lang else [lang]
     lang = lang_parts[0].lower()
@@ -48,12 +44,7 @@ def get_premium_country_lang(accept_lang, mapping):
     # if the language was just "en", default to US
     if cc == "en":
         cc = "us"
-
-    if languages := mapping.get(cc):
-        if lang in languages.keys():
-            return cc, lang
-        return cc, list(languages.keys())[0]
-    return cc, "en"
+    return cc
 
 
 def enable_or_404(

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -39,16 +39,15 @@ def _get_cc_from_request(request, premium_mapping):
     return "us"
 
 
-def get_premium_country_lang(accept_lang, mapping, cc=None):
+def get_premium_country_lang(accept_lang, mapping):
     lang = accept_lang.split(",")[0]
     lang_parts = lang.split("-") if lang and "-" in lang else [lang]
     lang = lang_parts[0].lower()
-    if cc is None:
-        cc = lang_parts[1] if len(lang_parts) >= 2 else lang_parts[0]
-        cc = cc.lower()
-        # if the language was just "en", default to US
-        if cc == "en":
-            cc = "us"
+    cc = lang_parts[1] if len(lang_parts) >= 2 else lang_parts[0]
+    cc = cc.lower()
+    # if the language was just "en", default to US
+    if cc == "en":
+        cc = "us"
 
     if languages := mapping.get(cc):
         if lang in languages.keys():

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -242,8 +242,8 @@ def guess_country_from_accept_lang(accept_lang: str) -> str:
         # Subtag is probably a script, like "Hans" in "zh-Hans-CN"
         # Loop to the next subtag, which might be a ISO 3166 country code
 
-    # Guess the country from a simple language tag
-    cc = _PRIMARY_LANGUAGE_TO_COUNTRY.get(lang, lang)
+    # Guess the country from a simple language tag, default to United States
+    cc = _PRIMARY_LANGUAGE_TO_COUNTRY.get(lang, "us")
     return cc
 
 

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -35,15 +35,28 @@ def _get_cc_from_request(request):
     return "us"
 
 
+# Map a primary language to the most probably country
+# For many west European countries, the language has the same code as the country.
+# For example, German (de) has the same code as Germany (de)
+_PRIMARY_LANGUAGE_TO_COUNTRY = {
+    "en": "us",  # English -> United States
+}
+
+
 def get_premium_country_lang(accept_lang):
-    lang = accept_lang.split(",")[0]
-    lang_parts = lang.split("-") if lang and "-" in lang else [lang]
-    lang = lang_parts[0].lower()
-    cc = lang_parts[1] if len(lang_parts) >= 2 else lang_parts[0]
-    cc = cc.lower()
-    # if the language was just "en", default to US
-    if cc == "en":
-        cc = "us"
+    rawlang = accept_lang.split(",")[0]
+    if rawlang and "-" in rawlang:
+        subtags = rawlang.split("-")
+    else:
+        subtags = [rawlang]
+
+    if len(subtags) >= 2:
+        # Use the region subtag of a Language-Region tag as the country
+        cc = subtags[1].lower()
+    else:
+        # Guess the country from a simple language tag
+        lang = subtags[0].lower()
+        cc = _PRIMARY_LANGUAGE_TO_COUNTRY.get(lang, lang)
     return cc
 
 

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -247,10 +247,8 @@ def guess_country_from_accept_lang(accept_lang: str) -> str:
         maybe_region = maybe_region_raw.lower()
 
         # Look for a special case
-        try:
-            return _LANGUAGE_TAG_TO_COUNTRY_OVERRIDE[(lang, maybe_region)]
-        except KeyError:
-            pass
+        if override := _LANGUAGE_TAG_TO_COUNTRY_OVERRIDE.get((lang, maybe_region)):
+            return override
 
         if len(maybe_region) <= 1:
             # One-character extension or empty, stop processing


### PR DESCRIPTION
As part of MPP-3264, this PR improves how an `Accept-Language` header is turned into a country, mostly to see if premium plans are allowed for the user.

In some cases, the country is guessed from the `Accept-Language` header:

* When the infrastructure does not set the `X-Client-Region` header
* When a background task is using the `Accept-Language` header from Firefox Accounts (FxA) signup.

This was handled in two ways:
* Web request code used `privaterelay.utils.get_premium_country_lang`, which returned a country and language, and discarded the language.
* Background code used `emails.models.Profile.fxa_locale_in_premium_country`, which duplicated some of the logic in `privaterelay.utils.get_premium_country_lang`

This code replaces `get_premium_country_lang` with `guess_country_from_accept_lang`, and uses the same logic in both places. `guess_country_from_accept_lang` only returns a lower-cased country code.

The new function fixes several issues with language to country mapping for existing premium and EU expansion countries, when the language code is not identical to the lower-cased country code, such as:

* Czech (`cs`) returns the Czech Republic (`cz`), instead of invalid country code `cs`
* Danish (`da`) returns Denmark (`dk`), instead of invalid country code `da`
* Estonian (`et`) returns Estonia (`ee`), instead of Ethiopia (`et`)
* Greek (`el`) returns Greece (`gr`), instead of invalid country code `el`
* Luxembourgish (`lb`) return Luxembourg (`lu`), instead of Lebanon (`lb`)
* Slovenian (`sl`) returns Slovenia (`si`), instead of Sierra Leone (`sl`)
* Welsh (`cy`) returns the United Kingdom (`gb`) rather than Cyprus (`cy`)

It also handles cases not handled by the previous code, such as:

* A language tag with a quality specification, such as `de; q=1.0` (should be Germany (`de`), was invalid `de; q=1.0`)
* A Language-Script tag, such as `zh-Hant` (treated as China (`cn`), was invalid code `hant`)
* A Language-Variant tag, such as `sl-rozaj` (treated as Slovenia (`si`), was invalid code `rozaj`)
* A Language-Script-Region tag, such as `zh-Hant-TW` (treated as Taiwan (`tw`), was invalid code `hant`)
* An "any language" tag, such as `*` (was invalid code `*`, now treated as an error)
* An invalid language tag, such as `**` (was invalid code `**`, now treated as an error)

The test cases, which drove the development of the function, are pulled from several sources:

* Previous tests for `get_premium_country_lang`
* Django's tests for [test_parse_spec_http_header](https://github.com/django/django/blob/848fe70f3ee6dc151831251076dc0a4a9db5a0ec/tests/i18n/tests.py#L1332), which include good and bad `Accept-Language` headers and good headers with quality strings (`en; q=0.8`)
* Firefox's default `Accept-Language` headers. These are set in Pontoon as the translation for "en-US, en" in Firefox, `intl.properties`, such as the [German translation](https://pontoon.mozilla.org/de/firefox/toolkit/chrome/global/intl.properties/?string=81017) to `de, en-US, en`. The full list is in the `Locales` tab, and can be downloaded (mostly) as:
    ```sh
    curl 'https://pontoon.mozilla.org/other-locales/?entity=81017&locale=de' \
    -H 'x-requested-with: XMLHttpRequest'
    ```
   This JSON includes all but the German (`de`) translation, which can be manually added. I transformed it into test cases, then selected the expected country from CLDR data (more on that later)
* Examples of language tags from [RFC 5646, "Tags for Identifying Languages"]((https://www.rfc-editor.org/rfc/rfc5646.html), [Appendix A, "Examples of Language Tags (Informative)"](https://www.rfc-editor.org/rfc/rfc5646.html#appendix-A), which include many different formats and corner cases not previously handled.

The mapping from languages to countries `_PRIMARY_LANGUAGE_TO_COUNTRY` comes from the Unicode consortium's [Common Locale Data Repository (CLDR) v43.0 Supplemental Data](https://www.unicode.org/cldr/charts/43/supplemental/index.html). The official data is in XML, but the same data is exported as JSON at https://github.com/unicode-org/cldr-json, and as [human-readable HTML](https://www.unicode.org/cldr/charts/42/supplemental/language_territory_information.html). I processed the file [territoryInfo.json](https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-core/supplemental/territoryInfo.json), limited to the 135 [Firefox languages](https://pontoon.mozilla.org/es-ES/firefox/toolkit/chrome/global/intl.properties/?string=81017) for `intl.properties`, to find the country with the highest population of speakers of that language. This worked as expected for most countries, and helped find the cases where the language code does not match the lower-cased country code (for example, Japanese `ja` to Japan `jp`). It also included official languages (Luxembourgish `lb` to Luxembourg `lu`), which may improve country detection for the EU expansion. 

I tweaked one entry. Spanish (`es`) is mapped to Spain (`es`), even though there are more Spanish speakers in Mexico, and I expect Mexicans to use `es-MX` as their primary language.

There were some additional special cases which might be rare in the wild, but required special handling.

* `ca-valencia`, from Firefox's [Catalan (Valencian)](https://pontoon.mozilla.org/ca-valencia/firefox/toolkit/chrome/global/intl.properties/?string=81017). Catalan (`ca`) has the most speakers in France (`fr`), but this Language-Script combination for the [Valencian language](https://en.wikipedia.org/wiki/Valencian_language) implies Spain (`es`).
* `es-419`, a special test case of a [UN M49](https://en.wikipedia.org/wiki/UN_M49) code for [Latin America and the Caribbean](https://en.wikipedia.org/wiki/Latin_America_and_the_Caribbean). I picked Mexico `mx`, which has the most Spanish speakers. Other UN M49 codes are not handled, and get the default country for that language.
* `gl-gl`, from Firefox's [Galician](https://pontoon.mozilla.org/gl/firefox/toolkit/chrome/global/intl.properties/?string=81017). This means "Galician as spoken in Greenland", which appears to be a mistake by the translators, since [Galician](https://en.wikipedia.org/wiki/Galician_language) is mostly spoken in [Galucia, Spain](https://en.wikipedia.org/wiki/Galicia_(Spain)) (`ES-GA`), with some speakers in Portugal, and (almost?) none in Greenland. I picked Spain (`es`) for this combo.

## How to test
I used the unit tests to develop and test this code, rather than integration testing. I don't think any value will be added by integration testing in a browser, but you can try it.

You may want to cross-check the languages with the premium countries in [privaterelay/plans.py](https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/plans.py#L523), as well as CLDR's [Territory-Language Information](https://www.unicode.org/cldr/charts/42/supplemental/territory_language_information.html), to see if you agree with the languages that would lead to a user being placed in those countries.

See if the code and comments are sufficient to understand what is going on, or if more documentation is needed.

## Follow-on Work
I was tempted to add some logging to see how often `X-Client-Region` agrees with `Accept-Language`, and what errors are raised. That data could be useful for validating `guess_country_from_accept_lang` and potentially replacing it with a machine learning algorithm. However, this PR is already big enough, and that task can be started when we plan to use the data.

We should also capitalize country codes (`US` instead of `us`), to make it clearer when a code is a language code (`es` for Spanish) versus a country code (`ES` for Spain), and to conform to [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).