### PR TITLE
MPP-3265 improve 403 error message

### DIFF
--- a/api/authentication.py
+++ b/api/authentication.py
@@ -139,7 +139,9 @@ class FxaTokenAuthentication(BaseAuthentication):
                 uid=fxa_uid, provider="fxa"
             ).select_related("user")[0]
         except IndexError:
-            raise PermissionDenied("Authenticated user does not have a Relay account.")
+            raise PermissionDenied(
+                "Authenticated user does not have a Relay account. Have they accepted the terms?"
+            )
         user = sa.user
 
         if user:

--- a/api/tests/authentication_tests.py
+++ b/api/tests/authentication_tests.py
@@ -328,7 +328,7 @@ class FxaTokenAuthenticationTest(TestCase):
         assert response.status_code == 403
         assert (
             response.json()["detail"]
-            == "Authenticated user does not have a Relay account."
+            == "Authenticated user does not have a Relay account. Have they accepted the terms?"
         )
         assert cache.get(get_cache_key(non_user_token)) == fxa_response
 


### PR DESCRIPTION
This PR is for #MPP-3265.

If we receive a valid FXA token but the user doesn't have a Relay account, it might be because the client hasn't `POST`ed to the `/terms-accepted-user/` endpoint yet.

How to test:
1. Configure Firefox desktop to use a server with this code change
2. Go to `about:config`
3. Set `signon.firefoxRelay.feature` to `enabled` without going thru the opt-in flow
4. Try to use the Relay feature in Firefox
5. Watch the error message in the network panel

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).