### PR TITLE
MPP-2959: Subdomain can be edited through PATCH request

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -132,6 +132,7 @@ class ProfileSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = [
             "id",
+            "subdomain",
             "has_premium",
             "has_phone",
             "has_vpn",

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -106,7 +106,8 @@ class DomainAddressSerializer(PremiumValidatorsMixin, serializers.ModelSerialize
 
 
 class StrictReadOnlyFieldsMixin:
-    """Raises a validation error (400) if read only fields are in the body of PUT/PATCH requests.
+    """
+    Raises a validation error (400) if read only fields are in the body of PUT/PATCH requests.
 
     This class comes from https://github.com/encode/django-rest-framework/issues/1655#issuecomment-1197033853,
     where different solutions to mitigating 200 response codes in read-only fields are discussed.
@@ -122,9 +123,17 @@ class StrictReadOnlyFieldsMixin:
         read_only_fields = set(
             field_name for field_name, field in self.fields.items() if field.read_only
         ).union(set(getattr(self.Meta, "read_only_fields", set())))
-        received_read_only_fields = set(self.initial_data).intersection(
-            read_only_fields
+
+        # Getting implicit read only fields that are in the Profile model, but were not defined in the serializer.
+        # By default, they won't update if put in the body of a request, but they still give a 200 response (which we don't want).
+        implicit_read_only_fields = set(
+            field for field in vars(self.Meta.model) if field not in self.fields
         )
+
+        received_read_only_fields = set(self.initial_data).intersection(
+            read_only_fields.union(implicit_read_only_fields)
+        )
+
         if received_read_only_fields:
             errors = {}
             for field_name in received_read_only_fields:

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -6,10 +6,6 @@ from waffle import get_waffle_flag_model
 
 from emails.models import DomainAddress, Profile, RelayAddress
 
-import logging
-
-log = logging.getLogger(__name__)
-
 
 class PremiumValidatorsMixin:
     # the user must be premium to set block_list_emails=True
@@ -110,10 +106,7 @@ class DomainAddressSerializer(PremiumValidatorsMixin, serializers.ModelSerialize
 
 
 class StrictReadOnlyFieldsMixin:
-    """Raises a validation error (400) if read only fields are in the body of requests."""
-
-    # Gets added to "error_messages" in the Serializer class using this mixin
-    default_error_messages = {"read_only": ("This field is read only")}
+    """Raises a validation error (400) if read only fields are in the body of PUT/PATCH requests."""
 
     def validate(self, attrs):
         attrs = super().validate(attrs)
@@ -128,12 +121,11 @@ class StrictReadOnlyFieldsMixin:
         received_read_only_fields = set(self.initial_data).intersection(
             read_only_fields
         )
-
         if received_read_only_fields:
             errors = {}
             for field_name in received_read_only_fields:
                 errors[field_name] = serializers.ErrorDetail(
-                    self.error_messages["read_only"], code="read_only"
+                    "This field is read only", code="read_only"
                 )
 
             raise serializers.ValidationError(errors)

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -106,7 +106,11 @@ class DomainAddressSerializer(PremiumValidatorsMixin, serializers.ModelSerialize
 
 
 class StrictReadOnlyFieldsMixin:
-    """Raises a validation error (400) if read only fields are in the body of PUT/PATCH requests."""
+    """Raises a validation error (400) if read only fields are in the body of PUT/PATCH requests.
+
+    This class comes from https://github.com/encode/django-rest-framework/issues/1655#issuecomment-1197033853,
+    where different solutions to mitigating 200 response codes in read-only fields are discussed.
+    """
 
     def validate(self, attrs):
         attrs = super().validate(attrs)

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -104,6 +104,27 @@ def test_post_domainaddress_no_subdomain_error(premium_user, prem_api_client) ->
     }
 
 
+def test_patch_premium_user_subdomain_cannot_be_changed(
+    premium_user, prem_api_client
+) -> None:
+    """A premium user should not be able to edit their subdomain."""
+    premium_profile = premium_user.profile
+    original_subdomain = "helloworld"
+    premium_profile.subdomain = original_subdomain
+    premium_profile.save()
+
+    new_subdomain = "helloworldd"
+    response = prem_api_client.patch(
+        reverse(viewname="profiles-detail", args=[premium_user.id]),
+        data={"subdomain": new_subdomain},
+        format="json",
+    )
+
+    ret_data = response.json()
+
+    assert ret_data["subdomain"] == original_subdomain
+
+
 def test_post_domainaddress_user_flagged_error(premium_user, prem_api_client) -> None:
     """A flagged user cannot create a new domain address."""
     premium_profile = premium_user.profile

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -111,6 +111,7 @@ def test_patch_premium_user_subdomain_cannot_be_changed(
     premium_profile = premium_user.profile
     original_subdomain = "helloworld"
     premium_profile.subdomain = original_subdomain
+    READ_ONLY_RES = "This field is read only"
     premium_profile.save()
 
     new_subdomain = "helloworldd"
@@ -123,9 +124,9 @@ def test_patch_premium_user_subdomain_cannot_be_changed(
     ret_data = response.json()
     premium_profile.refresh_from_db()
 
-    assert ret_data["subdomain"] == original_subdomain
+    assert ret_data["subdomain"][0] == READ_ONLY_RES
     assert premium_profile.subdomain == original_subdomain
-    assert response.status_code == 200
+    assert response.status_code == 400
 
 
 def test_patch_profile_fields_are_read_only_by_default(premium_user, prem_api_client):
@@ -150,7 +151,7 @@ def test_patch_profile_fields_are_read_only_by_default(premium_user, prem_api_cl
 
     assert premium_profile.num_address_deleted == expected_num_address_deleted
     assert premium_profile.date_subscribed == expected_date_subscribed
-    assert response.status_code == 200
+    assert response.status_code == 400
 
 
 def test_post_domainaddress_user_flagged_error(premium_user, prem_api_client) -> None:

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -111,7 +111,6 @@ def test_patch_premium_user_subdomain_cannot_be_changed(
     premium_profile = premium_user.profile
     original_subdomain = "helloworld"
     premium_profile.subdomain = original_subdomain
-    READ_ONLY_RES = "This field is read only"
     premium_profile.save()
 
     new_subdomain = "helloworldd"
@@ -124,7 +123,7 @@ def test_patch_premium_user_subdomain_cannot_be_changed(
     ret_data = response.json()
     premium_profile.refresh_from_db()
 
-    assert ret_data["subdomain"][0] == READ_ONLY_RES
+    assert ret_data["subdomain"][0] == "This field is read only"
     assert premium_profile.subdomain == original_subdomain
     assert response.status_code == 400
 

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -123,34 +123,128 @@ def test_patch_premium_user_subdomain_cannot_be_changed(
     ret_data = response.json()
     premium_profile.refresh_from_db()
 
-    assert ret_data["subdomain"][0] == "This field is read only"
+    assert ret_data.get("subdomain", [""])[0] == "This field is read only"
     assert premium_profile.subdomain == original_subdomain
     assert response.status_code == 400
 
 
 def test_patch_profile_fields_are_read_only_by_default(premium_user, prem_api_client):
-    """A field in the Profile model should be read only by default if it is not mentioned in the ProfileSerializer class fields.
+    """
+    A field in the Profile model should be read only by default, and return a 400 response code
+    (see StrictReadOnlyFieldsMixin in api/serializers/__init__.py), if it is not mentioned in the ProfileSerializer class fields.
 
-    Tested two fields, date_subscribed and num_address_deleted to see if the behavior matches what is described here: https://www.django-rest-framework.org/api-guide/serializers/#specifying-read-only-fields
+    Two fields were tested, num_address_deleted, and sent_welcome_email to see if the behavior matches what is described here: https://www.django-rest-framework.org/api-guide/serializers/#specifying-read-only-fields
     """
     premium_profile = premium_user.profile
     expected_num_address_deleted = premium_profile.num_address_deleted
-    expected_date_subscribed = premium_profile.date_subscribed
+    expected_sent_welcome_email = premium_profile.sent_welcome_email
 
     response = prem_api_client.patch(
         reverse(viewname="profiles-detail", args=[premium_user.id]),
         data={
-            "date_subscribed": "2023-08-12T13:12:13.850828Z",
             "num_address_deleted": 5,
+            "sent_welcome_email": True,
         },
+        format="json",
+    )
+
+    ret_data = response.json()
+    premium_profile.refresh_from_db()
+
+    assert premium_profile.num_address_deleted == expected_num_address_deleted
+    assert premium_profile.sent_welcome_email == expected_sent_welcome_email
+    assert ret_data.get("sent_welcome_email", [""])[0] == "This field is read only"
+    assert ret_data.get("num_address_deleted", [""])[0] == "This field is read only"
+    assert response.status_code == 400
+
+
+def test_profile_non_read_only_fields_update_correctly(premium_user, prem_api_client):
+    """
+    A field that is not read only should update correctly on a patch request.
+
+    "Not read only" meaning that it was defined in the serializers fields, but not read_only_fields.
+    """
+    premium_profile = premium_user.profile
+    old_onboarding_state = premium_profile.onboarding_state
+    old_email_tracker_remove_value = premium_profile.remove_level_one_email_trackers
+
+    response = prem_api_client.patch(
+        reverse(viewname="profiles-detail", args=[premium_user.id]),
+        data={
+            "onboarding_state": 1,
+            "remove_level_one_email_trackers": True,
+        },
+        format="json",
+    )
+
+    ret_data = response.json()
+    premium_profile.refresh_from_db()
+
+    assert (
+        ret_data.get("remove_level_one_email_trackers", None)
+        != old_email_tracker_remove_value
+    )
+    assert (
+        premium_profile.remove_level_one_email_trackers
+        != old_email_tracker_remove_value
+    )
+    assert premium_profile.remove_level_one_email_trackers is True
+    assert ret_data.get("remove_level_one_email_trackers", None) is True
+    assert ret_data.get("onboarding_state", None) != old_onboarding_state
+    assert premium_profile.onboarding_state == 1
+    assert ret_data.get("onboarding_state", None) == 1
+    assert response.status_code == 200
+
+
+def test_profile_patch_with_model_and_serializer_fields(premium_user, prem_api_client):
+    premium_profile = premium_user.profile
+
+    response = prem_api_client.patch(
+        reverse(viewname="profiles-detail", args=[premium_user.id]),
+        data={"subdomain": "vanilla", "num_address_deleted": 5},
         format="json",
     )
 
     premium_profile.refresh_from_db()
 
-    assert premium_profile.num_address_deleted == expected_num_address_deleted
-    assert premium_profile.date_subscribed == expected_date_subscribed
     assert response.status_code == 400
+    assert premium_profile.subdomain != "vanilla"
+    assert premium_profile.num_address_deleted == 0
+
+
+def test_profile_patch_with_non_read_only_and_read_only_fields(
+    premium_user, prem_api_client
+):
+    """A request that includes at least one read only field will give a 400 response"""
+    premium_profile = premium_user.profile
+    old_onboarding_state = premium_profile.onboarding_state
+
+    response = prem_api_client.patch(
+        reverse(viewname="profiles-detail", args=[premium_user.id]),
+        data={"onboarding_state": 1, "subdomain": "vanilla"},
+        format="json",
+    )
+
+    ret_data = response.json()
+    premium_profile.refresh_from_db()
+
+    assert premium_profile.onboarding_state == old_onboarding_state
+    assert ret_data.get("subdomain", [""])[0] == "This field is read only"
+    assert response.status_code == 400
+
+
+def test_profile_patch_fields_that_dont_exist(premium_user, prem_api_client):
+    """A request sent with only fields that don't exist give a 200 response (this is the default behavior django provides, we decided to leave it as is)"""
+    response = prem_api_client.patch(
+        reverse(viewname="profiles-detail", args=[premium_user.id]),
+        data={
+            "nonsense": False,
+            "blabla": "blabla",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200
 
 
 def test_post_domainaddress_user_flagged_error(premium_user, prem_api_client) -> None:


### PR DESCRIPTION
This PR fixes MPP-2959.

How to test:

* Verify that the test is successful by running `pytest api/tests/views_tests.py"

Testing manually:

1. Go to the Relay dashboard
2. Send a request to /api/v1/profiles/<uid\>/  with the body {"subdomain": "<a new subdomain\>"}. <img width="1236" alt="Screenshot 2023-08-17 091222" src="https://github.com/mozilla/fx-private-relay/assets/59676643/04fcf0ce-0cee-4c8e-a88e-a12aa9946898">
3. Refresh the page, and observe the subdomain to ensure that it was not changed.
4. Observe that you get a response code of "400"


# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] ~l10n changes have been submitted to the l10n repository, if any.~
