### PR TITLE
MPP-3298: Fix for interactions being blocked in mobile view

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -48,7 +48,7 @@ export const Layout = (props: Props) => {
   const router = useRouter();
   const hasPremium: boolean = profiles.data?.[0].has_premium ?? false;
   const usersData = useUsers().data?.[0];
-  const [mobileMenuExpanded, setMobileMenuExpanded] = useState<boolean>();
+  const [mobileMenuExpanded, setMobileMenuExpanded] = useState<boolean>(false);
 
   useEffect(() => {
     makeToast(l10n, usersData);

--- a/frontend/src/components/layout/navigation/MobileNavigation.module.scss
+++ b/frontend/src/components/layout/navigation/MobileNavigation.module.scss
@@ -9,6 +9,10 @@
   z-index: 1;
   max-height: calc(100vh - 100%);
   overflow-y: auto;
+
+  &.not-active {
+    display: none;
+  }
 }
 
 #mobile-menu {

--- a/frontend/src/components/layout/navigation/MobileNavigation.tsx
+++ b/frontend/src/components/layout/navigation/MobileNavigation.tsx
@@ -71,7 +71,7 @@ export const MobileNavigation = (props: Props) => {
   return (
     <nav
       aria-label={l10n.getString("nav-menu-mobile")}
-      className={`${styles["mobile-menu"]}`}
+      className={`${styles["mobile-menu"]} ${toggleMenuStateClass}`}
     >
       {/* Below we have conditional rendering of menu items  */}
       <ul


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3298.

- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description

Disabled the the parent mobile-menu element when the toggle menu is not expanded. This prevents the invisible mobile menu from appearing and blocking interactions with elements under it.

# Screenshot (if applicable)
New (we can see here that the info icon is clickable): 

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/b187ce3c-e3f1-4001-8238-9aabb99e1102)

Old (mobile-menu blocking elements, see in prod):

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/dc6a1f5f-3079-4208-a636-70f12bdaec1e)

# How to test

* Check whether interactions with the website are valid and whether buttons are clickable in a mobile view (inspect element, and click the mobile symbol).

# Checklist (Definition of Done)
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
