### PR TITLE
MPP-2083: Retire eu_country_expansion flag, frontend

### DIFF
--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -366,7 +366,7 @@ export const WhatsNewMenu = (props: Props) => {
   };
 
   if (
-    isFlagActive(props.runtimeData, "eu_country_expansion") &&
+    typeof props.runtimeData !== "undefined" &&
     !props.profile.has_premium &&
     [
       "bg",

--- a/frontend/src/hooks/api/runtimeData.ts
+++ b/frontend/src/hooks/api/runtimeData.ts
@@ -12,7 +12,6 @@ export type FlagNames =
   | "firefox_integration"
   | "mailing_list_announcement"
   | "premium_promo_banners"
-  | "eu_country_expansion"
   | "mask_redesign"
   | "mobile_app";
 type WaffleFlag = [FlagNames, boolean];

--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -307,11 +307,7 @@ const Faq: NextPage = () => {
                 id="faq-availability"
                 question={l10n.getString("faq-question-availability-question")}
               >
-                <p>
-                  {isFlagActive(runtimeData.data, "eu_country_expansion")
-                    ? l10n.getString("faq-question-availability-answer-v4")
-                    : l10n.getString("faq-question-availability-answer-v2")}
-                </p>
+                <p>{l10n.getString("faq-question-availability-answer-v4")}</p>
               </QAndA>
               <QAndA
                 id="faq-replies"

--- a/frontend/src/pages/index.page.tsx
+++ b/frontend/src/pages/index.page.tsx
@@ -21,7 +21,6 @@ import { BundleBanner } from "../components/landing/BundleBanner";
 import { useFlaggedAnchorLinks } from "../hooks/flaggedAnchorLinks";
 import { useL10n } from "../hooks/l10n";
 import { HighlightedFeatures } from "../components/landing/HighlightedFeatures";
-import { isFlagActive } from "../functions/waffle";
 
 const Home: NextPage = () => {
   const l10n = useL10n();
@@ -137,11 +136,7 @@ const Home: NextPage = () => {
                 entries={[
                   {
                     q: l10n.getString("faq-question-availability-question"),
-                    a: isFlagActive(runtimeData.data, "eu_country_expansion")
-                      ? l10n.getString("faq-question-availability-answer-v4")
-                      : l10n.getString(
-                          "faq-question-landing-page-availability",
-                        ),
+                    a: l10n.getString("faq-question-availability-answer-v4"),
                   },
                   {
                     q: l10n.getString("faq-question-what-is-question-2"),

--- a/frontend/src/pages/premium.page.tsx
+++ b/frontend/src/pages/premium.page.tsx
@@ -17,7 +17,6 @@ import { useFlaggedAnchorLinks } from "../hooks/flaggedAnchorLinks";
 import { useL10n } from "../hooks/l10n";
 import { Localized } from "../components/Localized";
 import { HighlightedFeatures } from "../components/landing/HighlightedFeatures";
-import { isFlagActive } from "../functions/waffle";
 
 const PremiumPromo: NextPage = () => {
   const l10n = useL10n();
@@ -45,11 +44,7 @@ const PremiumPromo: NextPage = () => {
   ) : (
     <LinkButton
       href="/premium/waitlist"
-      title={
-        isFlagActive(runtimeData.data, "eu_country_expansion")
-          ? l10n.getString("premium-promo-availability-warning-4")
-          : l10n.getString("premium-promo-availability-warning-2")
-      }
+      title={l10n.getString("premium-promo-availability-warning-4")}
     >
       {l10n.getString("waitlist-submit-label-2")}
     </LinkButton>
@@ -65,11 +60,7 @@ const PremiumPromo: NextPage = () => {
               <p />
             </Localized>
             {cta}
-            <p>
-              {isFlagActive(runtimeData.data, "eu_country_expansion")
-                ? l10n.getString("premium-promo-availability-warning-4")
-                : l10n.getString("premium-promo-availability-warning-2")}
-            </p>
+            <p>{l10n.getString("premium-promo-availability-warning-4")}</p>
           </div>
           <div className={styles["hero-image"]}>
             <Image src={HeroImage} alt="" />


### PR DESCRIPTION
Followup to https://github.com/mozilla/fx-private-relay/pull/3745, to remove the flag from the UI code as well. Assumes the flag to always be active.

- [x] l10n changes have been submitted to the l10n repository, if any. https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/155
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
