### PR TITLE
MPP-3386 - Update tooltip for free users

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -33,6 +33,5 @@ profile-maxed-aliases-without-phone-description = You’ve hit your { $limit }-m
 profile-maxed-aliases-cta = Upgrade to { -brand-name-premium }
 profile-label-set-your-custom-domain-free-user = Get your own email domain with { -brand-name-premium }
 
-
 tooltip-email-domain-explanation-title-free = Get your own { -brand-name-relay } Email Domain
 tooltip-email-domain-explanation-part-one-free = With { -brand-name-premium }, you can create unlimited, custom { -brand-name-relay } masks on the go using a unique { -brand-name-relay } email domain — you won’t even have to generate them here first.

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -32,3 +32,7 @@ profile-maxed-aliases-with-phone-description = You’ve hit your { $limit }-mask
 profile-maxed-aliases-without-phone-description = You’ve hit your { $limit }-mask limit on your free { -brand-name-relay } account. Upgrade to { -brand-name-relay-premium } for unlimited email masks.
 profile-maxed-aliases-cta = Upgrade to { -brand-name-premium }
 profile-label-set-your-custom-domain-free-user = Get your own email domain with { -brand-name-premium }
+
+
+tooltip-email-domain-explanation-title-free = Get your own { -brand-name-relay } Email Domain
+tooltip-email-domain-explanation-part-one-free = With { -brand-name-premium }, you can create unlimited, custom { -brand-name-relay } masks on the go using a unique { -brand-name-relay } email domain — you won’t even have to generate them here first.

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -33,5 +33,5 @@ profile-maxed-aliases-without-phone-description = You’ve hit your { $limit }-m
 profile-maxed-aliases-cta = Upgrade to { -brand-name-premium }
 profile-label-set-your-custom-domain-free-user = Get your own email domain with { -brand-name-premium }
 
-tooltip-email-domain-explanation-title-free = Get your own { -brand-name-relay } Email Domain
+tooltip-email-domain-explanation-title-free = Get your own { -brand-name-relay } email domain
 tooltip-email-domain-explanation-part-one-free = With { -brand-name-premium }, you can create unlimited, custom { -brand-name-relay } masks on the go using a unique { -brand-name-relay } email domain — you won’t even have to generate them here first.

--- a/frontend/src/components/dashboard/subdomain/SubdomainInfoTooltip.tsx
+++ b/frontend/src/components/dashboard/subdomain/SubdomainInfoTooltip.tsx
@@ -24,14 +24,14 @@ import styles from "./SubdomainInfoTooltip.module.scss";
 import { Localized } from "../../Localized";
 import { InfoModal } from "../../InfoModal";
 
