### PR TITLE
fix MPP-3372: add default "US" region to phonenumbers.parse

### DIFF
--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -1280,6 +1280,8 @@ def multi_reply(
         ("+13025550001", "text"),  # Same last 4 digits as below
         ("+13035550001", "text"),  # Same last 4 digits as above
         ("+13045551301", "text"),  # Last 4 match first 4 of oldest
+        ("64192", "text"),  # shortcode
+        ("+15062345678", "text"),  # CA number
         ("+13055550002", "text"),  # Text from number
         ("+13055550002", "call"),  # Call from same number
         ("+14045550003", "call"),  # Most recent call, never texted

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -1137,7 +1137,8 @@ def _match_senders_by_prefix(
         contacts = InboundContact.objects.filter(relay_number=relay_number).all()
         contacts_by_number: dict[str, InboundContact] = {}
         for contact in contacts:
-            pn = phonenumbers.parse(contact.inbound_number)
+            # TODO: don't default to US when we support other regions
+            pn = phonenumbers.parse(contact.inbound_number, "US")
             e164 = phonenumbers.format_number(pn, phonenumbers.PhoneNumberFormat.E164)
             if e164 not in contacts_by_number:
                 contacts_by_number[e164] = contact


### PR DESCRIPTION
WIP until I finish writing the "hot to test" steps ...

This PR fixes #MPP-3372.

How to test:
Note: Probably easiest to push this branch to dev server, or set up [end-to-end local phone dev](https://github.com/mozilla/fx-private-relay/blob/main/docs/end-to-end-local-phone-dev.md). I spent a long time trying to find a site or app that sends messages from a shortcode AND accepts Twilio numbers, but I didn't find one. So, to test this, you'll have to add an `InboundContact` with a shortcode to your Relay number in dev server.

1. Set up a phone mask
2. Go to `/admin/` and sign in
3. Go to https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/admin/phones/inboundcontact/add/ 
   * Pick your dev server Relay number (you might need to `heroku pg:psql` to find it faster
   * Use 64192 as the inbound number
   * Make up the rest of the values however you like
4. Send a test message to your dev server Relay number
5. Reply to the message
   * [x] It should work!


- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).