### PR TITLE
MPP-3008: Revert #3773, changes for iOS close button fix

### DIFF
--- a/frontend/src/components/Banner.module.scss
+++ b/frontend/src/components/Banner.module.scss
@@ -41,6 +41,7 @@
     border-style: none;
     border-radius: $border-radius-sm;
     cursor: pointer;
+    padding: 0;
 
     &:hover {
       background-color: $color-blue-50;

--- a/frontend/src/components/InfoModal.module.scss
+++ b/frontend/src/components/InfoModal.module.scss
@@ -33,6 +33,7 @@
       right: $spacing-sm;
       top: $spacing-sm;
       width: 30px;
+      padding: 0;
 
       &:hover {
         background-color: $color-blue-50;

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.module.scss
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.module.scss
@@ -69,6 +69,10 @@ button.trigger {
   border-radius: $border-radius-sm;
   width: min($content-sm, calc(100vw - 2 * $spacing-md));
 
+  button {
+    padding: 0;
+  }
+
   &::before {
     content: "";
     height: 12px;

--- a/frontend/src/components/layout/topmessage/CsatSurvey.module.scss
+++ b/frontend/src/components/layout/topmessage/CsatSurvey.module.scss
@@ -29,6 +29,7 @@
     justify-content: center;
     border-radius: $border-radius-sm;
     cursor: pointer;
+    padding: 0;
 
     &:hover {
       background-color: $color-blue-50;

--- a/frontend/src/components/layout/topmessage/InterviewRecruitment.module.scss
+++ b/frontend/src/components/layout/topmessage/InterviewRecruitment.module.scss
@@ -29,6 +29,7 @@ $dismissButtonWidth: 30px;
     justify-content: center;
     border-radius: $border-radius-sm;
     cursor: pointer;
+    padding: 0;
 
     &:hover {
       background-color: $color-blue-50;

--- a/frontend/src/components/layout/topmessage/PhoneSurvey.module.scss
+++ b/frontend/src/components/layout/topmessage/PhoneSurvey.module.scss
@@ -29,6 +29,7 @@ $dismissButtonWidth: 30px;
     justify-content: center;
     border-radius: $border-radius-sm;
     cursor: pointer;
+    padding: 0;
 
     &:hover {
       background-color: $color-blue-50;

--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -53,10 +53,6 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-button {
-  padding: 0;
-}
-
 img,
 picture,
 video,


### PR DESCRIPTION
This PR fixes MPP-3008.

Originally, in PR #3773, the fix I made was adding a global padding of 0 to buttons. However, Vincent mentioned that there are small changes (non-blocking) that occur to other elements because of this (https://github.com/mozilla/fx-private-relay/pull/3773#issuecomment-1682052078). With this in mind, I added a padding of 0 only to elements which I know are breaking.

# Bug description

"On iOS devices (tested on iOS 16), the "X" icon disappears in areas where the SVG element is a child of the button element. The issue describes this for the info modal, but John also noticed this on a survey banner (https://mozilla-hub.atlassian.net/browse/MPP-3008?focusedCommentId=715256). From the inspector, I noticed that this happens because some extra padding gets added from the user-agent (browser) style sheets, although there might be some other reasoning related to svg viewports and iOS."

# How to test
A way you can test this specific branch is by doing the following:

* Follow the instructions to release this branch to dev, https://github.com/mozilla/fx-private-relay/blob/main/docs/release_process.md#release-to-dev (Or let me know when you are reviewing, and I can do this for you)
* Then go to https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/accounts/profile/ on an iOS device
* Tap on the “i” button next to the “Set your unique ⁨Relay⁩ email domain“;
* Observe the opened modal;

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
