### PR TITLE
MPP-3283: Rewrite translations document

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -675,8 +675,8 @@ user's region.
 The subscription platform (version 2) uses [Stripe][]. A [Stripe product][] represents
 each Relay plan, such as the premium email service. A [Stripe price][] represents how a
 user will pay. The price has an associated product, a currency, tax details, and a term.
-Many Relay plans have monthly and yearly subscription terms. The VPN bundle has yearly
-terms.
+Many Relay plans have monthly and yearly subscription terms. The VPN bundle only has a
+yearly subscription term.
 
 The subscription platform associates a price with a region. Product reports may use this
 to segment purchasers by region.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -28,6 +28,7 @@ includes Mozilla- and Relay-specific notes.
   - [Managing Languages and Translations](#managing-languages-and-translations)
   - [Shipping Translations](#shipping-translations)
   - [Adding New Translations](#adding-new-translations)
+  - [Relay Assumes Left-To-Right Script](#relay-assumes-left-to-right-script)
 - [The Technical Details of Region Selection](#the-technical-details-of-region-selection)
   - [Identifying the User's Region](#identifying-the-users-region)
   - [Identifying Available Plans and Prices](#identifying-available-plans-and-prices)
@@ -432,17 +433,6 @@ issues in translated strings with manual testing.
 Relay supports over 20 languages. This section details the technologies used to deploy
 those translations.
 
-> [!WARNING]
-> None of Relay's supported languages use [right-to-left scripts][].
-> [Hebrew][], [Arabic][], and [Persian][] are the most widespread right-to-left
-> modern writing systems. The Relay engineers will spend significant effort to
-> support the first right-to-left script.
-
-[Arabic]: https://en.wikipedia.org/wiki/Arabic_script
-[Hebrew]: https://en.wikipedia.org/wiki/Hebrew_alphabet
-[Persian]: https://en.wikipedia.org/wiki/Persian_alphabet
-[right-to-left scripts]: https://en.wikipedia.org/wiki/Right-to-left_script
-
 ### Identifying the User's Preferred Languages
 
 The browser communicates the user's preferred languages with each web request. The
@@ -632,6 +622,41 @@ high-level steps are:
 
 The section [Submitting Pending Translations](#submitting-pending-translations) details the
 development process.
+
+### Relay Assumes Left-To-Right Script
+
+All Relay-supported languages use a left-to-right (LTR) script. For example, the
+default Relay language is English, the same language as this document. English uses the
+Latin script, written left-to-right.
+
+> [!WARNING]
+> None of Relay's supported languages use [right-to-left scripts][]. For other Mozilla
+> projects, it was a challenge to support the first right-to-left (RTL) language.
+
+To add the first RTL script, developers must educate themselves on [internationalization
+techniques][]. Designers will learn RTL conventions. Developers examine every webpage,
+email, and UI element. The content should work regardless of text direction. Buttons
+should flow with the text direction. Some existing translation strings will change and
+need re-translation. The new language translation team will want to review strings in
+the context of the website.
+
+The first right-to-left language is the hardest. The next languages are as easy to add
+as other left-to-right languages.
+
+[Hebrew][], [Arabic][], and [Persian][] are the most widespread right-to-left modern
+writing systems. The support website has localized content in [Hebrew][support-hebrew],
+[Arabic][support-arabic], and [Persian][support-persian]. These pages show right-to-left
+layouts. Compare them to a left-to-right layout such as the [French localization][].
+
+[Arabic]: https://en.wikipedia.org/wiki/Arabic_script
+[Hebrew]: https://en.wikipedia.org/wiki/Hebrew_alphabet
+[Persian]: https://en.wikipedia.org/wiki/Persian_alphabet
+[right-to-left scripts]: https://en.wikipedia.org/wiki/Right-to-left_script
+[internationalization techniques]: https://www.w3.org/International/techniques/authoring-html
+[support-hebrew]: https://support.mozilla.org/he/
+[support-arabic]: https://support.mozilla.org/ar/
+[support-persian]: https://support.mozilla.org/fa/
+[French localization]: https://support.mozilla.org/fr/
 
 ## The Technical Details of Region Selection
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -66,6 +66,19 @@ of the content appears in their preferred language. The product details are in t
 primary supported language for their region. This may be different from the user's
 preferred language. The price is in their region's currency.
 
+The Relay phone plan is a premium plan that is available in Canada and the United
+States. The user cannot buy a phone plan unless they are in one of those countries. A
+new premium user submits their real number. Relay sends a message to the user's number
+with a verification code. After verifying their real number, the user picks a Relay mask
+number. Relay only suggests mask numbers from the same country as the user's real phone.
+After the user selects a Relay mask number, Relay sends an welcome message from their
+mask number. Relay sends all the messages with English text.
+
+When an external contact sends an SMS text to a mask number, the service forwards the
+message to the Relay user. The forwarded message has a prefix identifying the sender's
+number. The content is not translated. When an external contact calls the mask number,
+Relay starts a call with the Relay user.
+
 When a user installs the Relay Add-On, the content is also in their preferred language.
 The Add-On reflects the Relay premium plan availability in their region.
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -351,7 +351,7 @@ The Relay engineer updates the data structures in [privaterelay/plans.py][]:
 3. Add new prices details in `_STRIPE_PLAN_DATA`
 4. Add a new section in `_RELAY_PLANS`, such as `premium_expansion`, with the expanded
    regions
-5. Update the relevant functions to take a boolean signalling the waffle flag is
+5. Update the relevant functions to take a boolean signaling the waffle flag is
    on or off. See [PR #3745][], which retired the 2023 expansion flag, for
    details.
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -710,10 +710,11 @@ Relay developers will see these terms as they work in this topic:
   without per-locale code changes. This is often abbreviated **i18n**, to stand for the
   starting letter "i", the next 18 letters, and the ending letter "n". This abbreviation
   also avoids the spelling differences between American and British English.
-- **[Localization][]**: Adapting software to a specific locale. This includes translating
-  text and using locale-specific formats. This is often abbreviated **L10n**, in a
-  similar way to i18n. A capital "L" avoids confusing a lowercase "l" with an
-  uppercase "I".
+- **[Language][]**: A spoken or written system of communication. English is a broad
+  language category. A language can be specific to a region, such as German spoken in
+  Switzerland. In localization, the written system can be important as well. For
+  example, Chinese can vary between mainland China and other regions. It can also
+  use Simplified or Traditional Chinese script when written.
 - **[Locale][]**: Shared cultural conventions that appear in a user interface. This
   can include language, letters, and currencies. It can also include formats for prices,
   numbers, dates, and times. For example, American English can be a locale. This locale
@@ -722,15 +723,14 @@ Relay developers will see these terms as they work in this topic:
   number in a short date is the month ("9/12/2023" for September 12, 2023).
   English-speaking users in other regions share some of these conventions. Other
   conventions, like currency and date formats, will vary.
+- **[Localization][]**: Adapting software to a specific locale. This includes translating
+  text and using locale-specific formats. This is often abbreviated **L10n**, in a
+  similar way to i18n. A capital "L" avoids confusing a lowercase "l" with an
+  uppercase "I".
 - **[Region][]**: An [administrative division][] that can be the basis for a
   locale. Mozilla prefers to use "Region" instead of "**Country**" when talking about
   localization. A region can include areas within a country, as well as areas that
   span countries.
-- **[Language][]**: A spoken or written system of communication. English is a broad
-  language category. A language can be specific to a region, such as German spoken in
-  Switzerland. In localization, the written system can be important as well. For
-  example, Chinese can vary between mainland China and other regions. It can also
-  use Simplified or Traditional Chinese script when written.
 - **[Translation][]**: The process of adapting language strings or patterns to a
   second language. This is one aspect of Localization. At Mozilla, American English is
   the source language for interface text.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -761,13 +761,9 @@ In most cases, Mozilla uses the standard identifiers. There are exceptions for c
 usage and legacy cases. Relay users should follow the standards, unless Mozilla has an
 established exception.
 
-- **Region**: [ISO 3166][] is a multi-part standard for identifying countries,
-  territories, and subdivisions. The [ISO 3166-1 alpha-2][] code (two uppercase
-  letters) is common as a region identifier.
-  - Mozilla uses the ISO 3166-1 alpha-2 code for a region when available. For example,
-    `"US"` identifies the United States, and `"DE"` identifies Germany. An
-    exception is [Valencia][], which uses `"valencia"`. Another is the
-    [Surselva Region][], which uses `"sursilv"`.
+- **Currency**: [ISO 4217][] defines codes for currencies.
+  - The Subscription Platform and Relay use the upper-case, three-letter codes.
+    For example, `"USD"` for United States dollars and `"EUR"` for Euros.
 - **Language**: [ISO 639][] is a multi-part standard for identifying languages.
   Library of Congress has a [table of languages][] with [ISO 639-2][] codes (three
   Wikipedia has a [useful table][] of [ISO 639-1][] codes (two lowercase letters). The
@@ -801,9 +797,13 @@ established exception.
     websites break when parsing a header with qvalues. Firefox and other browsers do not
     use qvalues in `Accept-Language` defaults. Instead, the order of languages is the
     order of preference.
-- **Currency**: [ISO 4217][] defines codes for currencies.
-  - The Subscription Platform and Relay use the upper-case, three-letter codes.
-    For example, `"USD"` for United States dollars and `"EUR"` for Euros.
+- **Region**: [ISO 3166][] is a multi-part standard for identifying countries,
+  territories, and subdivisions. The [ISO 3166-1 alpha-2][] code (two uppercase
+  letters) is common as a region identifier.
+  - Mozilla uses the ISO 3166-1 alpha-2 code for a region when available. For example,
+    `"US"` identifies the United States, and `"DE"` identifies Germany. An
+    exception is [Valencia][], which uses `"valencia"`. Another is the
+    [Surselva Region][], which uses `"sursilv"`.
 
 ["Identifying the User's Preferred Languages"]: #identifying-the-users-preferred-languages
 [BCP 47]: https://www.rfc-editor.org/info/bcp47

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -27,6 +27,7 @@ includes Mozilla- and Relay-specific notes.
   - [Picking the Language](#picking-the-language)
   - [Managing Languages and Translations](#managing-languages-and-translations)
   - [Shipping Translations](#shipping-translations)
+  - [Adding New Translations](#adding-new-translations)
 - [The Technical Details of Region Selection](#the-technical-details-of-region-selection)
   - [Identifying the User's Region](#identifying-the-users-region)
   - [Identifying Available Plans and Prices](#identifying-available-plans-and-prices)
@@ -583,19 +584,6 @@ Pontoon. Relay's continuous testing creates Docker images that include the trans
 The [Django back end][] uses select Fluent files. The front end uses translations
 embedded into the JavaScript during Docker image creation.
 
-Relay developers create new translatable strings when updating the service. The
-in-progress strings are in the Relay repository. The source strings change often during
-development. The front end uses [frontend/pendingTranslations.ftl][]. The back end code
-uses [privaterelay/pending_locales/en/pending.ftl][].
-
-New approved strings go through several steps to get translated. The developers open a
-pull request to the translation repository. The Localization team reviews the new
-strings. When the Localization team merges the changes, Pontoon imports the new strings.
-The language teams translate the strings. Pontoon exports them to the translation
-repository. The nightly action updates the submodule to pull in the latest translations.
-The release Docker image includes the new translations. Once released, the users see the
-content in their language.
-
 ["en" bundle]: https://github.com/mozilla-l10n/fx-private-relay-l10n/tree/main/en
 [Django back end]: https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/ftl_bundles.py
 [FAQ page]: https://relay.firefox.com/faq/
@@ -617,6 +605,33 @@ content in their language.
 [privaterelay/locales]: https://github.com/mozilla/fx-private-relay/tree/main/privaterelay
 [subscription pages]: https://subscriptions.firefox.com/subscriptions
 [support.mozilla.org]: https://support.mozilla.org/
+
+### Adding New Translations
+
+Many teams and systems work together to get new translations to Relay users. The
+high-level steps are:
+
+1. A Relay designer and copy-editor create designs with new strings.
+2. A Relay developer adds pending strings to the Relay repository.
+3. Relay staff refine the strings during feature development.
+4. A Relay developer submits the strings to the translation repository.
+5. The Localization team reviews the strings.
+6. The Localization team merges the accepted strings into the translation repository.
+7. Pontoon imports the new strings.
+8. Translators translate the new strings.
+9. Pontoon exports translations to the translation repository.
+10. The nightly GitHub action updates the Relay repository with the latest translations.
+11. The continuous testing process builds a release Docker image with the
+    translations.
+12. The continuous integration process releases the Docker image to the stage environment.
+13. The Quality Assurance (QA) team checks the stage environment. They verify the
+    features and translations.
+14. A Service Reliability Engineer (SRE) releases the Docker image to the production
+    environment. Users see the new content in their language.
+15. A Relay developer removes the pending strings from the Relay repository.
+
+The section [Submitting Pending Translations](#submitting-pending-translations) details the
+development process.
 
 ## The Technical Details of Region Selection
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -556,7 +556,7 @@ done when they are busy or out of office.
 Translations for Relay, and many projects at Mozilla, use the [Fluent format][fluent].
 The ["en" bundle][relay-l10n-en] (American / generic English) has the source
 translations. Developers split the translations into functional areas, such as
-[`faq.ftl`][] for the [FAQ page][]. The other language bundles are translations of the
+[faq.ftl][] for the [FAQ page][]. The other language bundles are translations of the
 `"en"` bundle, coordinated in Pontoon. The continuous integration process creates Docker
 images that include the translations. The [Django back end][ftl-bundles] uses select
 Fluent files. The front end uses translations embedded into the JavaScript during
@@ -579,7 +579,6 @@ their language.
 [Firefox Relay Add-on]: https://addons.mozilla.org/firefox/addon/private-relay/
 [Firefox Relay Website]: https://relay.firefox.com/
 [addons.mozilla.org]: https://addons.mozilla.org/
-[fluent]: https://projectfluent.org/
 [ftl-bundles]: https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/ftl_bundles.py
 [ga-l10n-sync]: https://github.com/mozilla/fx-private-relay/actions/workflows/l10n-sync.yml
 [mozilla-l10n/fx-private-relay-add-on-l10n]: https://github.com/mozilla-l10n/fx-private-relay-add-on-l10n
@@ -758,7 +757,6 @@ established exception.
 [ISO 639-1]: https://en.wikipedia.org/wiki/ISO_639-1
 [ISO 639-2]: https://en.wikipedia.org/wiki/ISO_639-2
 [ISO 639]: https://en.wikipedia.org/wiki/ISO_639
-[RFC 4647]: https://www.rfc-editor.org/rfc/rfc4647.html
 [RFC 5646]: https://www.rfc-editor.org/rfc/rfc5646.html
 [RFC 9110]: https://www.rfc-editor.org/rfc/rfc9110#field.accept-language
 [Surselva Region]: https://en.wikipedia.org/wiki/Surselva_Region

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -46,8 +46,8 @@ are available, then the user gets English.
 The user sees different plan details based on their region. On the homepage there is a
 table comparing Relay premium plans. If a premium plan is available in their region,
 they see a price in their local currency. If a premium plan is not available, the user
-sees a prompt to join a waitlist. The FAQ also changes, to omit entries for plans that
-are unavailable in the user's region.
+sees a prompt to join a waitlist. The FAQ also changes, to omit entries for unavailable
+plans.
 
 A new or logged-out user sees the sign-in buttons in the page header. The button text is
 "Sign Up" and "Sign In" in the English localization. The text will be different if the
@@ -72,16 +72,16 @@ The Add-On reflects the Relay premium plan availability in their region.
 
 ## Development Workflows
 
-The project `README.md` has basic instructions on ["working with
-translations"][readme-wwt]. This section has more details.
+The project `README.md` has basic instructions on
+[working with translations][readme-wwt]. This section has more details.
 
 [readme-wwt]: ../README.md#working-with-translations
 
 ### Loading Translations
 
 The translations are in a separate repository, and included as a
-[submodule][git-submodules]. This combines a separate repository with a
-specific commit in that repository.
+[submodule][git-submodules]. This references a specific commit in
+a separate repository.
 
 When cloning a repo, you can also fetch the translations:
 
@@ -99,8 +99,13 @@ git submodule update
 
 When checking out a branch, `git status` may show `privaterelay/locales` has changed.
 This is because the submodule commit is out of sync with the branch. To sync the
-submodule with the branch, you can run `git submodule update --remote`. To automate
-syncing the translations submodule, set the configuration:
+submodule with the branch, run:
+
+```sh
+git submodule update --remote
+```
+
+To automate syncing the translations submodule, set the configuration:
 
 ```sh
 git config --global submodule.recurse true
@@ -137,8 +142,10 @@ This is a powerful tool that requires deeper understanding of `git`. See
 [About Git][gh-git] for a tutorial, and
 [On undoing, fixing, or removing commits in git][sr-fixup] for a guided experience.
 
+The process is:
+
 1. Run `git rebase origin/main`, and take care of any conflicts.
-2. Find the commit that changed locals with `git log -- privaterelay/locales`.
+2. Find the commit that changed the submodule with `git log -- privaterelay/locales`.
 3. Start an interactive rebase with `git rebase -i origin/main`. A rebase plan will open
    in your editor.
 4. Edit the commit line, changing from `pick` to `edit`. Save the rebase plan and exit
@@ -158,11 +165,11 @@ In the rebase planner, `git` will annotate the line with an `# empty` suffix.
 
 ### Nightly Translation Updates
 
-A GitHub action, ["Fetch latest strings from the l10n repo"][action-l10n], updates
+A GitHub action, [Fetch latest strings from the l10n repo][action-l10n], updates
 translations. The action runs at midnight UTC. It updates the `privaterelay/locales`
 submodule to the latest commit. The commit message is "Merge in latest l10n strings". If
 there are no translation updates, then there will be no commit. The action status is
-still "success" if there are no updates.
+still "success".
 
 The action uses a Personal Access Token (PAT), required to create the commit. If the
 nightly update fails, check that the PAT is still valid, and regenerate as needed.
@@ -171,23 +178,23 @@ nightly update fails, check that the PAT is still valid, and regenerate as neede
 
 ### Adding New Translatable Strings During Development
 
-Relay translations use [Fluent localization system][fluent]. To start working with translations,
+Relay translations use the [Fluent localization system][fluent]. To start working with translations,
 **read the documentation from the Fluent team**.
 
 Read the [Fluent Syntax Guide][fl-syntax] while looking at some Relay `.ftl` files. This
-guide documents the syntax and promotes specific usage, such as:
+guide describes the syntax and promotes specific usage, such as:
 
 - [Variables][fl-syntax-variables] for strings with inserted values
-- [References][fl-syntax-references] for using strings like product names inside other strings
-- [Selectors][fl-syntax-selectors] for strings that include a number or count
+- [References][fl-syntax-references] for product names inside other strings
+- [Selectors][fl-syntax-selectors] for including a number or count
 
 The Fluent document [Good Practices for Developers][good-practice] has useful tips.
 
 **Use pending translations when developing content for Relay**. This is because the
-English text can change many times during development. If these string entered the
-mature translation process, these changes would cause problems. The i18n team reviews
-mature translation changes. Translation teams spend time and effort translating strings.
-Development progress would slow down., and translators would waste effort. Pending
+English text can change many times during development. Strings that are still changing
+are not a good fit for the translation process. The Localization team reviews
+translation changes. Translation teams spend time and effort translating strings.
+Development progress would slow down, and translators would waste effort. Pending
 translations avoid these issues.
 
 The pending translations for the front end are in [frontend/pendingTranslations.ftl][].
@@ -196,7 +203,7 @@ front and back ends need the string, duplicate it to both files. These files are
 Relay codebase, not the translations submodule. Include pending translation changes with
 the pull request that uses them.
 
-**Do not re-use IDs for new or updated strings**. The translations of an existing string
+**Do not re-use IDs for new or updated strings**. The translations of existing strings
 are valid and used in live content. When updating content, add a digit to the string ID
 to signal it will replace another string. For example,
 `premium-promo-availability-warning-4` replaces `premium-promo-availability-warning-3`.
@@ -218,7 +225,9 @@ more natural with embedded HTML. For example, prose that links to other content 
 an embedded `<a>` element.
 
 For Relay strings that include HTML, set the string to the complete sentence or UI
-element. Inject element attributes as variables. For example, if the rendered HTML is:
+element. Inject element attributes as variables.
+
+For example, if the rendered HTML is:
 
 ```html
 <p class="relay-footnote">
@@ -229,7 +238,7 @@ element. Inject element attributes as variables. For example, if the rendered HT
 </p>
 ```
 
-The Fluent string, with helper comments, would be something like:
+The Fluent string, with helper comments, could be:
 
 ```text
 #   { $settings_url } (url) - full link to the settings page
@@ -241,12 +250,12 @@ email-footer-pref-link =
 ```
 
 Translators can re-arrange the sentence as needed for their language. The Pontoon UI
-helps translators translate HTML strings. Pontoon linters detect some translation issues
+helps translators with HTML strings. Pontoon linters detect some translation issues
 such as malformed HTML and missing variables. The URL and attributes are not part of the
 string. Translators can not break them by changing them like translations. The values
 can change in the future without requiring re-translation.
 
-The Django email template may look like:
+The Django email template could be:
 
 ```html
 <p class="relay-footnote">
@@ -256,8 +265,8 @@ The Django email template may look like:
 </p>
 ```
 
-The frontend uses the `<Localized>` component for strings with embedded HTML. See the
-[profile-label-welcome-html][] code for details.
+The front end uses the `<Localized>` component for strings with embedded HTML. See the
+[profile-label-welcome-html][] code for an example.
 
 [profile-label-welcome-html]: https://github.com/mozilla/fx-private-relay/blob/f5c5ebf568639810db45de1ebb69f2498600d58c/frontend/src/pages/accounts/profile.page.tsx#L285-L293
 
@@ -286,9 +295,9 @@ git checkout main
 ```
 
 Copy translations from the pending translations to the proper files in
-`private/locales/en/`. Do not change the translation files for other languages.
-The pending translations for the front end are in [frontend/pendingTranslations.ftl][].
-The same for the back end are in
+`private/locales/en/`. Do not change the translation files for other languages. Pontoon
+handles those during import and export. The pending translations for the front end are
+in [frontend/pendingTranslations.ftl][]. The same for the back end are in
 [privaterelay/pending_locales/en/pending.ftl][]. A change can include strings from both
 files.
 
@@ -305,7 +314,7 @@ git push -u origin message-updates-yyymmdd
 You can then visit [mozilla-l10n/fx-private-relay-l10n][] to create the pull request.
 You can make changes in the local submodule branch for any code review feedback.
 
-After approval, the Mozilla l10n team merges the new strings. The next nightly
+After approval, the Localization team merges the new strings. The next nightly
 translation update brings the new strings into Relay's `main` branch. You should then
 create a pull request to remove the redundant strings from the pending files.
 
@@ -314,51 +323,42 @@ create a pull request to remove the redundant strings from the pending files.
 ### Expanding a Premium Plan
 
 Adding new regions to a premium plan is a cross-company effort. The Legal team ensures
-Mozilla can do business in the new region. The Subscription Platform integrates the
+Mozilla can do business in the new region. The Subscription Platform team integrates the
 expanded tax requirements. The Localization team identifies languages for the new
 region. Quality Assurance tests the experience in the new region and language. Customer
 Support expands support documents. Managers at several levels coordinate the work.
 
 Premium plan expansion can take months. A Relay engineer should **create a waffle flag
 for the expansion effort**. This allows engineers to ship partial changes without
-affecting current users. Staff with the flag enabled can test expansion code in stage
-and production.
+affecting current users.
 
 The Subscription Platform (version 2) uses [Stripe][stripe] for paid services. A
 [Stripe Price][stripe-price] tracks currency, taxes, and a subscription term. Relay
 subscription terms are monthly or yearly. There are usually two prices per region, one
-for each term. The Subscription Platform also uses a price to track language and region.
+for each term. The Subscription Platform also uses the price to track language and region.
 The product details are in the selected language. The Localization team helps pick the
-region's primary language. Product reports use the price to segment purchases by region.
+region's primary language. The product reports use the price to segment purchases by
+region.
 
-The Relay product manager create the Prices on the Stripe webpage. The product manager
+The Relay product manager create the prices on the Stripe webpage. The product manager
 shares the new price IDs with the Relay engineers. In some cases, complex criteria
 selects the price for a region. For example, a region can use the prices of a different
 region. Another case is when a region has per-language prices. The manager highlights
 these complex cases.
 
-The product manager shares the new price IDs with the Relay engineers. In some cases,
-complex criteria selects the price for a region. For example, a region can use the
-prices of a different region. Another case is when a region has per-language prices.
-The manager highlights these complex cases.
-
 The Relay engineer updates the data structures in [privaterelay/plans.py][]:
 
-1. New currencies in `CurrencyStr`
-2. New regions in `CountryStr`
-3. New prices details in `_STRIPE_PLAN_DATA`
-4. A new section in `_RELAY_PLANS`, such as `premium_expansion`, with the expanded
+1. Add new currencies in `CurrencyStr`
+2. Add new regions in `CountryStr`
+3. Add new prices details in `_STRIPE_PLAN_DATA`
+4. Add a new section in `_RELAY_PLANS`, such as `premium_expansion`, with the expanded
    regions
 5. Update the relevant functions to take a boolean signalling the waffle flag is
    on or off. See [PR #3745][pr-3745], which retired the 2023 expansion flag, for
    details.
 
-Relay staff can turn on the waffle flag for themselves and others. With an enabled flag,
-users can view new content and test buying a subscription.
-
-In development and stage, there are test prices connected to the
-[Stripe test mode][stripe-test]. A test visitor from the United States will get these
-prices. Other regions get the production prices.
+Relay staff can turn on the expansion flag for themselves and others. With an enabled
+flag, users can view new content and test buying a subscription.
 
 > [!NOTE]
 > Testing subscriptions in a new region requires setting the preferred language.
@@ -367,7 +367,7 @@ prices. Other regions get the production prices.
 >
 > Do not use a language-switcher extension. Many extensions are not allowed to run on Firefox
 > Accounts. Inconsistent language preferences may invalidate testing. See
-> [Identifying The User's Preferred Languages](#identifying-the-users-preferred-languages)
+> "[Identifying The User's Preferred Languages](#identifying-the-users-preferred-languages)"
 > for more information.
 
 When the expansion ships to all users, a Relay engineer can cleanup the data
@@ -382,21 +382,20 @@ structures:
 [pr-3745]: https://github.com/mozilla/fx-private-relay/pull/3745
 [stripe]: https://stripe.com
 [stripe-price]: https://stripe.com/docs/api/prices
-[stripe-test]: https://stripe.com/docs/test-mode
 
 ### Viewing Translation Errors
 
-The web server library [django-ftl][] logs when a translation is not available. The log
+The back-end library [django-ftl][] logs when a translation is not available. The log
 message writes to `stderr` with severity `ERROR` and name `django_ftl.message_errors`.
 The log message looks like:
 
 > FTL exception for locale [es-mx], message 'relay-email-your-dashboard',
 > args {}: KeyError('relay-email-your-dashboard')"
 
-The report [FTL Errors in Relay Production][ftl-report] gathers and categorizes recent
-errors. The filter "supported" means Relay has an assigned language team in Pontoon. The
-other filters are by locale and key (or string ID). A Relay engineer uses this report to
-detect issues with a team's translation. The report also implies the traffic volume for
+The report "[FTL Errors in Relay Production][ftl-report]" gathers and categorizes recent
+errors. The filter _supported_ means Relay has an assigned language team in Pontoon. The
+other filters are by _locale_ and _key_ (or string ID). A Relay engineer uses this report to
+detect issues with a team's translation. The report also measures the traffic volume for
 unsupported languages.
 
 The source query defines the list of supported languages. The list needs an update when
@@ -411,8 +410,8 @@ catch issues in translated strings with manual testing.
 
 ## The Technical Details of Translation
 
-Relay supports 26 languages (as of September 2023). This section details the
-technologies used to deploy those translations.
+Relay supports over 20 languages. This section details the technologies used to deploy
+those translations.
 
 > [!WARNING]
 > None of Relay's supported languages use [right-to-left scripts][].
@@ -430,18 +429,19 @@ technologies used to deploy those translations.
 The browser communicates the user's preferred languages with each web request. The
 [`Accept-Language` header][accept-lang] encodes this preference. The default header for
 Firefox downloaded in the US is "`en-US, en`". This header specifies a preference for
-English as spoken in the United States. If that is not available, it specifies to
-fallback to generic English.
+English as spoken in the United States. If that is not available, fallback to generic
+English.
 
+Browsers detect a user's desired language when setting up for the first time. For
+example, a browser could ask the operating system. The browser defaults change based on
+the language. A Firefox user could change the defaults by typing `about:config` in the
+location bar. After accepting the risk, they can find and change the key
+`intl.accept_languages`. This changes the `Accept-Language` header sent to websites.
 Most users do not change their language settings and keep the browser defaults.
-Browsers use different methods to detect a user's language and pick good defaults.
-A Firefox user could change the defaults by typing `about:config` in the location bar.
-After accepting the risk, they can find and change the key `intl.accept_languages`. This
-changes the `Accept-Language` header sent to websites.
 
 Translators use Pontoon to set the value for `intl.accept_languages`. See the
 [intl.properties][intl-props] group, LOCALES tab, for values for each language.
-Note that most end in "`en-US, en`" as fallback languages. All include `en` for
+Note that many end in "`en-US, en`" as fallback languages. All include "`en`" for
 generic English.
 
 Some browser extensions allow changing `Accept-Language`. This can be useful for testing
@@ -477,9 +477,10 @@ are no supported languages, the code falls back to English (`"en"`).
 ### Managing Languages and Translations
 
 Mozilla uses [Pontoon][pontoon] to identify supported languages and coordinate
-translation work. [Volunteer translation teams][pt-teams] coordinate their own
-translation work. They set translation standards and decide which projects to support.
-Locale codes identify translation teams. Many teams identifiers are a language code
+translations. [Volunteer translation teams][pt-teams] coordinate their own
+translation work. They set standards and decide which projects to support.
+
+Language tags identify translation teams. Many team identifiers are a language code
 (such as "`fr`" for [French][pt-fr], or `"scn"` for [Sicilian][pt-scn]). Other teams
 use a language-plus-region code, such as `"es-ES"` for
 [Spanish spoken in Spain][pt-es-ES]. A longer code is `"ca-valencia"` for
@@ -488,8 +489,8 @@ use a language-plus-region code, such as `"es-ES"` for
 Some teams are active and quick to translate, such as the [French][pt-fr] and
 [German][pt-de] teams. Some teams volunteer to translate a project, such as
 [Interlingua][pt-ia-relay]. Other teams have few or no active members, such as
-[Luxembourgish][pt-lb]. Small teams focus their resources on a few projects. The Mozilla
-localization team (Slack channel `#l10n`) is familiar with team capacity. This team
+[Luxembourgish][pt-lb]. These small teams focus their resources on a few projects. The
+Localization team (Slack channel `#l10n`) is familiar with team capacity. This team
 decides when to expand a project to new languages. They reach out to the language
 team leads to ask for expansion.
 
@@ -539,7 +540,7 @@ Some relevant repositories include:
 - [mozilla-l10n/sumo-l10n][] for [support.mozilla.org][]
 - [mozilla/addons-frontend][] for [addons.mozilla.org][]
 
-Pontoon writes new translations as new commits to their repository. Relay projects
+Pontoon writes translation updates as new commits to their repository. Relay projects
 include the translation repositories as [git submodules][git-submodules], such as
 [privaterelay/locales][]. A submodule references a specific commit in a separate
 repository. A [GitHub action][ga-l10n-sync] updates this commit to the latest each
@@ -548,16 +549,16 @@ night. This action synchronizes the main Relay branch with the latest translatio
 This synchronization strategy works best for Relay. It balances up-to-date translation
 changes against the complexity of submodules. There are other strategies. Some
 projects allow Pontoon to write to their code repository. This clutters commit history
-with translations. It also runs continuous integration tests for each translation. Other
-projects keep a copy of translations and sync them when needed. This requires manual
-work, documentation, and discipline. It often falls to a single engineer, and is not
-done when they are busy or out of office.
+with translations. It also runs continuous integration tests for each translation
+update. Other projects keep a copy of translations and sync them when needed. This
+requires manual work, documentation, and discipline. It often falls to a single
+engineer, and is not done when they are busy or out of office.
 
 Translations for Relay, and many projects at Mozilla, use the [Fluent format][fluent].
 The ["en" bundle][relay-l10n-en] (American / generic English) has the source
 translations. Developers split the translations into functional areas, such as
 [faq.ftl][] for the [FAQ page][]. The other language bundles are translations of the
-`"en"` bundle, coordinated in Pontoon. The continuous integration process creates Docker
+`"en"` bundle, coordinated in Pontoon. Relay's continuous testing creates Docker
 images that include the translations. The [Django back end][ftl-bundles] uses select
 Fluent files. The front end uses translations embedded into the JavaScript during
 Docker image creation.
@@ -567,13 +568,13 @@ in-progress strings are in the Relay repository. The source strings change often
 development. The front end uses [frontend/pendingTranslations.ftl][]. The back end code
 uses [privaterelay/pending_locales/en/pending.ftl][].
 
-Approved strings are ready for translation. The developers open a pull request to the
-translation repository. The localization team reviews the new strings. When the
-localization team merges the changes, Pontoon imports the new strings. The language
-teams translate the strings. Pontoon exports them to the translation repository. The
-nightly action updates the submodule to pull in the latest translations. The release
-Docker image includes the new translations. Once released, the users see the content in
-their language.
+New approved strings go through several steps to get translated. The developers open a
+pull request to the translation repository. The Localization team reviews the new
+strings. When the Localization team merges the changes, Pontoon imports the new strings.
+The language teams translate the strings. Pontoon exports them to the translation
+repository. The nightly action updates the submodule to pull in the latest translations.
+The release Docker image includes the new translations. Once released, the users see the
+content in their language.
 
 [Firefox Accounts]: https://accounts.firefox.com/
 [Firefox Relay Add-on]: https://addons.mozilla.org/firefox/addon/private-relay/
@@ -605,7 +606,7 @@ technologies used to distinguish users by region.
 ### Identifying the User's Region
 
 The stage and production deployments use similar load balancers. These set a
-`X-Client-Region` header based on their IP address. There is no way for a user to
+`X-Client-Region` header based on the visitor's IP address. There is no way for a user to
 override this region selection. A tester can use a [VPN][moz-vpn] to change their
 IP address and their detected region.
 
@@ -614,13 +615,12 @@ addresses do not have a clear region. The development deployment does not have t
 header. Local development also omits the header.
 
 Without a `X-Client-Region` header, the code guesses a region from the `Accept-Language`
-header. The `Accept-Language` fallback looks for a language code with a regional
-variant. For example, the language code `"es-MX"` (Mexican Spanish) implies region code
-`"MX"` (Mexico). When there is no regional variant, the code guesses a probable region
-from a [lookup table][]. The lookup table uses Unicode
-[Common Locale Data Repository][cldr] (CLDR) [Supplemental Data][cldr-sup]. The
-[Language-Territory Information][cldr-lti] includes estimates of language speakers by
-region.
+header. The language fallback looks for a language code with a regional variant. For
+example, the language code `"es-MX"` (Mexican Spanish) implies region code `"MX"`
+(Mexico). When there is no regional variant, the code guesses a probable region from a
+[lookup table][]. The lookup table uses Unicode [Common Locale Data Repository][cldr]
+(CLDR) [Supplemental Data][cldr-sup]. The [Language-Territory Information][cldr-lti]
+data includes estimates of language speakers by region.
 
 [cldr-lti]: https://www.unicode.org/cldr/charts/42/supplemental/language_territory_information.html
 [cldr-sup]: https://www.unicode.org/cldr/charts/42/supplemental/index.html
@@ -637,14 +637,14 @@ user's region.
 The subscription platform (version 2) uses [Stripe][stripe]. A
 [Stripe product][stripe-product] represents each Relay plan, such as the premium email
 service. A [Stripe price][stripe-price] represents how a user will pay. The price has
-an associate plan / product, a currency, tax details, and the term. Many Relay plans have
+an associated product, a currency, tax details, and a term. Many Relay plans have
 monthly and yearly subscription terms. The VPN bundle has yearly terms.
 
 The subscription platform associates a price with a region. Product reports may use this
 to segment purchasers by region.
 
 The subscription platform associates a price with a language. On the subscription page,
-product details appear in the price language. The rest of the subscription page appear
+product details appear in the price language. The rest of the subscription page appears
 in the user's preferred language. For most users, the price language and preferred
 language should be the same.
 
@@ -655,8 +655,14 @@ based on language. Belgium users share the price in Euros of a neighbor, based o
 language. Switzerland has separate prices for German, French, and Italian speakers.
 All the Swiss prices are in Swiss Francs. See [privaterelay/plans.py][] for details.
 
+In development and stage, there are test prices connected to the
+[Stripe test mode][stripe-test]. One feature of test mode is fake credit cards. These
+cards allow testing without paying real money, and testing failure modes. A test visitor
+from the United States will get these prices. Other regions get the production prices.
+
 [/api/v1/runtime_data]: https://relay.firefox.com/api/v1/runtime_data
 [stripe-product]: https://stripe.com/docs/api/products
+[stripe-test]: https://stripe.com/docs/test-mode
 
 ## Terms
 
@@ -671,18 +677,17 @@ Relay developers will see these terms as they work in this topic:
   similar way to i18n. A capital "L" avoids confusing a lowercase "l" with an
   uppercase "I".
 - **[Locale][]**: Shared cultural conventions that appear in a user interface. This
-  can include language, script and currencies. It can also include formats for prices,
-  numbers, dates, and times. The identifier for many locales is the combination of a
-  language code and a region code. An example is `"en-US"` to specify English speakers
-  in America. It implies the English alphabet in left-to-right text. Prices should be
-  in US Dollars (USD, "$5.99"). Numbers use commas as thousands separators (525,960
-  minutes in a year). The first number in a short date the month ("9/12/2023" for
-  September 12, 2023). English-speaking users in other regions share some of these
-  conventions. Other conventions, like currency and date formats, will vary.
+  can include language, letters, and currencies. It can also include formats for prices,
+  numbers, dates, and times. For example, American English can be a locale. This locale
+  uses the English alphabet in left-to-right text. Prices are in US Dollars (USD, "$5.99").
+  Numbers use commas as thousands separators (525,960 minutes in a year). The first
+  number in a short date is the month ("9/12/2023" for September 12, 2023).
+  English-speaking users in other regions share some of these conventions. Other
+  conventions, like currency and date formats, will vary.
 - **[Region][]**: An [administrative division][] that can be the basis for a
   locale. Mozilla prefers to use "Region" instead of "**Country**" when talking about
-  localization. A Region can include areas within a country and areas that span
-  countries.
+  localization. A region can include areas within a country, as well as areas that
+  span countries.
 - **[Language][]**: A spoken or written system of communication. English is a broad
   language category. A language can be specific to a region, such as German spoken in
   Switzerland. In localization, the written system can be important as well. For
@@ -710,7 +715,8 @@ established exception.
 - **Region**: [ISO 3166][] is a multi-part standard for identifying countries,
   territories, and subdivisions. The [ISO 3166-1 alpha-2][] code (two uppercase
   letters) is common as a region identifier.
-  - Mozilla uses the ISO 3166-1 alpha-2 code for a region when available. An
+  - Mozilla uses the ISO 3166-1 alpha-2 code for a region when available. For example,
+    `"US"` identifies the United States, and `"DE"` identifies Germany. An
     exception is [Valencia][], which uses `"valencia"`. Another is the
     [Surselva Region][], which uses `"sursilv"`.
 - **Language**: [ISO 639][] is a multi-part standard for identifying languages.
@@ -718,13 +724,16 @@ established exception.
   letters). The Library of Congress has a [table of languages][iso-639-2-list]
   with [ISO 639-2][] codes (three lowercase letters). This table has the related
   ISO 639-1 codes, when available.
-  - Mozilla uses the ISO 639-1 two-letter code when available. Mozilla falls back to the ISO
+  - Mozilla uses the ISO 639-1 two-letter code when available. For example, `"en"`
+    identifies English, and `"fr"` identifies French. Mozilla falls back to the ISO
     639-2 three-letter code (such as `"yue"` for [Cantonese][]).
 - **Locale**: Locales are usually identified by a language tag. This is a language
   identifier, plus extra identifiers as needed. [RFC 5646][], "Tags for Identifying
   Languages", defines language tags. This RFC is the second half of [BCP 47][].
   The "Accept-Language" header ([RFC 9110][]) uses language tags. This
   header is how a web browser communicates the user's preferred language.
+  - Mozilla uses language tags to identify locales. For
+    example, `"fr"` identifies generic French, and `"es-ES"` for Spanish in Spain.
   - Pontoon uses `"en"`, rather than `"en-US"`, for [English][] as written in the
     [United States][]. Other English-speaking locales include the region. For example,
     `"en-GB"` identifies English as used in the [United Kingdom][] .
@@ -745,8 +754,8 @@ established exception.
     use qvalues in `Accept-Language` defaults. Instead, the order of languages is the
     order of preference.
 - **Currency**: [ISO 4217][] defines codes for currencies.
-  - The Subscription Platform and Relay use the upper-case, three-letter codes. Some
-    examples are `"USD"` for United States dollars and `"EUR"` for Euros.
+  - The Subscription Platform and Relay use the upper-case, three-letter codes.
+    For example, `"USD"` for United States dollars and `"EUR"` for Euros.
 
 [BCP 47]: https://www.rfc-editor.org/info/bcp47
 [Cantonese]: https://en.wikipedia.org/wiki/Cantonese

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -191,11 +191,10 @@ Development progress would slow down., and translators would waste effort. Pendi
 translations avoid these issues.
 
 The pending translations for the front end are in [frontend/pendingTranslations.ftl][].
-The same for the back end are in
-[privaterelay/pending_locales/en/pending.ftl][]. If both the front and back ends need
-the string, duplicate it to both files. These files are in the Relay codebase, not the
-translations submodule. Include pending translation changes with the pull request that
-uses them.
+The back end strings are in [privaterelay/pending_locales/en/pending.ftl][]. If both the
+front and back ends need the string, duplicate it to both files. These files are in the
+Relay codebase, not the translations submodule. Include pending translation changes with
+the pull request that uses them.
 
 **Do not re-use IDs for new or updated strings**. The translations of an existing string
 are valid and used in live content. When updating content, add a digit to the string ID
@@ -632,23 +631,30 @@ region.
 
 ### Identifying Available Plans and Prices
 
-The user's region determines what premium plans are available. The API sends this
-data from [/api/v1/runtime_data][], and the website adjusts content based on
-availability in the user's region.
+The user's region determines what premium plans are available. The API sends this data
+from [/api/v1/runtime_data][]. The website adjusts content based on availability in the
+user's region.
 
-The subscription platform uses [Stripe][stripe]. A [Stripe product][stripe-product]
-represents each Relay plan, such as the premium email service.
-A [Stripe price][stripe-price] represents what a user will pay, and is a combination
-of plan / product, region(s), language, and the term (monthly or yearly). Many
-regions have their own price, such as Denmark, which uses the Danish language and the krone.
-Others share the price of a nearby region, such as Austria, which uses Germany's prices
-in German and Euros. A minority, such as Belgium and Switzerland, are more complex,
-choosing a price based on language. See [privaterelay/plans.py][] for details.
+The subscription platform (version 2) uses [Stripe][stripe]. A
+[Stripe product][stripe-product] represents each Relay plan, such as the premium email
+service. A [Stripe price][stripe-price] represents how a user will pay. The price has
+an associate plan / product, a currency, tax details, and the term. Many Relay plans have
+monthly and yearly subscription terms. The VPN bundle has yearly terms.
 
-The "price" includes a translation of the plan / products details, which is the main
-reason that language is a sometimes a factor in price selection. A user purchasing a
-Relay plan will see the product details in the "price" language, and the rest of the
-webpage in their browser preferred language, which could be the same or different.
+The subscription platform associates a price with a region. Product reports may use this
+to segment purchasers by region.
+
+The subscription platform associates a price with a language. On the subscription page,
+product details appear in the price language. The rest of the subscription page appear
+in the user's preferred language. For most users, the price language and preferred
+language should be the same.
+
+Many regions have their own price, such as Denmark, which uses the Danish language and
+the krone. Others share the price of a nearby region, such as Austria, which uses
+Germany's prices in German and Euros. A minority are more complex, choosing a price
+based on language. Belgium users share the price in Euros of a neighbor, based on
+language. Switzerland has separate prices for German, French, and Italian speakers.
+All the Swiss prices are in Swiss Francs. See [privaterelay/plans.py][] for details.
 
 [/api/v1/runtime_data]: https://relay.firefox.com/api/v1/runtime_data
 [stripe-product]: https://stripe.com/docs/api/products
@@ -657,80 +663,91 @@ webpage in their browser preferred language, which could be the same or differen
 
 Relay developers will see these terms as they work in this topic:
 
-- **Internationalization** - The design and engineering effort to make it
-  possible to adapt a service to various languages and regions with minimal or no
-  engineering changes. This is often abbreviated **i18n**, to stand for the starting
-  letter "i", the next 18 letters, and the ending letter "n". This abbreviation
+- **[Internationalization][]**: Designing a service to adapt to different locales
+  without per-locale code changes. This is often abbreviated **i18n**, to stand for the
+  starting letter "i", the next 18 letters, and the ending letter "n". This abbreviation
   also avoids the spelling differences between American and British English.
-- **Localization** - The process for adapting software to a specific locale,
-  including translating text and using locale-specific features. This is often
-  abbreviated **L10n**, in a similar way to i18n, but with a capital "L" since a
-  lowercase "l" might look like an uppercase "I".
-- **Locale** - A shared set of parameters, such as language, currency, number
-  date, and time formats shared by a group of users. The identifier for many locales is
-  the combination of a language code and a region code. An example is `"en-US"` to
-  specify English speakers in America, implying US Dollars (USD, "$5.99"), left-to-right
-  text, commas as thousands separators (525,960 minutes in a year), as well as the
-  default date and time formats ("9/12/2023" for September 12, 2023).
-- **Region** - An [administrative division][admin-div] that can be the basis for a
-  locale. Mozilla prefers to use "Region" instead of **Country**, as "Region" can
-  includes areas that useful for defining locales but may fall short of universal
-  recognition as a country.
-- **Language** - A spoken or written language. A language can have a simple
-  identifier, such as `"en"` for English; a regional variant, such as `"de-CH"` for
-  German spoken in Switzerland; or a more complex identifier, such as `"zh-CN-Hans"`,
-  for Chinese as spoken in mainland China with Simplified Chinese characters.
-- **Translation** - The process of adapting language strings or patterns to a
-  second language. This is one aspect of Localization.
+- **[Localization][]**: Adapting software to a specific locale. This includes translating
+  text and using locale-specific formats. This is often abbreviated **L10n**, in a
+  similar way to i18n. A capital "L" avoids confusing a lowercase "l" with an
+  uppercase "I".
+- **[Locale][]**: Shared cultural conventions that appear in a user interface. This
+  can include language, script and currencies. It can also include formats for prices,
+  numbers, dates, and times. The identifier for many locales is the combination of a
+  language code and a region code. An example is `"en-US"` to specify English speakers
+  in America. It implies the English alphabet in left-to-right text. Prices should be
+  in US Dollars (USD, "$5.99"). Numbers use commas as thousands separators (525,960
+  minutes in a year). The first number in a short date the month ("9/12/2023" for
+  September 12, 2023). English-speaking users in other regions share some of these
+  conventions. Other conventions, like currency and date formats, will vary.
+- **[Region][]**: An [administrative division][] that can be the basis for a
+  locale. Mozilla prefers to use "Region" instead of "**Country**" when talking about
+  localization. A Region can include areas within a country and areas that span
+  countries.
+- **[Language][]**: A spoken or written system of communication. English is a broad
+  language category. A language can be specific to a region, such as German spoken in
+  Switzerland. In localization, the written system can be important as well. For
+  example, Chinese can vary between mainland China and other regions. It can also
+  use Simplified or Traditional Chinese script when written.
+- **[Translation][]**: The process of adapting language strings or patterns to a
+  second language. This is one aspect of Localization. At Mozilla, American English is
+  the source language for interface text.
 
-[admin-div]: https://en.wikipedia.org/wiki/Administrative_division
+[Internationalization]: https://en.wikipedia.org/wiki/Internationalization_and_localization
+[Localization]: https://en.wikipedia.org/wiki/Internationalization_and_localization
+[Locale]: https://en.wikipedia.org/wiki/Locale_(computer_software)
+[Language]: https://en.wikipedia.org/wiki/Language
+[Translation]: https://en.wikipedia.org/wiki/Translation
+[administrative division]: https://en.wikipedia.org/wiki/Administrative_division
+[Region]: https://en.wikipedia.org/wiki/Region
 
 ## Standards for Identifiers
 
 There are internet standard identifiers for regions, languages, locales, and currency.
-In most cases, Mozilla uses the standard identifiers, but there are exceptions, mostly
-in legacy cases. Relay users should follow the standards, unless Mozilla has an
+In most cases, Mozilla uses the standard identifiers. There are exceptions for common
+usage and legacy cases. Relay users should follow the standards, unless Mozilla has an
 established exception.
 
-- **Region** - [ISO 3166][] is a multi-part standard for identifying countries,
+- **Region**: [ISO 3166][] is a multi-part standard for identifying countries,
   territories, and subdivisions. The [ISO 3166-1 alpha-2][] code (two uppercase
-  letters) is widely used as region identifiers.
-  - Mozilla uses the ISO 3166-1 alpha-2 code for a region when available. Some
-    exceptions are [Valencia][], which uses `"valencia"`, and the [Surselva Region][],
-    which uses `"sursilv"`.
-- **Language** - [ISO 639][] is a multi-part standard for identifying languages.
+  letters) is common as a region identifier.
+  - Mozilla uses the ISO 3166-1 alpha-2 code for a region when available. An
+    exception is [Valencia][], which uses `"valencia"`. Another is the
+    [Surselva Region][], which uses `"sursilv"`.
+- **Language**: [ISO 639][] is a multi-part standard for identifying languages.
   Wikipedia has a [useful table][iso-639-1-list] of [ISO 639-1][] codes (two lowercase
-  letters), and the Library of Congress has a [table of languages][iso-639-2-list] that
-  lists the languages with an [ISO 639-2][] code (three lowercase letters) and their ISO
-  639-1 codes.
-  - Mozilla uses the ISO 639-1 two-letter code when available, falling back to the ISO
+  letters). The Library of Congress has a [table of languages][iso-639-2-list]
+  with [ISO 639-2][] codes (three lowercase letters). This table has the related
+  ISO 639-1 codes, when available.
+  - Mozilla uses the ISO 639-1 two-letter code when available. Mozilla falls back to the ISO
     639-2 three-letter code (such as `"yue"` for [Cantonese][]).
-- **Locale** - Locales are usually identified by a language tag, a language identifier
-  plus extra identifiers as needed. [BCP 47][] collects two RFCs, [RFC 4647][],
-  "Matching of Language Tags", and [RFC 5646][], "Tags for Identifying Languages". RFC
-  5646 defines the format of these tags, used in the "Accept-Language" header
-  ([RFC 9110][]) by a web browser for the user's preferred language.
+- **Locale**: Locales are usually identified by a language tag. This is a language
+  identifier, plus extra identifiers as needed. [RFC 5646][], "Tags for Identifying
+  Languages", defines language tags. This RFC is the second half of [BCP 47][].
+  The "Accept-Language" header ([RFC 9110][]) uses language tags. This
+  header is how a web browser communicates the user's preferred language.
   - Pontoon uses `"en"`, rather than `"en-US"`, for [English][] as written in the
-    [United States][]. Other English-speaking locales include the region, such as
-    `"en-GB"` for English as written in the [United Kingdom][].
-  - For most localizations, the default Firefox `Accept-Language` header ends in
-    the fallback languages "`en-US, en`" (see the [intl.properties][intl-props] group).
-  - Mozilla uses the identifiers
-    `"zh-CN"` for [Simplified Chinese as common in China][pt-zh-CN] and
-    `"zh-TW"` for [Traditional Chinese as common in Taiwan][pt-zh-TW].
-    [Most browsers][so-browsers], including [Firefox][pt-zh-CN-intl-prop],
-    follow this convention for the `Accept-Language` header.
-    Recent standards may instead emphasize the script (such as
-    `"zh-Hans"` for Han Simplified, or `"zh-Hans-CN"` to specify China, and
-    `"zh-Hant"` for Han Traditional, or `"zh-Hant-TW"` to specify Taiwan).
+    [United States][]. Other English-speaking locales include the region. For example,
+    `"en-GB"` identifies English as used in the [United Kingdom][] .
+  - The default Firefox `Accept-Language` header for every language includes `"en"`.
+    Most also include "`en-US`". See ["Identifying the User's Preferred Languages"][] for
+    more details.
+  - Mozilla uses the language tag `"zh-CN"` for
+    [Simplified Chinese as common in China][pt-zh-CN]. The language tag `"zh-TW"` stands
+    for [Traditional Chinese as common in Taiwan][pt-zh-TW]. Recent standards may
+    instead emphasize the script. For example, `"zh-Hans"` means Han Simplified, and
+    `"zh-Hant"` means Han Traditional. A region can make the tag more specific, such as
+    `"zh-Hans-CN"`. [Most browsers][so-browsers], including
+    [Firefox][pt-zh-CN-intl-prop], use `"zh-CN"` and `"zh-TW"` in the `Accept-Language`
+    header. Mozilla web services may need to handle the `-Hans` and `-Hant` variants.
   - [RFC 9110][] specifies "quality values", or "qvalues" to weight language
-    preferences, such as `"Accept-Language: en-US,en;q=0.5"`. In general,
-    browsers such as Firefox do not use qvalues, since they break some websites.
-    Instead, the order of languages is the order of preference.
-- **Currency** - [ISO 4217][] defines codes for currencies.
-  - The Subscription Platform and Relay use the upper-case,
-    three-letter codes, such as `"USD"` for United States dollars and `"EUR"` for
-    Euros.
+    preferences. The header `"Accept-Language: en-US,en;q=0.5"` uses qvalues. Some
+    websites break when parsing a header with qvalues. Firefox and other browsers do not
+    use qvalues in `Accept-Language` defaults. Instead, the order of languages is the
+    order of preference.
+- **Currency**: [ISO 4217][] defines codes for currencies.
+  - The Subscription Platform and Relay use the upper-case, three-letter codes. Some
+    examples are `"USD"` for United States dollars and `"EUR"` for Euros.
 
 [BCP 47]: https://www.rfc-editor.org/info/bcp47
 [Cantonese]: https://en.wikipedia.org/wiki/Cantonese
@@ -754,3 +771,4 @@ established exception.
 [pt-zh-CN]: https://pontoon.mozilla.org/zh-CN/
 [pt-zh-TW]: https://pontoon.mozilla.org/zh-TW/
 [so-browsers]: https://stackoverflow.com/questions/69709824/what-is-the-typical-chinese-language-code-for-the-accept-language-header
+["Identifying the User's Preferred Languages"]: #identifying-the-users-preferred-languages

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -39,7 +39,7 @@ includes Mozilla- and Relay-specific notes.
 
 Localization affects the user's experience in several ways.
 
-When an user first visits the Relay website, their browser gets the page in English.
+When a user first visits the Relay website, their browser gets the page in English.
 The English page is pre-rendered for fast loading. The page is then
 re-rendered into their preferred language. When none of the user's preferred languages
 are available, then the user gets English.
@@ -73,7 +73,7 @@ States. The user cannot buy a phone plan unless they are in one of those countri
 new premium user submits their real number. Relay sends a message to the user's number
 with a verification code. After verifying their real number, the user picks a Relay mask
 number. Relay only suggests mask numbers from the same country as the user's real phone.
-After the user selects a Relay mask number, Relay sends an welcome message from their
+After the user selects a Relay mask number, Relay sends a welcome message from their
 mask number. Relay sends all the messages with English text.
 
 When an external contact sends an SMS text to a mask number, the service forwards the
@@ -265,7 +265,7 @@ email-footer-pref-link =
 Translators can re-arrange the sentence as needed for their language. The Pontoon UI
 helps translators with HTML strings. Pontoon linters detect some translation issues
 such as malformed HTML and missing variables. The URL and attributes are not part of the
-string. Translators can not break them by changing them like translations. The values
+string. Translators cannot break them by changing them like translations. The values
 can change in the future without requiring re-translation.
 
 The Django email template could be:
@@ -662,7 +662,7 @@ layouts. Compare them to a left-to-right layout such as the [French localization
 
 Relay premium plans are not available world-wide, only in some regions. As of September
 2023, the premium email service is available in 34 regions. Phone infrastructure varies,
-so the phone service in available in only 2 regions. This section details the
+so the phone service is available in only 2 regions. This section details the
 technologies used to distinguish users by region.
 
 ### Identifying the User's Region

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -514,7 +514,7 @@ reach out to the language team leads to ask for expansion.
 Language support varies among [Mozilla projects][]. Some relevant projects, and the
 supported languages as of September 2023, include:
 
-- [Firefox Relay Website][pontoon-relay] (26 languages)
+- [Firefox Relay Website][pontoon-relay-website] (26 languages)
 - [Firefox Relay Add-on][pontoon-relay-add-on] (26 languages)
 - [Firefox Accounts][pontoon-fxa] (78 languages)
 - [Mozilla.org][pontoon-mozilla-org] (98 languages)
@@ -524,7 +524,7 @@ supported languages as of September 2023, include:
 Relay staff can check translation status on the Pontoon project sites. They may use the
 completeness of translated strings to decide to turn on a feature for a region. They
 may focus on completeness of the Relay-specific project. These are the projects for the
-[Firefox Relay Website][pontoon-relay] and the [Add-on][pontoon-relay-add-on].
+[Firefox Relay Website][pontoon-relay-website] and the [Add-on][pontoon-relay-add-on].
 Relay staff may identify critical strings in other projects for integration efforts.
 
 [Catalan spoken in the Valencian Community of Spain]: https://pontoon.mozilla.org/ca-valencia/
@@ -542,7 +542,7 @@ Relay staff may identify critical strings in other projects for integration effo
 [pontoon-fxa]: https://pontoon.mozilla.org/projects/firefox-accounts/
 [pontoon-mozilla-org]: https://pontoon.mozilla.org/projects/mozillaorg/
 [pontoon-relay-add-on]: https://pontoon.mozilla.org/projects/firefox-relay-add-on/
-[pontoon-relay]: https://pontoon.mozilla.org/projects/firefox-relay-website/
+[pontoon-relay-website]: https://pontoon.mozilla.org/projects/firefox-relay-website/
 [pontoon-sumo]: https://pontoon.mozilla.org/projects/sumo/
 [support-for-relay]: https://support.mozilla.org/en-US/products/relay
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -327,8 +327,14 @@ You can then visit [mozilla-l10n/fx-private-relay-l10n][] to create the pull req
 You can make changes in the local submodule branch for any code review feedback.
 
 After approval, the Localization team merges the new strings. The next nightly
-translation update brings the new strings into Relay's `main` branch. You should then
-create a pull request to remove the redundant strings from the pending files.
+translation update brings the new strings into Relay's `main` branch.
+
+At this point, the pending translations have redundant strings. The Fluent code may log
+warnings about these strings. The duplicate strings may confuse Relay engineers. Create
+a new Relay pull request to remove the migrated strings. The pending translations for
+the front end are in [frontend/pendingTranslations.ftl][]. The same for the back end are
+in [privaterelay/pending_locales/en/pending.ftl][]. A change can include removing
+strings from both files.
 
 [mozilla-l10n/fx-private-relay-l10n]: https://github.com/mozilla-l10n/fx-private-relay-l10n
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -642,8 +642,9 @@ technologies used to distinguish users by region.
 
 ### Identifying the User's Region
 
-The stage and production deployments use similar load balancers. These set a
-`X-Client-Region` header based on the visitor's IP address. There is no way for a user to
+The stage and production deployments use similar load balancers. The Service Reliability
+Engineers (SREs) configured these to add an `X-Client-Region` header. The header value
+is the visitor's region, based on their IP address. There is no way for a user to
 override this region selection. A tester can use a [VPN][] to change their IP address
 and their detected region.
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -56,7 +56,7 @@ they enter a new email, they go through account creation. Firefox Accounts store
 real email and preferred language on their new profile.
 
 The user generates a Relay email mask, which they use instead of their real email on
-other websites. When that website sends an email to the Relay email mask, Relay forwards
+other services. When that service sends an email to the Relay email mask, Relay forwards
 the email to the user's real email. The forwarded email has header and footer sections
 surrounding the original content. These sections appear in the user's preferred language
 from their Firefox Account.
@@ -400,8 +400,8 @@ The source query defines the list of supported languages. The list needs an upda
 a new language team takes on the Relay project. A Relay engineer can update the query,
 called a "data source" in Looker, to add the new team.
 
-There are no error reports for the front-end website or the add-on. Relay engineers or QA
-catch issues in translated strings with manual testing.
+There are no error reports for the front end or the add-on. Relay engineers or QA catch
+issues in translated strings with manual testing.
 
 [django-ftl]: https://github.com/django-ftl/django-ftl
 [FTL Errors in Relay Production]: https://lookerstudio.google.com/reporting/63983869-6199-43b8-acb5-52971ffdd023
@@ -443,10 +443,10 @@ Note that many end in "`en-US, en`" as fallback languages. All include "`en`" fo
 generic English.
 
 Some browser extensions allow changing `Accept-Language`. This can be useful for testing
-translations on the Relay website. Extensions are be
-[disabled on some websites][] due to security concerns. These websites
-include Firefox Accounts and the Subscription Platform. Do not use language-switcher
-extensions when testing user flows for buying subscriptions.
+translations on the Relay front end. Extensions are [disabled on some websites][] due to
+security concerns. These websites include Firefox Accounts and the Subscription
+Platform. Do not use language-switcher extensions when testing user flows for buying
+subscriptions.
 
 [`Accept-Language` header]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
 [intl.properties]: https://pontoon.mozilla.org/es-ES/firefox/toolkit/chrome/global/intl.properties/?string=81017
@@ -630,7 +630,7 @@ language speakers by region.
 ### Identifying Available Plans and Prices
 
 The user's region determines what premium plans are available. The API sends this data
-from [/api/v1/runtime_data][]. The website adjusts content based on availability in the
+in [/api/v1/runtime_data][]. The front end adjusts content based on availability in the
 user's region.
 
 The subscription platform (version 2) uses [Stripe][]. A [Stripe product][] represents

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,8 +1,17 @@
 # Internationalization, Localization, and Translation
 
 Relay users come from several regions and speak various languages. Relay developers need
-to consider internationalization and localization (see [Terms](#terms)) when designing
-features and making changes. This overview includes Mozilla- and Relay-specific notes.
+to prepare for these variations when implementing features. Specialists call this design
+discipline _internationalization_ and _localization_ (see [Terms](#terms)). This overview
+includes Mozilla- and Relay-specific notes.
+
+<!--
+  Note: This manual table of contents (TOC) duplicates a GitHub feature, a table of
+  contents behind a UI element:
+  https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/
+  If maintenance of this TOC becomes a larger burden than the benefit of an overview,
+  then consider removing it.
+-->
 
 - [How a User Experiences Relay](#how-a-user-experiences-relay)
 - [Development Workflows](#development-workflows)
@@ -29,10 +38,10 @@ features and making changes. This overview includes Mozilla- and Relay-specific 
 
 Localization affects the user's experience in several ways.
 
-When an user first visits the Relay website, their browser gets the English server-side
-rendered page, and then the page is re-rendered by JavaScript into their preferred
-language. When none of the user's preferred languages are available, then the user gets
-English.
+When an user first visits the Relay website, their browser gets the page in English.
+The English page is pre-rendered for fast loading. The page is then
+re-rendered into their preferred language. When none of the user's preferred languages
+are available, then the user gets English.
 
 The user sees different plan details based on their region. On the homepage there is a
 table comparing Relay premium plans. If a premium plan is available in their region,
@@ -40,34 +49,39 @@ they see a price in their local currency. If a premium plan is not available, th
 sees a prompt to join a waitlist. The FAQ also changes, to omit entries for plans that
 are unavailable in the user's region.
 
-When a user selects a sign-in button (in the page header, labeled "Sign Up" and "Sign
-In" in the English localization), they go to the Firefox Accounts website, and see
-content in their preferred language. If they enter a new email, they go through Firefox
-Account creation, and Firefox Accounts stores their preferred language on their profile.
+A new or logged-out user sees the sign-in buttons in the page header. The button text is
+"Sign Up" and "Sign In" in the English localization. The text will be different if the
+user's preferred language is not English. When a user selects a sign-in button, they go
+to the Firefox Accounts website. This website is also in their preferred language. If
+they enter a new email, they go through account creation. Firefox Accounts stores their
+real email and preferred language on their new profile.
 
-When a user receives a forwarded email, there is a header and footer surrounding the
-forwarded email content, translated into their preferred language, captured at Firefox
-Account creation.
+The user generates a Relay email mask, which they use instead of their real email on
+other websites. When that website sends an email to the Relay email mask, Relay forwards
+the email to the user's real email. The forwarded email has header and footer sections
+surrounding the original content. These sections appear in the user's preferred language
+from their Firefox Account.
 
-When a user selects a premium plan, they go to the Firefox Subscriptions website. The
-page appears in their preferred language, except for the product details, which are in
-the primary supported language for their region. The price is in their region's
-currency.
+When a user selects a premium plan, they go to the Firefox Subscriptions website. Most
+of the content appears in their preferred language. The product details are in the
+primary supported language for their region. This may be different from the user's
+preferred language. The price is in their region's currency.
 
-When a user installs the Relay Add-On, the content is also in their preferred language,
-and reflects the Relay premium plan availability in their region.
+When a user installs the Relay Add-On, the content is also in their preferred language.
+The Add-On reflects the Relay premium plan availability in their region.
 
 ## Development Workflows
 
-See "Working with translations" in the project [README.md][readme-wwt] for basic
-instructions on working with translations, such as adding new strings.
+The project `README.md` has basic instructions on ["working with
+translations"][readme-wwt]. This section has more details.
 
 [readme-wwt]: ../README.md#working-with-translations
 
 ### Loading Translations
 
 The translations are in a separate repository, and included as a
-[submodule][git-submodules].
+[submodule][git-submodules]. This combines a separate repository with a
+specific commit in that repository.
 
 When cloning a repo, you can also fetch the translations:
 
@@ -83,10 +97,10 @@ git submodule init
 git submodule update
 ```
 
-When checking out a branch, `git status` may show `privaterelay/locales` has changed,
-when it is just synced with the branch. To sync the translations with the branch, you
-can run `git submodule update --remote`. To automatically sync the translations
-submodule when switching branches, set the configuration:
+When checking out a branch, `git status` may show `privaterelay/locales` has changed.
+This is because the submodule commit is out of sync with the branch. To sync the
+submodule with the branch, you can run `git submodule update --remote`. To automate
+syncing the translations submodule, set the configuration:
 
 ```sh
 git config --global submodule.recurse true
@@ -96,12 +110,13 @@ git config --global submodule.recurse true
 
 ### Rebasing a Branch
 
-When rebasing a branch to pick up changes from `main`, you may see
-`privaterelay/locales` in the "Changes not staged for commit". **Do not add this
-directory**, as it may revert translations to an earlier version.
+When rebasing a branch to pick up changes from `main`, the submodule commit may now be
+out of sync. You may see `privaterelay/locales` in the "Changes not staged for commit".
+**Do not add this directory**, as it may revert translations to an earlier version.
 
-If you already added it to "Changes to be committed" (also known as the staging area),
-for example with `git add -u`, you can remove it with:
+If you already added it, for example with `git add -u`, it is now in the staging area.
+This is the "official" name of the "Changes to be committed" section. You can remove it
+with:
 
 ```sh
 git restore --staged privaterelay/locales
@@ -117,8 +132,8 @@ git checkout -- privaterelay/locales/
 
 ### Reverting a Translation Commit
 
-If you accidentally commit an update to `privaterelay/locales`, you can remove it with
-`git rebase`. This is a powerful tool that requires deeper understanding of `git`. See
+If you commit an update to `privaterelay/locales`, you can remove it with `git rebase`.
+This is a powerful tool that requires deeper understanding of `git`. See
 [About Git][gh-git] for a tutorial, and
 [On undoing, fixing, or removing commits in git][sr-fixup] for a guided experience.
 
@@ -128,51 +143,58 @@ If you accidentally commit an update to `privaterelay/locales`, you can remove i
    in your editor.
 4. Edit the commit line, changing from `pick` to `edit`. Save the rebase plan and exit
    the editor to start the rebase.
-5. When rebasing gets to the target the commit, run `git checkout head~1 --
-privaterelay/locales` to get the submodule version _before_ your change and
-   automatically stage it (put it into "Changes to be committed").
+5. When rebasing gets to the target the commit, run
+   `git checkout head~1 -- privaterelay/locales`. This sets the submodule version
+   _before_ your change and stages it. You can run `git status` to confirm it is in
+   "Changes to be committed".
 6. Run `git rebase --continue` to continue the rebase.
 
 If the only change in the commit was updating the submodule, you'll now have an empty
-commit. You can remove it with another interactive rebase by removing the commit line
-(which `git` will annotate with a `# empty` suffix).
+commit. You can remove it with another interactive rebase by removing the commit line.
+In the rebase planner, `git` will annotate the line with an `# empty` suffix.
 
 [gh-git]: https://docs.github.com/en/get-started/using-git/about-git
 [sr-fixup]: https://sethrobertson.github.io/GitFixUm/fixup.html
 
 ### Nightly Translation Updates
 
-A GitHub action ["Fetch latest strings from the l10n repo"][ga-l10n] runs at midnight
-UTC and updates the `privaterelay/locales` submodule to the latest commit. The commit
-message is "Merge in latest l10n strings". If there are no translation updates, then
-there will be no commit, but the action will still finish successfully.
+A GitHub action, ["Fetch latest strings from the l10n repo"][action-l10n], updates
+translations. The action runs at midnight UTC. It updates the `privaterelay/locales`
+submodule to the latest commit. The commit message is "Merge in latest l10n strings". If
+there are no translation updates, then there will be no commit. The action status is
+still "success" if there are no updates.
 
 The action uses a Personal Access Token (PAT), required to create the commit. If the
 nightly update fails, check that the PAT is still valid, and regenerate as needed.
 
-[ga-l10n]: https://github.com/mozilla/fx-private-relay/actions/workflows/l10n-sync.yml
+[action-l10n]: https://github.com/mozilla/fx-private-relay/actions/workflows/l10n-sync.yml
 
 ### Adding New Translatable Strings During Development
 
-If this is your first time working with translations, read the [Fluent Syntax
-Guide][fl-syntax] while looking at some Relay `.ftl` files. This guide documents the
-syntax and promotes specific usage, such as:
+Relay translations use [Fluent localization system][fluent]. To start working with translations,
+read the documentation from the Fluent team.
+
+Read the [Fluent Syntax Guide][fl-syntax] while looking at some Relay `.ftl` files. This
+guide documents the syntax and promotes specific usage, such as:
 
 - [Variables][fl-syntax-variables] for strings with inserted values
 - [References][fl-syntax-references] for using strings like product names inside other strings
 - [Selectors][fl-syntax-selectors] for strings that include a number or count
 
-The document [Good Practices for Developers][good-practice] has useful tips for writing
-strings, such as:
+The Fluent document [Good Practices for Developers][good-practice] has useful tips.
 
-- Write Everything Twice
-- Prefer separate messages over variants for UI logic
+Use pending translations when developing content for Relay. This is because the English
+text can change many times during development. If these string entered the mature
+translation process, these changes would cause problems. The i18n team reviews mature
+translation changes. Translation teams spend time and effort translating strings.
+Development progress would slow down., and translators would waste effort. Pending
+translations avoid these issues.
 
-Use pending translations when developing new content or updating content for Relay. The
-product manager and other reviewers can make tweaks to the content during acceptance,
-without throwing away translator work or requiring ID updates. The pending translations
-for the frontend are in [frontend/pendingTranslations.ftl][], and the pending
-translations for the backend are in [privaterelay/pending_locales/en/pending.ftl][].
+The pending translations for the front end are in [frontend/pendingTranslations.ftl][].
+The pending translations for the back end are in
+[privaterelay/pending_locales/en/pending.ftl][]. If both the front and back ends need
+the string, duplicate it to both files. These files are in the Relay codebase, not the
+translations submodule.
 
 When updating content, add a digit to the string ID to help make it clear that this will
 replace another string. For example, `premium-promo-availability-warning-4` replaces
@@ -182,38 +204,45 @@ replace another string. For example, `premium-promo-availability-warning-4` repl
 [fl-syntax-selectors]: https://projectfluent.org/fluent/guide/selectors.html
 [fl-syntax-variables]: https://projectfluent.org/fluent/guide/variables.html
 [fl-syntax]: https://projectfluent.org/fluent/guide/
+[fluent]: https://projectfluent.org/
 [frontend/pendingTranslations.ftl]: https://github.com/mozilla/fx-private-relay/blob/main/frontend/pendingTranslations.ftl
 [good-practice]: https://github.com/projectfluent/fluent/wiki/Good-Practices-for-Developers
 [privaterelay/pending_locales/en/pending.ftl]: https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/pending_locales/en/pending.ftl
 
 #### Translatable Strings with Embedded HTML
 
-Some Relay strings are more natural with embedded HTML, especially prose that links to
-other content. For Relay strings that include HTML, set the string to the complete
-sentence or UI element, and inject element attributes as variables. For example, if the
-rendered HTML is:
+Translation is simple when the string has no embedded formatting. Some Relay strings are
+more natural with embedded HTML. For example, prose that links to other content may have
+an embedded `<a>` element.
+
+For Relay strings that include HTML, set the string to the complete sentence or UI
+element. Inject element attributes as variables. For example, if the rendered HTML is:
 
 ```html
 <p class="relay-footnote">
   To change your email preference, see
-  <a class="never-blue" href="https://relay.firefox.com/accounts/settings/">
+  <a class="a-ext-link" href="https://relay.firefox.com/accounts/settings/">
     Relay Settings
   </a>
 </p>
 ```
 
-The Fluent string would be something like:
+The Fluent string, with helper comments, would be something like:
 
 ```text
+#   { $settings_url } (url) - full link to the settings page
+#   { $link_attrs } (string) - specific attributes added to links
+#   { settings-headline } (string) - the title of the settings page
 email-footer-pref-link =
   To change your email preference, see
-  <a href="${ settings_url }" ${ link_attrs }>{ settings-headline }</a>
+  <a href="{ $settings_url }" { $link_attrs }>{ settings-headline }</a>
 ```
 
-Translators can re-arrange the sentence as needed for their language, while avoiding
-mistranslating a URL or HTML attributes. The Pontoon UI helps translators with HTML
-strings, and Pontoon linters detect some translation issues such as malformed HTML and
-missing variables.
+Translators can re-arrange the sentence as needed for their language. The Pontoon UI
+helps translators translate HTML strings. Pontoon linters detect some translation issues
+such as malformed HTML and missing variables. The URL and attributes are not part of the
+string. Translators can not break them by changing them like translations. The values
+can change in the future without requiring re-translation.
 
 The Django email template may look like:
 
@@ -221,7 +250,7 @@ The Django email template may look like:
 <p class="relay-footnote">
   {% ftlmsg 'email-footer-pref-link'
   settings_url=SITE_ORIGIN|add:'/accounts/settings/'
-  link_attrs='class="never-blue"' %}
+  link_attrs='class="a-ext-link"' %}
 </p>
 ```
 
@@ -236,9 +265,9 @@ The `privaterelay/locales` directory is a checkout of the git repository
 [mozilla-l10n/fx-private-relay-i10n][]. To add new strings for translation,
 open a pull request against that repository.
 
-The `privaterelay/locales` checkout is an `https` checkout by default, requiring a
-GitHub password when pushing the branch. To switch to an `ssh` checkout and use your SSH
-key:
+The `privaterelay/locales` checkout is an `https` checkout by default. You will need to
+authenticate with a GitHub password when pushing the branch. To switch to an `ssh`
+checkout and authenticate with your SSH key:
 
 ```sh
 cd privaterelay/locales
@@ -254,9 +283,12 @@ git fetch
 git checkout main
 ```
 
-Copy translations from [frontend/pendingTranslations.ftl][] and / or
-[privaterelay/pending_locales/en/pending.ftl][] to the proper files in
+Copy translations from the pending translations to the proper files in
 `private/locales/en/`. Do not change the translation files for other languages.
+The pending translations for the front end are in [frontend/pendingTranslations.ftl][].
+The pending translations for the back end are in
+[privaterelay/pending_locales/en/pending.ftl][]. A change can include strings from both
+files.
 
 When ready, create and push a branch:
 
@@ -268,13 +300,12 @@ git commit -u
 git push -u origin message-updates-yyymmdd
 ```
 
-You can then visit [mozilla-l10n/fx-private-relay-i10n][] to create the pull request,
-and make changes locally for any code review feedback.
+You can then visit [mozilla-l10n/fx-private-relay-i10n][] to create the pull request.
+You can make changes in the local submodule branch for any code review feedback.
 
-After the l10n team merges the new strings, the next nightly translation update brings
-them into Relay's `main` branch. At that point, you should create a pull request to
-remove the redundant strings from `frontend/pendingTranslations.ftl` and
-`privaterelay/pending_locales/en/pending.ftl`.
+After approval, the l10n team merges the new strings. The next nightly translation
+update brings the new strings into Relay's `main` branch. You should then
+create a pull request to remove the redundant strings from the pending files.
 
 [mozilla-l10n/fx-private-relay-i10n]: https://github.com/mozilla-l10n/fx-private-relay-l10n
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -9,8 +9,7 @@ includes Mozilla- and Relay-specific notes.
   Note: This manual table of contents (TOC) duplicates a GitHub feature, a table of
   contents behind a UI element:
   https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/
-  If maintenance of this TOC becomes a larger burden than the benefit of an overview,
-  then consider removing it.
+  If maintenance of this TOC becomes a burden, then remove it.
 -->
 
 - [How a User Experiences Relay](#how-a-user-experiences-relay)
@@ -72,16 +71,15 @@ The Add-On reflects the Relay premium plan availability in their region.
 
 ## Development Workflows
 
-The project `README.md` has basic instructions on
-[working with translations][readme-wwt]. This section has more details.
+The project `README.md` has basic instructions on [working with translations][]. This
+section has more details.
 
-[readme-wwt]: ../README.md#working-with-translations
+[working with translations]: ../README.md#working-with-translations
 
 ### Loading Translations
 
-The translations are in a separate repository, and included as a
-[submodule][git-submodules]. This references a specific commit in
-a separate repository.
+The translations are in a separate repository, and included as a [submodule][]. This
+references a specific commit in a separate repository.
 
 When cloning a repo, you can also fetch the translations:
 
@@ -111,7 +109,7 @@ To automate syncing the translations submodule, set the configuration:
 git config --global submodule.recurse true
 ```
 
-[git-submodules]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
+[submodule]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
 
 ### Rebasing a Branch
 
@@ -138,9 +136,9 @@ git checkout -- privaterelay/locales/
 ### Reverting a Translation Commit
 
 If you commit an update to `privaterelay/locales`, you can remove it with `git rebase`.
-This is a powerful tool that requires deeper understanding of `git`. See
-[About Git][gh-git] for a tutorial, and
-[On undoing, fixing, or removing commits in git][sr-fixup] for a guided experience.
+This is a powerful tool that requires deeper understanding of `git`. See [About Git][]
+for a tutorial, and [On undoing, fixing, or removing commits in git][] for a guided
+experience.
 
 The process is:
 
@@ -160,12 +158,12 @@ If the only change in the commit was updating the submodule, you'll now have an 
 commit. You can remove it with another interactive rebase by removing the commit line.
 In the rebase planner, `git` will annotate the line with an `# empty` suffix.
 
-[gh-git]: https://docs.github.com/en/get-started/using-git/about-git
-[sr-fixup]: https://sethrobertson.github.io/GitFixUm/fixup.html
+[About Git]: https://docs.github.com/en/get-started/using-git/about-git
+[On undoing, fixing, or removing commits in git]: https://sethrobertson.github.io/GitFixUm/fixup.html
 
 ### Nightly Translation Updates
 
-A GitHub action, [Fetch latest strings from the l10n repo][action-l10n], updates
+A GitHub action, [Fetch latest strings from the l10n repo][], updates
 translations. The action runs at midnight UTC. It updates the `privaterelay/locales`
 submodule to the latest commit. The commit message is "Merge in latest l10n strings". If
 there are no translation updates, then there will be no commit. The action status is
@@ -174,21 +172,21 @@ still "success".
 The action uses a Personal Access Token (PAT), required to create the commit. If the
 nightly update fails, check that the PAT is still valid, and regenerate as needed.
 
-[action-l10n]: https://github.com/mozilla/fx-private-relay/actions/workflows/l10n-sync.yml
+[Fetch latest strings from the l10n repo]: https://github.com/mozilla/fx-private-relay/actions/workflows/l10n-sync.yml
 
 ### Adding New Translatable Strings During Development
 
-Relay translations use the [Fluent localization system][fluent]. To start working with translations,
+Relay translations use the [Fluent localization system][]. To start working with translations,
 **read the documentation from the Fluent team**.
 
-Read the [Fluent Syntax Guide][fl-syntax] while looking at some Relay `.ftl` files. This
-guide describes the syntax and promotes specific usage, such as:
+Read the [Fluent Syntax Guide][] while looking at some Relay `.ftl` files. This guide
+describes the syntax and promotes specific usage, such as:
 
-- [Variables][fl-syntax-variables] for strings with inserted values
-- [References][fl-syntax-references] for product names inside other strings
-- [Selectors][fl-syntax-selectors] for including a number or count
+- [Variables][] for strings with inserted values
+- [References][] for product names inside other strings
+- [Selectors][] for including a number or count
 
-The Fluent document [Good Practices for Developers][good-practice] has useful tips.
+The Fluent document [Good Practices for Developers][] has useful tips.
 
 **Use pending translations when developing content for Relay**. This is because the
 English text can change many times during development. Strings that are still changing
@@ -209,13 +207,13 @@ to signal it will replace another string. For example,
 `premium-promo-availability-warning-4` replaces `premium-promo-availability-warning-3`.
 Remove the old strings when they are no longer referenced in the code.
 
-[fl-syntax-references]: https://projectfluent.org/fluent/guide/references.html
-[fl-syntax-selectors]: https://projectfluent.org/fluent/guide/selectors.html
-[fl-syntax-variables]: https://projectfluent.org/fluent/guide/variables.html
-[fl-syntax]: https://projectfluent.org/fluent/guide/
-[fluent]: https://projectfluent.org/
+[Fluent Syntax Guide]: https://projectfluent.org/fluent/guide/
+[Fluent localization system]: https://projectfluent.org/
+[Good Practices for Developers]: https://github.com/projectfluent/fluent/wiki/Good-Practices-for-Developers
+[References]: https://projectfluent.org/fluent/guide/references.html
+[Selectors]: https://projectfluent.org/fluent/guide/selectors.html
+[Variables]: https://projectfluent.org/fluent/guide/variables.html
 [frontend/pendingTranslations.ftl]: https://github.com/mozilla/fx-private-relay/blob/main/frontend/pendingTranslations.ftl
-[good-practice]: https://github.com/projectfluent/fluent/wiki/Good-Practices-for-Developers
 [privaterelay/pending_locales/en/pending.ftl]: https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/pending_locales/en/pending.ftl
 
 #### Translatable Strings with Embedded HTML
@@ -332,8 +330,8 @@ Premium plan expansion can take months. A Relay engineer should **create a waffl
 for the expansion effort**. This allows engineers to ship partial changes without
 affecting current users.
 
-The Subscription Platform (version 2) uses [Stripe][stripe] for paid services. A
-[Stripe Price][stripe-price] tracks currency, taxes, and a subscription term. Relay
+The Subscription Platform (version 2) uses [Stripe][] for paid services. A
+[Stripe Price][] tracks currency, taxes, and a subscription term. Relay
 subscription terms are monthly or yearly. There are usually two prices per region, one
 for each term. The Subscription Platform also uses the price to track language and region.
 The product details are in the selected language. The Localization team helps pick the
@@ -354,7 +352,7 @@ The Relay engineer updates the data structures in [privaterelay/plans.py][]:
 4. Add a new section in `_RELAY_PLANS`, such as `premium_expansion`, with the expanded
    regions
 5. Update the relevant functions to take a boolean signalling the waffle flag is
-   on or off. See [PR #3745][pr-3745], which retired the 2023 expansion flag, for
+   on or off. See [PR #3745][], which retired the 2023 expansion flag, for
    details.
 
 Relay staff can turn on the expansion flag for themselves and others. With an enabled
@@ -379,9 +377,9 @@ structures:
 3. Remove other code and documentation references to the expansion waffle flag
 
 [privaterelay/plans.py]: https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/plans.py
-[pr-3745]: https://github.com/mozilla/fx-private-relay/pull/3745
-[stripe]: https://stripe.com
-[stripe-price]: https://stripe.com/docs/api/prices
+[PR #3745]: https://github.com/mozilla/fx-private-relay/pull/3745
+[Stripe]: https://stripe.com
+[Stripe Price]: https://stripe.com/docs/api/prices
 
 ### Viewing Translation Errors
 
@@ -392,9 +390,9 @@ The log message looks like:
 > FTL exception for locale [es-mx], message 'relay-email-your-dashboard',
 > args {}: KeyError('relay-email-your-dashboard')"
 
-The report "[FTL Errors in Relay Production][ftl-report]" gathers and categorizes recent
-errors. The filter _supported_ means Relay has an assigned language team in Pontoon. The
-other filters are by _locale_ and _key_ (or string ID). A Relay engineer uses this report to
+The report "[FTL Errors in Relay Production][]" gathers and categorizes recent errors.
+The filter _supported_ means Relay has an assigned language team in Pontoon. The other
+filters are by _locale_ and _key_ (or string ID). A Relay engineer uses this report to
 detect issues with a team's translation. The report also measures the traffic volume for
 unsupported languages.
 
@@ -406,7 +404,7 @@ There are no error reports for the front-end website or the add-on. Relay engine
 catch issues in translated strings with manual testing.
 
 [django-ftl]: https://github.com/django-ftl/django-ftl
-[ftl-report]: https://lookerstudio.google.com/reporting/63983869-6199-43b8-acb5-52971ffdd023
+[FTL Errors in Relay Production]: https://lookerstudio.google.com/reporting/63983869-6199-43b8-acb5-52971ffdd023
 
 ## The Technical Details of Translation
 
@@ -427,7 +425,7 @@ those translations.
 ### Identifying the User's Preferred Languages
 
 The browser communicates the user's preferred languages with each web request. The
-[`Accept-Language` header][accept-lang] encodes this preference. The default header for
+[`Accept-Language` header][] encodes this preference. The default header for
 Firefox downloaded in the US is "`en-US, en`". This header specifies a preference for
 English as spoken in the United States. If that is not available, fallback to generic
 English.
@@ -440,110 +438,110 @@ location bar. After accepting the risk, they can find and change the key
 Most users do not change their language settings and keep the browser defaults.
 
 Translators use Pontoon to set the value for `intl.accept_languages`. See the
-[intl.properties][intl-props] group, LOCALES tab, for values for each language.
+[intl.properties][] group, LOCALES tab, for values for each language.
 Note that many end in "`en-US, en`" as fallback languages. All include "`en`" for
 generic English.
 
 Some browser extensions allow changing `Accept-Language`. This can be useful for testing
 translations on the Relay website. Extensions are be
-[disabled on some websites][quar-domain] due to security concerns. These websites
+[disabled on some websites][] due to security concerns. These websites
 include Firefox Accounts and the Subscription Platform. Do not use language-switcher
 extensions when testing user flows for buying subscriptions.
 
-[accept-lang]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
-[intl-props]: https://pontoon.mozilla.org/es-ES/firefox/toolkit/chrome/global/intl.properties/?string=81017
-[quar-domain]: https://support.mozilla.org/en-US/kb/quarantined-domains
+[`Accept-Language` header]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
+[intl.properties]: https://pontoon.mozilla.org/es-ES/firefox/toolkit/chrome/global/intl.properties/?string=81017
+[disabled on some websites]: https://support.mozilla.org/en-US/kb/quarantined-domains
 
 ### Picking the Language
 
 Relay may not support the user's top preferred language, but picks the best match.
 Different contexts use different implementations:
 
-| Context            | Implementation       | `Accept-Language` source      | Content Scope  |
-| :----------------- | :------------------- | :---------------------------- | :------------- |
-| API and Web Server | [Django][dj-lang]    | Web Browser                   | Error messages |
-| Background Tasks   | [Django][dj-lang]    | Firefox Accounts (at sign-up) | Emails         |
-| Website            | [Fluent][flt-lang]   | Web Browser                   | Relay Website  |
-| Add-On             | [i18n API][ext-i18n] | Web Browser                   | Add-on         |
+| Context            | Implementation                          | `Accept-Language` source      | Content Scope  |
+| :----------------- | :-------------------------------------- | :---------------------------- | :------------- |
+| API and Web Server | [Django middleware][]                   | Web Browser                   | Error messages |
+| Background Tasks   | [Django's parse_accept_lang_header()][] | Firefox Accounts (at sign-up) | Emails         |
+| Website            | [@fluent/langneg][]                     | Web Browser                   | Relay Website  |
+| Add-On             | [i18n API][]                            | Web Browser                   | Add-on         |
 
 Each implementation parses the `Accept-Language` header into languages. They start at
 the first entry and continue until there is a match to a supported language. If there
 are no supported languages, the code falls back to English (`"en"`).
 
-[dj-lang]: https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#how-django-discovers-language-preference
-[ext-i18n]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n
-[flt-lang]: https://github.com/projectfluent/fluent.js/tree/main/fluent-langneg
+[@fluent/langneg]: https://github.com/projectfluent/fluent.js/tree/main/fluent-langneg
+[Django middleware]: https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#how-django-discovers-language-preference
+[Django's parse_accept_lang_header()]: https://github.com/django/django/blob/2c6ebb65c9eb6b11347d907127b82d31e04569e5/django/utils/translation/trans_real.py#L618C1-L639C13
+[i18n API]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n
 
 ### Managing Languages and Translations
 
-Mozilla uses [Pontoon][pontoon] to identify supported languages and coordinate
-translations. [Volunteer translation teams][pt-teams] coordinate their own
-translation work. They set standards and decide which projects to support.
+Mozilla uses [Pontoon][] to identify supported languages and coordinate translations.
+[Volunteer translation teams][] coordinate their own translation work. They set
+standards and decide which projects to support.
 
 Language tags identify translation teams. Many team identifiers are a language code
-(such as "`fr`" for [French][pt-fr], or `"scn"` for [Sicilian][pt-scn]). Other teams
-use a language-plus-region code, such as `"es-ES"` for
-[Spanish spoken in Spain][pt-es-ES]. A longer code is `"ca-valencia"` for
-[Catalan spoken in the Valencian Community of Spain][pt-ca-valencia].
+(such as "`fr`" for [French][], or `"scn"` for [Sicilian][]). Other teams use a
+language-plus-region code, such as `"es-ES"` for [Spanish spoken in Spain][]. A longer
+code is `"ca-valencia"` for [Catalan spoken in the Valencian Community of Spain][].
 
-Some teams are active and quick to translate, such as the [French][pt-fr] and
-[German][pt-de] teams. Some teams volunteer to translate a project, such as
-[Interlingua][pt-ia-relay]. Other teams have few or no active members, such as
-[Luxembourgish][pt-lb]. These small teams focus their resources on a few projects. The
-Localization team (Slack channel `#l10n`) is familiar with team capacity. This team
-decides when to expand a project to new languages. They reach out to the language
-team leads to ask for expansion.
+Some teams are active and quick to translate, such as the [French][] and [German][]
+teams. Some teams volunteer to translate a project, such as [Interlingua][]. Other teams
+have few or no active members, such as [Luxembourgish][]. These small teams focus their
+resources on a few projects. The Localization team (Slack channel `#l10n`) is familiar
+with team capacity. This team decides when to expand a project to new languages. They
+reach out to the language team leads to ask for expansion.
 
-Language support varies among [Mozilla projects][pt-projs]. Some relevant projects, and
-the supported languages as of September 2023, include:
+Language support varies among [Mozilla projects][]. Some relevant projects, and the
+supported languages as of September 2023, include:
 
-- [Firefox Relay Website][pt-proj-relay] (26 languages)
-- [Firefox Relay Add-on][pt-proj-addon] (26 languages)
-- [Firefox Accounts][pt-proj-fxa] (78 languages)
-- [Mozilla.org][pt-proj-bedrock] (98 languages)
-- [SUMO][pt-proj-sumo] for [support.mozilla.org][sumo-relay] (87 languages)
-- [AMO Frontend][pt-proj-amo] for [addons.mozilla.org][amo-relay] (64 languages)
+- [Firefox Relay Website][pontoon-relay] (26 languages)
+- [Firefox Relay Add-on][pontoon-relay-add-on] (26 languages)
+- [Firefox Accounts][pontoon-fxa] (78 languages)
+- [Mozilla.org][pontoon-mozilla-org] (98 languages)
+- [SUMO][pontoon-sumo] for [support.mozilla.org][support-for-relay] (87 languages)
+- [AMO Frontend][pontoon-amo-frontend] for [addons.mozilla.org][addons-relay-page] (64 languages)
 
 Relay staff can check translation status on the Pontoon project sites. They may use
 the completeness of translated strings to decide to turn on a feature for a region.
 
-[amo-relay]: https://addons.mozilla.org/en-US/firefox/addon/private-relay/
-[pontoon]: https://pontoon.mozilla.org/
-[pt-ca-valencia]: https://pontoon.mozilla.org/ca-valencia/
-[pt-de]: https://pontoon.mozilla.org/de/
-[pt-es-ES]: https://pontoon.mozilla.org/es-ES/
-[pt-fr]: https://pontoon.mozilla.org/fr/
-[pt-ia-relay]: https://pontoon.mozilla.org/ia/firefox-relay-website/
-[pt-lb]: https://pontoon.mozilla.org/lb/
-[pt-proj-addon]: https://pontoon.mozilla.org/projects/firefox-relay-add-on/
-[pt-proj-amo]: https://pontoon.mozilla.org/projects/amo-frontend/
-[pt-proj-bedrock]: https://pontoon.mozilla.org/projects/mozillaorg/
-[pt-proj-fxa]: https://pontoon.mozilla.org/projects/firefox-accounts/
-[pt-proj-relay]: https://pontoon.mozilla.org/projects/firefox-relay-website/
-[pt-proj-sumo]: https://pontoon.mozilla.org/projects/sumo/
-[pt-projs]: https://pontoon.mozilla.org/projects/
-[pt-scn]: https://pontoon.mozilla.org/scn/
-[pt-teams]: https://pontoon.mozilla.org/teams/
-[sumo-relay]: https://support.mozilla.org/en-US/products/relay
+[Catalan spoken in the Valencian Community of Spain]: https://pontoon.mozilla.org/ca-valencia/
+[French]: https://pontoon.mozilla.org/fr/
+[German]: https://pontoon.mozilla.org/de/
+[Interlingua]: https://pontoon.mozilla.org/ia/firefox-relay-website/
+[Luxembourgish]: https://pontoon.mozilla.org/lb/
+[Mozilla projects]: https://pontoon.mozilla.org/projects/
+[Pontoon]: https://pontoon.mozilla.org/
+[Sicilian]: https://pontoon.mozilla.org/scn/
+[Spanish spoken in Spain]: https://pontoon.mozilla.org/es-ES/
+[Volunteer translation teams]: https://pontoon.mozilla.org/teams/
+[addons-relay-page]: https://addons.mozilla.org/en-US/firefox/addon/private-relay/
+[pontoon-amo-frontend]: https://pontoon.mozilla.org/projects/amo-frontend/
+[pontoon-fxa]: https://pontoon.mozilla.org/projects/firefox-accounts/
+[pontoon-mozilla-org]: https://pontoon.mozilla.org/projects/mozillaorg/
+[pontoon-relay-add-on]: https://pontoon.mozilla.org/projects/firefox-relay-add-on/
+[pontoon-relay]: https://pontoon.mozilla.org/projects/firefox-relay-website/
+[pontoon-sumo]: https://pontoon.mozilla.org/projects/sumo/
+[support-for-relay]: https://support.mozilla.org/en-US/products/relay
 
 ### Shipping Translations
 
 Pontoon syncs translations between its database and code repositories. The
-[Mozilla Localization Team][mozilla-l10n] GitHub organization hosts most project
-translation repositories. The Pontoon project page has a link to the project repository.
-Some relevant repositories include:
+[Mozilla Localization Team][] GitHub organization hosts most project translation
+repositories. The Pontoon project page has a link to the project repository. Some
+relevant repositories include:
 
 - [mozilla-l10n/fx-private-relay-l10n][] for the [Firefox Relay Website][]
 - [mozilla-l10n/fx-private-relay-add-on-l10n][] for the [Firefox Relay Add-on][]
-- [mozilla/fxa-content-server-l10n][] for [Firefox Accounts][], including [subscription pages][]
+- [mozilla/fxa-content-server-l10n][] for [Firefox Accounts][],
+  including [subscription pages][]
 - [mozilla-l10n/www-l10n][] for [mozilla.org][]
 - [mozilla-l10n/sumo-l10n][] for [support.mozilla.org][]
 - [mozilla/addons-frontend][] for [addons.mozilla.org][]
 
 Pontoon writes translation updates as new commits to their repository. Relay projects
-include the translation repositories as [git submodules][git-submodules], such as
+include the translation repositories as [git submodules][], such as
 [privaterelay/locales][]. A submodule references a specific commit in a separate
-repository. A [GitHub action][ga-l10n-sync] updates this commit to the latest each
+repository. A [GitHub action][] updates this commit to the latest each
 night. This action synchronizes the main Relay branch with the latest translations.
 
 This synchronization strategy works best for Relay. It balances up-to-date translation
@@ -554,14 +552,13 @@ update. Other projects keep a copy of translations and sync them when needed. Th
 requires manual work, documentation, and discipline. It often falls to a single
 engineer, and is not done when they are busy or out of office.
 
-Translations for Relay, and many projects at Mozilla, use the [Fluent format][fluent].
-The ["en" bundle][relay-l10n-en] (American / generic English) has the source
-translations. Developers split the translations into functional areas, such as
-[faq.ftl][] for the [FAQ page][]. The other language bundles are translations of the
-`"en"` bundle, coordinated in Pontoon. Relay's continuous testing creates Docker
-images that include the translations. The [Django back end][ftl-bundles] uses select
-Fluent files. The front end uses translations embedded into the JavaScript during
-Docker image creation.
+Translations for Relay, and many projects at Mozilla, use the [Fluent format][]. The
+["en" bundle][] (American / generic English) has the source translations. Developers
+split the translations into functional areas, such as [faq.ftl][] for the [FAQ page][].
+The other language bundles are translations of the `"en"` bundle, coordinated in
+Pontoon. Relay's continuous testing creates Docker images that include the translations.
+The [Django back end][] uses select Fluent files. The front end uses translations
+embedded into the JavaScript during Docker image creation.
 
 Relay developers create new translatable strings when updating the service. The
 in-progress strings are in the Relay repository. The source strings change often during
@@ -576,25 +573,27 @@ repository. The nightly action updates the submodule to pull in the latest trans
 The release Docker image includes the new translations. Once released, the users see the
 content in their language.
 
+["en" bundle]: https://github.com/mozilla-l10n/fx-private-relay-l10n/tree/main/en
+[Django back end]: https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/ftl_bundles.py
+[FAQ page]: https://relay.firefox.com/faq/
 [Firefox Accounts]: https://accounts.firefox.com/
 [Firefox Relay Add-on]: https://addons.mozilla.org/firefox/addon/private-relay/
 [Firefox Relay Website]: https://relay.firefox.com/
+[Fluent format]: https://projectfluent.org/
+[GitHub action]: https://github.com/mozilla/fx-private-relay/actions/workflows/l10n-sync.yml
+[Mozilla Localization Team]: https://github.com/mozilla-l10n
 [addons.mozilla.org]: https://addons.mozilla.org/
-[ftl-bundles]: https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/ftl_bundles.py
-[ga-l10n-sync]: https://github.com/mozilla/fx-private-relay/actions/workflows/l10n-sync.yml
+[faq.ftl]: https://github.com/mozilla-l10n/fx-private-relay-l10n/blob/main/en/faq.ftl
+[git submodules]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
 [mozilla-l10n/fx-private-relay-add-on-l10n]: https://github.com/mozilla-l10n/fx-private-relay-add-on-l10n
 [mozilla-l10n/sumo-l10n]: https://github.com/mozilla-l10n/sumo-l10n
 [mozilla-l10n/www-l10n]: https://github.com/mozilla-l10n/www-l10n
-[mozilla-l10n]: https://github.com/mozilla-l10n
 [mozilla.org]: https://www.mozilla.org/
 [mozilla/addons-frontend]: https://github.com/mozilla/addons-frontend/locale
 [mozilla/fxa-content-server-l10n]: https://github.com/mozilla/fxa-content-server-l10n
 [privaterelay/locales]: https://github.com/mozilla/fx-private-relay/tree/main/privaterelay
-[relay-l10n-en]: https://github.com/mozilla-l10n/fx-private-relay-l10n/tree/main/en
 [subscription pages]: https://subscriptions.firefox.com/subscriptions
 [support.mozilla.org]: https://support.mozilla.org/
-[faq.ftl]: https://github.com/mozilla-l10n/fx-private-relay-l10n/blob/main/en/faq.ftl
-[FAQ page]: https://relay.firefox.com/faq/
 
 ## The Technical Details of Region Selection
 
@@ -607,8 +606,8 @@ technologies used to distinguish users by region.
 
 The stage and production deployments use similar load balancers. These set a
 `X-Client-Region` header based on the visitor's IP address. There is no way for a user to
-override this region selection. A tester can use a [VPN][moz-vpn] to change their
-IP address and their detected region.
+override this region selection. A tester can use a [VPN][] to change their IP address
+and their detected region.
 
 The `X-Client-Region` header is sometimes missing. In stage and production, some IP
 addresses do not have a clear region. The development deployment does not have the
@@ -618,15 +617,15 @@ Without a `X-Client-Region` header, the code guesses a region from the `Accept-L
 header. The language fallback looks for a language code with a regional variant. For
 example, the language code `"es-MX"` (Mexican Spanish) implies region code `"MX"`
 (Mexico). When there is no regional variant, the code guesses a probable region from a
-[lookup table][]. The lookup table uses Unicode [Common Locale Data Repository][cldr]
-(CLDR) [Supplemental Data][cldr-sup]. The [Language-Territory Information][cldr-lti]
-data includes estimates of language speakers by region.
+[lookup table][]. The lookup table uses Unicode [Common Locale Data Repository][] (CLDR)
+[Supplemental Data][]. The [Language-Territory Information][] data includes estimates of
+language speakers by region.
 
-[cldr-lti]: https://www.unicode.org/cldr/charts/42/supplemental/language_territory_information.html
-[cldr-sup]: https://www.unicode.org/cldr/charts/42/supplemental/index.html
-[cldr]: https://cldr.unicode.org/
+[Common Locale Data Repository]: https://cldr.unicode.org/
+[Language-Territory Information]: https://www.unicode.org/cldr/charts/42/supplemental/language_territory_information.html
+[Supplemental Data]: https://www.unicode.org/cldr/charts/42/supplemental/index.html
+[VPN]: https://www.mozilla.org/products/vpn
 [lookup table]: https://github.com/mozilla/fx-private-relay/blob/f5c5ebf568639810db45de1ebb69f2498600d58c/privaterelay/utils.py#L72-L216
-[moz-vpn]: https://www.mozilla.org/products/vpn
 
 ### Identifying Available Plans and Prices
 
@@ -634,11 +633,11 @@ The user's region determines what premium plans are available. The API sends thi
 from [/api/v1/runtime_data][]. The website adjusts content based on availability in the
 user's region.
 
-The subscription platform (version 2) uses [Stripe][stripe]. A
-[Stripe product][stripe-product] represents each Relay plan, such as the premium email
-service. A [Stripe price][stripe-price] represents how a user will pay. The price has
-an associated product, a currency, tax details, and a term. Many Relay plans have
-monthly and yearly subscription terms. The VPN bundle has yearly terms.
+The subscription platform (version 2) uses [Stripe][]. A [Stripe product][] represents
+each Relay plan, such as the premium email service. A [Stripe price][] represents how a
+user will pay. The price has an associated product, a currency, tax details, and a term.
+Many Relay plans have monthly and yearly subscription terms. The VPN bundle has yearly
+terms.
 
 The subscription platform associates a price with a region. Product reports may use this
 to segment purchasers by region.
@@ -655,14 +654,14 @@ based on language. Belgium users share the price in Euros of a neighbor, based o
 language. Switzerland has separate prices for German, French, and Italian speakers.
 All the Swiss prices are in Swiss Francs. See [privaterelay/plans.py][] for details.
 
-In development and stage, there are test prices connected to the
-[Stripe test mode][stripe-test]. One feature of test mode is fake credit cards. These
-cards allow testing without paying real money, and testing failure modes. A test visitor
-from the United States will get these prices. Other regions get the production prices.
+In development and stage, there are test prices connected to the [Stripe test mode][].
+One feature of test mode is fake credit cards. These cards allow testing without paying
+real money, and testing failure modes. A test visitor from the United States will get
+these prices. Other regions get the production prices.
 
 [/api/v1/runtime_data]: https://relay.firefox.com/api/v1/runtime_data
-[stripe-product]: https://stripe.com/docs/api/products
-[stripe-test]: https://stripe.com/docs/test-mode
+[Stripe product]: https://stripe.com/docs/api/products
+[Stripe test mode]: https://stripe.com/docs/test-mode
 
 ## Terms
 
@@ -698,12 +697,12 @@ Relay developers will see these terms as they work in this topic:
   the source language for interface text.
 
 [Internationalization]: https://en.wikipedia.org/wiki/Internationalization_and_localization
-[Localization]: https://en.wikipedia.org/wiki/Internationalization_and_localization
-[Locale]: https://en.wikipedia.org/wiki/Locale_(computer_software)
 [Language]: https://en.wikipedia.org/wiki/Language
+[Locale]: https://en.wikipedia.org/wiki/Locale_(computer_software)
+[Localization]: https://en.wikipedia.org/wiki/Internationalization_and_localization
+[Region]: https://en.wikipedia.org/wiki/Region
 [Translation]: https://en.wikipedia.org/wiki/Translation
 [administrative division]: https://en.wikipedia.org/wiki/Administrative_division
-[Region]: https://en.wikipedia.org/wiki/Region
 
 ## Standards for Identifiers
 
@@ -720,10 +719,9 @@ established exception.
     exception is [Valencia][], which uses `"valencia"`. Another is the
     [Surselva Region][], which uses `"sursilv"`.
 - **Language**: [ISO 639][] is a multi-part standard for identifying languages.
-  Wikipedia has a [useful table][iso-639-1-list] of [ISO 639-1][] codes (two lowercase
-  letters). The Library of Congress has a [table of languages][iso-639-2-list]
-  with [ISO 639-2][] codes (three lowercase letters). This table has the related
-  ISO 639-1 codes, when available.
+  Library of Congress has a [table of languages][] with [ISO 639-2][] codes (three
+  Wikipedia has a [useful table][] of [ISO 639-1][] codes (two lowercase letters). The
+  lowercase letters). This table has the related ISO 639-1 codes, when available.
   - Mozilla uses the ISO 639-1 two-letter code when available. For example, `"en"`
     identifies English, and `"fr"` identifies French. Mozilla falls back to the ISO
     639-2 three-letter code (such as `"yue"` for [Cantonese][]).
@@ -735,19 +733,19 @@ established exception.
   - Mozilla uses language tags to identify locales. For
     example, `"fr"` identifies generic French, and `"es-ES"` for Spanish in Spain.
   - Pontoon uses `"en"`, rather than `"en-US"`, for [English][] as written in the
-    [United States][]. Other English-speaking locales include the region. For example,
-    `"en-GB"` identifies English as used in the [United Kingdom][] .
+    United States. Other English-speaking locales include the region. For example,
+    `"en-GB"` identifies English as used in the United Kingdom .
   - The default Firefox `Accept-Language` header for every language includes `"en"`.
     Most also include "`en-US`". See ["Identifying the User's Preferred Languages"][] for
     more details.
   - Mozilla uses the language tag `"zh-CN"` for
-    [Simplified Chinese as common in China][pt-zh-CN]. The language tag `"zh-TW"` stands
-    for [Traditional Chinese as common in Taiwan][pt-zh-TW]. Recent standards may
-    instead emphasize the script. For example, `"zh-Hans"` means Han Simplified, and
-    `"zh-Hant"` means Han Traditional. A region can make the tag more specific, such as
-    `"zh-Hans-CN"`. [Most browsers][so-browsers], including
-    [Firefox][pt-zh-CN-intl-prop], use `"zh-CN"` and `"zh-TW"` in the `Accept-Language`
-    header. Mozilla web services may need to handle the `-Hans` and `-Hant` variants.
+    [Simplified Chinese as common in China][]. The language tag `"zh-TW"` stands for
+    [Traditional Chinese as common in Taiwan][]. Recent standards may instead emphasize
+    the script. For example, `"zh-Hans"` means Han Simplified, and `"zh-Hant"` means Han
+    Traditional. A region can make the tag more specific, such as `"zh-Hans-CN"`.
+    [Most browsers][], including [Firefox][], use `"zh-CN"` and `"zh-TW"` in the
+    `Accept-Language` header. Mozilla web services may need to handle the `-Hans` and
+    `-Hant` variants.
   - [RFC 9110][] specifies "quality values", or "qvalues" to weight language
     preferences. The header `"Accept-Language: en-US,en;q=0.5"` uses qvalues. Some
     websites break when parsing a header with qvalues. Firefox and other browsers do not
@@ -757,25 +755,23 @@ established exception.
   - The Subscription Platform and Relay use the upper-case, three-letter codes.
     For example, `"USD"` for United States dollars and `"EUR"` for Euros.
 
+["Identifying the User's Preferred Languages"]: #identifying-the-users-preferred-languages
 [BCP 47]: https://www.rfc-editor.org/info/bcp47
 [Cantonese]: https://en.wikipedia.org/wiki/Cantonese
 [English]: https://en.wikipedia.org/wiki/English_language
+[Firefox]: https://pontoon.mozilla.org/zh-CN/firefox/toolkit/chrome/global/intl.properties/?string=81017
 [ISO 3166-1 alpha-2]: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [ISO 3166]: https://en.wikipedia.org/wiki/ISO_3166
 [ISO 4217]: https://en.wikipedia.org/wiki/ISO_4217
 [ISO 639-1]: https://en.wikipedia.org/wiki/ISO_639-1
 [ISO 639-2]: https://en.wikipedia.org/wiki/ISO_639-2
 [ISO 639]: https://en.wikipedia.org/wiki/ISO_639
+[Most browsers]: https://stackoverflow.com/questions/69709824/what-is-the-typical-chinese-language-code-for-the-accept-language-header
 [RFC 5646]: https://www.rfc-editor.org/rfc/rfc5646.html
 [RFC 9110]: https://www.rfc-editor.org/rfc/rfc9110#field.accept-language
+[Simplified Chinese as common in China]: https://pontoon.mozilla.org/zh-CN/
 [Surselva Region]: https://en.wikipedia.org/wiki/Surselva_Region
-[United Kingdom]: https://en.wikipedia.org/wiki/United_Kingdom
-[United States]: https://en.wikipedia.org/wiki/United_States
+[Traditional Chinese as common in Taiwan]: https://pontoon.mozilla.org/zh-TW/
 [Valencia]: https://en.wikipedia.org/wiki/Valencia
-[iso-639-1-list]: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-[iso-639-2-list]: https://www.loc.gov/standards/iso639-2/php/English_list.php
-[pt-zh-CN-intl-prop]: https://pontoon.mozilla.org/zh-CN/firefox/toolkit/chrome/global/intl.properties/?string=81017
-[pt-zh-CN]: https://pontoon.mozilla.org/zh-CN/
-[pt-zh-TW]: https://pontoon.mozilla.org/zh-TW/
-[so-browsers]: https://stackoverflow.com/questions/69709824/what-is-the-typical-chinese-language-code-for-the-accept-language-header
-["Identifying the User's Preferred Languages"]: #identifying-the-users-preferred-languages
+[table of languages]: https://www.loc.gov/standards/iso639-2/php/English_list.php
+[useful table]: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -672,16 +672,16 @@ The user's region determines what premium plans are available. The API sends thi
 in [/api/v1/runtime_data][]. The front end adjusts content based on availability in the
 user's region.
 
-The subscription platform (version 2) uses [Stripe][]. A [Stripe product][] represents
+The [Subscription Platform][] (version 2) uses [Stripe][]. A [Stripe product][] represents
 each Relay plan, such as the premium email service. A [Stripe price][] represents how a
 user will pay. The price has an associated product, a currency, tax details, and a term.
 Many Relay plans have monthly and yearly subscription terms. The VPN bundle only has a
 yearly subscription term.
 
-The subscription platform associates a price with a region. Product reports may use this
+The Subscription Platform associates a price with a region. Product reports may use this
 to segment purchasers by region.
 
-The subscription platform associates a price with a language. On the subscription page,
+The Subscription Platform associates a price with a language. On the subscription page,
 product details appear in the price language. The rest of the subscription page appears
 in the user's preferred language. For most users, the price language and preferred
 language should be the same.
@@ -701,6 +701,7 @@ these prices. Other regions get the production prices.
 [/api/v1/runtime_data]: https://relay.firefox.com/api/v1/runtime_data
 [Stripe product]: https://stripe.com/docs/api/products
 [Stripe test mode]: https://stripe.com/docs/test-mode
+[Subscription Platform]: https://mozilla.github.io/ecosystem-platform/relying-parties/reference/sub-plat-features
 
 ## Terms
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -521,8 +521,11 @@ supported languages as of September 2023, include:
 - [SUMO][pontoon-sumo] for [support.mozilla.org][support-for-relay] (87 languages)
 - [AMO Frontend][pontoon-amo-frontend] for [addons.mozilla.org][addons-relay-page] (64 languages)
 
-Relay staff can check translation status on the Pontoon project sites. They may use
-the completeness of translated strings to decide to turn on a feature for a region.
+Relay staff can check translation status on the Pontoon project sites. They may use the
+completeness of translated strings to decide to turn on a feature for a region. They
+may focus on completeness of the Relay-specific project. These are the projects for the
+[Firefox Relay Website][pontoon-relay] and the [Add-on][pontoon-relay-add-on].
+Relay staff may identify critical strings in other projects for integration efforts.
 
 [Catalan spoken in the Valencian Community of Spain]: https://pontoon.mozilla.org/ca-valencia/
 [French]: https://pontoon.mozilla.org/fr/

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -318,7 +318,8 @@ When ready, create and push a branch:
 cd privaterelay/locales
 git branch message-updates-yyymmdd
 git status
-git commit -u
+git add -u
+git commit
 git push -u origin message-updates-yyymmdd
 ```
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -293,7 +293,7 @@ git checkout main
 ```
 
 Copy translations from the pending translations to the proper files in
-`private/locales/en/`. Do not change the translation files for other languages. Pontoon
+`privaterelay/locales/en/`. Do not change the translation files for other languages. Pontoon
 handles those during import and export. The pending translations for the front end are
 in [frontend/pendingTranslations.ftl][]. The same for the back end are in
 [privaterelay/pending_locales/en/pending.ftl][]. A change can include strings from both

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -90,7 +90,6 @@ submodule when switching branches, set the configuration:
 
 ```sh
 git config --global submodule.recurse true
-
 ```
 
 [git-submodules]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
@@ -320,7 +319,7 @@ new content and purchase flows.
 >
 > This is because many language-switcher extensions are not allowed to run on Firefox
 > Accounts, and email forwarding processes use the `Accept-Language` header captured by
-> Firefox Account. See
+> Firefox Accounts. See
 > [Identifying The User's Preferred Languages](#identifying-the-users-preferred-languages)
 > for more information.
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -629,8 +629,9 @@ default Relay language is English, the same language as this document. English u
 Latin script, written left-to-right.
 
 > [!WARNING]
-> None of Relay's supported languages use [right-to-left scripts][]. For other Mozilla
-> projects, it was a challenge to support the first right-to-left (RTL) language.
+> None of Relay's supported languages use [right-to-left scripts][]. Other Mozilla
+> projects support right-to-left (RTL) languages. They spent significant time and effort
+> to add the first RTL language.
 
 To add the first RTL script, developers must educate themselves on [internationalization
 techniques][]. Designers will learn RTL conventions. Developers examine every webpage,
@@ -789,8 +790,8 @@ established exception.
   - The Subscription Platform and Relay use the upper-case, three-letter codes.
     For example, `"USD"` for United States dollars and `"EUR"` for Euros.
 - **Language**: [ISO 639][] is a multi-part standard for identifying languages.
-  Library of Congress has a [table of languages][] with [ISO 639-2][] codes (three
   Wikipedia has a [useful table][] of [ISO 639-1][] codes (two lowercase letters). The
+  Library of Congress has a [table of languages][] with [ISO 639-2][] codes (three
   lowercase letters). This table has the related ISO 639-1 codes, when available.
   - Mozilla uses the ISO 639-1 two-letter code when available. For example, `"en"`
     identifies English, and `"fr"` identifies French. Mozilla falls back to the ISO

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -53,17 +53,17 @@ plans.
 A new or logged-out user sees the sign-in buttons in the page header. The button text is
 "Sign Up" and "Sign In" in the English localization. The text will be different if the
 user's preferred language is not English. When a user selects a sign-in button, they go
-to the Firefox Accounts website. This website is also in their preferred language. If
-they enter a new email, they go through account creation. Firefox Accounts stores their
-real email and preferred language on their new profile.
+to the Accounts website. This website is also in their preferred language. If they enter
+a new email, they go through account creation. Their new account profile stores their
+real email and preferred language.
 
 The user generates a Relay email mask, which they use instead of their real email on
 other services. When that service sends an email to the Relay email mask, Relay forwards
 the email to the user's real email. The forwarded email has header and footer sections
 surrounding the original content. These sections appear in the user's preferred language
-from their Firefox Account.
+from their Mozilla account.
 
-When a user selects a premium plan, they go to the Firefox Subscriptions website. Most
+When a user selects a premium plan, they go to the Subscription Platform website. Most
 of the content appears in their preferred language. The product details are in the
 primary supported language for their region. This may be different from the user's
 preferred language. The price is in their region's currency.
@@ -383,10 +383,10 @@ flag, users can view new content and test buying a subscription.
 > [!NOTE]
 > Testing subscriptions in a new region requires setting the preferred language.
 > Change the browser language preference, `intl.accept_languagues` in `about:config`.
-> Use a Firefox Account created with that language preference.
+> Use a Mozilla account created with that language preference.
 >
-> Do not use a language-switcher extension. Many extensions are not allowed to run on Firefox
-> Accounts. Inconsistent language preferences may invalidate testing. See
+> Do not use a language-switcher extension. Many extensions are not allowed to run on the
+> Accounts website. Inconsistent language preferences may invalidate testing. See
 > "[Identifying The User's Preferred Languages](#identifying-the-users-preferred-languages)"
 > for more information.
 
@@ -455,9 +455,8 @@ generic English.
 
 Some browser extensions allow changing `Accept-Language`. This can be useful for testing
 translations on the Relay front end. Extensions are [disabled on some websites][] due to
-security concerns. These websites include Firefox Accounts and the Subscription
-Platform. Do not use language-switcher extensions when testing user flows for buying
-subscriptions.
+security concerns. These websites include Accounts and the Subscription Platform. Do not
+use language-switcher extensions when testing user flows for buying subscriptions.
 
 [`Accept-Language` header]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
 [intl.properties]: https://pontoon.mozilla.org/es-ES/firefox/toolkit/chrome/global/intl.properties/?string=81017
@@ -468,12 +467,12 @@ subscriptions.
 Relay may not support the user's top preferred language, but picks the best match.
 Different contexts use different implementations:
 
-| Context            | Implementation                          | `Accept-Language` source      | Content Scope  |
-| :----------------- | :-------------------------------------- | :---------------------------- | :------------- |
-| API and Web Server | [Django middleware][]                   | Web Browser                   | Error messages |
-| Background Tasks   | [Django's parse_accept_lang_header()][] | Firefox Accounts (at sign-up) | Emails         |
-| Website            | [@fluent/langneg][]                     | Web Browser                   | Relay Website  |
-| Add-On             | [i18n API][]                            | Web Browser                   | Add-on         |
+| Context            | Implementation                          | `Accept-Language` source     | Content Scope  |
+| :----------------- | :-------------------------------------- | :--------------------------- | :------------- |
+| API and Web Server | [Django middleware][]                   | Web Browser                  | Error messages |
+| Background Tasks   | [Django's parse_accept_lang_header()][] | Mozilla account (at sign-up) | Emails         |
+| Website            | [@fluent/langneg][]                     | Web Browser                  | Relay Website  |
+| Add-On             | [i18n API][]                            | Web Browser                  | Add-on         |
 
 Each implementation parses the `Accept-Language` header into languages. They start at
 the first entry and continue until there is a match to a supported language. If there
@@ -507,7 +506,7 @@ supported languages as of September 2023, include:
 
 - [Firefox Relay Website][pontoon-relay-website] (26 languages)
 - [Firefox Relay Add-on][pontoon-relay-add-on] (26 languages)
-- [Firefox Accounts][pontoon-fxa] (78 languages)
+- [Accounts][pontoon-accounts] (78 languages)
 - [Mozilla.org][pontoon-mozilla-org] (98 languages)
 - [SUMO][pontoon-sumo] for [support.mozilla.org][support-for-relay] (87 languages)
 - [AMO Frontend][pontoon-amo-frontend] for [addons.mozilla.org][addons-relay-page] (64 languages)
@@ -529,8 +528,8 @@ Relay staff may identify critical strings in other projects for integration effo
 [Spanish spoken in Spain]: https://pontoon.mozilla.org/es-ES/
 [Volunteer translation teams]: https://pontoon.mozilla.org/teams/
 [addons-relay-page]: https://addons.mozilla.org/en-US/firefox/addon/private-relay/
+[pontoon-accounts]: https://pontoon.mozilla.org/projects/firefox-accounts/
 [pontoon-amo-frontend]: https://pontoon.mozilla.org/projects/amo-frontend/
-[pontoon-fxa]: https://pontoon.mozilla.org/projects/firefox-accounts/
 [pontoon-mozilla-org]: https://pontoon.mozilla.org/projects/mozillaorg/
 [pontoon-relay-add-on]: https://pontoon.mozilla.org/projects/firefox-relay-add-on/
 [pontoon-relay-website]: https://pontoon.mozilla.org/projects/firefox-relay-website/
@@ -546,7 +545,7 @@ relevant repositories include:
 
 - [mozilla-l10n/fx-private-relay-l10n][] for the [Firefox Relay Website][]
 - [mozilla-l10n/fx-private-relay-add-on-l10n][] for the [Firefox Relay Add-on][]
-- [mozilla/fxa-content-server-l10n][] for [Firefox Accounts][],
+- [mozilla/fxa-content-server-l10n][] for [Accounts][],
   including [subscription pages][]
 - [mozilla-l10n/www-l10n][] for [mozilla.org][]
 - [mozilla-l10n/sumo-l10n][] for [support.mozilla.org][]
@@ -575,9 +574,9 @@ The [Django back end][] uses select Fluent files. The front end uses translation
 embedded into the JavaScript during Docker image creation.
 
 ["en" bundle]: https://github.com/mozilla-l10n/fx-private-relay-l10n/tree/main/en
+[Accounts]: https://accounts.firefox.com/
 [Django back end]: https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/ftl_bundles.py
 [FAQ page]: https://relay.firefox.com/faq/
-[Firefox Accounts]: https://accounts.firefox.com/
 [Firefox Relay Add-on]: https://addons.mozilla.org/firefox/addon/private-relay/
 [Firefox Relay Website]: https://relay.firefox.com/
 [Fluent format]: https://projectfluent.org/

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -172,7 +172,7 @@ nightly update fails, check that the PAT is still valid, and regenerate as neede
 ### Adding New Translatable Strings During Development
 
 Relay translations use [Fluent localization system][fluent]. To start working with translations,
-read the documentation from the Fluent team.
+**read the documentation from the Fluent team**.
 
 Read the [Fluent Syntax Guide][fl-syntax] while looking at some Relay `.ftl` files. This
 guide documents the syntax and promotes specific usage, such as:
@@ -183,22 +183,25 @@ guide documents the syntax and promotes specific usage, such as:
 
 The Fluent document [Good Practices for Developers][good-practice] has useful tips.
 
-Use pending translations when developing content for Relay. This is because the English
-text can change many times during development. If these string entered the mature
-translation process, these changes would cause problems. The i18n team reviews mature
-translation changes. Translation teams spend time and effort translating strings.
+**Use pending translations when developing content for Relay**. This is because the
+English text can change many times during development. If these string entered the
+mature translation process, these changes would cause problems. The i18n team reviews
+mature translation changes. Translation teams spend time and effort translating strings.
 Development progress would slow down., and translators would waste effort. Pending
 translations avoid these issues.
 
 The pending translations for the front end are in [frontend/pendingTranslations.ftl][].
-The pending translations for the back end are in
+The same for the back end are in
 [privaterelay/pending_locales/en/pending.ftl][]. If both the front and back ends need
 the string, duplicate it to both files. These files are in the Relay codebase, not the
-translations submodule.
+translations submodule. Include pending translation changes with the pull request that
+uses them.
 
-When updating content, add a digit to the string ID to help make it clear that this will
-replace another string. For example, `premium-promo-availability-warning-4` replaces
-`premium-promo-availability-warning-3`. Do not re-use IDs for new strings.
+**Do not re-use IDs for new or updated strings**. The translations of an existing string
+are valid and used in live content. When updating content, add a digit to the string ID
+to signal it will replace another string. For example,
+`premium-promo-availability-warning-4` replaces `premium-promo-availability-warning-3`.
+Remove the old strings when they are no longer referenced in the code.
 
 [fl-syntax-references]: https://projectfluent.org/fluent/guide/references.html
 [fl-syntax-selectors]: https://projectfluent.org/fluent/guide/selectors.html
@@ -262,7 +265,7 @@ The frontend uses the `<Localized>` component for strings with embedded HTML. Se
 ### Submitting Pending Translations
 
 The `privaterelay/locales` directory is a checkout of the git repository
-[mozilla-l10n/fx-private-relay-i10n][]. To add new strings for translation,
+[mozilla-l10n/fx-private-relay-l10n][]. To add new strings for translation,
 open a pull request against that repository.
 
 The `privaterelay/locales` checkout is an `https` checkout by default. You will need to
@@ -286,7 +289,7 @@ git checkout main
 Copy translations from the pending translations to the proper files in
 `private/locales/en/`. Do not change the translation files for other languages.
 The pending translations for the front end are in [frontend/pendingTranslations.ftl][].
-The pending translations for the back end are in
+The same for the back end are in
 [privaterelay/pending_locales/en/pending.ftl][]. A change can include strings from both
 files.
 
@@ -300,34 +303,45 @@ git commit -u
 git push -u origin message-updates-yyymmdd
 ```
 
-You can then visit [mozilla-l10n/fx-private-relay-i10n][] to create the pull request.
+You can then visit [mozilla-l10n/fx-private-relay-l10n][] to create the pull request.
 You can make changes in the local submodule branch for any code review feedback.
 
-After approval, the l10n team merges the new strings. The next nightly translation
-update brings the new strings into Relay's `main` branch. You should then
+After approval, the Mozilla l10n team merges the new strings. The next nightly
+translation update brings the new strings into Relay's `main` branch. You should then
 create a pull request to remove the redundant strings from the pending files.
 
-[mozilla-l10n/fx-private-relay-i10n]: https://github.com/mozilla-l10n/fx-private-relay-l10n
+[mozilla-l10n/fx-private-relay-l10n]: https://github.com/mozilla-l10n/fx-private-relay-l10n
 
 ### Expanding a Premium Plan
 
-Adding new regions to a premium plan is a cross-company effort, requiring help and
-support from the Subscription Platform, Quality Assurance, Legal, Localization, and
-Customer Support. This section describes the code changes for Relay.
+Adding new regions to a premium plan is a cross-company effort. The Legal team ensures
+Mozilla can do business in the new region. The Subscription Platform integrates the
+expanded tax requirements. The Localization team identifies languages for the new
+region. Quality Assurance tests the experience in the new region and language. Customer
+Support expands support documents. Managers at several levels coordinate the work.
 
-Premium plan expansion can take months. A Relay engineer should create a waffle flag for
-the expansion effort, so that engineers can incrementally ship expansion changes and
-staff can test expansion in production.
+Premium plan expansion can take months. A Relay engineer should **create a waffle flag
+for the expansion effort**. This allows engineers to ship partial changes without
+affecting current users. Staff with the flag enabled can test expansion code in stage
+and production.
 
-The Relay product manager creates Stripe prices for each subscription term (such as
-monthly and yearly) for each new region, and gives the price IDs to the Relay engineer.
-The product manager works with the Localization team to pick the primary language for
-that region as well. Relay engineering does not need to know this choice, unless there
-are multiple prices distinguished by language for a single region.
+The Subscription Platform (version 2) uses [Stripe][stripe] for paid services. A
+[Stripe Price][stripe-price] tracks currency, taxes, and a subscription term. Relay
+subscription terms are monthly or yearly. There are usually two prices per region, one
+for each term. The Subscription Platform also uses a price to track language and region.
+The product details are in the selected language. The Localization team helps pick the
+region's primary language. Product reports use the price to segment purchases by region.
 
-In September 2023, the product manager creates Stripe prices manually, and so we've only
-set them up for production. In development and stage, the active testing price is for
-the United States in English.
+The Relay product manager create the Prices on the Stripe webpage. The product manager
+shares the new price IDs with the Relay engineers. In some cases, complex criteria
+selects the price for a region. For example, a region can use the prices of a different
+region. Another case is when a region has per-language prices. The manager highlights
+these complex cases.
+
+The product manager shares the new price IDs with the Relay engineers. In some cases,
+complex criteria selects the price for a region. For example, a region can use the
+prices of a different region. Another case is when a region has per-language prices.
+The manager highlights these complex cases.
 
 The Relay engineer updates the data structures in [privaterelay/plans.py][]:
 
@@ -340,17 +354,20 @@ The Relay engineer updates the data structures in [privaterelay/plans.py][]:
    on or off. See [PR #3745][pr-3745], which retired the 2023 expansion flag, for
    details.
 
-Relay staff can turn on the waffle flag for themselves and others, and test the
-new content and purchase flows.
+Relay staff can turn on the waffle flag for themselves and others. With an enabled flag,
+users can view new content and test buying a subscription.
+
+In development and stage, there are test prices connected to the
+[Stripe test mode][stripe-test]. A test visitor from the United States will get these
+prices. Other regions get the production prices.
 
 > [!NOTE]
-> When testing account and purchase flows, change the browser language preference
-> (`intl.accept_languagues`) rather than use an extension, and use a Firefox Account
-> created with that language preference.
+> Testing subscriptions in a new region requires setting the preferred language.
+> Change the browser language preference, `intl.accept_languagues` in `about:config`.
+> Use a Firefox Account created with that language preference.
 >
-> This is because many language-switcher extensions are not allowed to run on Firefox
-> Accounts, and email forwarding processes use the `Accept-Language` header captured by
-> Firefox Accounts. See
+> Do not use a language-switcher extension. Many extensions are not allowed to run on Firefox
+> Accounts. Inconsistent language preferences may invalidate testing. See
 > [Identifying The User's Preferred Languages](#identifying-the-users-preferred-languages)
 > for more information.
 
@@ -358,32 +375,36 @@ When the expansion ships to all users, a Relay engineer can cleanup the data
 structures:
 
 1. Merge the expanded section in `_RELAY_PLANS`, and re-sort
-2. Drop the expansion boolean, or add a comment for the unused variable, or leave
-   flexible code for future expansions.
+2. Drop the expansion boolean. Or, add a comment for the unused variable. Or, if time
+   allows, leave flexible code for future expansions.
 3. Remove other code and documentation references to the expansion waffle flag
 
 [privaterelay/plans.py]: https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/plans.py
 [pr-3745]: https://github.com/mozilla/fx-private-relay/pull/3745
+[stripe]: https://stripe.com
+[stripe-price]: https://stripe.com/docs/api/prices
+[stripe-test]: https://stripe.com/docs/test-mode
 
 ### Viewing Translation Errors
 
 The web server library [django-ftl][] logs when a translation is not available. The log
-message, sent to `stderr` with severity `ERROR` and name `django_ftl.message_errors`,
-looks like:
+message writes to `stderr` with severity `ERROR` and name `django_ftl.message_errors`.
+The log message looks like:
 
 > FTL exception for locale [es-mx], message 'relay-email-your-dashboard',
 > args {}: KeyError('relay-email-your-dashboard')"
 
 The report [FTL Errors in Relay Production][ftl-report] gathers and categorizes recent
-errors by "supported" (which means Relay has an assigned language team in Pontoon),
-locale, and key (string ID). A Relay engineer uses this report to detect issues with a
-particular team's translation files, or to find the top unsupported languages.
+errors. The filter "supported" means Relay has an assigned language team in Pontoon. The
+other filters are by locale and key (or string ID). A Relay engineer uses this report to
+detect issues with a team's translation. The report also implies the traffic volume for
+unsupported languages.
 
-The supported language list is manually added to the source query. A Relay engineer
-updates the query (called a "data source" in Looker) when new language teams take on the
-Relay projects.
+The source query defines the list of supported languages. The list needs an update when
+a new language team takes on the Relay project. A Relay engineer can update the query,
+called a "data source" in Looker, to add the new team.
 
-There are no error reports for the frontend website or the add-on. Relay engineers or QA
+There are no error reports for the front-end website or the add-on. Relay engineers or QA
 catch issues in translated strings with manual testing.
 
 [django-ftl]: https://github.com/django-ftl/django-ftl
@@ -396,34 +417,41 @@ technologies used to deploy those translations.
 
 > [!WARNING]
 > None of Relay's supported languages use [right-to-left scripts][].
-> The Relay engineers will need to spend significant effort to support one
-> of these languages, such as [Arabic][] or [Hebrew][].
+> [Hebrew][], [Arabic][], and [Persian][] are the most widespread right-to-left
+> modern writing systems. The Relay engineers will spend significant effort to
+> support the first right-to-left script.
 
-[Arabic]: https://en.wikipedia.org/wiki/Arabic
-[Hebrew]: https://en.wikipedia.org/wiki/Hebrew_language
+[Arabic]: https://en.wikipedia.org/wiki/Arabic_script
+[Hebrew]: https://en.wikipedia.org/wiki/Hebrew_alphabet
+[Persian]: https://en.wikipedia.org/wiki/Persian_alphabet
 [right-to-left scripts]: https://en.wikipedia.org/wiki/Right-to-left_script
 
 ### Identifying the User's Preferred Languages
 
-The browser communicates the user's preferred languages with an
-[`Accept-Language` header][accept-lang], sent with each web request. The default for
-Firefox downloaded in the US is "`en-US, en`", which specifies either English as spoken
-in the United States, or fallback to generic English.
+The browser communicates the user's preferred languages with each web request. The
+[`Accept-Language` header][accept-lang] encodes this preference. The default header for
+Firefox downloaded in the US is "`en-US, en`". This header specifies a preference for
+English as spoken in the United States. If that is not available, it specifies to
+fallback to generic English.
 
-Most users do not change their language settings and keep the browser defaults. The
-[generic Firefox download page][ff-download] redirects the user to a download page that
-best matches their region and language, which includes a default language preference. A
-user can then change the `Accept-Language` header in `about:config`, key
-`intl.accept_languages`. The per-language default preferences are available in Pontoon
-in the [intl.properties][intl-props] group. Each localized version of Firefox should
-include "`en-US, en`" as fallback languages.
+Most users do not change their language settings and keep the browser defaults.
+Browsers use different methods to detect a user's language and pick good defaults.
+A Firefox user could change the defaults by typing `about:config` in the location bar.
+After accepting the risk, they can find and change the key `intl.accept_languages`. This
+changes the `Accept-Language` header sent to websites.
 
-Some browser extensions allow changing `Accept-Language`, but may be
-[disabled on some websites][quar-domain], such as Firefox Accounts, due to security
-concerns.
+Translators use Pontoon to set the value for `intl.accept_languages`. See the
+[intl.properties][intl-props] group, LOCALES tab, for values for each language.
+Note that most end in "`en-US, en`" as fallback languages. All include `en` for
+generic English.
+
+Some browser extensions allow changing `Accept-Language`. This can be useful for testing
+translations on the Relay website. Extensions are be
+[disabled on some websites][quar-domain] due to security concerns. These websites
+include Firefox Accounts and the Subscription Platform. Do not use language-switcher
+extensions when testing user flows for buying subscriptions.
 
 [accept-lang]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
-[ff-download]: https://www.mozilla.org/firefox/new/
 [intl-props]: https://pontoon.mozilla.org/es-ES/firefox/toolkit/chrome/global/intl.properties/?string=81017
 [quar-domain]: https://support.mozilla.org/en-US/kb/quarantined-domains
 
@@ -439,9 +467,9 @@ Different contexts use different implementations:
 | Website            | [Fluent][flt-lang]   | Web Browser                   | Relay Website  |
 | Add-On             | [i18n API][ext-i18n] | Web Browser                   | Add-on         |
 
-Each of these starts at the first entry in `Accept-Language` and continues until it hits
-a match in the supported languages. If there are no supported languages, the code falls
-back to English (`"en"`).
+Each implementation parses the `Accept-Language` header into languages. They start at
+the first entry and continue until there is a match to a supported language. If there
+are no supported languages, the code falls back to English (`"en"`).
 
 [dj-lang]: https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#how-django-discovers-language-preference
 [ext-i18n]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n
@@ -450,20 +478,21 @@ back to English (`"en"`).
 ### Managing Languages and Translations
 
 Mozilla uses [Pontoon][pontoon] to identify supported languages and coordinate
-translation work. [Volunteer translation teams][pt-teams] coordinate the translation
-work, set standards, and decide which projects to support. Teams identifiers are a
-language code (such as "`fr`" for [French][pt-fr], or `"scn"` for [Sicilian][pt-scn]),
-or a language-plus-region code (such as `"es-ES"` for
-[Spanish spoken in Spain][pt-es-ES], or `"ca-valencia"` for
-[Catalan spoken in the Valencian Community of Spain][pt-ca-valencia]).
+translation work. [Volunteer translation teams][pt-teams] coordinate their own
+translation work. They set translation standards and decide which projects to support.
+Locale codes identify translation teams. Many teams identifiers are a language code
+(such as "`fr`" for [French][pt-fr], or `"scn"` for [Sicilian][pt-scn]). Other teams
+use a language-plus-region code, such as `"es-ES"` for
+[Spanish spoken in Spain][pt-es-ES]. A longer code is `"ca-valencia"` for
+[Catalan spoken in the Valencian Community of Spain][pt-ca-valencia].
 
 Some teams are active and quick to translate, such as the [French][pt-fr] and
 [German][pt-de] teams. Some teams volunteer to translate a project, such as
 [Interlingua][pt-ia-relay]. Other teams have few or no active members, such as
-[Luxembourgish][pt-lb], and focus their resources on a few projects. The Mozilla
-localization team (Slack channel `#l10n`) is familiar with team capacity, and helps
-decide if and when to expand a project to new languages, and reaches out to the
-language team leads.
+[Luxembourgish][pt-lb]. Small teams focus their resources on a few projects. The Mozilla
+localization team (Slack channel `#l10n`) is familiar with team capacity. This team
+decides when to expand a project to new languages. They reach out to the language
+team leads to ask for expansion.
 
 Language support varies among [Mozilla projects][pt-projs]. Some relevant projects, and
 the supported languages as of September 2023, include:
@@ -499,39 +528,58 @@ the completeness of translated strings to decide to turn on a feature for a regi
 
 ### Shipping Translations
 
-Pontoon syncs translations between its database and code repositories, most hosted in
-the [Mozilla Localization Team][mozilla-l10n] GitHub organization. The Pontoon project
-page has a link to the project repository. Some relevant repositories include:
+Pontoon syncs translations between its database and code repositories. The
+[Mozilla Localization Team][mozilla-l10n] GitHub organization hosts most project
+translation repositories. The Pontoon project page has a link to the project repository.
+Some relevant repositories include:
 
-- [mozilla-l10n/fx-private-relay-i10n][] for the Firefox Relay Website
-- [mozilla-l10n/fx-private-relay-add-on-l10n][] for the Firefox Relay Add-on
-- [mozilla/fxa-content-server-l10n][] for Firefox Accounts, including subscription pages
-- [mozilla-l10n/www-l10n][] for mozilla.org
-- [mozilla-l10n/sumo-l10n][] for support.mozilla.org
-- [mozilla/addons-frontend][] for addons.mozilla.org
+- [mozilla-l10n/fx-private-relay-l10n][] for the [Firefox Relay Website][]
+- [mozilla-l10n/fx-private-relay-add-on-l10n][] for the [Firefox Relay Add-on][]
+- [mozilla/fxa-content-server-l10n][] for [Firefox Accounts][], including [subscription pages][]
+- [mozilla-l10n/www-l10n][] for [mozilla.org][]
+- [mozilla-l10n/sumo-l10n][] for [support.mozilla.org][]
+- [mozilla/addons-frontend][] for [addons.mozilla.org][]
 
-Relay projects include the translations as [git submodules][git-submodules], such as
-[privaterelay/locales][]. A submodule references a specific commit in a separate repository.
-A [GitHub action][ga-l10n-sync] updates this commit reference nightly to get the
-latest translations from Pontoon. This strategy works better for Relay than other
-strategies, such as letting Pontoon write directly to the code repository, or
-periodically syncing translations.
+Pontoon writes new translations as new commits to their repository. Relay projects
+include the translation repositories as [git submodules][git-submodules], such as
+[privaterelay/locales][]. A submodule references a specific commit in a separate
+repository. A [GitHub action][ga-l10n-sync] updates this commit to the latest each
+night. This action synchronizes the main Relay branch with the latest translations.
+
+This synchronization strategy works best for Relay. It balances up-to-date translation
+changes against the complexity of submodules. There are other strategies. Some
+projects allow Pontoon to write to their code repository. This clutters commit history
+with translations. It also runs continuous integration tests for each translation. Other
+projects keep a copy of translations and sync them when needed. This requires manual
+work, documentation, and discipline. It often falls to a single engineer, and is not
+done when they are busy or out of office.
 
 Translations for Relay, and many projects at Mozilla, use the [Fluent format][fluent].
 The ["en" bundle][relay-l10n-en] (American / generic English) has the source
-translations, split into functional areas, such as website pages. The other language
-bundles are translations of the `"en"` bundle, coordinated in Pontoon. The continuous
-integration process creates Docker images that include the Fluent files, both in the
-source form used by the [Django backend][ftl-bundles], and embedded into the website
-JavaScript.
+translations. Developers split the translations into functional areas, such as
+[`faq.ftl`][] for the [FAQ page][]. The other language bundles are translations of the
+`"en"` bundle, coordinated in Pontoon. The continuous integration process creates Docker
+images that include the translations. The [Django back end][ftl-bundles] uses select
+Fluent files. The front end uses translations embedded into the JavaScript during
+Docker image creation.
 
-Relay developers create new translatable strings when updating the service. The website
-code uses [frontend/pendingTranslations.ftl][], and the backend code uses
-[privaterelay/pending_locales/en/pending.ftl][]. These strings change often during
-development. When the strings are in their final form, the developers moved them to the
-relevant Pontoon repository, via a pull request, for translation to the supported
-languages.
+Relay developers create new translatable strings when updating the service. The
+in-progress strings are in the Relay repository. The source strings change often during
+development. The front end uses [frontend/pendingTranslations.ftl][]. The back end code
+uses [privaterelay/pending_locales/en/pending.ftl][].
 
+Approved strings are ready for translation. The developers open a pull request to the
+translation repository. The localization team reviews the new strings. When the
+localization team merges the changes, Pontoon imports the new strings. The language
+teams translate the strings. Pontoon exports them to the translation repository. The
+nightly action updates the submodule to pull in the latest translations. The release
+Docker image includes the new translations. Once released, the users see the content in
+their language.
+
+[Firefox Accounts]: https://accounts.firefox.com/
+[Firefox Relay Add-on]: https://addons.mozilla.org/firefox/addon/private-relay/
+[Firefox Relay Website]: https://relay.firefox.com/
+[addons.mozilla.org]: https://addons.mozilla.org/
 [fluent]: https://projectfluent.org/
 [ftl-bundles]: https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/ftl_bundles.py
 [ga-l10n-sync]: https://github.com/mozilla/fx-private-relay/actions/workflows/l10n-sync.yml
@@ -539,35 +587,42 @@ languages.
 [mozilla-l10n/sumo-l10n]: https://github.com/mozilla-l10n/sumo-l10n
 [mozilla-l10n/www-l10n]: https://github.com/mozilla-l10n/www-l10n
 [mozilla-l10n]: https://github.com/mozilla-l10n
+[mozilla.org]: https://www.mozilla.org/
 [mozilla/addons-frontend]: https://github.com/mozilla/addons-frontend/locale
 [mozilla/fxa-content-server-l10n]: https://github.com/mozilla/fxa-content-server-l10n
 [privaterelay/locales]: https://github.com/mozilla/fx-private-relay/tree/main/privaterelay
 [relay-l10n-en]: https://github.com/mozilla-l10n/fx-private-relay-l10n/tree/main/en
+[subscription pages]: https://subscriptions.firefox.com/subscriptions
+[support.mozilla.org]: https://support.mozilla.org/
+[faq.ftl]: https://github.com/mozilla-l10n/fx-private-relay-l10n/blob/main/en/faq.ftl
+[FAQ page]: https://relay.firefox.com/faq/
 
 ## The Technical Details of Region Selection
 
 Relay premium plans are not available world-wide, only in some regions. As of September
-2023, the premium email service is available in 34 regions, and the phone service in 2
-regions. This section details the technologies used to distinguish by region.
+2023, the premium email service is available in 34 regions. Phone infrastructure varies,
+so the phone service in available in only 2 regions. This section details the
+technologies used to distinguish users by region.
 
 ### Identifying the User's Region
 
-In the stage and production deployments, the load balancer sets a `X-Client-Region`
-header that identifies the user's region, based on their IP address. There is no
-way for a user to override this region selection. A tester can use a [VPN][moz-vpn] to
-change their region.
+The stage and production deployments use similar load balancers. These set a
+`X-Client-Region` header based on their IP address. There is no way for a user to
+override this region selection. A tester can use a [VPN][moz-vpn] to change their
+IP address and their detected region.
 
-When the `X-Client-Region` header is not available, then the code falls back to the
-`Accept-Language` header to guess the user's region. The `X-Client-Region` header is not
-available in the development deployment or in local development, and may not be
-available in stage and production deployments for some IP addresses.
+The `X-Client-Region` header is sometimes missing. In stage and production, some IP
+addresses do not have a clear region. The development deployment does not have the
+header. Local development also omits the header.
 
-The `Accept-Language` fallback looks for a language code with a regional variant, such
-as `es-MX` for Mexican Spanish, and uses that region. If the language code does not
-include a region, then the code guesses a probable region from a [lookup table][].
-The [Language-Territory Information][cldr-lti] from the Unicode
-[Common Locale Data Repository][cldr] (CLDR) [Supplemental Data][cldr-sup], which
-estimates of language speakers by region, provides the data for the lookup table.
+Without a `X-Client-Region` header, the code guesses a region from the `Accept-Language`
+header. The `Accept-Language` fallback looks for a language code with a regional
+variant. For example, the language code `"es-MX"` (Mexican Spanish) implies region code
+`"MX"` (Mexico). When there is no regional variant, the code guesses a probable region
+from a [lookup table][]. The lookup table uses Unicode
+[Common Locale Data Repository][cldr] (CLDR) [Supplemental Data][cldr-sup]. The
+[Language-Territory Information][cldr-lti] includes estimates of language speakers by
+region.
 
 [cldr-lti]: https://www.unicode.org/cldr/charts/42/supplemental/language_territory_information.html
 [cldr-sup]: https://www.unicode.org/cldr/charts/42/supplemental/index.html
@@ -596,9 +651,7 @@ Relay plan will see the product details in the "price" language, and the rest of
 webpage in their browser preferred language, which could be the same or different.
 
 [/api/v1/runtime_data]: https://relay.firefox.com/api/v1/runtime_data
-[stripe-price]: https://stripe.com/docs/api/prices
 [stripe-product]: https://stripe.com/docs/api/products
-[stripe]: https://stripe.com
 
 ## Terms
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,43 +1,673 @@
-# Translation and Localization
-Translations are maintained in separate repositories that are managed by the
-[Mozilla Localization Team](https://github.com/mozilla-l10n). There is a
-Pontoon project for the
-[Relay Website](https://pontoon.mozilla.org/projects/firefox-relay-website/)
-(which includes strings for the back-end email forwarding task)
-and for the
-[Add-on](https://pontoon.mozilla.org/projects/firefox-relay-add-on/). More
-than 20 languages are supported.
+# Internationalization, Localization, and Translation
 
-The translation repositories are included as submodules, such as
-`privaterelay/locales`. The submodule refers to a specific commit in the
-separate repository. A GitHub action periodically updates this to the latest
-commit, bringing in any new translations or other changes from the localization
-team.
+Relay users come from several regions and speak various languages. Relay developers need
+to consider internationalization and localization (see [Terms](#terms)) when designing
+features and making changes. This overview includes Mozilla- and Relay-specific notes.
 
-The translation bundles use the [Fluent format](https://projectfluent.org/).
-They are included in the Docker image that is deployed to the stage and
-production environments, and read by the email processing apps at runtime. They
-are also embedded in the JavaScript during the build process, so that the
-website text is translated.
+- [How a User Experiences Relay](#how-a-user-experiences-relay)
+- [Development Workflows](#development-workflows)
+  - [Loading Translations](#loading-translations)
+  - [Rebasing a Branch](#rebasing-a-branch)
+  - [Reverting a Translation Commit](#reverting-a-translation-commit)
+  - [Nightly Translation Updates](#nightly-translation-updates)
+  - [Adding New Translatable Strings During Development](#adding-new-translatable-strings-during-development)
+  - [Submitting Pending Translations](#submitting-pending-translations)
+  - [Expanding a Premium Plan](#expanding-a-premium-plan)
+  - [Viewing Translation Errors](#viewing-translation-errors)
+- [The Technical Details of Translation](#the-technical-details-of-translation)
+  - [Identifying the User's Preferred Languages](#identifying-the-users-preferred-languages)
+  - [Picking the Language](#picking-the-language)
+  - [Managing Languages and Translations](#managing-languages-and-translations)
+  - [Shipping Translations](#shipping-translations)
+- [The Technical Details of Region Selection](#the-technical-details-of-region-selection)
+  - [Identifying the User's Region](#identifying-the-users-region)
+  - [Identifying Available Plans and Prices](#identifying-available-plans-and-prices)
+- [Terms](#terms)
+- [Standards for Identifiers](#standards-for-identifiers)
 
-The user's desired language is parsed from the `Accept-Language` header,
-provided by their browser. When the user signs up for a Mozilla Account, their
-`Accept-Language` header is captured, and this is used for translated headers in
-forwarded emails. When a user visits the Relay website or uses the add-on,
-their current `Accept-Language` header is used.
+## How a User Experiences Relay
 
-There may not be an exact match between the desired language and those
-supported by Firefox Relay. The website uses
-[@fluent/langneg](https://github.com/projectfluent/fluent.js/tree/master/fluent-langneg)
-to determine the best match. The email forwarding code uses custom Python. In
-either case, if there is no best match, we fall back to English (`en`).
+Localization affects the user's experience in several ways.
 
-The email forwarding code logs an error when a translation is missing. These
-logs (with log name `django_ftl.message_errors`) can be processed in BigQuery
-to find issues with supported languages and to measure the popularity of
-unsupported languages. There are no logs for missing translations in the
-website front-end or the add-on.
+When an user first visits the Relay website, their browser gets the English server-side
+rendered page, and then the page is re-rendered by JavaScript into their preferred
+language. When none of the user's preferred languages are available, then the user gets
+English.
 
-See "Working with translations" in the project
-[README.md](../README.md#working-with-translations) for instructions on working
-with translations, such as adding new strings.
+The user sees different plan details based on their region. On the homepage there is a
+table comparing Relay premium plans. If a premium plan is available in their region,
+they see a price in their local currency. If a premium plan is not available, the user
+sees a prompt to join a waitlist. The FAQ also changes, to omit entries for plans that
+are unavailable in the user's region.
+
+When a user selects a sign-in button (in the page header, labeled "Sign Up" and "Sign
+In" in the English localization), they go to the Firefox Accounts website, and see
+content in their preferred language. If they enter a new email, they go through Firefox
+Account creation, and Firefox Accounts stores their preferred language on their profile.
+
+When a user receives a forwarded email, there is a header and footer surrounding the
+forwarded email content, translated into their preferred language, captured at Firefox
+Account creation.
+
+When a user selects a premium plan, they go to the Firefox Subscriptions website. The
+page appears in their preferred language, except for the product details, which are in
+the primary supported language for their region. The price is in their region's
+currency.
+
+When a user installs the Relay Add-On, the content is also in their preferred language,
+and reflects the Relay premium plan availability in their region.
+
+## Development Workflows
+
+See "Working with translations" in the project [README.md][readme-wwt] for basic
+instructions on working with translations, such as adding new strings.
+
+[readme-wwt]: ../README.md#working-with-translations
+
+### Loading Translations
+
+The translations are in a separate repository, and included as a
+[submodule][git-submodules].
+
+When cloning a repo, you can also fetch the translations:
+
+```sh
+git clone --recurse-submodules https://github.com/mozilla/fx-private-relay.git
+```
+
+If you didn't use `--recurse-submodules` when cloning, you can setup up translations
+with:
+
+```sh
+git submodule init
+git submodule update
+```
+
+When checking out a branch, `git status` may show `privaterelay/locales` has changed,
+when it is just synced with the branch. To sync the translations with the branch, you
+can run `git submodule update --remote`. To automatically sync the translations
+submodule when switching branches, set the configuration:
+
+```sh
+git config --global submodule.recurse true
+
+```
+
+[git-submodules]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
+
+### Rebasing a Branch
+
+When rebasing a branch to pick up changes from `main`, you may see
+`privaterelay/locales` in the "Changes not staged for commit". **Do not add this
+directory**, as it may revert translations to an earlier version.
+
+If you already added it to "Changes to be committed" (also known as the staging area),
+for example with `git add -u`, you can remove it with:
+
+```sh
+git restore --staged privaterelay/locales
+```
+
+To remove it from the changed files, you can run _one of_:
+
+```sh
+git submodule update --remote
+git restore privaterelay/locales
+git checkout -- privaterelay/locales/
+```
+
+### Reverting a Translation Commit
+
+If you accidentally commit an update to `privaterelay/locales`, you can remove it with
+`git rebase`. This is a powerful tool that requires deeper understanding of `git`. See
+[About Git][gh-git] for a tutorial, and
+[On undoing, fixing, or removing commits in git][sr-fixup] for a guided experience.
+
+1. Run `git rebase origin/main`, and take care of any conflicts.
+2. Find the commit that changed locals with `git log -- privaterelay/locales`.
+3. Start an interactive rebase with `git rebase -i origin/main`. A rebase plan will open
+   in your editor.
+4. Edit the commit line, changing from `pick` to `edit`. Save the rebase plan and exit
+   the editor to start the rebase.
+5. When rebasing gets to the target the commit, run `git checkout head~1 --
+privaterelay/locales` to get the submodule version _before_ your change and
+   automatically stage it (put it into "Changes to be committed").
+6. Run `git rebase --continue` to continue the rebase.
+
+If the only change in the commit was updating the submodule, you'll now have an empty
+commit. You can remove it with another interactive rebase by removing the commit line
+(which `git` will annotate with a `# empty` suffix).
+
+[gh-git]: https://docs.github.com/en/get-started/using-git/about-git
+[sr-fixup]: https://sethrobertson.github.io/GitFixUm/fixup.html
+
+### Nightly Translation Updates
+
+A GitHub action ["Fetch latest strings from the l10n repo"][ga-l10n] runs at midnight
+UTC and updates the `privaterelay/locales` submodule to the latest commit. The commit
+message is "Merge in latest l10n strings". If there are no translation updates, then
+there will be no commit, but the action will still finish successfully.
+
+The action uses a Personal Access Token (PAT), required to create the commit. If the
+nightly update fails, check that the PAT is still valid, and regenerate as needed.
+
+[ga-l10n]: https://github.com/mozilla/fx-private-relay/actions/workflows/l10n-sync.yml
+
+### Adding New Translatable Strings During Development
+
+If this is your first time working with translations, read the [Fluent Syntax
+Guide][fl-syntax] while looking at some Relay `.ftl` files. This guide documents the
+syntax and promotes specific usage, such as:
+
+- [Variables][fl-syntax-variables] for strings with inserted values
+- [References][fl-syntax-references] for using strings like product names inside other strings
+- [Selectors][fl-syntax-selectors] for strings that include a number or count
+
+The document [Good Practices for Developers][good-practice] has useful tips for writing
+strings, such as:
+
+- Write Everything Twice
+- Prefer separate messages over variants for UI logic
+
+Use pending translations when developing new content or updating content for Relay. The
+product manager and other reviewers can make tweaks to the content during acceptance,
+without throwing away translator work or requiring ID updates. The pending translations
+for the frontend are in [frontend/pendingTranslations.ftl][], and the pending
+translations for the backend are in [privaterelay/pending_locales/en/pending.ftl][].
+
+When updating content, add a digit to the string ID to help make it clear that this will
+replace another string. For example, `premium-promo-availability-warning-4` replaces
+`premium-promo-availability-warning-3`. Do not re-use IDs for new strings.
+
+[fl-syntax-references]: https://projectfluent.org/fluent/guide/references.html
+[fl-syntax-selectors]: https://projectfluent.org/fluent/guide/selectors.html
+[fl-syntax-variables]: https://projectfluent.org/fluent/guide/variables.html
+[fl-syntax]: https://projectfluent.org/fluent/guide/
+[frontend/pendingTranslations.ftl]: https://github.com/mozilla/fx-private-relay/blob/main/frontend/pendingTranslations.ftl
+[good-practice]: https://github.com/projectfluent/fluent/wiki/Good-Practices-for-Developers
+[privaterelay/pending_locales/en/pending.ftl]: https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/pending_locales/en/pending.ftl
+
+#### Translatable Strings with Embedded HTML
+
+Some Relay strings are more natural with embedded HTML, especially prose that links to
+other content. For Relay strings that include HTML, set the string to the complete
+sentence or UI element, and inject element attributes as variables. For example, if the
+rendered HTML is:
+
+```html
+<p class="relay-footnote">
+  To change your email preference, see
+  <a class="never-blue" href="https://relay.firefox.com/accounts/settings/">
+    Relay Settings
+  </a>
+</p>
+```
+
+The Fluent string would be something like:
+
+```text
+email-footer-pref-link =
+  To change your email preference, see
+  <a href="${ settings_url }" ${ link_attrs }>{ settings-headline }</a>
+```
+
+Translators can re-arrange the sentence as needed for their language, while avoiding
+mistranslating a URL or HTML attributes. The Pontoon UI helps translators with HTML
+strings, and Pontoon linters detect some translation issues such as malformed HTML and
+missing variables.
+
+The Django email template may look like:
+
+```html
+<p class="relay-footnote">
+  {% ftlmsg 'email-footer-pref-link'
+  settings_url=SITE_ORIGIN|add:'/accounts/settings/'
+  link_attrs='class="never-blue"' %}
+</p>
+```
+
+The frontend uses the `<Localized>` component for strings with embedded HTML. See the
+[profile-label-welcome-html][] code for details.
+
+[profile-label-welcome-html]: https://github.com/mozilla/fx-private-relay/blob/f5c5ebf568639810db45de1ebb69f2498600d58c/frontend/src/pages/accounts/profile.page.tsx#L285-L293
+
+### Submitting Pending Translations
+
+The `privaterelay/locales` directory is a checkout of the git repository
+[mozilla-l10n/fx-private-relay-i10n][]. To add new strings for translation,
+open a pull request against that repository.
+
+The `privaterelay/locales` checkout is an `https` checkout by default, requiring a
+GitHub password when pushing the branch. To switch to an `ssh` checkout and use your SSH
+key:
+
+```sh
+cd privaterelay/locales
+git remote set-url origin git@github.com:mozilla-l10n/fx-private-relay-l10n.git
+git remote set-url origin --push git@github.com:mozilla-l10n/fx-private-relay-l10n.git
+```
+
+To prepare translatable strings for a pull request, first checkout the main branch:
+
+```sh
+cd privaterelay/locales
+git fetch
+git checkout main
+```
+
+Copy translations from [frontend/pendingTranslations.ftl][] and / or
+[privaterelay/pending_locales/en/pending.ftl][] to the proper files in
+`private/locales/en/`. Do not change the translation files for other languages.
+
+When ready, create and push a branch:
+
+```sh
+cd privaterelay/locales
+git branch message-updates-yyymmdd
+git status
+git commit -u
+git push -u origin message-updates-yyymmdd
+```
+
+You can then visit [mozilla-l10n/fx-private-relay-i10n][] to create the pull request,
+and make changes locally for any code review feedback.
+
+After the l10n team merges the new strings, the next nightly translation update brings
+them into Relay's `main` branch. At that point, you should create a pull request to
+remove the redundant strings from `frontend/pendingTranslations.ftl` and
+`privaterelay/pending_locales/en/pending.ftl`.
+
+[mozilla-l10n/fx-private-relay-i10n]: https://github.com/mozilla-l10n/fx-private-relay-l10n
+
+### Expanding a Premium Plan
+
+Adding new regions to a premium plan is a cross-company effort, requiring help and
+support from the Subscription Platform, Quality Assurance, Legal, Localization, and
+Customer Support. This section describes the code changes for Relay.
+
+Premium plan expansion can take months. A Relay engineer should create a waffle flag for
+the expansion effort, so that engineers can incrementally ship expansion changes and
+staff can test expansion in production.
+
+The Relay product manager creates Stripe prices for each subscription term (such as
+monthly and yearly) for each new region, and gives the price IDs to the Relay engineer.
+The product manager works with the Localization team to pick the primary language for
+that region as well. Relay engineering does not need to know this choice, unless there
+are multiple prices distinguished by language for a single region.
+
+In September 2023, the product manager creates Stripe prices manually, and so we've only
+set them up for production. In development and stage, the active testing price is for
+the United States in English.
+
+The Relay engineer updates the data structures in [privaterelay/plans.py][]:
+
+1. New currencies in `CurrencyStr`
+2. New regions in `CountryStr`
+3. New prices details in `_STRIPE_PLAN_DATA`
+4. A new section in `_RELAY_PLANS`, such as `premium_expansion`, with the expanded
+   regions
+5. Update the relevant functions to take a boolean signalling the waffle flag is
+   on or off. See [PR #3745][pr-3745], which retired the 2023 expansion flag, for
+   details.
+
+Relay staff can turn on the waffle flag for themselves and others, and test the
+new content and purchase flows.
+
+> [!NOTE]
+> When testing account and purchase flows, change the browser language preference
+> (`intl.accept_languagues`) rather than use an extension, and use a Firefox Account
+> created with that language preference.
+>
+> This is because many language-switcher extensions are not allowed to run on Firefox
+> Accounts, and email forwarding processes use the `Accept-Language` header captured by
+> Firefox Account. See
+> [Identifying The User's Preferred Languages](#identifying-the-users-preferred-languages)
+> for more information.
+
+When the expansion ships to all users, a Relay engineer can cleanup the data
+structures:
+
+1. Merge the expanded section in `_RELAY_PLANS`, and re-sort
+2. Drop the expansion boolean, or add a comment for the unused variable, or leave
+   flexible code for future expansions.
+3. Remove other code and documentation references to the expansion waffle flag
+
+[privaterelay/plans.py]: https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/plans.py
+[pr-3745]: https://github.com/mozilla/fx-private-relay/pull/3745
+
+### Viewing Translation Errors
+
+The web server library [django-ftl][] logs when a translation is not available. The log
+message, sent to `stderr` with severity `ERROR` and name `django_ftl.message_errors`,
+looks like:
+
+> FTL exception for locale [es-mx], message 'relay-email-your-dashboard',
+> args {}: KeyError('relay-email-your-dashboard')"
+
+The report [FTL Errors in Relay Production][ftl-report] gathers and categorizes recent
+errors by "supported" (which means Relay has an assigned language team in Pontoon),
+locale, and key (string ID). A Relay engineer uses this report to detect issues with a
+particular team's translation files, or to find the top unsupported languages.
+
+The supported language list is manually added to the source query. A Relay engineer
+updates the query (called a "data source" in Looker) when new language teams take on the
+Relay projects.
+
+There are no error reports for the frontend website or the add-on. Relay engineers or QA
+catch issues in translated strings with manual testing.
+
+[django-ftl]: https://github.com/django-ftl/django-ftl
+[ftl-report]: https://lookerstudio.google.com/reporting/63983869-6199-43b8-acb5-52971ffdd023
+
+## The Technical Details of Translation
+
+Relay supports 26 languages (as of September 2023). This section details the
+technologies used to deploy those translations.
+
+> [!WARNING]
+> None of Relay's supported languages use [right-to-left scripts][].
+> The Relay engineers will need to spend significant effort to support one
+> of these languages, such as [Arabic][] or [Hebrew][].
+
+[Arabic]: https://en.wikipedia.org/wiki/Arabic
+[Hebrew]: https://en.wikipedia.org/wiki/Hebrew_language
+[right-to-left scripts]: https://en.wikipedia.org/wiki/Right-to-left_script
+
+### Identifying the User's Preferred Languages
+
+The browser communicates the user's preferred languages with an
+[`Accept-Language` header][accept-lang], sent with each web request. The default for
+Firefox downloaded in the US is "`en-US, en`", which specifies either English as spoken
+in the United States, or fallback to generic English.
+
+Most users do not change their language settings and keep the browser defaults. The
+[generic Firefox download page][ff-download] redirects the user to a download page that
+best matches their region and language, which includes a default language preference. A
+user can then change the `Accept-Language` header in `about:config`, key
+`intl.accept_languages`. The per-language default preferences are available in Pontoon
+in the [intl.properties][intl-props] group. Each localized version of Firefox should
+include "`en-US, en`" as fallback languages.
+
+Some browser extensions allow changing `Accept-Language`, but may be
+[disabled on some websites][quar-domain], such as Firefox Accounts, due to security
+concerns.
+
+[accept-lang]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
+[ff-download]: https://www.mozilla.org/firefox/new/
+[intl-props]: https://pontoon.mozilla.org/es-ES/firefox/toolkit/chrome/global/intl.properties/?string=81017
+[quar-domain]: https://support.mozilla.org/en-US/kb/quarantined-domains
+
+### Picking the Language
+
+Relay may not support the user's top preferred language, but picks the best match.
+Different contexts use different implementations:
+
+| Context            | Implementation       | `Accept-Language` source      | Content Scope  |
+| :----------------- | :------------------- | :---------------------------- | :------------- |
+| API and Web Server | [Django][dj-lang]    | Web Browser                   | Error messages |
+| Background Tasks   | [Django][dj-lang]    | Firefox Accounts (at sign-up) | Emails         |
+| Website            | [Fluent][flt-lang]   | Web Browser                   | Relay Website  |
+| Add-On             | [i18n API][ext-i18n] | Web Browser                   | Add-on         |
+
+Each of these starts at the first entry in `Accept-Language` and continues until it hits
+a match in the supported languages. If there are no supported languages, the code falls
+back to English (`"en"`).
+
+[dj-lang]: https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#how-django-discovers-language-preference
+[ext-i18n]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n
+[flt-lang]: https://github.com/projectfluent/fluent.js/tree/main/fluent-langneg
+
+### Managing Languages and Translations
+
+Mozilla uses [Pontoon][pontoon] to identify supported languages and coordinate
+translation work. [Volunteer translation teams][pt-teams] coordinate the translation
+work, set standards, and decide which projects to support. Teams identifiers are a
+language code (such as "`fr`" for [French][pt-fr], or `"scn"` for [Sicilian][pt-scn]),
+or a language-plus-region code (such as `"es-ES"` for
+[Spanish spoken in Spain][pt-es-ES], or `"ca-valencia"` for
+[Catalan spoken in the Valencian Community of Spain][pt-ca-valencia]).
+
+Some teams are active and quick to translate, such as the [French][pt-fr] and
+[German][pt-de] teams. Some teams volunteer to translate a project, such as
+[Interlingua][pt-ia-relay]. Other teams have few or no active members, such as
+[Luxembourgish][pt-lb], and focus their resources on a few projects. The Mozilla
+localization team (Slack channel `#l10n`) is familiar with team capacity, and helps
+decide if and when to expand a project to new languages, and reaches out to the
+language team leads.
+
+Language support varies among [Mozilla projects][pt-projs]. Some relevant projects, and
+the supported languages as of September 2023, include:
+
+- [Firefox Relay Website][pt-proj-relay] (26 languages)
+- [Firefox Relay Add-on][pt-proj-addon] (26 languages)
+- [Firefox Accounts][pt-proj-fxa] (78 languages)
+- [Mozilla.org][pt-proj-bedrock] (98 languages)
+- [SUMO][pt-proj-sumo] for [support.mozilla.org][sumo-relay] (87 languages)
+- [AMO Frontend][pt-proj-amo] for [addons.mozilla.org][amo-relay] (64 languages)
+
+Relay staff can check translation status on the Pontoon project sites. They may use
+the completeness of translated strings to decide to turn on a feature for a region.
+
+[amo-relay]: https://addons.mozilla.org/en-US/firefox/addon/private-relay/
+[pontoon]: https://pontoon.mozilla.org/
+[pt-ca-valencia]: https://pontoon.mozilla.org/ca-valencia/
+[pt-de]: https://pontoon.mozilla.org/de/
+[pt-es-ES]: https://pontoon.mozilla.org/es-ES/
+[pt-fr]: https://pontoon.mozilla.org/fr/
+[pt-ia-relay]: https://pontoon.mozilla.org/ia/firefox-relay-website/
+[pt-lb]: https://pontoon.mozilla.org/lb/
+[pt-proj-addon]: https://pontoon.mozilla.org/projects/firefox-relay-add-on/
+[pt-proj-amo]: https://pontoon.mozilla.org/projects/amo-frontend/
+[pt-proj-bedrock]: https://pontoon.mozilla.org/projects/mozillaorg/
+[pt-proj-fxa]: https://pontoon.mozilla.org/projects/firefox-accounts/
+[pt-proj-relay]: https://pontoon.mozilla.org/projects/firefox-relay-website/
+[pt-proj-sumo]: https://pontoon.mozilla.org/projects/sumo/
+[pt-projs]: https://pontoon.mozilla.org/projects/
+[pt-scn]: https://pontoon.mozilla.org/scn/
+[pt-teams]: https://pontoon.mozilla.org/teams/
+[sumo-relay]: https://support.mozilla.org/en-US/products/relay
+
+### Shipping Translations
+
+Pontoon syncs translations between its database and code repositories, most hosted in
+the [Mozilla Localization Team][mozilla-l10n] GitHub organization. The Pontoon project
+page has a link to the project repository. Some relevant repositories include:
+
+- [mozilla-l10n/fx-private-relay-i10n][] for the Firefox Relay Website
+- [mozilla-l10n/fx-private-relay-add-on-l10n][] for the Firefox Relay Add-on
+- [mozilla/fxa-content-server-l10n][] for Firefox Accounts, including subscription pages
+- [mozilla-l10n/www-l10n][] for mozilla.org
+- [mozilla-l10n/sumo-l10n][] for support.mozilla.org
+- [mozilla/addons-frontend][] for addons.mozilla.org
+
+Relay projects include the translations as [git submodules][git-submodules], such as
+[privaterelay/locales][]. A submodule references a specific commit in a separate repository.
+A [GitHub action][ga-l10n-sync] updates this commit reference nightly to get the
+latest translations from Pontoon. This strategy works better for Relay than other
+strategies, such as letting Pontoon write directly to the code repository, or
+periodically syncing translations.
+
+Translations for Relay, and many projects at Mozilla, use the [Fluent format][fluent].
+The ["en" bundle][relay-l10n-en] (American / generic English) has the source
+translations, split into functional areas, such as website pages. The other language
+bundles are translations of the `"en"` bundle, coordinated in Pontoon. The continuous
+integration process creates Docker images that include the Fluent files, both in the
+source form used by the [Django backend][ftl-bundles], and embedded into the website
+JavaScript.
+
+Relay developers create new translatable strings when updating the service. The website
+code uses [frontend/pendingTranslations.ftl][], and the backend code uses
+[privaterelay/pending_locales/en/pending.ftl][]. These strings change often during
+development. When the strings are in their final form, the developers moved them to the
+relevant Pontoon repository, via a pull request, for translation to the supported
+languages.
+
+[fluent]: https://projectfluent.org/
+[ftl-bundles]: https://github.com/mozilla/fx-private-relay/blob/main/privaterelay/ftl_bundles.py
+[ga-l10n-sync]: https://github.com/mozilla/fx-private-relay/actions/workflows/l10n-sync.yml
+[mozilla-l10n/fx-private-relay-add-on-l10n]: https://github.com/mozilla-l10n/fx-private-relay-add-on-l10n
+[mozilla-l10n/sumo-l10n]: https://github.com/mozilla-l10n/sumo-l10n
+[mozilla-l10n/www-l10n]: https://github.com/mozilla-l10n/www-l10n
+[mozilla-l10n]: https://github.com/mozilla-l10n
+[mozilla/addons-frontend]: https://github.com/mozilla/addons-frontend/locale
+[mozilla/fxa-content-server-l10n]: https://github.com/mozilla/fxa-content-server-l10n
+[privaterelay/locales]: https://github.com/mozilla/fx-private-relay/tree/main/privaterelay
+[relay-l10n-en]: https://github.com/mozilla-l10n/fx-private-relay-l10n/tree/main/en
+
+## The Technical Details of Region Selection
+
+Relay premium plans are not available world-wide, only in some regions. As of September
+2023, the premium email service is available in 34 regions, and the phone service in 2
+regions. This section details the technologies used to distinguish by region.
+
+### Identifying the User's Region
+
+In the stage and production deployments, the load balancer sets a `X-Client-Region`
+header that identifies the user's region, based on their IP address. There is no
+way for a user to override this region selection. A tester can use a [VPN][moz-vpn] to
+change their region.
+
+When the `X-Client-Region` header is not available, then the code falls back to the
+`Accept-Language` header to guess the user's region. The `X-Client-Region` header is not
+available in the development deployment or in local development, and may not be
+available in stage and production deployments for some IP addresses.
+
+The `Accept-Language` fallback looks for a language code with a regional variant, such
+as `es-MX` for Mexican Spanish, and uses that region. If the language code does not
+include a region, then the code guesses a probable region from a [lookup table][].
+The [Language-Territory Information][cldr-lti] from the Unicode
+[Common Locale Data Repository][cldr] (CLDR) [Supplemental Data][cldr-sup], which
+estimates of language speakers by region, provides the data for the lookup table.
+
+[cldr-lti]: https://www.unicode.org/cldr/charts/42/supplemental/language_territory_information.html
+[cldr-sup]: https://www.unicode.org/cldr/charts/42/supplemental/index.html
+[cldr]: https://cldr.unicode.org/
+[lookup table]: https://github.com/mozilla/fx-private-relay/blob/f5c5ebf568639810db45de1ebb69f2498600d58c/privaterelay/utils.py#L72-L216
+[moz-vpn]: https://www.mozilla.org/products/vpn
+
+### Identifying Available Plans and Prices
+
+The user's region determines what premium plans are available. The API sends this
+data from [/api/v1/runtime_data][], and the website adjusts content based on
+availability in the user's region.
+
+The subscription platform uses [Stripe][stripe]. A [Stripe product][stripe-product]
+represents each Relay plan, such as the premium email service.
+A [Stripe price][stripe-price] represents what a user will pay, and is a combination
+of plan / product, region(s), language, and the term (monthly or yearly). Many
+regions have their own price, such as Denmark, which uses the Danish language and the krone.
+Others share the price of a nearby region, such as Austria, which uses Germany's prices
+in German and Euros. A minority, such as Belgium and Switzerland, are more complex,
+choosing a price based on language. See [privaterelay/plans.py][] for details.
+
+The "price" includes a translation of the plan / products details, which is the main
+reason that language is a sometimes a factor in price selection. A user purchasing a
+Relay plan will see the product details in the "price" language, and the rest of the
+webpage in their browser preferred language, which could be the same or different.
+
+[/api/v1/runtime_data]: https://relay.firefox.com/api/v1/runtime_data
+[stripe-price]: https://stripe.com/docs/api/prices
+[stripe-product]: https://stripe.com/docs/api/products
+[stripe]: https://stripe.com
+
+## Terms
+
+Relay developers will see these terms as they work in this topic:
+
+- **Internationalization** - The design and engineering effort to make it
+  possible to adapt a service to various languages and regions with minimal or no
+  engineering changes. This is often abbreviated **i18n**, to stand for the starting
+  letter "i", the next 18 letters, and the ending letter "n". This abbreviation
+  also avoids the spelling differences between American and British English.
+- **Localization** - The process for adapting software to a specific locale,
+  including translating text and using locale-specific features. This is often
+  abbreviated **L10n**, in a similar way to i18n, but with a capital "L" since a
+  lowercase "l" might look like an uppercase "I".
+- **Locale** - A shared set of parameters, such as language, currency, number
+  date, and time formats shared by a group of users. The identifier for many locales is
+  the combination of a language code and a region code. An example is `"en-US"` to
+  specify English speakers in America, implying US Dollars (USD, "$5.99"), left-to-right
+  text, commas as thousands separators (525,960 minutes in a year), as well as the
+  default date and time formats ("9/12/2023" for September 12, 2023).
+- **Region** - An [administrative division][admin-div] that can be the basis for a
+  locale. Mozilla prefers to use "Region" instead of **Country**, as "Region" can
+  includes areas that useful for defining locales but may fall short of universal
+  recognition as a country.
+- **Language** - A spoken or written language. A language can have a simple
+  identifier, such as `"en"` for English; a regional variant, such as `"de-CH"` for
+  German spoken in Switzerland; or a more complex identifier, such as `"zh-CN-Hans"`,
+  for Chinese as spoken in mainland China with Simplified Chinese characters.
+- **Translation** - The process of adapting language strings or patterns to a
+  second language. This is one aspect of Localization.
+
+[admin-div]: https://en.wikipedia.org/wiki/Administrative_division
+
+## Standards for Identifiers
+
+There are internet standard identifiers for regions, languages, locales, and currency.
+In most cases, Mozilla uses the standard identifiers, but there are exceptions, mostly
+in legacy cases. Relay users should follow the standards, unless Mozilla has an
+established exception.
+
+- **Region** - [ISO 3166][] is a multi-part standard for identifying countries,
+  territories, and subdivisions. The [ISO 3166-1 alpha-2][] code (two uppercase
+  letters) is widely used as region identifiers.
+  - Mozilla uses the ISO 3166-1 alpha-2 code for a region when available. Some
+    exceptions are [Valencia][], which uses `"valencia"`, and the [Surselva Region][],
+    which uses `"sursilv"`.
+- **Language** - [ISO 639][] is a multi-part standard for identifying languages.
+  Wikipedia has a [useful table][iso-639-1-list] of [ISO 639-1][] codes (two lowercase
+  letters), and the Library of Congress has a [table of languages][iso-639-2-list] that
+  lists the languages with an [ISO 639-2][] code (three lowercase letters) and their ISO
+  639-1 codes.
+  - Mozilla uses the ISO 639-1 two-letter code when available, falling back to the ISO
+    639-2 three-letter code (such as `"yue"` for [Cantonese][]).
+- **Locale** - Locales are usually identified by a language tag, a language identifier
+  plus extra identifiers as needed. [BCP 47][] collects two RFCs, [RFC 4647][],
+  "Matching of Language Tags", and [RFC 5646][], "Tags for Identifying Languages". RFC
+  5646 defines the format of these tags, used in the "Accept-Language" header
+  ([RFC 9110][]) by a web browser for the user's preferred language.
+  - Pontoon uses `"en"`, rather than `"en-US"`, for [English][] as written in the
+    [United States][]. Other English-speaking locales include the region, such as
+    `"en-GB"` for English as written in the [United Kingdom][].
+  - For most localizations, the default Firefox `Accept-Language` header ends in
+    the fallback languages "`en-US, en`" (see the [intl.properties][intl-props] group).
+  - Mozilla uses the identifiers
+    `"zh-CN"` for [Simplified Chinese as common in China][pt-zh-CN] and
+    `"zh-TW"` for [Traditional Chinese as common in Taiwan][pt-zh-TW].
+    [Most browsers][so-browsers], including [Firefox][pt-zh-CN-intl-prop],
+    follow this convention for the `Accept-Language` header.
+    Recent standards may instead emphasize the script (such as
+    `"zh-Hans"` for Han Simplified, or `"zh-Hans-CN"` to specify China, and
+    `"zh-Hant"` for Han Traditional, or `"zh-Hant-TW"` to specify Taiwan).
+  - [RFC 9110][] specifies "quality values", or "qvalues" to weight language
+    preferences, such as `"Accept-Language: en-US,en;q=0.5"`. In general,
+    browsers such as Firefox do not use qvalues, since they break some websites.
+    Instead, the order of languages is the order of preference.
+- **Currency** - [ISO 4217][] defines codes for currencies.
+  - The Subscription Platform and Relay use the upper-case,
+    three-letter codes, such as `"USD"` for United States dollars and `"EUR"` for
+    Euros.
+
+[BCP 47]: https://www.rfc-editor.org/info/bcp47
+[Cantonese]: https://en.wikipedia.org/wiki/Cantonese
+[English]: https://en.wikipedia.org/wiki/English_language
+[ISO 3166-1 alpha-2]: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+[ISO 3166]: https://en.wikipedia.org/wiki/ISO_3166
+[ISO 4217]: https://en.wikipedia.org/wiki/ISO_4217
+[ISO 639-1]: https://en.wikipedia.org/wiki/ISO_639-1
+[ISO 639-2]: https://en.wikipedia.org/wiki/ISO_639-2
+[ISO 639]: https://en.wikipedia.org/wiki/ISO_639
+[RFC 4647]: https://www.rfc-editor.org/rfc/rfc4647.html
+[RFC 5646]: https://www.rfc-editor.org/rfc/rfc5646.html
+[RFC 9110]: https://www.rfc-editor.org/rfc/rfc9110#field.accept-language
+[Surselva Region]: https://en.wikipedia.org/wiki/Surselva_Region
+[United Kingdom]: https://en.wikipedia.org/wiki/United_Kingdom
+[United States]: https://en.wikipedia.org/wiki/United_States
+[Valencia]: https://en.wikipedia.org/wiki/Valencia
+[iso-639-1-list]: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+[iso-639-2-list]: https://www.loc.gov/standards/iso639-2/php/English_list.php
+[pt-zh-CN-intl-prop]: https://pontoon.mozilla.org/zh-CN/firefox/toolkit/chrome/global/intl.properties/?string=81017
+[pt-zh-CN]: https://pontoon.mozilla.org/zh-CN/
+[pt-zh-TW]: https://pontoon.mozilla.org/zh-TW/
+[so-browsers]: https://stackoverflow.com/questions/69709824/what-is-the-typical-chinese-language-code-for-the-accept-language-header

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -679,7 +679,9 @@ Many Relay plans have monthly and yearly subscription terms. The VPN bundle only
 yearly subscription term.
 
 The Subscription Platform associates a price with a region. Product reports may use this
-to segment purchasers by region.
+to segment purchasers by region. Relay detects the user's region and determines what
+plans are available. Relay selects the relevant price ID when sending a user to the
+Subscription Platform. The Subscription Platform [does not confirm the user's region][].
 
 The Subscription Platform associates a price with a language. On the subscription page,
 product details appear in the price language. The rest of the subscription page appears
@@ -693,6 +695,12 @@ based on language. Belgium users share the price in Euros of a neighbor, based o
 language. Switzerland has separate prices for German, French, and Italian speakers.
 All the Swiss prices are in Swiss Francs. See [privaterelay/plans.py][] for details.
 
+The Subscription Platform supports certain [markets and currencies][]. The Subscription
+Platform has configured Stripe to reject payments from outside these markets.
+A Relay user's payment method, such as a credit card, has a payment region. The
+user region detected by Relay may differ from the user's payment region. Relay may say a
+user can buy a plan, and then Stripe may reject payment.
+
 In development and stage, there are test prices connected to the [Stripe test mode][].
 One feature of test mode is fake credit cards. These cards allow testing without paying
 real money, and testing failure modes. A test visitor from the United States will get
@@ -702,6 +710,8 @@ these prices. Other regions get the production prices.
 [Stripe product]: https://stripe.com/docs/api/products
 [Stripe test mode]: https://stripe.com/docs/test-mode
 [Subscription Platform]: https://mozilla.github.io/ecosystem-platform/relying-parties/reference/sub-plat-features
+[does not confirm the user's region]: https://mozilla.github.io/ecosystem-platform/relying-parties/reference/sub-plat-features#geo-restrictions
+[markets and currencies]: https://mozilla-hub.atlassian.net/wiki/spaces/FJT/pages/173539548/Supported+Markets+and+Currencies
 
 ## Terms
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -152,8 +152,8 @@ git checkout -- privaterelay/locales/
 
 If you commit an update to `privaterelay/locales`, you can remove it with `git rebase`.
 This is a powerful tool that requires deeper understanding of `git`. See [About Git][]
-for a tutorial, and [On undoing, fixing, or removing commits in git][] for a guided
-experience.
+for a tutorial. See [On undoing, fixing, or removing commits in git][] for a guided
+experience. See [Oh Shit, Git!?!] for an emotional experience.
 
 The process is:
 
@@ -175,6 +175,7 @@ In the rebase planner, `git` will annotate the line with an `# empty` suffix.
 
 [About Git]: https://docs.github.com/en/get-started/using-git/about-git
 [On undoing, fixing, or removing commits in git]: https://sethrobertson.github.io/GitFixUm/fixup.html
+[Oh Shit, Git!?!]: https://ohshitgit.com/
 
 ### Nightly Translation Updates
 


### PR DESCRIPTION
Rewrite the translations document, including lessons learned during the EU expansion effort, and creating a framework for future tips and tricks.

* Add "How a User Experiences Relay", to detail how language and region detection changes the user experience
* Add "Development Workflows" section, expand workflows
* Add "The Technical Details of Translation" section, expand content
* Add "The Technical Details of Region Selection", including the difference between stage and production
* Add "Terms" section
* Add "Standards for Identifiers" sections, documenting the changes in country identifiers to ISO 3116-1 alpha-2, and including notes where Mozilla deviates from the standards.
* Rewrite in active voice
* Switch to reference-style links to focus on prose