### PR TITLE
MPP-3262: save utms in cookies to restore after redirects

### DIFF
--- a/frontend/src/functions/cookies.ts
+++ b/frontend/src/functions/cookies.ts
@@ -1,3 +1,5 @@
+import ReactGa from "react-ga";
+
 export function getCookie(cookieId: string): string | undefined {
   if (typeof document === "undefined") {
     // When server-side rendering:
@@ -40,4 +42,32 @@ export function clearCookie(cookieId: string) {
 
 export function getCsrfToken(): string | undefined {
   return getCookie("csrftoken");
+}
+
+export function convertUtmCookieToGaField(
+  utmCookie: string,
+): ReactGa.FieldsObject {
+  /*
+   * To preserve utm url param values thru FxA redirects, the server-side
+   * middleware:StoreUtmsInCookie stores utm params in cookies with this format:
+   * utm_medium=firefox-desktop;
+   * utm_source=modal;
+   * utm_content=manage-masks-global;
+   *
+   * analytics.js traffic source field names are in this format:
+   * campaignMedium
+   * campaignSource
+   * campaignContent
+   *
+   * So, convert the cookie names and values to GA field names & values
+   */
+  const campaignField = utmCookie.split("=");
+  const campaignFieldName = campaignField[0].replace("utm_", "");
+  const capitalizedCampaignFieldName =
+    campaignFieldName.charAt(0).toUpperCase() + campaignFieldName.slice(1);
+  const campaignFieldValue = campaignField[1];
+  const gaField: ReactGa.FieldsObject = {};
+  const gaFieldName = `campaign${capitalizedCampaignFieldName}`;
+  gaField[gaFieldName] = campaignFieldValue;
+  return gaField;
 }

--- a/frontend/src/pages/_app.page.tsx
+++ b/frontend/src/pages/_app.page.tsx
@@ -14,6 +14,7 @@ import { initialiseApiMocks } from "../apiMocks/initialise";
 import { mockIds } from "../apiMocks/mockData";
 import { useIsLoggedIn } from "../hooks/session";
 import "@stripe/stripe-js";
+import { clearCookie, convertUtmCookieToGaField } from "../functions/cookies";
 
 if (process.env.NEXT_PUBLIC_MOCK_API === "true") {
   initialiseApiMocks();
@@ -65,11 +66,19 @@ function MyApp({ Component, pageProps }: AppProps) {
       titleCase: false,
       debug: process.env.NEXT_PUBLIC_DEBUG === "true",
     });
-    ReactGa.set({
+    const gaFields: ReactGa.FieldsObject = {
       anonymizeIp: true,
       transport: "beacon",
-    });
+    };
     const cookies = document.cookie.split("; ");
+    cookies.forEach((item) => {
+      if (item.trim().startsWith("utm_")) {
+        const cookieId = item.split("=")[0];
+        Object.assign(gaFields, convertUtmCookieToGaField(item));
+        clearCookie(cookieId);
+      }
+    });
+    ReactGa.set(gaFields);
     const gaEventCookies = cookies.filter((item) =>
       item.trim().startsWith("server_ga_event:"),
     );

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -312,6 +312,7 @@ if DEBUG:
 MIDDLEWARE += [
     "django.middleware.security.SecurityMiddleware",
     "csp.middleware.CSPMiddleware",
+    "privaterelay.middleware.StoreUtmsInCookie",
     "privaterelay.middleware.RedirectRootIfLoggedIn",
     "privaterelay.middleware.RelayStaticFilesMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
When a browser goes directly to a page that requires login, we redirect them to FxA. The redirect drops any utm_* url params, so we can't see where these browsers came from.

So, this change:
1. Adds a backend middleware which stores any utm_* params into cookies.
2. Adds frontend code to set GA fields for the utm cookie values.

### This PR fixes #MPP-3262.

### How to test:
1. Open a browser session that is NOT signed into 127.0.0.1:8000
2. Open the console and choose "Persist Logs"
3. Visit http://127.0.0.1:8000/accounts/profile/?utm_medium=firefox-desktop&utm_source=modal&utm_campaign=limit&utm_content=manage-masks-global
   * [ ] The GA output should show that it set `campaign*` fields to the values in the `utm_*` url params
   * [ ] It should redirect to FxA sign-in
4. Complete sign in via FxA
   * [ ] You should land back on the dashboard again

### Checklist
- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).