### PR TITLE
MPP-3385: Encoding subdomain for GET request sent to accounts/profiles/subdomain

### DIFF
--- a/frontend/src/components/dashboard/subdomain/SearchForm.tsx
+++ b/frontend/src/components/dashboard/subdomain/SearchForm.tsx
@@ -20,6 +20,7 @@ export const SubdomainSearchForm = (props: Props) => {
   const onSubmit: FormEventHandler = async (event) => {
     event.preventDefault();
 
+    // Encoding URI component to handle trailing white spaces
     const isAvailable = await getAvailability(
       encodeURIComponent(subdomainInput),
     );


### PR DESCRIPTION
This PR fixes MPP-3385.

# Bug description
The subdomain query string was not encoded, so when a there are trailing whitespaces in the subdomain, they do not get sent in the requests query.

The issue occurs during the onboarding flow, and the subdomain picker in the dashboard (if onboarding was skipped).

[Demo of bug](https://github.com/mozilla/fx-private-relay/assets/59676643/1046539a-72b9-4d4f-82ec-e8a0b81a7b2e)

# Bug fix screenshot (if applicable)

https://github.com/mozilla/fx-private-relay/assets/59676643/7bf2d450-f52e-4943-a376-353fa8bc5b34

# How to test
Onboarding:

1. Access the dashboard with a premium account
2. Proceed to the 2nd step of the onboarding process
3. Enter a valid domain followed by a space;
4. [Acceptance criteria] Observe that the registration modal does not pop up, and a toast error notification occurs.

Subdomain Picker:

1. Access the dashboard with a premium account
2. Skip the onboarding step
3. Click "Get your own email domain with ⁨Premium⁩" to go to the subdomain picker
4. Enter a valid domain followed by a space;
5. [Acceptance criteria] Observe that the registration modal does not pop up, and a toast error notification occurs.

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] ~l10n changes have been submitted to the l10n repository, if any.~
