### PR TITLE
MPP-3323: Info icon tooltip in generate mask modal should only be active on hover

### DIFF
--- a/frontend/src/components/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip.tsx
@@ -12,7 +12,7 @@ export type Props = {
 
 export const InfoTooltip = (props: Props) => {
   const tooltipTriggerState = useTooltipTriggerState({ delay: 0 });
-  const triggerRef = useRef<HTMLButtonElement>(null);
+  const triggerRef = useRef<HTMLSpanElement>(null);
 
   const tooltipTrigger = useTooltipTrigger({}, tooltipTriggerState, triggerRef);
   const { tooltipProps } = useTooltip(
@@ -22,14 +22,10 @@ export const InfoTooltip = (props: Props) => {
 
   return (
     <span className={styles.wrapper}>
-      <button
+      <span
         ref={triggerRef}
-        // Set to type="button" to prevent wrapping forms from being submitted
-        // when the info icon is clicked:
-        type="button"
         {...tooltipTrigger.triggerProps}
         className={styles.trigger}
-        disabled
       >
         <InfoIcon
           alt={props.alt}
@@ -37,7 +33,7 @@ export const InfoTooltip = (props: Props) => {
           width={18}
           height={18}
         />
-      </button>
+      </span>
       {tooltipTriggerState.isOpen && (
         <span
           className={styles.tooltip}

--- a/frontend/src/components/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip.tsx
@@ -29,6 +29,7 @@ export const InfoTooltip = (props: Props) => {
         type="button"
         {...tooltipTrigger.triggerProps}
         className={styles.trigger}
+        disabled
       >
         <InfoIcon
           alt={props.alt}


### PR DESCRIPTION
This PR fixes MPP-3323.

# Bug description

After clicking the "Generate new mask" button then clicking the info icon button next to "Block promotional emails", clicking the "Learn more" link in the tool tip cause it to disappear, making the "Learn more" unclickable. _See MPP-3323 for full steps to reproduce._

# Screenshot 
(Old)
blob:https://mozilla-hub.atlassian.net/1f407440-8fd8-4b84-878f-b0413447f54c#media-blob-url=true&id=ffdcc805-f428-4a55-b79a-42579841f75d&collection=&contextId=342591&height=972&width=1905&alt=

(New)
[New version](https://i.gyazo.com/20bf1d3ef1a7731e28fc0c16b2b1cc6e.gif)

# How to test

1. Navigate to the Relay dashboard;

2. Click on the “Generate new mask” button;

3. Select “@<custom domain> mask”;

4. Click on the “i” tooltip button;

5. Hover over the tooltip to open it again;

6. Hover over the tooltip content and try to click on the “Learn more” link;

Newly expected behaviour is that the "Learn more" button should bring you to /faq/#faq-promotional-email-blocking.

# Checklist (Definition of Done)
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
