### PR TITLE
MPP-3321: Clear block_list_emails for non-premium users

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -662,6 +662,8 @@ class RelayAddress(models.Model):
             self.description = ""
             self.generated_for = ""
             self.used_on = ""
+        if not self.user.profile.has_premium:
+            self.block_list_emails = False
         return super().save(*args, **kwargs)
 
     @property
@@ -764,7 +766,8 @@ class DomainAddress(models.Model):
             if not pattern_valid or address_contains_badword:
                 raise DomainAddrUnavailableException(unavailable_address=self.address)
             user_profile.update_abuse_metric(address_created=True)
-        # TODO: validate user is premium to set block_list_emails
+        if not user_profile.has_premium:
+            self.block_list_emails = False
         if not user_profile.server_storage:
             self.description = ""
         return super().save(*args, **kwargs)

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -265,7 +265,7 @@ class SNSNotificationTest(TestCase):
         assert self.ra.num_blocked == 1
 
     def test_block_list_email_former_premium_user(self) -> None:
-        """When an alias is blocking list emails, list emails should not forward."""
+        """List emails are forwarded for formerly premium users."""
         self.ra.user = self.premium_user
         self.ra.save()
         self.ra.block_list_emails = True

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -264,6 +264,28 @@ class SNSNotificationTest(TestCase):
         assert self.ra.num_forwarded == 0
         assert self.ra.num_blocked == 1
 
+    def test_block_list_email_former_premium_user(self) -> None:
+        """When an alias is blocking list emails, list emails should not forward."""
+        self.ra.user = self.premium_user
+        self.ra.save()
+        self.ra.block_list_emails = True
+        self.ra.save()
+
+        # Remove premium from the user
+        fxa_account = self.premium_user.profile.fxa
+        fxa_account.extra_data["subscriptions"] = []
+        fxa_account.save()
+        assert not self.premium_user.profile.has_premium
+        self.ra.refresh_from_db()
+
+        _sns_notification(EMAIL_SNS_BODIES["single_recipient_list"])
+
+        self.mock_send_raw_email.assert_called_once()
+        self.ra.refresh_from_db()
+        assert self.ra.num_forwarded == 1
+        assert self.ra.num_blocked == 0
+        assert self.ra.block_list_emails is False
+
     def test_spamVerdict_FAIL_default_still_relays(self) -> None:
         """For a default user, spam email will still relay."""
         _sns_notification(EMAIL_SNS_BODIES["spamVerdict_FAIL"])


### PR DESCRIPTION
Users who were formerly premium customers may have `block_list_emails` set on their random or domain masks. This would block list emails when forwarding, forward other emails, and then fail when updating the forward / block counts for the address, due to the changes in PR #3651. This may cause our code to re-process the email multiple times.

This PR fixes this bug (MPP-3321) with three changes:

* Remove the pre-save signal handler that raises a `BadRequest` when a non-premium user attempts to set `block_list_emails`. This does not change the API, which checks this in the serializer and returns an error, but does fix the bug.
* Check if the user has premium in the email-handling code before blocking list emails. This prevents previously premium users from using this feature.
* Clear `block_list_emails` when saving a random or domain mask. This will fix the data going forward, as masks are used.

This is sufficient to fix the bug. Users may still see blocking set to "Promotional" on the website. A cleaner task could be added to periodically clear `block_list_emails` from formerly premium accounts, but that would be a larger change than this bug fix

## How to test
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
