### PR TITLE
MPP-3262: only set campaign ga fields if utm cookies are present

### DIFF
--- a/frontend/src/pages/_app.page.tsx
+++ b/frontend/src/pages/_app.page.tsx
@@ -66,19 +66,26 @@ function MyApp({ Component, pageProps }: AppProps) {
       titleCase: false,
       debug: process.env.NEXT_PUBLIC_DEBUG === "true",
     });
-    const gaFields: ReactGa.FieldsObject = {
-      anonymizeIp: true,
-      transport: "beacon",
-    };
     const cookies = document.cookie.split("; ");
-    cookies.forEach((item) => {
-      if (item.trim().startsWith("utm_")) {
-        const cookieId = item.split("=")[0];
-        Object.assign(gaFields, convertUtmCookieToGaField(item));
-        clearCookie(cookieId);
-      }
-    });
-    ReactGa.set(gaFields);
+    if (cookies.some((cookie) => cookie.trim().startsWith("utm_"))) {
+      const gaFields: ReactGa.FieldsObject = {
+        anonymizeIp: true,
+        transport: "beacon",
+      };
+      cookies.forEach((item) => {
+        if (item.trim().startsWith("utm_")) {
+          const cookieId = item.split("=")[0];
+          Object.assign(gaFields, convertUtmCookieToGaField(item));
+          clearCookie(cookieId);
+        }
+      });
+      ReactGa.set(gaFields);
+    } else {
+      ReactGa.set({
+        anonymizeIp: true,
+        transport: "beacon",
+      });
+    }
     const gaEventCookies = cookies.filter((item) =>
       item.trim().startsWith("server_ga_event:"),
     );


### PR DESCRIPTION
Note: this may be an alternative fix to https://github.com/mozilla/fx-private-relay/pull/3774 but it needs more thorough testing.

This PR fixes a bug with #MPP-3262. (See https://mozilla.slack.com/archives/G01CAHTUJ9L/p1692027548063739)

How to test:
* With a mix of browsers that are signed-in or signed-out of Relay ...
* Open the "Console" dev tool panel
* Filter it to show "pageview" output
* Go to a number of urls with ?utm_* values, eg., http://127.0.0.1:8000/accounts/profile/?utm_medium=firefox-desktop&utm_source=modal&utm_campaign=limit&utm_content=manage-masks-global
   * [ ] Confirmt the pageview events show the proper values sent to GA

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).