### PR TITLE
MPP-3381 - Fix issue with language not being pre-set on page load

### DIFF
--- a/frontend/src/components/waitlist/WaitlistPage.tsx
+++ b/frontend/src/components/waitlist/WaitlistPage.tsx
@@ -26,7 +26,7 @@ export const WaitlistPage = (props: Props) => {
     runtimeData.data?.PERIODICAL_PREMIUM_PLANS.country_code.toUpperCase() ??
     (currentLocale.split("-")[1]?.toUpperCase() as string | undefined);
   const [country, setCountry] = useState<string>();
-  const [locale, setLocale] = useState<string>('en');
+  const [locale, setLocale] = useState<string>("en");
   const usersData = useUsers();
   const [email, setEmail] = useState<string | undefined>(
     usersData.data?.[0]?.email,
@@ -42,13 +42,14 @@ export const WaitlistPage = (props: Props) => {
   }, [email, usersData]);
 
   useEffect(() => {
-    setLocale(props.supportedLocales.find(
-      (supportedLocale) =>
-        supportedLocale.toLowerCase() ===
-        currentLocale.split("-")[0].toLowerCase(),
-    ) ?? "en")
-  }, [currentLocale, props.supportedLocales])
-
+    setLocale(
+      props.supportedLocales.find(
+        (supportedLocale) =>
+          supportedLocale.toLowerCase() ===
+          currentLocale.split("-")[0].toLowerCase(),
+      ) ?? "en",
+    );
+  }, [currentLocale, props.supportedLocales]);
 
   const onSubmit: FormEventHandler = async (event) => {
     event.preventDefault();

--- a/frontend/src/components/waitlist/WaitlistPage.tsx
+++ b/frontend/src/components/waitlist/WaitlistPage.tsx
@@ -26,13 +26,7 @@ export const WaitlistPage = (props: Props) => {
     runtimeData.data?.PERIODICAL_PREMIUM_PLANS.country_code.toUpperCase() ??
     (currentLocale.split("-")[1]?.toUpperCase() as string | undefined);
   const [country, setCountry] = useState<string>();
-  const [locale, setLocale] = useState<string>(
-    props.supportedLocales.find(
-      (supportedLocale) =>
-        supportedLocale.toLowerCase() ===
-        currentLocale.split("-")[0].toLowerCase(),
-    ) ?? "en",
-  );
+  const [locale, setLocale] = useState<string>('en');
   const usersData = useUsers();
   const [email, setEmail] = useState<string | undefined>(
     usersData.data?.[0]?.email,
@@ -46,6 +40,15 @@ export const WaitlistPage = (props: Props) => {
       setEmail(usersData.data[0].email);
     }
   }, [email, usersData]);
+
+  useEffect(() => {
+    setLocale(props.supportedLocales.find(
+      (supportedLocale) =>
+        supportedLocale.toLowerCase() ===
+        currentLocale.split("-")[0].toLowerCase(),
+    ) ?? "en")
+  }, [currentLocale, props.supportedLocales])
+
 
   const onSubmit: FormEventHandler = async (event) => {
     event.preventDefault();


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3381 https://mozilla-hub.atlassian.net/browse/MPP-3381 
 

<!-- When adding a new feature: -->

# New feature description

The language field is NOT automatically populated with the browser specific language

# Screenshot (if applicable)
 
https://github.com/mozilla/fx-private-relay/assets/3924990/87febda8-c3c0-4ea5-b043-e3571d76d520
 
# How to test

**Prerequisites:**

- Do NOT be signed into any Relay account; 
- Have a VPN set to a non-Premium country (e.g. Turkey, Brazil, etc);
- Be on any of the Waitlist pages;\
- Have Browser language set to one of the following languages: - English, Japanese, Polish, Portuguese, Spanish; 

**Steps to reproduce:**

Click on the preferred language field;

Select any language from the list;

Change the browser's language to any of the listed languages and refresh the waitlist page;

**Expected result:**

The language field is automatically populated with the specific language;
 

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
