### PR TITLE
Do Not Merge - Spike for MPP-3375: Handle inline images

### DIFF
--- a/emails/tests/fixtures/inline-image.email
+++ b/emails/tests/fixtures/inline-image.email
@@ -1,0 +1,55 @@
+Mime-Version: 1.0 (MailClient 1.1.1)
+Date: Tue, 5 Sep 2023 14:42:46 -0700
+Subject: Test Email
+From: Your Friend <friend@mail.example.com>
+To: Your Relay Address <ebsbdsan7@test.com>
+Content-Type: multipart/related;
+	type="multipart/alternative";
+	boundary="MailClient=_85CB3D2B-71DA-4F6C-9F70-F0735457C609"
+Message-Id: <CAJwPAzZ1F8G-0KSCS73x2FX+iG5HMo9+Dndy4GkNVnR28+M1tA@mail.gmail.com>
+
+--MailClient=_85CB3D2B-71DA-4F6C-9F70-F0735457C609
+Content-Type: multipart/alternative;
+	boundary="MailClient=_0C16924A-AE2E-42A3-B146-6CF67E5439A3"
+
+--MailClient=_0C16924A-AE2E-42A3-B146-6CF67E5439A3
+Content-Type: text/plain;
+	charset=utf-8
+Content-Transfer-Encoding: Quoted-Printable
+
+Here is an inline image:
+
+=E2=80=93 Your Friend
+--MailClient=_0C16924A-AE2E-42A3-B146-6CF67E5439A3
+Content-Type: text/html;
+	charset=utf-8
+Content-Transfer-Encoding: Quoted-Printable
+
+<!doctype html><html><body><div dir=3D"ltr">Here is an inline image:&nbsp;<=
+img src=3D"cid:0A0AD2F8-6672-45A8-8248-0AC6C7282970" style=3D"max-width: 10=
+0%; width: 12px;"><div><br></div><div dir=3D"ltr"><ul style=3D"list-style-t=
+ype: &quot;=E2=80=93  &quot;; margin: 0px; padding-inline-start: 1.8em;" di=
+r=3D"ltr"><li>Your Friend</li></ul></div></div></body></html>
+
+--MailClient=_0C16924A-AE2E-42A3-B146-6CF67E5439A3--
+--MailClient=_85CB3D2B-71DA-4F6C-9F70-F0735457C609
+Content-Type: image/png;
+	name="clock-purple.png"
+Content-Transfer-Encoding: base64
+Content-Disposition: inline;
+	filename="clock-purple.png"
+Content-ID: <0A0AD2F8-6672-45A8-8248-0AC6C7282970>
+
+iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAA7DAAAOwwHHb6hkAAAA
+GXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAeFJREFUOI2Nk79rU1EcxT/f+14S
+neoPnNXB4qARKZ2DrQ51tsSki4KNLoa0+gf4D9ikGaRpILrEUBxFIgjpIji4KAUrumRylBaxNTF5
+xyEv+oit9kzfeznnfO89936NEZTTuiCPeYkp4BQQAG3glXNU83X7EOXbsHh8Q4e2uxQROcCNGofo
+Cx5t97j/4Jl1GRKXZnV4q8NLxB2gj7GCkerBibhxzIwpoBJ2vHvU50UlpxiAD+B8ikAK+CK4tvDU
+3ox0XgfWl7OqSjQFl3e+8RDIWymjJPAO6AlSC40/4lJGnwoNG486ldKaxPEa8Jwj6czIhVnUouIQ
+Z0ZDKKzZW6AOeIG45SSmAQJR3ye4v2BQA0BccQyeCr/Px4MaeDE2w/KkP9zcge4e3K+ljBRZfy40
+bPy7TzfxEzA8n8EnOZvwmQBaUXWhYcf3OkF8l3PhFdpuKDJj9qBXcMZcaNByLmAVEGJ+OauJ/4nL
+13VRYh4IAo9Vl1+z9xgVwJNoltKa/Jc4MJ4DcROVxbptGEB5RongCE3gEoMw6wY1L8am7dLpeSRx
+ZMPOcaDltriab1rn9zCVZ5TQGEUZt9l/mAJgZSzBvZtP7AdEpnGIpTmdd31yGNPAaaAPtAUtOaqL
+dduI8n8BrMOp3hG9OkYAAAAASUVORK5CYII=
+--MailClient=_85CB3D2B-71DA-4F6C-9F70-F0735457C609--
+

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -34,6 +34,7 @@ from emails.models import (
     get_domains_from_settings,
 )
 from emails.utils import (
+    ReplyMetadata,
     b64_lookup_key,
     decrypt_reply_metadata,
     derive_reply_keys,
@@ -392,7 +393,7 @@ class SNSNotificationTest(TestCase):
         lookup_key, encryption_key = derive_reply_keys(
             get_message_id_bytes("CA+J4FJFw0TXCr63y9dGcauvCGaZ7pXxspzOjEDhRpg5Zh4ziWg")
         )
-        metadata = {
+        metadata: ReplyMetadata = {
             "message-id": str(uuid4()),
             "from": "sender@external.example.com",
         }
@@ -427,7 +428,8 @@ class SNSNotificationTest(TestCase):
         assert sender == "a1b2c3d4@test.com"
         assert recipient == "sender@external.example.com"
         assert headers == {
-            "Content-Type": headers["Content-Type"],
+            "Content-Type": 'text/plain; charset="utf-8"',
+            "Content-Transfer-Encoding": "7bit",
             "Subject": "Re: Test Mozilla User New Domain Address",
             "From": sender,
             "Reply-To": sender,

--- a/emails/types.py
+++ b/emails/types.py
@@ -1,4 +1,5 @@
 """Types for email functions"""
+from tempfile import SpooledTemporaryFile
 from typing import Any, Literal
 from io import IOBase
 
@@ -7,7 +8,7 @@ MessageBodyContent = dict[Literal["Charset", "Data"], str]
 MessageBody = dict[Literal["Text", "Html"], MessageBodyContent]
 
 # Attachment path and data stream
-AttachmentPair = tuple[str, IOBase]
+AttachmentPair = tuple[str | None, IOBase | SpooledTemporaryFile[bytes]]
 
 # Headers for outgoing emails
 OutgoingHeaderName = Literal[

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -2,6 +2,7 @@ import base64
 import contextlib
 from email.header import Header
 from email.headerregistry import Address
+from email.message import EmailMessage
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.application import MIMEApplication
@@ -200,7 +201,7 @@ def get_welcome_email(user: User, format: str) -> str:
 def ses_send_raw_email(
     source_address: str,
     destination_address: str,
-    message: MIMEMultipart,
+    message: EmailMessage,
 ) -> SendRawEmailResponseTypeDef:
     emails_config = apps.get_app_config("emails")
     assert isinstance(emails_config, EmailsConfig)
@@ -225,7 +226,7 @@ def create_message(
     headers: OutgoingHeaders,
     message_body: MessageBody,
     attachments: list[AttachmentPair] | None = None,
-) -> MIMEMultipart:
+) -> EmailMessage:
     msg_with_headers = _start_message_with_headers(headers)
     msg_with_body = _add_body_to_message(msg_with_headers, message_body)
     if not attachments:
@@ -234,18 +235,17 @@ def create_message(
     return msg_with_attachments
 
 
-def _start_message_with_headers(headers: OutgoingHeaders) -> MIMEMultipart:
+def _start_message_with_headers(headers: OutgoingHeaders) -> EmailMessage:
     # Create a multipart/mixed parent container.
-    msg = MIMEMultipart("mixed")
+    msg = EmailMessage()
+    msg.make_mixed()
     # Add headers
     for name, value in headers.items():
         msg[name] = value
     return msg
 
 
-def _add_body_to_message(
-    msg: MIMEMultipart, message_body: MessageBody
-) -> MIMEMultipart:
+def _add_body_to_message(msg: EmailMessage, message_body: MessageBody) -> EmailMessage:
     # Create a multipart/alternative child container.
     msg_body = MIMEMultipart("alternative")
 
@@ -269,8 +269,8 @@ def _add_body_to_message(
 
 
 def _add_attachments_to_message(
-    msg: MIMEMultipart, attachments: list[AttachmentPair]
-) -> MIMEMultipart:
+    msg: EmailMessage, attachments: list[AttachmentPair]
+) -> EmailMessage:
     # attach attachments
     for actual_att_name, attachment in attachments:
         # Define the attachment part and encode it using MIMEApplication.

--- a/emails/views.py
+++ b/emails/views.py
@@ -654,9 +654,22 @@ def _convert_content(
         email_message[header] = value
         assert email_message.as_string()
 
-    # Find the content
-    body = email_message.get_body()  # returns text, html, or related
-    # TODO: here
+    # Find and replace the content
+    # TODO: Test the results of this conversion
+    text_body = email_message.get_body("text")
+    if text_body:
+        assert isinstance(text_body, EmailMessage)
+        text_content = text_body.get_content()
+        new_text_content = _convert_text_content(text_content, to_address)
+        text_body.set_content(new_text_content)
+    html_body = email_message.get_body("html")
+    if html_body:
+        assert isinstance(html_body, EmailMessage)
+        html_content = html_body.get_content()
+        new_content = _convert_html_content(
+            html_content, address, to_address, from_address
+        )
+        html_body.set_content(new_content)
 
     return email_message
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -619,16 +619,10 @@ def _sns_message(message_json: AWS_SNSMessageJSON) -> HttpResponse:
     return HttpResponse("Sent email to final recipient.", status=200)
 
 
-def _convert_content(
+def _replace_headers(
     received_email: EmailMessage,
     headers: OutgoingHeaders,
-    to_address: str,
-    from_address: str,
-    language: str,
-    has_premium: bool,
-    sample_trackers: bool,
-    remove_level_one_trackers: bool,
-) -> tuple[EmailMessage, int]:
+) -> EmailMessage:
     # Look for changes to top-level headers
     drop_headers = set(
         _h.lower()
@@ -670,6 +664,21 @@ def _convert_content(
         del received_email[header]
         received_email[header] = value
         assert received_email.as_string()
+
+    return received_email
+
+
+def _convert_content(
+    received_email: EmailMessage,
+    headers: OutgoingHeaders,
+    to_address: str,
+    from_address: str,
+    language: str,
+    has_premium: bool,
+    sample_trackers: bool,
+    remove_level_one_trackers: bool,
+) -> tuple[EmailMessage, int]:
+    received_email = _replace_headers(received_email, headers)
 
     # Find and replace the content
     # TODO: Test the results of this conversion

--- a/emails/views.py
+++ b/emails/views.py
@@ -656,7 +656,7 @@ def _convert_content(
 
     # Find and replace the content
     # TODO: Test the results of this conversion
-    text_body = email_message.get_body("text")
+    text_body = email_message.get_body("plain")
     if text_body:
         assert isinstance(text_body, EmailMessage)
         text_content = text_body.get_content()


### PR DESCRIPTION
This is a spike for MPP-3375, changing email processing to handle inline images, opened for feedback purposes. **DO NOT MERGE** I think this is too much for a single PR, so I'm going to break it up, but this is where I'm headed.

Previously, the code would:

* Load an email as a Python `email.EmailMessage`
* Walk the email to extract the HTML content, plaintext content, and any attachments
* Create a wrapped version of the HTML and plaintext content
* Create a new email (`multipart/mixed`) with the content and attachments
* Send that email

Inline images were not attachments, but instead top-level objects in a `multipart/related` section, so they were dropped by this method.

The new code does this:

* Load an email as a Python `email.EmailMessage`
* Replace the headers, dropping most, keeping some, and changing others
* Find the HTML and plaintext content, and replace it in-place
* Send that email

This preserves any inline attachments, as well as other MIME sections that we don't quite understand. The new email has the same structure as the previous email.

Other changes:

* Add a way to load serialized email files as fixtures, and generate a fake SNS JSON envelope
* Change mocks to mock the S3 loading function, rather than the html/text/attachments level
* Add types to more functions
* Refactors, renaming, and deleting code