### PR TITLE
MPP-3381 - Change how we get user locale

### DIFF
--- a/frontend/src/components/waitlist/WaitlistPage.tsx
+++ b/frontend/src/components/waitlist/WaitlistPage.tsx
@@ -42,14 +42,19 @@ export const WaitlistPage = (props: Props) => {
   }, [email, usersData]);
 
   useEffect(() => {
-    setLocale(
-      props.supportedLocales.find(
-        (supportedLocale) =>
-          supportedLocale.toLowerCase() ===
-          currentLocale.split("-")[0].toLowerCase(),
-      ) ?? "en",
-    );
-  }, [currentLocale, props.supportedLocales]);
+    // Check if navigator and navigator.language are available
+    if (navigator && navigator.language) {
+      const userLanguage = navigator.language.toLowerCase();
+
+      // Find the supported locale that matches the user's language
+      const matchedLocale = props.supportedLocales.find(
+        (supportedLocale) => supportedLocale.toLowerCase() === userLanguage,
+      );
+
+      // Set the locale to the matched locale or fallback to "en" if not found
+      setLocale(matchedLocale || "en");
+    }
+  }, [props.supportedLocales]);
 
   const onSubmit: FormEventHandler = async (event) => {
     event.preventDefault();

--- a/frontend/src/components/waitlist/WaitlistPage.tsx
+++ b/frontend/src/components/waitlist/WaitlistPage.tsx
@@ -44,7 +44,7 @@ export const WaitlistPage = (props: Props) => {
   useEffect(() => {
     // Check if navigator and navigator.language are available
     if (navigator && navigator.language) {
-      const userLanguage = navigator.language.toLowerCase();
+      const userLanguage = navigator.language.split("-")[0].toLowerCase();
 
       // Find the supported locale that matches the user's language
       const matchedLocale = props.supportedLocales.find(


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3381 bug found after first review.

 
# New feature description

Fix for when the language field is NOT automatically populated with the browser specific language. 

This specific PR addresses issue with 'pl' not showing up when chosen as browser language. 

# Screenshot (if applicable)

Chrome: 

<img width="423" alt="image" src="https://github.com/mozilla/fx-private-relay/assets/3924990/88c50a1f-b1bb-4185-9124-594db772a0ab">
<img width="382" alt="image" src="https://github.com/mozilla/fx-private-relay/assets/3924990/c4088c0b-50e5-4a08-af3b-2a332da02d73">


FF: 

<img width="653" alt="image" src="https://github.com/mozilla/fx-private-relay/assets/3924990/473733d0-9346-4119-8a27-20f30d2e4e1f">
<img width="472" alt="image" src="https://github.com/mozilla/fx-private-relay/assets/3924990/66eb8e1b-f9e0-40e9-8b50-6f1f5db5e1a2">


## How to test
**Prerequisites:**

- Do NOT be signed into any Relay account;
- Have a VPN set to a non-Premium country (e.g. Turkey, Brazil, etc);
- Be on any of the Waitlist pages; 
- Have Browser language set to one of the following languages: - English, Japanese, Polish, Portuguese, Spanish;

**Steps to reproduce:**

Click on the preferred language field;

Select any language from the list;

Change the browser's language to any of the listed languages and refresh the waitlist page;

Expected result:

The language field is automatically populated with the specific language;

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
