### PR TITLE
MPP-3363: Fix Country Code detected by CDN

### DIFF
--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -316,7 +316,6 @@ def test_get_countries_info_bad_accept_language(rf) -> None:
     }
 
 
-@pytest.mark.xfail(reason="MPP-3363")
 def test_get_countries_info_cdn_language(rf) -> None:
     request = rf.get("/api/v1/runtime_data", HTTP_X_CLIENT_REGION="DE")
     mapping = get_premium_country_language_mapping()

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -316,6 +316,31 @@ def test_get_countries_info_bad_accept_language(rf) -> None:
     }
 
 
+@pytest.mark.xfail(reason="MPP-3363")
+def test_get_countries_info_cdn_language(rf) -> None:
+    request = rf.get("/api/v1/runtime_data", HTTP_X_CLIENT_REGION="DE")
+    mapping = get_premium_country_language_mapping()
+    result = get_countries_info_from_request_and_mapping(request, mapping)
+    assert result == {
+        "country_code": "DE",
+        "countries": sorted(mapping.keys()),
+        "available_in_country": True,
+        "plan_country_lang_mapping": mapping,
+    }
+
+
+def test_get_countries_info_no_language(rf) -> None:
+    request = rf.get("/api/v1/runtime_data")
+    mapping = get_premium_country_language_mapping()
+    result = get_countries_info_from_request_and_mapping(request, mapping)
+    assert result == {
+        "country_code": "US",
+        "countries": sorted(mapping.keys()),
+        "available_in_country": True,
+        "plan_country_lang_mapping": mapping,
+    }
+
+
 #
 # flag_is_active_in_task tests
 #

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -56,7 +56,7 @@ def get_countries_info_from_lang_and_mapping(
 
 def _get_cc_from_request(request: HttpRequest) -> str:
     if "X-Client-Region" in request.headers:
-        return request.headers["X-Client-Region"].lower()
+        return request.headers["X-Client-Region"].upper()
     if "Accept-Language" in request.headers:
         return _get_cc_from_lang(request.headers["Accept-Language"])
     return "US"


### PR DESCRIPTION
When the CDN detects a country and reports it via the `X-Client-Region` header, uppercase the country string. This feature is only available on stage and production.

This PR fixes MPP-3363. Previously, the string was lowercased, which caused a mismatch with the changes in PR #3747.

How to test:

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).