### PR TITLE
MPP-3008 iOS not displaying close buttons

### DIFF
--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -53,6 +53,10 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+button {
+  padding: 0;
+}
+
 img,
 picture,
 video,


### PR DESCRIPTION
This PR fixes MPP-3008.

# Bug description
On iOS devices (tested on iOS 16), the "X" icon disappears in areas where the SVG element is a child of the button element. The issue describes this for the info modal, but John also noticed this on a survey banner (https://mozilla-hub.atlassian.net/browse/MPP-3008?focusedCommentId=715256). From the inspector, I noticed that this happens because some extra padding gets added from the user-agent (browser) style sheets, although there might be some other reasoning related to svg viewports and iOS. 

To fix this, I added a global padding of 0 to buttons (instead of going into every component that has a close button and adding 0 padding to it). The buttons that use padding for design reasons are defined in their respective scss modules, and this overrides the global css. 

# Screenshot (if applicable)
![IMG-20230814-WA0000](https://github.com/mozilla/fx-private-relay/assets/59676643/b1437a00-884b-4a0f-8800-7c5206b427aa)

# How to test
There is no clear way run the local server on your phone, because there will be an error when trying to log in to your FxA (redirect_uri error). Because of this, testing is a bit difficult. I tested by using my Mac and connecting an iPhone that has the dev site loaded, then used the inspector.

A way you can test this specific branch is by doing the following: 
* Follow the instructions to release this branch to dev, https://github.com/mozilla/fx-private-relay/blob/main/docs/release_process.md#release-to-dev 
* Then go to https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/accounts/profile/ on an iOS device
* Tap on the “i” button next to the “Set your unique ⁨Relay⁩ email domain“;
* Observe the opened modal;


# Checklist (Definition of Done)
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
