### PR TITLE
MPP-3446 and MPP-3450 Labels Misalignment Fix

### DIFF
--- a/frontend/src/components/dashboard/aliases/MaskCard.module.scss
+++ b/frontend/src/components/dashboard/aliases/MaskCard.module.scss
@@ -90,10 +90,9 @@
         @media screen and (min-width: $content-lg) {
           max-width: 400px;
         }
-        @media screen and (min-width: calc($screen-lg + 120px)) {
-          max-width: calc(
-            $content-md - 100px
-          ); // Handles long custom domains, prevents going off page.
+        // Stops long mask domain from cutting into the "Block promotions label"
+        @media screen and (min-width: calc($content-xl)) {
+          max-width: calc($content-md - 100px);
         }
       }
 
@@ -151,7 +150,7 @@
     color: $color-grey-40;
     border-radius: $border-radius-sm;
     width: $layout-sm;
-    z-index: 999;
+    z-index: 3; // Ensures that the button gets placed above the copied label (needed for long custom domains at viewport width ~ 780px)
 
     @media (any-pointer: coarse) {
       width: $layout-md;

--- a/frontend/src/components/dashboard/aliases/MaskCard.module.scss
+++ b/frontend/src/components/dashboard/aliases/MaskCard.module.scss
@@ -48,10 +48,12 @@
     .copy-button-wrapper {
       display: flex;
       align-items: center;
-      position: relative;
 
       @media screen and #{$mq-md} {
         gap: $spacing-sm;
+      }
+      @media screen and (max-width: $screen-xs) {
+        overflow: hidden;
       }
     }
 
@@ -112,7 +114,7 @@
       @media screen and (max-width: $screen-md) {
         @include text-body-sm;
       }
-      @media screen and (max-width: 380px) {
+      @media screen and (max-width: $content-sm) {
         position: absolute;
         right: 0;
       }

--- a/frontend/src/components/dashboard/aliases/MaskCard.module.scss
+++ b/frontend/src/components/dashboard/aliases/MaskCard.module.scss
@@ -30,6 +30,7 @@
     display: flex;
     align-items: center;
     flex-wrap: wrap;
+    position: relative;
 
     @media screen and #{$mq-md} {
       gap: $spacing-sm;
@@ -47,7 +48,11 @@
     .copy-button-wrapper {
       display: flex;
       align-items: center;
-      gap: $spacing-sm;
+      position: relative;
+
+      @media screen and #{$mq-md} {
+        gap: $spacing-sm;
+      }
     }
 
     .copy-button {
@@ -83,7 +88,7 @@
         @media screen and (min-width: $content-lg) {
           max-width: 400px;
         }
-        @media screen and #{$mq-lg} {
+        @media screen and (min-width: calc($screen-lg + 120px)) {
           max-width: calc(
             $content-md - 100px
           ); // Handles long custom domains, prevents going off page.
@@ -102,14 +107,15 @@
       font-weight: 600;
       opacity: 1;
       pointer-events: none;
+      z-index: 2;
 
-      @media screen and (max-width: $screen-sm) {
+      @media screen and (max-width: $screen-md) {
         @include text-body-sm;
       }
       @media screen and (max-width: 380px) {
         // Magic number: 380px to avoid element going off screen.
         position: absolute;
-        right: $spacing-lg;
+        right: 0;
       }
 
       &[aria-hidden="true"] {
@@ -127,6 +133,8 @@
 
       @media screen and #{$mq-lg} {
         display: initial;
+        position: absolute;
+        right: 0;
       }
     }
   }
@@ -142,6 +150,7 @@
     color: $color-grey-40;
     border-radius: $border-radius-sm;
     width: $layout-sm;
+    z-index: 999;
 
     @media (any-pointer: coarse) {
       width: $layout-md;

--- a/frontend/src/components/dashboard/aliases/MaskCard.module.scss
+++ b/frontend/src/components/dashboard/aliases/MaskCard.module.scss
@@ -91,7 +91,7 @@
           max-width: 400px;
         }
         // Stops long mask domain from cutting into the "Block promotions label"
-        @media screen and (min-width: calc($content-xl)) {
+        @media screen and (min-width: $content-xl) {
           max-width: calc($content-md - 100px);
         }
       }

--- a/frontend/src/components/dashboard/aliases/MaskCard.module.scss
+++ b/frontend/src/components/dashboard/aliases/MaskCard.module.scss
@@ -107,13 +107,12 @@
       font-weight: 600;
       opacity: 1;
       pointer-events: none;
-      z-index: 2;
+      z-index: 2; // Places copied label above promotions label
 
       @media screen and (max-width: $screen-md) {
         @include text-body-sm;
       }
       @media screen and (max-width: 380px) {
-        // Magic number: 380px to avoid element going off screen.
         position: absolute;
         right: 0;
       }


### PR DESCRIPTION
This PR fixes MPP-3446 and MPP-3450.

# Bug description
The promotions label next to the relay mask can go off the page when the mask is long. This issue was caused by a fix I made for MPP-3380. 

Also, on mobile screens such as an iPhone 12, the copied label causes the page width to be smaller then the screen size.

Bug 1             |  Bug 2
:-------------------------:|:-------------------------:
![Untitled](https://github.com/mozilla/fx-private-relay/assets/59676643/28a21592-1f48-4c81-8b59-ca94a52afa0d)  |  ![Untitled](https://github.com/mozilla/fx-private-relay/assets/59676643/6a049d5c-e73d-45f0-af40-421646c6c61c)

# Screenshot of fix

Copied label will be placed above the correctly aligned promo label, and dissapears after a few seconds.
![image](https://github.com/mozilla/fx-private-relay/assets/59676643/129b1b00-c0be-4e5d-b709-1ddd4b1049a0)

Better positioning for copied label in mobile screens to avoid going off page.
![image](https://github.com/mozilla/fx-private-relay/assets/59676643/6a906a62-dfde-4880-ac2c-019986c5c6ae)

# How to test
1. Go to [Relay](https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net/accounts/profile/) dashboard and sign into a premium account
2. Click “Generate mask” and enter a long custom domain (60 chars)
3. Click on the block promotions checkbox, and generate the mask.
4. [Acceptance Criteria] Observe that the “Block promotions” label is aligned correctly.
5. Enter a mobile viewport via inspector (i.e iPhone 12 or others)
6. [Acceptance Criteria] Click copy on the relay mask, observe that the label does not go off the page.

# Checklist (Definition of Done)
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
