### PR TITLE
MPP-3346: Attribute error on empty POST request to /accounts/profile/subdomain

### DIFF
--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -548,6 +548,27 @@ class ProfileAddSubdomainTest(ProfileTestCase):
         with self.assertRaisesMessage(CannotMakeSubdomainException, expected_msg):
             self.profile.add_subdomain("mozilla")
 
+    def test_empty_subdomain_raises(self) -> None:
+        self.upgrade_to_premium()
+        expected_msg = "error-subdomain-cannot-be-empty-or-null"
+
+        with self.assertRaisesMessage(CannotMakeSubdomainException, expected_msg):
+            self.profile.add_subdomain("")
+
+    def test_null_subdomain_raises(self) -> None:
+        self.upgrade_to_premium()
+        expected_msg = "error-subdomain-cannot-be-empty-or-null"
+
+        with self.assertRaisesMessage(CannotMakeSubdomainException, expected_msg):
+            self.profile.add_subdomain(None)
+
+    def test_subdomain_with_space_at_end_raises(self) -> None:
+        self.upgrade_to_premium()
+        expected_msg = "error-subdomain-not-available"
+
+        with self.assertRaisesMessage(CannotMakeSubdomainException, expected_msg):
+            self.profile.add_subdomain("mydomain ")
+
 
 class ProfileSaveTest(ProfileTestCase):
     """Tests for Profile.save()"""
@@ -634,6 +655,7 @@ class ValidAvailableSubdomainTest(TestCase):
     """Tests for valid_available_subdomain()"""
 
     ERR_NOT_AVAIL = "error-subdomain-not-available"
+    ERR_EMPTY_OR_NULL = "error-subdomain-cannot-be-empty-or-null"
 
     def reserve_subdomain_for_new_user(self, subdomain: str) -> User:
         user = make_premium_test_user()
@@ -687,6 +709,22 @@ class ValidAvailableSubdomainTest(TestCase):
     def test_subdomain_with_dash_at_front_raises(self) -> None:
         with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
             valid_available_subdomain("-mydomain")
+
+    def test_empty_subdomain_raises(self) -> None:
+        with self.assertRaisesMessage(
+            CannotMakeSubdomainException, self.ERR_EMPTY_OR_NULL
+        ):
+            valid_available_subdomain("")
+
+    def test_null_subdomain_raises(self) -> None:
+        with self.assertRaisesMessage(
+            CannotMakeSubdomainException, self.ERR_EMPTY_OR_NULL
+        ):
+            valid_available_subdomain(None)
+
+    def test_subdomain_with_space_at_end_raises(self) -> None:
+        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
+            valid_available_subdomain("mydomain ")
 
 
 class ProfileDisplayNameTest(ProfileTestCase):

--- a/frontend/src/components/dashboard/subdomain/SearchForm.tsx
+++ b/frontend/src/components/dashboard/subdomain/SearchForm.tsx
@@ -20,7 +20,9 @@ export const SubdomainSearchForm = (props: Props) => {
   const onSubmit: FormEventHandler = async (event) => {
     event.preventDefault();
 
-    const isAvailable = await getAvailability(subdomainInput);
+    const isAvailable = await getAvailability(
+      encodeURIComponent(subdomainInput),
+    );
     if (!isAvailable) {
       toast(
         l10n.getString("error-subdomain-not-available-2", {

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -86,7 +86,7 @@ def profile_subdomain(request):
             available = valid_available_subdomain(subdomain)
             return JsonResponse({"available": available})
         else:
-            subdomain = request.POST.get("subdomain", "")
+            subdomain = request.POST.get("subdomain", None)
             profile.add_subdomain(subdomain)
             return JsonResponse(
                 {"status": "Accepted", "message": "success-subdomain-registered"},

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -86,7 +86,7 @@ def profile_subdomain(request):
             available = valid_available_subdomain(subdomain)
             return JsonResponse({"available": available})
         else:
-            subdomain = request.POST.get("subdomain", None)
+            subdomain = request.POST.get("subdomain", "")
             profile.add_subdomain(subdomain)
             return JsonResponse(
                 {"status": "Accepted", "message": "success-subdomain-registered"},


### PR DESCRIPTION
This PR fixes MPP-3346.

# Bug description

Sending a POST request to /accounts/profile/subdomain with no body or a subdomain with no value causes an error.

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/10009130-6468-4af5-86fe-0aa27c44ef09)

# Bug fix (if applicable)

The issue occurs in https://github.com/mozilla/fx-private-relay/blob/896ad748babbbb277a545751cbde855d5e2703cb/emails/models.py#L371, where the "None" was getting sent (see https://github.com/mozilla/fx-private-relay/commit/896ad748babbbb277a545751cbde855d5e2703cb) to the string.lower() function. 

With the change, we don't get the error after sending the request.

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/9079b504-33d2-429c-ad9d-c21bc05c5a72)

# How to test
1. Send a POST request to /accounts/profile/subdomain with an empty body
2. [Acceptance Criteria] Observe that no Attribute Error occurs in the response after sending the request.


# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
