### PR TITLE
Run Jest tests in a single process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
             mkdir --parents /tmp/workspace/test-results/frontend-coverage
             npm test --workspace frontend -- \
               --ci \
+              --runInBand \
               --coverageDirectory=/tmp/workspace/test-results/frontend-coverage
       - store_test_results:
           path: frontend/junit.xml


### PR DESCRIPTION
We're still seeing test failures like #3740 and #3741, making yesterday's dependency updates painful.

Try the suggested mitigation from [Jest Troubleshooting: Tests are Extremely Slow on Docker and/or Continuous Integration (CI) server](https://jestjs.io/docs/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server) of using `--runInBand` to restrict tests to a single thread.

CircleCI tests run 6x-8x slower than on my laptop (M2 Pro). The only test slow enough to report is the profile test, and this appears to be because the "axe accessibility testing" is slow (970 ms). In CircleCI, it appears that threaded tests may be interfering with each other and making each test suite shutdown slow.

|Test|M2 Pro|CircleCI Before|CircleCI after
|----|:---|:---|:---|
|formatPhone          |_fast_ | 8.316 s|_fast_ |
|filterAliases        |_fast_ |10.987 s|_fast_ |
|CountdownTimer       |_fast_ |11.509 s|_fast_ |
|fxaFlowTracker       |_fast_ |11.104 s|_fast_ |
|localLabels          |_fast_ |12.217 s|_fast_ |
|localDismissal       |_fast_ |11.911 s|_fast_ |
|AddressPickerModal   |_fast_ |13.794 s|_fast_ |
|AliasGenerationButton|_fast_ |16.204 s|_fast_ |
|AliasDeletionButton  |_fast_ |17.193 s|_fast_ |
|Navigation           |_fast_ |17.181 s|_fast_ |
|CsatSurvey           |_fast_ |18.723 s|_fast_ |
|WhatsNewDashboard    |_fast_ |19.495 s|_fast_ |
|WaitlistPage         |_fast_ |19.503 s|_fast_ |
|faq                  |_fast_ |20.398 s|_fast_ |
|AliasList            |_fast_ |21.635 s|_fast_ |
|phone                |_fast_ |21.992 s|_fast_ |
|settings             |_fast_ |22.202 s|_fast_ |
|premium              |_fast_ |22.166 s|_fast_ |
|index                |_fast_ |24.718 s| 5.102 s|
|profile              |5.454 s|32.590 s|18.64 s|
|**Total**            |6.607 s|43.744 s|43.835 s|