### PR TITLE
Fix not being able to tap elements on mobile

### DIFF
--- a/frontend/src/components/layout/navigation/MobileNavigation.module.scss
+++ b/frontend/src/components/layout/navigation/MobileNavigation.module.scss
@@ -9,6 +9,11 @@
   z-index: 1;
   max-height: calc(100vh - 100%);
   overflow-y: auto;
+  pointer-events: none;
+
+  &.is-active {
+    pointer-events: auto;
+  }
 }
 
 #mobile-menu {
@@ -20,23 +25,23 @@
   // otherwise it might get exposed when the browser "overscrolls":
   opacity: 0;
 
-  &.not-active {
+  .not-active & {
     animation: slide-out 300ms cubic-bezier(0.52, -0.14, 0.31, 1.2);
     animation-iteration-count: 1;
     animation-fill-mode: forwards;
   }
 
-  &.is-active {
+  .is-active & {
     animation: slide-in 450ms cubic-bezier(0.52, -0.14, 0.31, 1.2);
     animation-iteration-count: 1;
     animation-fill-mode: forwards;
   }
 
   @media (prefers-reduced-motion) {
-    &.not-active {
+    .not-active & {
       animation: none;
     }
-    &.is-active {
+    .is-active & {
       animation: none;
     }
   }

--- a/frontend/src/components/layout/navigation/MobileNavigation.tsx
+++ b/frontend/src/components/layout/navigation/MobileNavigation.tsx
@@ -71,12 +71,12 @@ export const MobileNavigation = (props: Props) => {
   return (
     <nav
       aria-label={l10n.getString("nav-menu-mobile")}
-      className={`${styles["mobile-menu"]}`}
+      className={`${styles["mobile-menu"]} ${toggleMenuStateClass}`}
     >
       {/* Below we have conditional rendering of menu items  */}
       <ul
         id={`${styles["mobile-menu"]}`}
-        className={`${styles["menu-item-list"]} ${toggleMenuStateClass}`}
+        className={`${styles["menu-item-list"]}`}
       >
         {isLoggedIn && (
           <li className={`${styles["menu-item"]} ${styles["user-info"]}`}>


### PR DESCRIPTION
The mobile menu intercepted all taps underneath it, even when it wasn't visible, leading to the user not being able to interact with most of the page. This fixes that.

This is probably fallout from https://github.com/mozilla/fx-private-relay/pull/3652, and I found out about it by trying to verify https://github.com/mozilla/fx-private-relay/issues/3223#issuecomment-1644319245.

How to test: in responsive design mode with tap simulation enabled, or on an actual phone (in either Firefox and Chrome, at least), don't expand the mobile menu, but try to tap elements present in the area where the mobile menu would be visible when expanded. Before this fix, that shouldn't work, but after this fix, it should.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, CSS fix
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