-export type Props = {
+export type SubdomainInfoTooltipProps = {
   hasPremium: boolean;
 };
 
 /**
  * Shows the user more info on how to use their Relay custom domain mask.
  */
-export const SubdomainInfoTooltip = (props: Props) => {
+export const SubdomainInfoTooltip = (props: SubdomainInfoTooltipProps) => {
   const isLargeScreen = useMinViewportWidth("md");
   const { hasPremium } = props;
 

--- a/frontend/src/components/dashboard/subdomain/SubdomainInfoTooltip.tsx
+++ b/frontend/src/components/dashboard/subdomain/SubdomainInfoTooltip.tsx
@@ -23,22 +23,36 @@ import { useL10n } from "../../../hooks/l10n";
 import styles from "./SubdomainInfoTooltip.module.scss";
 import { Localized } from "../../Localized";
 import { InfoModal } from "../../InfoModal";
-import { useProfiles } from "../../../hooks/api/profile";
+
+export type Props = {
+  hasPremium: boolean;
+};
 
 /**
  * Shows the user more info on how to use their Relay custom domain mask.
  */
-export const SubdomainInfoTooltip = () => {
+export const SubdomainInfoTooltip = (props: Props) => {
   const isLargeScreen = useMinViewportWidth("md");
+  const { hasPremium } = props;
 
-  return <>{isLargeScreen ? <ExplainerTrigger /> : <MobileExplainerModal />}</>;
+  return (
+    <>
+      {isLargeScreen ? (
+        <ExplainerTrigger hasPremium={hasPremium} />
+      ) : (
+        <MobileExplainerModal hasPremium={hasPremium} />
+      )}
+    </>
+  );
 };
 
-const MobileExplainerModal = () => {
+export type MobileExplainerModalProps = {
+  hasPremium: boolean;
+};
+
+const MobileExplainerModal = (props: MobileExplainerModalProps) => {
   const modalState = useOverlayTriggerState({});
-  const profileData = useProfiles();
-  const profile = profileData.data?.[0];
-  const has_premium = profile && profile.has_premium;
+  const { hasPremium } = props;
   const l10n = useL10n();
 
   const subdomainTooltipButton = (
@@ -50,7 +64,7 @@ const MobileExplainerModal = () => {
     >
       <InfoIcon
         alt={l10n.getString(
-          has_premium
+          hasPremium
             ? "tooltip-email-domain-explanation-title"
             : "tooltip-email-domain-explanation-title-free",
         )}
@@ -60,7 +74,7 @@ const MobileExplainerModal = () => {
     </button>
   );
 
-  const subdomainExplanationBody = has_premium ? (
+  const subdomainExplanationBody = hasPremium ? (
     <>
       <p>{l10n.getString("tooltip-email-domain-explanation-part-one")}</p>
       <br />
@@ -99,15 +113,17 @@ const MobileExplainerModal = () => {
   );
 };
 
-const ExplainerTrigger = () => {
+export type ExplainerTriggerProps = {
+  hasPremium: boolean;
+};
+
+const ExplainerTrigger = (props: ExplainerTriggerProps) => {
   const l10n = useL10n();
   const explainerState = useOverlayTriggerState({});
   const overlayRef = useRef<HTMLDivElement>(null);
   const openButtonRef = useRef<HTMLButtonElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
-  const profileData = useProfiles();
-  const profile = profileData.data?.[0];
-  const has_premium = profile && profile.has_premium;
+  const { hasPremium } = props;
 
   const openButtonProps = useButton(
     { onPress: () => explainerState.open() },
@@ -135,7 +151,7 @@ const ExplainerTrigger = () => {
       >
         <InfoIcon
           alt={l10n.getString(
-            has_premium
+            hasPremium
               ? "tooltip-email-domain-explanation-title"
               : "tooltip-email-domain-explanation-title-free",
           )}
@@ -152,7 +168,7 @@ const ExplainerTrigger = () => {
             positionProps={positionProps}
             ref={overlayRef}
           >
-            {has_premium ? (
+            {hasPremium ? (
               <>
                 <p>
                   {l10n.getString("tooltip-email-domain-explanation-part-one")}

--- a/frontend/src/components/dashboard/subdomain/SubdomainInfoTooltip.tsx
+++ b/frontend/src/components/dashboard/subdomain/SubdomainInfoTooltip.tsx
@@ -23,6 +23,7 @@ import { useL10n } from "../../../hooks/l10n";
 import styles from "./SubdomainInfoTooltip.module.scss";
 import { Localized } from "../../Localized";
 import { InfoModal } from "../../InfoModal";
+import { useProfiles } from "../../../hooks/api/profile";
 
 /**
  * Shows the user more info on how to use their Relay custom domain mask.
@@ -35,6 +36,9 @@ export const SubdomainInfoTooltip = () => {
 
 const MobileExplainerModal = () => {
   const modalState = useOverlayTriggerState({});
+  const profileData = useProfiles();
+  const profile = profileData.data?.[0];
+  const has_premium = profile && profile.has_premium;
   const l10n = useL10n();
 
   const subdomainTooltipButton = (
@@ -45,14 +49,18 @@ const MobileExplainerModal = () => {
       }}
     >
       <InfoIcon
-        alt={l10n.getString("tooltip-email-domain-explanation-title")}
+        alt={l10n.getString(
+          has_premium
+            ? "tooltip-email-domain-explanation-title"
+            : "tooltip-email-domain-explanation-title-free",
+        )}
         width={18}
         height={18}
       />
     </button>
   );
 
-  const subdomainExplanationBody = (
+  const subdomainExplanationBody = has_premium ? (
     <>
       <p>{l10n.getString("tooltip-email-domain-explanation-part-one")}</p>
       <br />
@@ -70,6 +78,8 @@ const MobileExplainerModal = () => {
         </Localized>
       </p>
     </>
+  ) : (
+    <p>{l10n.getString("tooltip-email-domain-explanation-part-one-free")}</p>
   );
 
   const subdomainInfoModal = modalState.isOpen ? (
@@ -95,6 +105,9 @@ const ExplainerTrigger = () => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const openButtonRef = useRef<HTMLButtonElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const profileData = useProfiles();
+  const profile = profileData.data?.[0];
+  const has_premium = profile && profile.has_premium;
 
   const openButtonProps = useButton(
     { onPress: () => explainerState.open() },
@@ -121,7 +134,11 @@ const ExplainerTrigger = () => {
         ref={openButtonRef}
       >
         <InfoIcon
-          alt={l10n.getString("tooltip-email-domain-explanation-title")}
+          alt={l10n.getString(
+            has_premium
+              ? "tooltip-email-domain-explanation-title"
+              : "tooltip-email-domain-explanation-title-free",
+          )}
           width={18}
           height={18}
         />
@@ -135,21 +152,35 @@ const ExplainerTrigger = () => {
             positionProps={positionProps}
             ref={overlayRef}
           >
-            <p>{l10n.getString("tooltip-email-domain-explanation-part-one")}</p>
-            <br />
-            <p>{l10n.getString("tooltip-email-domain-explanation-part-two")}</p>
-            <br />
-            <p>
-              <Localized
-                id="tooltip-email-domain-explanation-part-three"
-                vars={{ mozmail: "mozmail.com" }}
-                elems={{
-                  p: <p />,
-                }}
-              >
-                <span />
-              </Localized>
-            </p>
+            {has_premium ? (
+              <>
+                <p>
+                  {l10n.getString("tooltip-email-domain-explanation-part-one")}
+                </p>
+                <br />
+                <p>
+                  {l10n.getString("tooltip-email-domain-explanation-part-two")}
+                </p>
+                <br />
+                <p>
+                  <Localized
+                    id="tooltip-email-domain-explanation-part-three"
+                    vars={{ mozmail: "mozmail.com" }}
+                    elems={{
+                      p: <p />,
+                    }}
+                  >
+                    <span />
+                  </Localized>
+                </p>
+              </>
+            ) : (
+              <p>
+                {l10n.getString(
+                  "tooltip-email-domain-explanation-part-one-free",
+                )}
+              </p>
+            )}
             <button
               {...closeButtonProps}
               ref={closeButtonRef}

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -220,13 +220,12 @@ const Profile: NextPage = () => {
           @{profile.subdomain}.{getRuntimeConfig().mozmailDomain}
         </span>
       </>
+    ) : profile.has_premium ? (
+      <a className={styles["open-button"]} href="#mpp-choose-subdomain">
+        {l10n.getString("profile-label-set-your-custom-domain-free-user")}
+      </a>
     ) : (
-      <Link
-        className={styles["open-button"]}
-        href={
-          profile.has_premium ? "#mpp-choose-subdomain" : "/premium#pricing"
-        }
-      >
+      <Link className={styles["open-button"]} href={"/premium#pricing"}>
         {l10n.getString("profile-label-set-your-custom-domain-free-user")}
       </Link>
     );

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -23,7 +23,7 @@ import styles from "./profile.module.scss";
 import BottomBannerIllustration from "../../../public/images/woman-couch-left.svg";
 import UpsellBannerUs from "./images/upsell-banner-us.svg";
 import UpsellBannerNonUs from "./images/upsell-banner-nonus.svg";
-import { CheckBadgeIcon, LockIcon } from "../../components/Icons";
+import { CheckBadgeIcon, LockIcon, PencilIcon } from "../../components/Icons";
 import { Layout } from "../../components/layout/Layout";
 import { useProfiles } from "../../hooks/api/profile";
 import {
@@ -58,6 +58,7 @@ import { useL10n } from "../../hooks/l10n";
 import { Localized } from "../../components/Localized";
 import { clearCookie, getCookie, setCookie } from "../../functions/cookies";
 import { SubdomainInfoTooltip } from "../../components/dashboard/subdomain/SubdomainInfoTooltip";
+import Link from "next/link";
 
 const Profile: NextPage = () => {
   const runtimeData = useRuntimeData();
@@ -220,16 +221,14 @@ const Profile: NextPage = () => {
         </span>
       </>
     ) : (
-      <>
-        <a
-          className={styles["open-button"]}
-          href={
-            profile.has_premium ? "#mpp-choose-subdomain" : "/premium#pricing"
-          }
-        >
-          {l10n.getString("profile-label-set-your-custom-domain-free-user")}
-        </a>
-      </>
+      <Link
+        className={styles["open-button"]}
+        href={
+          profile.has_premium ? "#mpp-choose-subdomain" : "/premium#pricing"
+        }
+      >
+        {l10n.getString("profile-label-set-your-custom-domain-free-user")}
+      </Link>
     );
 
   const numberFormatter = new Intl.NumberFormat(getLocale(l10n), {
@@ -290,8 +289,13 @@ const Profile: NextPage = () => {
             <span className={styles.greeting} />
           </Localized>
           <strong className={styles.subdomain}>
-            {typeof profile.subdomain === "string" ? (
+            {/* render check badge if subdomain is set and user has premium
+            render pencil icon if subdomain is not set but user has premium
+            render lock icon by default */}
+            {typeof profile.subdomain === "string" && profile.has_premium ? (
               <CheckBadgeIcon alt="" />
+            ) : typeof profile.subdomain !== "string" && profile.has_premium ? (
+              <PencilIcon alt="" className={styles["pencil-icon"]} />
             ) : (
               <LockIcon alt="" className={styles["lock-icon"]} />
             )}

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -221,7 +221,12 @@ const Profile: NextPage = () => {
       </>
     ) : (
       <>
-        <a className={styles["open-button"]} href="/premium#pricing">
+        <a
+          className={styles["open-button"]}
+          href={
+            profile.has_premium ? "#mpp-choose-subdomain" : "/premium#pricing"
+          }
+        >
           {l10n.getString("profile-label-set-your-custom-domain-free-user")}
         </a>
       </>
@@ -291,7 +296,7 @@ const Profile: NextPage = () => {
               <LockIcon alt="" className={styles["lock-icon"]} />
             )}
             {subdomainMessage}
-            <SubdomainInfoTooltip />
+            <SubdomainInfoTooltip hasPremium={profile.has_premium} />
           </strong>
         </div>
         <dl className={styles["account-stats"]}>

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -23,7 +23,7 @@ import styles from "./profile.module.scss";
 import BottomBannerIllustration from "../../../public/images/woman-couch-left.svg";
 import UpsellBannerUs from "./images/upsell-banner-us.svg";
 import UpsellBannerNonUs from "./images/upsell-banner-nonus.svg";
-import { PencilIcon, CheckBadgeIcon } from "../../components/Icons";
+import { CheckBadgeIcon, LockIcon } from "../../components/Icons";
 import { Layout } from "../../components/layout/Layout";
 import { useProfiles } from "../../hooks/api/profile";
 import {
@@ -221,7 +221,7 @@ const Profile: NextPage = () => {
       </>
     ) : (
       <>
-        <a className={styles["open-button"]} href="#mpp-choose-subdomain">
+        <a className={styles["open-button"]} href="/premium#pricing">
           {l10n.getString("profile-label-set-your-custom-domain-free-user")}
         </a>
       </>
@@ -288,7 +288,7 @@ const Profile: NextPage = () => {
             {typeof profile.subdomain === "string" ? (
               <CheckBadgeIcon alt="" />
             ) : (
-              <PencilIcon alt="" className={styles["pencil-icon"]} />
+              <LockIcon alt="" className={styles["lock-icon"]} />
             )}
             {subdomainMessage}
             <SubdomainInfoTooltip />


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3386 

L10N: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/157

# New feature description

“Get your own email domain with ⁨Premium⁩” tooltip displays the incorrect message for Free users

**Platforms affected:**

Across platforms 

**Browsers tested on:**

Across browsers; 
 

**Prerequisites:**

Be signed into a Free Relay account;

Have a VPN set to a country where Relay Premium is available (e.g. Romania, USA); 
 
# Screenshot (if applicable)

<img width="325" alt="image" src="https://github.com/mozilla/fx-private-relay/assets/3924990/ef43ee6d-7ab0-4407-af72-636aff23ecff">

# How to test
 
**Steps to reproduce:**

Navigate to the Relay email dashboard;

Click on the “i” tooltip button from the dashboard header;
 
**Expected result:**

The tooltip should display content specific to Free users;
  

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
