### PR TITLE
MPP-3380: Unhiding "copied" label and making it responsive

### DIFF
--- a/frontend/src/components/dashboard/aliases/MaskCard.module.scss
+++ b/frontend/src/components/dashboard/aliases/MaskCard.module.scss
@@ -48,7 +48,6 @@
       display: flex;
       align-items: center;
       gap: $spacing-sm;
-      overflow: hidden;
     }
 
     .copy-button {
@@ -76,13 +75,18 @@
         text-overflow: ellipsis;
 
         @media screen and #{$mq-sm} {
-          max-width: 350px;
+          max-width: 350px; // Flex items wrap on smaller screens, hence there is more space
         }
         @media screen and #{$mq-md} {
+          max-width: 320px;
+        }
+        @media screen and (min-width: $content-lg) {
           max-width: 400px;
         }
         @media screen and #{$mq-lg} {
-          max-width: none;
+          max-width: calc(
+            $content-md - 100px
+          ); // Handles long custom domains, prevents going off page.
         }
       }
 
@@ -97,6 +101,16 @@
       border-radius: $border-radius-md;
       font-weight: 600;
       opacity: 1;
+      pointer-events: none;
+
+      @media screen and (max-width: $screen-sm) {
+        @include text-body-sm;
+      }
+      @media screen and (max-width: 380px) {
+        // Magic number: 380px to avoid element going off screen.
+        position: absolute;
+        right: $spacing-lg;
+      }
 
       &[aria-hidden="true"] {
         opacity: 0;


### PR DESCRIPTION
This PR fixes MPP-3380.

# Bug description
After clicking the "copy" button on the domain, the "copied" confirmation label is cut off on mobile.
![image](https://github.com/mozilla/fx-private-relay/assets/59676643/59d7bad2-a09c-46ca-b28b-36b727ce2837)

I also noticed that other viewports were having the same issue. In addition, when a user has a long custom domain, the copied label does not get shown. ![Demo](https://github.com/mozilla/fx-private-relay/assets/59676643/78b69bf9-e9c2-4400-a455-8c1f80c7681a)

# New feature description
Label does not get cut off, and is responsive to different view ports. Long custom domains on a desktop screen correctly display an ellipsis now, to avoid the copied label being hidden. (Confirmed with Jess that this design is ok)

https://github.com/mozilla/fx-private-relay/assets/59676643/25c89702-00c6-43f0-9f43-e1331fe8a32e

# How to test

1. Be signed in to a premium user and go to the relay dashboard (also make sure mask_redesign waffle flag is on if testing locally)

2. For one of the generated masks, tap the “Copy” icon;

3. [Acceptance Criteria] Observe that the copied label is fully displayed.

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] ~I've added or updated relevant docs in the docs/ directory~
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] ~l10n changes have been submitted to the l10n repository, if any.~
