### PR TITLE
MPP-3407: Log SNS notification details

### DIFF
--- a/emails/utils.py
+++ b/emails/utils.py
@@ -362,6 +362,10 @@ def truncate(max_length: int, value: str) -> str:
     return Truncator(value).chars(max_length, truncate=ellipsis)
 
 
+class InvalidFromHeader(Exception):
+    pass
+
+
 def generate_from_header(original_from_address: str, relay_mask: str) -> str:
     """
     Return a From: header str using the original sender and a display name that
@@ -377,14 +381,7 @@ def generate_from_header(original_from_address: str, relay_mask: str) -> str:
         parsed_address = Address(addr_spec=original_address)
     except (InvalidHeaderDefect, IndexError) as e:
         # TODO: MPP-3407, MPP-3417 - Determine how to handle these
-        info_logger.error(
-            "generate_from_header",
-            extra={
-                "exception_type": type(e).__name__,
-                "original_from_address": original_from_address,
-            },
-        )
-        raise
+        raise InvalidFromHeader from e
 
     # Truncate the display name to 71 characters, so the sender portion fits on the
     # first line of a multi-line "From:" header, if it is ASCII. A utf-8 encoded header


### PR DESCRIPTION
After PR #3891 shipped, I had more data for MPP-3407. Two types of addresses caused `InvalidHeaderDefect`: 

* UTF-8 encoded addresses, like `=?utf-8?b?dGVzdEBleGFtcGxlLmNvbQ==?=` for `test@example.com`
* Unicode strings that do not appear to be email addresses, like `EÍlÍoÍnÍ`

and MPP-3417, `IndexError`, the `From` address is always an empty string.

I was unable to replicate these issues locally, because I couldn't get my mail providers to send emails with UTF-8 encoded headers, weird Unicode, or blank `From` addresses.

I am curious if this is a decoding error, or a double-encoding error, or something else. I'm logging the multiple ways the `From:` header can be encoded in the AWS SNS notification. I'm also "handling" the error by return a 503, so we should stop getting tracebacks in Sentry, just logs.

How to test:

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
