### PR TITLE
fix MPP-3174: add API docs for /terms-accepted-user/

### DIFF
--- a/docs/api_auth.md
+++ b/docs/api_auth.md
@@ -44,7 +44,7 @@ sequenceDiagram
 
 ## Firefox OAuth Token Authentication and Accept Terms of Service
 
-Similarly to the add-on, Firefox uses the [the FXA OAuth service][fxa-oauth] /oauth/token endpoint with `scope: ["https://identity.mozilla.com/apps/relay"]` to get the scoped access token that expires every 24 hours (see which calls [`getOAuthToken`][searchfox-getoauthtoken] [`accessTokenWithSessionToken`][searchfox-accesstokenwithsessiontoken]).
+Similarly to the add-on, Firefox uses the [the FXA OAuth service][fxa-oauth] `/oauth/token` endpoint with `scope: ["https://identity.mozilla.com/apps/relay"]` to get the scoped access token that expires every 24 hours (see which calls [`getOAuthToken`][searchfox-getoauthtoken] [`accessTokenWithSessionToken`][searchfox-accesstokenwithsessiontoken]).
 
 Like the add-on, Firefox uses this token to authenticate all requests to Relay. Firefox includes an `Authorization: Bearer {fxa-access-token}` header in all API requests. Unlike the add-on, Firefox must first `POST` to the Relay `/api/v1/terms-accepted-user` endpoint to state that the user accepted the Terms of Service. This `POST` will also create the new user and profile records in Relay.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,8 @@ django_settings_module = "privaterelay.settings"
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
-    "allauth.account",
-    "allauth.account.adapter",
-    "allauth.account.models",
-    "allauth.account.signals",
-    "allauth.socialaccount.models",
-    "allauth.socialaccount.providers.fxa",
-    "allauth.socialaccount.providers.fxa.views",
+    "allauth.account.*",
+    "allauth.socialaccount.*",
     "boto3",
     "botocore.config",
     "botocore.exceptions",


### PR DESCRIPTION
This PR fixes #MPP-3174.

# New feature description
Adds docs for the /terms-accepted-user/ API endpoint.

# Screenshot (if applicable)
### http://127.0.0.1:8000/api/v1/docs/#/terms-accepted-user/terms_accepted_user_create
![image](https://github.com/mozilla/fx-private-relay/assets/71928/7aac2338-9f06-4ccf-b15c-826119155b2e)
### http://127.0.0.1:8000/api/v1/docs/redoc/#tag/terms-accepted-user/operation/terms_accepted_user_create
![image](https://github.com/mozilla/fx-private-relay/assets/71928/d91d75cf-2cf6-442b-9723-e3561b4a0e00)

Not applicable.

# How to test
1. Go to http://127.0.0.1:8000/api/v1/docs/#/terms-accepted-user/terms_accepted_user_create
   * [ ] Look good?
2. Go to http://127.0.0.1:8000/api/v1/docs/redoc/#tag/terms-accepted-user/operation/terms_accepted_user_create
   * [ ] Look good?


# Checklist (Definition of Done)
- ~[x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.~
- [x] All acceptance criteria are met.
- ~[x] Jira ticket has been updated (if needed) to match changes made during the development process.~
- [x] I've added or updated relevant docs in the docs/ directory
- ~[x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.~
- ~[x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- ~[x] l10n changes have been submitted to the l10n repository, if any.~
