### PR TITLE
MPP-3227 - Show upsell only where premium is available

### DIFF
--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -299,9 +299,12 @@ const Profile: NextPage = () => {
             <dt className={styles.label}>
               {l10n.getString("profile-stat-label-aliases-used-2")}
             </dt>
-            {allAliases.length >= freeMaskLimit &&
-            !profile.has_premium &&
-            isPhonesAvailableInCountry(runtimeData.data) ? (
+            {/* If premium is available in the user's country and 
+            the user has reached their free mask limit and 
+            they are a free user, show the maxed masks tooltip */}
+            {isPeriodicalPremiumAvailableInCountry(runtimeData.data) &&
+            allAliases.length >= freeMaskLimit &&
+            !profile.has_premium ? (
               <dd className={`${styles.value} ${styles.maxed}`}>
                 <MaxedMasksTooltip>
                   {numberFormatter.format(allAliases.length)}
@@ -473,7 +476,12 @@ const Profile: NextPage = () => {
         totalEmailTrackersRemoved={profile.level_one_trackers_blocked}
       />
       <Layout runtimeData={runtimeData.data}>
-        {freeMaskLimitReached && <UpsellBanner />}
+        {/* If free user has reached their free mask limit and 
+        premium is available in their country, show upsell banner */}
+        {freeMaskLimitReached &&
+          isPeriodicalPremiumAvailableInCountry(runtimeData.data) && (
+            <UpsellBanner />
+          )}
         {isPhonesAvailableInCountry(runtimeData.data) ? (
           <DashboardSwitcher />
         ) : null}

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -303,8 +303,7 @@ const Profile: NextPage = () => {
             the user has reached their free mask limit and 
             they are a free user, show the maxed masks tooltip */}
             {isPeriodicalPremiumAvailableInCountry(runtimeData.data) &&
-            allAliases.length >= freeMaskLimit &&
-            !profile.has_premium ? (
+            freeMaskLimitReached ? (
               <dd className={`${styles.value} ${styles.maxed}`}>
                 <MaxedMasksTooltip>
                   {numberFormatter.format(allAliases.length)}


### PR DESCRIPTION
 
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes issue found in MPP-3227

# New feature description

From Andrei: Is this intended to be displayed to users from non-Premium countries as well? Such users see it as well, with a CTA for Premium that sends them to the Interstitial page where they only have Waitlist joining. Such users also keep seeing the greyed-out “+Generate new mask” button on the dashboard, but no other CTAs for Premium.

# Screenshot (if applicable)

![image](https://github.com/mozilla/fx-private-relay/assets/3924990/7b332847-da87-4c70-9d68-699388803d9f)
 
# How to test

Upsell should show only if premium is available in that country. 

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
