### PR TITLE
fix MPP-3437: handle and log ClientError during send_welcome_emails

### DIFF
--- a/emails/tests/mgmt_send_welcome_emails_tests.py
+++ b/emails/tests/mgmt_send_welcome_emails_tests.py
@@ -93,7 +93,7 @@ def client_error_on_invalid_email(*args, **kwargs):
 @pytest.mark.django_db
 def test_invalid_email_address_skips_invalid(
     mock_ses_client: MagicMock, caplog: pytest.LogCaptureFixture
-):
+) -> None:
     mock_ses_client.send_email.side_effect = client_error_on_invalid_email
     invalid_email_user = make_free_test_user("♩♪♫♬♭♮♯@±×÷√.com")
     invalid_email_user.profile.sent_welcome_email = False

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -35,8 +35,11 @@ from ..models import (
 )
 
 
-def make_free_test_user() -> User:
-    user = baker.make(User)
+def make_free_test_user(email: str = "") -> User:
+    if email:
+        user = baker.make(User, email=email)
+    else:
+        user = baker.make(User)
     user_profile = Profile.objects.get(user=user)
     user_profile.server_storage = True
     user_profile.save()


### PR DESCRIPTION
This PR fixes #MPP-3437.

How to test:
* [ ] Run `pytest`
Note: I couldn't find the exact invalid email address that caused the error in production. But the unit test here checks that the `send_welcome_emails` management command should:
1. Handle the resulting `ClientError`
2. Log it
3. Continue to send subsequent welcome emails

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).