### PR TITLE
MPP-2083: Retire `eu_country_expansion` flag, backend

### DIFF
--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -245,8 +245,6 @@ def runtime_data(request):
     switch_values = [(s.name, s.is_active()) for s in switches]
     samples = Sample.get_all()
     sample_values = [(s.name, s.is_active()) for s in samples]
-    eu_country_expansion = flag_is_active(request, "eu_country_expansion")
-    premium_mapping = get_premium_country_language_mapping(eu_country_expansion)
     return response.Response(
         {
             "FXA_ORIGIN": settings.FXA_BASE_ORIGIN,
@@ -255,7 +253,7 @@ def runtime_data(request):
             "BUNDLE_PRODUCT_ID": settings.BUNDLE_PROD_ID,
             "PHONE_PRODUCT_ID": settings.PHONE_PROD_ID,
             "PERIODICAL_PREMIUM_PLANS": get_countries_info_from_request_and_mapping(
-                request, premium_mapping
+                request, get_premium_country_language_mapping()
             ),
             "PHONE_PLANS": get_countries_info_from_request_and_mapping(
                 request, get_phone_country_language_mapping()

--- a/emails/models.py
+++ b/emails/models.py
@@ -180,10 +180,7 @@ class Profile(models.Model):
                 country = guess_country_from_accept_lang(self.fxa.extra_data["locale"])
             except AcceptLanguageError:
                 return False
-            eu_country_expansion = flag_is_active_in_task(
-                "eu_country_expansion", self.user
-            )
-            premium_countries = get_premium_countries(eu_country_expansion)
+            premium_countries = get_premium_countries()
             if country in premium_countries:
                 return True
         return False

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -10,7 +10,6 @@ from django.contrib.auth.models import User
 from django.test import override_settings, TestCase
 
 from allauth.socialaccount.models import SocialAccount
-from waffle.testutils import override_flag
 import pytest
 
 from model_bakery import baker
@@ -758,15 +757,10 @@ class ProfileFxaLocaleInPremiumCountryTest(ProfileTestCase):
     def test_no_fxa_account_returns_False(self) -> None:
         assert self.profile.fxa_locale_in_premium_country is False
 
-    @override_flag("eu_country_expansion", active=True)
-    def test_in_estonia_with_eu_expansion_flag(self):
+    def test_in_estonia(self):
+        """Estonia (EE) was added in August 2023."""
         self.set_fxa_locale("et-ee,et;q=0.8")
         assert self.profile.fxa_locale_in_premium_country is True
-
-    @override_flag("eu_country_expansion", active=False)
-    def test_in_estonia_without_eu_expansion_flag(self):
-        self.set_fxa_locale("et-ee,et;q=0.8")
-        assert self.profile.fxa_locale_in_premium_country is False
 
 
 class ProfileJoinedBeforePremiumReleaseTest(ProfileTestCase):

--- a/privaterelay/tests/plans_tests.py
+++ b/privaterelay/tests/plans_tests.py
@@ -1,6 +1,5 @@
 """Tests for privaterelay/plans.py"""
 
-from typing import Literal
 from pytest_django.fixtures import SettingsWrapper
 import pytest
 
@@ -29,56 +28,45 @@ def plan_settings(settings: SettingsWrapper) -> SettingsWrapper:
 _PREMIUM_COUNTRIES = [
     "at",
     "be",
+    "bg",
     "ca",
     "ch",
+    "cy",
+    "cz",
     "de",
+    "dk",
+    "ee",
     "es",
     "fi",
     "fr",
     "gb",
+    "gr",
+    "hr",
+    "hu",
     "ie",
     "it",
+    "lt",
+    "lu",
+    "lv",
+    "mt",
     "my",
     "nl",
     "nz",
+    "pl",
+    "pt",
+    "ro",
     "se",
     "sg",
-    "us",
-]
-_EU_EXPANSION_PREMIUM_COUNTRIES = [
-    "cy",
-    "ee",
-    "gr",
-    "lv",
-    "lt",
-    "lu",
-    "mt",
-    "pt",
-    "sk",
     "si",
-    # Added with MPP-3202
-    "bg",
-    "cz",
-    "dk",
-    "hr",
-    "hu",
-    "pl",
-    "ro",
+    "sk",
+    "us",
 ]
 _NON_PREMIUM_COUNTRY = "mx"
 
 
-def test_get_premium_countries_without_eu_country_expansion() -> None:
-    premium_countries = get_premium_countries(eu_country_expansion=False)
+def test_get_premium_countries() -> None:
+    premium_countries = get_premium_countries()
     assert sorted(premium_countries) == sorted(_PREMIUM_COUNTRIES)
-    assert _NON_PREMIUM_COUNTRY not in premium_countries
-
-
-def test_get_premium_countries_with_eu_country_expansion() -> None:
-    premium_countries = get_premium_countries(eu_country_expansion=True)
-    assert sorted(premium_countries) == sorted(
-        _PREMIUM_COUNTRIES + _EU_EXPANSION_PREMIUM_COUNTRIES
-    )
     assert _NON_PREMIUM_COUNTRY not in premium_countries
 
 
@@ -204,25 +192,15 @@ def check_country_language_mapping_for_monthly_plan(
         ("ro", "ro", "ro"),
     ),
 )
-@pytest.mark.parametrize("eu_expansion", (True, None))
 def test_get_premium_country_language_mapping(
     country: RelayCountryStr,
     language: LanguageStr,
     price_data_key: str,
-    eu_expansion: Literal[True, None],
 ) -> None:
-    mapping = get_premium_country_language_mapping(eu_country_expansion=eu_expansion)
-    if country in _EU_EXPANSION_PREMIUM_COUNTRIES and not eu_expansion:
-        assert country not in mapping
-    else:
-        check_country_language_mapping_for_monthly_plan(
-            country,
-            language,
-            price_data_key,
-            mapping,
-            _PREMIUM_PRICE_DATA,
-            _PREMIUM_PRICES,
-        )
+    mapping = get_premium_country_language_mapping()
+    check_country_language_mapping_for_monthly_plan(
+        country, language, price_data_key, mapping, _PREMIUM_PRICE_DATA, _PREMIUM_PRICES
+    )
 
 
 def test_get_premium_country_language_mapping_overrides(
@@ -234,7 +212,7 @@ def test_get_premium_country_language_mapping_overrides(
     plan_settings.PREMIUM_PLAN_ID_US_MONTHLY = stage_monthly_id
     assert plan_settings.PREMIUM_PLAN_ID_US_YEARLY != stage_yearly_id
     plan_settings.PREMIUM_PLAN_ID_US_YEARLY = stage_yearly_id
-    mapping = get_premium_country_language_mapping(True)
+    mapping = get_premium_country_language_mapping()
     assert mapping["us"]["en"]["monthly"]["id"] == stage_monthly_id
     assert mapping["us"]["en"]["yearly"]["id"] == stage_yearly_id
     assert mapping["ca"]["en"]["monthly"]["id"] == stage_monthly_id

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -306,7 +306,7 @@ def test_guess_country_from_accept_lang_short_primary_lang_fails(accept_lang) ->
 
 def test_get_countries_info_bad_accept_language(rf) -> None:
     request = rf.get("/api/v1/runtime_data", HTTP_ACCEPT_LANGUAGE="xx")
-    mapping = get_premium_country_language_mapping(None)
+    mapping = get_premium_country_language_mapping()
     result = get_countries_info_from_request_and_mapping(request, mapping)
     assert result == {
         "country_code": "",


### PR DESCRIPTION
The flag was turned on in production on 2023-08-01. This integrates the expanded premium countries into the existing countries, and treats the flag as on for everyone on the backend. There is additional work needed to retire the flag on the front-end.

- [x] I've updated unit tests
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).