### PR TITLE
fix MPP-3262: send pageview before redirecting to FXA login

### DIFF
--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -17,6 +17,7 @@ import {
   useTooltip,
   useTooltipTrigger,
 } from "react-aria";
+import ReactGa from "react-ga";
 import { useMenuTriggerState, useTooltipTriggerState } from "react-stately";
 import { toast } from "react-toastify";
 import styles from "./profile.module.scss";
@@ -78,6 +79,8 @@ const Profile: NextPage = () => {
   usePurchaseTracker(profileData.data?.[0]);
 
   if (!userData.isValidating && userData.error) {
+    // Send the pageview ping before redirecting so utms are recorded
+    ReactGa.pageview(document.location.href);
     if (document.location.hash) {
       setCookie("profile-location-hash", document.location.hash);
     }


### PR DESCRIPTION
This PR fixes #MPP-3262.

How to test:
1. Open the browser devtools console
   * [ ] Make sure it's set to show "info" level debug messages
2. Go to http://127.0.0.1:8000/accounts/profile/?utm_medium=firefox-desktop&utm_source=modal&utm_campaign=limit&utm_content=manage-masks-global
   * [ ] In the devtools console, you should see output like:
```
[react-ga] called ga('set', fieldsObject);
[react-ga] with fieldsObject: {"anonymizeIp":true,"transport":"beacon"}
[react-ga] called ga('send', 'pageview', path);
[react-ga] with path: /accounts/profile/?utm_medium=firefox-desktop&utm_source=modal&utm_campaign=limit&utm_content=manage-masks-global
```
3. After you finish FXA login, you should get back to your profile without any problems

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).