### PR TITLE
Group related Dependabot JS updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,28 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      eslint:
+        patterns:
+          - "@typescript-eslint/*"
+          - "eslint*"
+        exclude-patterns:
+          - "eslint-config-next"
+      jest:
+        patterns:
+          - "babel-jest"
+          - "jest"
+          - "jest-environment-jsdom"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-test-renderer"
+      testing-library:
+        patterns:
+          - "@testing-library/dom"
+          - "@testing-library/react"
+          - "@testing-library/user-event"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
This should hopefully cut down on some of the noise of ESLint updates, and ensure that packages that break unless they are updated together (like https://github.com/mozilla/fx-private-relay/pull/3648) are actually updated together.

See https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
