### PR TITLE
MPP-3389: Fix for mobile page resizing on initial load

### DIFF
--- a/frontend/src/components/landing/Reviews.module.scss
+++ b/frontend/src/components/landing/Reviews.module.scss
@@ -92,6 +92,7 @@
 .stars {
   display: flex;
   flex-direction: row;
+  padding-left: $spacing-xs;
 }
 
 .star {
@@ -152,6 +153,7 @@
 
   .review-item {
     display: flex;
+    overflow: hidden;
   }
 
   .review {


### PR DESCRIPTION
This PR fixes MPP-3389.

# Bug description
When opening the landing page on a mobile screen, it is initially zoomed out, and gets scaled into place. This issue is persistent when the user is redirected to the landing page, for example, when going from the faq page, then clicking on the relay logo to go back to the home page.

https://github.com/mozilla/fx-private-relay/assets/59676643/30013981-9a2e-452b-9419-ccd3eb831268

# Bug fix

Upon further investigation, the issue was being caused by the reviews section carousel that pans different reviews when clicking the left or right icons. Adding an `overflow: hidden;` to the review fixed the bug.

https://github.com/mozilla/fx-private-relay/assets/59676643/f3ce4c80-db6f-4017-aec0-8cfd510be9e9

# How to test

1. Navigate to the Relay landing page;

2. Open the hamburger menu and navigate to the FAQ page;

3. Tap on the Firefox Relay logo;

4. Observe the behaviour;

OR

1. Go to the reviews section on the landing page.

2. Pan left or right to switch between reviews.

3. Observe the behaviour;

# Acceptance criteria 

* The user is redirected to the landing page without issues, and no resizing occurs.

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
