### PR TITLE
Python dependencies - add some update hints, use some grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,23 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      testing-libraries:
+        patterns:
+          - "coverage"
+          - "model-bakery"
+          - "pytest-cov"
+          - "pytest-django"
+          - "responses"
+      typing-stubs:
+        patterns:
+          - "boto3-stubs"
+          - "botocore-stubs"
+          - "django-stubs"
+          - "djangorestframework-stubs"
+          - "mypy-boto3-ses"
+          - "types-pyOpenSSL"
+          - "types-requests"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -7,7 +7,9 @@ comes in.
 Typically, we receive update notifications from
 [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts),
 which periodically checks for new versions of dependencies, and then submits
-pull requests to update them.
+pull requests to update them. Project members can view the
+[details of the latest dependency scans](https://github.com/mozilla/fx-private-relay/network/updates)
+to troubleshoot issues.
 
 Some terms to be aware of:
 

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -241,3 +241,10 @@ are not ready to update, to get them out of the PR queue.
 We skip non-LTS versions (such as 5.0.0 and 5.1.0). Use the comment
 `@dependabot ignore this minor version` to close the PR and avoid new updates for
 that series.
+
+### django-debug-toolbar
+
+This package is development-only, and updates are generally safe to merge. To test,
+update the package, start the server, and load `/emails/wrapped_email_test` locally.
+The toolbar will be on the right side of the page, either expanded or minimized as
+"DjDT" in the upper right corner.

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -173,3 +173,71 @@ that it gets changed back (resulting in an empty commit) when committing.
 To watch files when running `npm run watch`. You can verify that this still
 works by running that command and making sure that the server restarts if you
 edit a source file.
+
+## pip / Python
+
+The Python requirements are in `/requirements.txt` at the project root. We
+do not distinguish between development and production requirements for Python.
+We recommend setting up and using a Python virtual environment, to keep Relay
+packages distinct from other system packages - see the
+[Development setup instructions](https://github.com/mozilla/fx-private-relay#development)
+for details.
+The command `python -m pip install -r requirements.txt` will install the packages.
+
+In general, Python library developers write release notes, even if Dependabot has
+trouble finding and linking to them. It is worth reading the release notes to
+determine the changes from the previous version, and take note of suggested changes
+to the Relay codebase.
+
+Python developers often follow the
+[Python version support schedule](https://www.python.org/downloads/), dropping support
+for old Python versions even with few code changes. These are often released as minor
+version updates, occasionally as major updates, but are generally safe updates
+for Relay. The currently used Python version can be found in several places, such
+as the
+[Development setup instructions](https://github.com/mozilla/fx-private-relay#development).
+Relay engineers attempt to update to new Python versions within 12
+months of their release.
+
+What follows is a list of dependencies and how to check for potential breakage
+when they release new versions:
+
+### black
+
+For linters, see the details of the `black style check` test step for any breaking
+syntax changes. If this test step passes, the upgrade is probably OK, and any warnings
+can be handled in later PRs.
+
+### pytest and plugins, coverage, model-bakery, responses
+
+For testing tools, a successful CI test run means the upgrade is probably OK, and any
+new warnings can be handled in later PRs.
+
+### mypy and type stub libraries
+
+For mypy and stub libraries, see the details of the `mypy type check` test step for any
+breaking typing changes. If this test step passes, the upgrade is probably OK, and any
+new warnings can be handled in later PRs.
+
+### boto3
+
+This library is generated from the API definition files for Amazon Web Services, and has
+an update almost every week. A successful CI test run means the upgrade is OK. See the
+upgrade notes for a taste of the changes AWS developers are making.
+
+### django
+
+Relay currently uses a Long Term Support (LTS) release of Django. See the
+[Django download page](https://www.djangoproject.com/download/) for version details.
+Patch versions of the current version (such as 3.2.19 to 3.2.20) are often
+security updates, and the release notes should be read to determine the impact
+to Relay, as well as merged as soon as possible.
+
+We try to update to the next LTS version within the year of release. This is often a
+multi-week process, requiring updates to several resources, and tracked in a GitHub
+issue and project task. Close dependency updates to the next LTS version if you
+are not ready to update, to get them out of the PR queue.
+
+We skip non-LTS versions (such as 5.0.0 and 5.1.0). Use the comment
+`@dependabot ignore this minor version` to close the PR and avoid new updates for
+that series.

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -221,9 +221,24 @@ new warnings can be handled in later PRs.
 
 ### boto3
 
-This library is generated from the API definition files for Amazon Web Services, and has
-an update almost every week. A successful CI test run means the upgrade is OK. See the
-upgrade notes for a taste of the changes AWS developers are making.
+This is the interface library for Amazon Web Services (AWS). This library is
+generated from the API definition files, and has multiple patch updates most
+weeks. A successful CI test run means the upgrade is OK.
+
+See the upgrade notes for a taste of the changes AWS developers are making to
+the services we use. We use clients for the following services in code:
+
+- S3 - Simple Storage Service
+- SES - Simple Email Service
+- SQS - Simple Queue Service
+
+We use these additional AWS services in the Relay system:
+
+- CloudFront - Content delivery network
+- IAM - Identity and Access Management
+- KMS - Key Management Service
+- Route53 - Domain Name Service
+- SNS - Simple Notification Service
 
 ### django
 

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -33,10 +33,11 @@ you're doing on the `main` branch. If the results differ, there's probably an
 issue with the update.
 **Make sure to do a fresh install of the dependencies when switching branches!**
 
-You can line up multiple Dependabot PRs for merging by adding the comment
-`@dependabot merge`. Dependabot will then automatically keep the PR up-to-date
-with changes in `main`, and merge it if the Checks continue to run successfully.
-Alternatively, you can use the CLI tool [`pmac`](https://github.com/willkg/paul-mclendahand).
+You can line up multiple Dependabot PRs for merging by using the "Merge when ready"
+button to add to the merge queue. The suggested comment `@dependabot merge`
+does not work with the merge queue, and will not merge the PR.
+Alternatively, you can use the CLI tool [`pmac`](https://github.com/willkg/paul-mclendahand)
+to manually group updates into a single PR.
 
 ## npm
 


### PR DESCRIPTION
This PR uses the new Dependabot grouping feature to group together the testing libraries and the typing stubs into single PRs. It also updates the dependency documentation:

* Link to the [details of the latest dependency scans](https://github.com/mozilla/fx-private-relay/network/updates)
* Update merge instructions for the merge queue
* Add some hints for some categories of Python package updates