### PR TITLE
MPP-3243 Rebrand Firefox Account in Firefox Relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 <img src="https://raw.githubusercontent.com/mozilla/fx-private-relay/11ad17e197e23a0453bfb74fa3670c87cfc35e36/frontend/src/components/landing/images/logo-firefox-relay.svg" width="250" />
 </p>
 
+
 # Private Relay
 
 <!-- Badges include: license, size of repository, overall coverage for project via coveralls.io on main branch, status of what is deployed via whatsdeployed.io and our circleci status for main branch. -->
-
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://raw.githubusercontent.com/mozilla/fx-private-relay/main/LICENSE)
 ![Repo Size](https://img.shields.io/github/repo-size/Mozilla/fx-private-relay)
 [![Coverage Status](https://coveralls.io/repos/github/mozilla/fx-private-relay/badge.svg?branch=main)](https://coveralls.io/github/mozilla/fx-private-relay?branch=main)
 [![What's Deployed](https://img.shields.io/badge/whatsdeployed-dev,stage,prod-green.svg)](https://whatsdeployed.io/s/60j/mozilla/fx-private-relay)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/mozilla/fx-private-relay/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/mozilla/fx-private-relay/tree/main)
+
 
 Private Relay provides generated email addresses to use in place of personal
 email addresses.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ To do so:
 
 6. [Go to the django-allauth social app admin
    page](http://127.0.0.1:8000/admin/socialaccount/socialapp/), sign in with the
-   superuser account you created above, and add a social app for Mozilla Accounts:
+   superuser account you created above, and add a social app for Firefox Accounts:
 
 | Field      | Value                                                   |
 | ---------- | ------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 
-# Private Relay
+# Private Relay 
 
 <!-- Badges include: license, size of repository, overall coverage for project via coveralls.io on main branch, status of what is deployed via whatsdeployed.io and our circleci status for main branch. -->
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://raw.githubusercontent.com/mozilla/fx-private-relay/main/LICENSE)
@@ -11,7 +11,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/mozilla/fx-private-relay/badge.svg?branch=main)](https://coveralls.io/github/mozilla/fx-private-relay?branch=main)
 [![What's Deployed](https://img.shields.io/badge/whatsdeployed-dev,stage,prod-green.svg)](https://whatsdeployed.io/s/60j/mozilla/fx-private-relay)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/mozilla/fx-private-relay/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/mozilla/fx-private-relay/tree/main)
-
+ 
 
 Private Relay provides generated email addresses to use in place of personal
 email addresses.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,15 @@
 <img src="https://raw.githubusercontent.com/mozilla/fx-private-relay/11ad17e197e23a0453bfb74fa3670c87cfc35e36/frontend/src/components/landing/images/logo-firefox-relay.svg" width="250" />
 </p>
 
-
-# Private Relay 
+# Private Relay
 
 <!-- Badges include: license, size of repository, overall coverage for project via coveralls.io on main branch, status of what is deployed via whatsdeployed.io and our circleci status for main branch. -->
+
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://raw.githubusercontent.com/mozilla/fx-private-relay/main/LICENSE)
 ![Repo Size](https://img.shields.io/github/repo-size/Mozilla/fx-private-relay)
 [![Coverage Status](https://coveralls.io/repos/github/mozilla/fx-private-relay/badge.svg?branch=main)](https://coveralls.io/github/mozilla/fx-private-relay?branch=main)
 [![What's Deployed](https://img.shields.io/badge/whatsdeployed-dev,stage,prod-green.svg)](https://whatsdeployed.io/s/60j/mozilla/fx-private-relay)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/mozilla/fx-private-relay/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/mozilla/fx-private-relay/tree/main)
- 
 
 Private Relay provides generated email addresses to use in place of personal
 email addresses.
@@ -30,7 +29,7 @@ them](https://www.facebook.com/business/help/606443329504150?helpref=faq_content
       - [Getting the latest translations](#getting-the-latest-translations)
       - [Add/update messages for translation](#addupdate-messages-for-translation)
       - [Commit translations for release](#commit-translations-for-release)
-    - [Recommended: Enable Firefox Accounts authentication](#recommended-enable-firefox-accounts-authentication)
+    - [Recommended: Enable Mozilla Accounts authentication](#recommended-enable-mozilla-accounts-authentication)
     - [Optional: Install and run the add-on locally](#optional-install-and-run-the-add-on-locally)
     - [Optional: Run a development server to compile the frontend](#optional-run-a-development-server-to-compile-the-frontend)
     - [Optional: Enable Premium Features](#optional-enable-premium-features)
@@ -39,6 +38,7 @@ them](https://www.facebook.com/business/help/606443329504150?helpref=faq_content
   - [Production Environments](#production-environments)
     - [Requirements](#requirements-1)
     - [Environment Variables](#environment-variables)
+
 ## Development
 
 Please refer to our [coding standards](docs/coding-standards.md) for code styles, naming conventions and other methodologies.
@@ -194,9 +194,9 @@ of the translations submodule:
 An automated process updates the submodule daily, bringing in any new changes
 and translations from the Localization Team.
 
-### Recommended: Enable Firefox Accounts authentication
+### Recommended: Enable Mozilla Accounts authentication
 
-To enable Firefox Accounts authentication on your local server, you can use the
+To enable Mozilla Accounts authentication on your local server, you can use the
 "Firefox Private Relay local dev" OAuth app on accounts.stage.mozaws.net.
 
 To do so:
@@ -222,11 +222,11 @@ To do so:
 
 6. [Go to the django-allauth social app admin
    page](http://127.0.0.1:8000/admin/socialaccount/socialapp/), sign in with the
-   superuser account you created above, and add a social app for Firefox Accounts:
+   superuser account you created above, and add a social app for Mozilla Accounts:
 
 | Field      | Value                                                   |
 | ---------- | ------------------------------------------------------- |
-| Provider   | Firefox Accounts                                        |
+| Provider   | Mozilla Accounts                                        |
 | Name       | `accounts.stage.mozaws.net`                             |
 | Client id  | `9ebfe2c2f9ea3c58`                                      |
 | Secret key | Request this from `#fx-private-relay-eng` Slack channel |
@@ -274,7 +274,7 @@ To enable the premium Relay features, we integrate with the [FXA Subscription
 Platform](https://mozilla.github.io/ecosystem-platform/relying-parties/reference/sub-plat-overview).
 At a high level, to set up Relay premium subscription, we:
 
-1. [Enable Firefox Accounts Authentication](#recommended-enable-firefox-accounts-authentication) as described above.
+1. [Enable Mozilla Accounts Authentication](#recommended-enable-firefox-accounts-authentication) as described above.
 
 2. Create a product & price in our [Stripe dashboard](https://dashboard.stripe.com/).
    (Ask in #subscription-platform Slack channel to get access to our Stripe dashboard.)
@@ -286,7 +286,7 @@ At a high level, to set up Relay premium subscription, we:
 
 In detail:
 
-1. [Enable Firefox Accounts Authentication](#recommended-enable-firefox-accounts-authentication) as described above.
+1. [Enable Mozilla Accounts Authentication](#recommended-enable-firefox-accounts-authentication) as described above.
 
 2. Go to our [Stripe dashboard](https://dashboard.stripe.com/).
    (Ask in #subscription-platform Slack channel to get access to our Stripe dashboard.)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ them](https://www.facebook.com/business/help/606443329504150?helpref=faq_content
   - [Production Environments](#production-environments)
     - [Requirements](#requirements-1)
     - [Environment Variables](#environment-variables)
-
 ## Development
 
 Please refer to our [coding standards](docs/coding-standards.md) for code styles, naming conventions and other methodologies.

--- a/docs/end-to-end-local-email-dev.md
+++ b/docs/end-to-end-local-email-dev.md
@@ -1,5 +1,4 @@
 # End-to-end Local Development
-
 Rather than operate SMTP directly, Relay uses AWS SES via HTTPS. So, a full
 local end-to-end setup works like this:
 
@@ -17,13 +16,12 @@ sequenceDiagram
 
 ## Requirements
 
-- Your own domain and the ability to publish MX and CNAME records to it
-- AWS account
-- (Suggested) [ngrok.io][ngrok] account
-- Enable Mozilla Accounts authentication (see README)
+* Your own domain and the ability to publish MX and CNAME records to it
+* AWS account
+* (Suggested) [ngrok.io][ngrok] account
+* Enable Mozilla Accounts authentication (see README)
 
 ## Overview
-
 At a high level, you will need to:
 
 1. Publish an MX record at your domain pointing to AWS SES
@@ -35,21 +33,20 @@ At a high level, you will need to:
 7. (Optional) [Convert to back-end processing](#convert-to-back-end-processing)
 
 ### Publish MX at your domain
-
-When a sending Mail Transfer Agents (MTA) delivers email to a domain, it
-queries that domain's DNS for an MX record. The MX record is the address of
-the SMTP server to which the sending MTA can connect. For Relay, that SMTP
+When a sending Mail Transfer Agents (MTA) delivers email to a domain, it 
+queries that domain's DNS for an MX record. The MX record is the address of 
+the SMTP server to which the sending MTA can connect. For Relay, that SMTP 
 server is AWS. So:
 
 1. Go to your domain's DNS and add a new MX record pointing to your AWS
    region. E.g.:
-   - Hostname: `*`
-   - Priority: 10
-   - Server: inbound-smtp.us-east-1.amazonaws.com
-   - TTL: 15
+   * Hostname: `*`
+   * Priority: 10
+   * Server: inbound-smtp.us-east-1.amazonaws.com
+   * TTL: 15
+
 
 ### Set up your AWS SES to send emails TO your app via HTTPS
-
 Since AWS will accept SMTP traffic from MTAs sending email to your domain,
 you will need to verify your domain ownership for AWS. Then, configure
 SES to send all inbound email to your app (via SNS HTTPS subscription). A
@@ -57,7 +54,6 @@ helpful tool for this is [ngrok][ngrok], which can proxy a public domain to
 your 127.0.0.1 server.
 
 #### Verify your domain ownership
-
 AWS needs to verify you own the domain before it will send its email to you.
 
 1. [Create a new domain identity][create-new-identity] in your SES "Verified
@@ -67,7 +63,6 @@ AWS needs to verify you own the domain before it will send its email to you.
    SES generated for you.
 
 #### (Suggested) Use ngrok to make your local server available
-
 When SES sends email thru an SNS HTTPS subscription, it is helpful to have a
 permanent public domain that proxies your local server. [ngrok](ngrok) is a
 handy tool for this.
@@ -88,18 +83,17 @@ Forwarding      https://myrelay.ngrok.io -> 127.0.0.1:8000
 
 Add the ngrok.io domain to the allowed hosts:
 
-- `DJANGO_ALLOWED_HOST=127.0.0.1,myrelay.ngrok.io`
+* `DJANGO_ALLOWED_HOST=127.0.0.1,myrelay.ngrok.io`
 
 In a different console, run the development server. Ensure:
 
-- The destination host works, such as http://127.0.0.1:8000
-- The ngrok.io hostname works, such as https://myrelay.ngrok.io
+* The destination host works, such as http://127.0.0.1:8000
+* The ngrok.io hostname works, such as https://myrelay.ngrok.io
 
 Mozilla Accounts authentication doesn't work with multiple domains. Most
 developers will continue to log in with FxA at http://127.0.0.1:8000
 
 #### Create SNS topic subscription that sends HTTPS POSTs to your local server
-
 To confirm an SNS HTTPS topic subscription, you need to receive and visit a
 confirmation link from AWS. But Relay also checks HTTPS POSTs are for the
 proper Topic ARN, so you need to do these steps in this order:
@@ -113,7 +107,6 @@ proper Topic ARN, so you need to do these steps in this order:
    url.
 
 #### Configure SES to send email to your SNS topic
-
 1. In your [SES Email Receiving][ses-email-receiving] panel, create a new rule
    set.
 2. In that rule set, create a rule "ses-all-inbound-to-sns"
@@ -122,45 +115,45 @@ proper Topic ARN, so you need to do these steps in this order:
 4. In [SES Email Receiving][ses-email-receiving], ensure the rule
    "ses-all-inbound-to-sns" is Active.
 
-### Configure your app to accept emails addressed to your domain
 
+### Configure your app to accept emails addressed to your domain
 Django and our Relay code have checks to make sure the HTTPS POSTs are for the
 right domain. So, you'll need to set some environment variable values:
 
-- `MOZMAIL_DOMAIN=yourdomain.com`
-- `RELAY_FROM_ADDRESS=relay@yourdomain.com`
+* `MOZMAIL_DOMAIN=yourdomain.com`
+* `RELAY_FROM_ADDRESS=relay@yourdomain.com`
 
 Note again: These are NOT your ngrok.io domain.
 
 ### Set up your AWS SES to send emails FROM your app
-
 The last part of Relay is sending emails FROM the Relay app to the real email
 addresses of the owners of Relay aliases. You will need to create an AWS SES
 Configuration set for your local Relay server. And, while in SES "sandbox"
 mode, you need to add one of your own email addresses as a verified identity.
 
 1. [Create an SES configuration set][create-ses-config].
-   - (All defaults are fine)
+   * (All defaults are fine)
 2. Set the AWS env vars:
-   - `AWS_SES_CONFIGSET`
-   - `AWS_REGION`
-   - `AWS_ACCESS_KEY_ID` _Must be set in the environment, not just in .env_
-   - `AWS_SECRET_ACCESS_KEY` _Also must be set in the environment_
-3. [Create a new verified identity][create-new-identity] email address.
-   - AWS will send you a confirmation link to the address.
-4. Register a local Relay user with this email address.
-5. Create an alias with this Relay user.
+   * `AWS_SES_CONFIGSET`
+   * `AWS_REGION`
+   * `AWS_ACCESS_KEY_ID` *Must be set in the environment, not just in .env*
+   * `AWS_SECRET_ACCESS_KEY` *Also must be set in the environment*
+2. [Create a new verified identity][create-new-identity] email address.
+   * AWS will send you a confirmation link to the address.
+3. Register a local Relay user with this email address.
+4. Create an alias with this Relay user.
 
 ### Send a test email
 
 1. Run your local Relay server and ngrok:
-   - `python manage.py runserver 127.0.0.1:8000`
-   - `ngrok http -subdomain=myrelay 127.0.0.1:8000`
+   * `python manage.py runserver 127.0.0.1:8000`
+   * `ngrok http -subdomain=myrelay 127.0.0.1:8000`
 2. Go to your favorite email address and send an email to the Relay alias you
    generated above.
 3. You should see a POST to `/emails/sns-inbound` in your `runserver` process!
 4. You should see the test email in the Inbox of the final destination/recipient of the alias!
-   - Note: the final destination/recipient address for the alias must be in your SES "verified identities" for SES to actually send it emails.
+   * Note: the final destination/recipient address for the alias must be in your SES "verified identities" for SES to actually send it emails. 
+
 
 [create-new-identity]: https://console.aws.amazon.com/ses/home?region=us-east-1#/verified-identities/create
 [ses-email-receiving]: https://console.aws.amazon.com/ses/home?region=us-east-1#/email-receiving
@@ -168,6 +161,7 @@ mode, you need to add one of your own email addresses as a verified identity.
 [ngrok-custom-subdomain]: https://ngrok.com/docs#http-subdomain
 [sns-topic-panel]: https://console.aws.amazon.com/sns/v3/home?region=us-east-1#/topics
 [create-ses-config]: https://console.aws.amazon.com/ses/home?region=us-east-1#/configuration-sets/create
+
 
 ## <a name="convert-to-store-in-s3"></a> (Optional) Convert to store in S3
 
@@ -188,30 +182,30 @@ The steps to setup S3 transfer:
 By adding the encryption key first, the AWS console will be able to add
 permissions as we use it.
 
-- Load the [Customer managed keys][customer-managed-keys] page, and select "Create Key"
-  - Step 1: Configure key
-    - Key type: Symmetric
-    - Advanced options: defaults are OK:
-      - Key material origin: KMS
-      - Regionality: Single-Region key
-    - Click "Next"
-  - Step 2: Add labels
-    - Alias: RelayKey or similar
-    - Description: This key is used to encrypt incoming SES messages processed by SNS, SQS, and S3.
-    - Tags: _None_
-    - Click "Next"
-  - Step 3: Define key administrative permissions
-    - Key administrators: Add your login user, if applicable
-    - Key deletion: Select Allow key administrators to delete this key (default)
-    - Click "Next"
-  - Step 4: Define key usage permissions
-    - This account: Add the app key user, if applicable
-    - Other AWS accounts: _None_
-  - Step 5: Review
-    - Add the statement below to the key policy
-    - Click "Finish"
+* Load the [Customer managed keys][customer-managed-keys] page, and select "Create Key"
+    * Step 1: Configure key
+        * Key type: Symmetric
+        * Advanced options: defaults are OK:
+            - Key material origin: KMS
+            - Regionality: Single-Region key
+        * Click "Next"
+    * Step 2: Add labels
+        * Alias: RelayKey or similar
+        * Description: This key is used to encrypt incoming SES messages processed by SNS, SQS, and S3.
+        * Tags: *None*
+        * Click "Next"
+    * Step 3: Define key administrative permissions
+        * Key administrators: Add your login user, if applicable
+        * Key deletion: Select Allow key administrators to delete this key (default)
+        * Click "Next"
+    * Step 4: Define key usage permissions
+        * This account: Add the app key user, if applicable
+        * Other AWS accounts: *None*
+    * Step 5: Review
+        * Add the statement below to the key policy
+        * Click "Finish"
 
-This Key Policy statement (change `111122223333` to your account number)
+This Key Policy statement (change ``111122223333`` to your account number)
 allows SES to access the key. Add it to key policy with the other statements:
 
 ```json
@@ -219,13 +213,17 @@ allows SES to access the key. Add it to key policy with the other statements:
   "Sid": "AllowSESToEncryptMessagesBelongingToThisAccount",
   "Effect": "Allow",
   "Principal": {
-    "Service": "ses.amazonaws.com"
+    "Service":"ses.amazonaws.com"
   },
-  "Action": ["kms:GenerateDataKey*", "kms:Encrypt", "kms:Decrypt"],
+  "Action": [
+    "kms:GenerateDataKey*",
+    "kms:Encrypt",
+    "kms:Decrypt"
+  ],
   "Resource": "*",
-  "Condition": {
-    "StringEquals": {
-      "AWS:SourceAccount": "111122223333"
+  "Condition":{
+    "StringEquals":{
+      "AWS:SourceAccount":"111122223333"
     },
     "StringLike": {
       "AWS:SourceArn": "arn:aws:ses:*"
@@ -239,20 +237,20 @@ allows SES to access the key. Add it to key policy with the other statements:
 ### Convert AWS SES to store emails in a new S3 bucket
 
 1. Go to [SES Email Receiving][ses-email-receiving].
-2. Select the ruleset `ses-all-inbound-to-sns`
-3. Select the rule `ses-all-inbound-to-sns`
+2. Select the ruleset ``ses-all-inbound-to-sns``
+3. Select the rule ``ses-all-inbound-to-sns``
 4. Select the "Actions" tab, and the "Edit"
-   - Step 3: Add actions:
-     - Click "Remove" to remove "Publish to Amazon SNS topic"
-     - In "Add new action", select "Deliver to S3 bucket"
-     - S3 bucket: Select "Create S3 bucket", and select a name like "fxrelay-emails-myusername"
-     - Object key prefix: emails
-     - Message encryption: De-select Enable (default)
-     - SNS topic: Select your existing SNS topic
-     - Click Next
-   - Review:
-     - Step 3 now shows "S3Action" for Action type
-     - Click "Save changes"
+    - Step 3: Add actions:
+        * Click "Remove" to remove "Publish to Amazon SNS topic"
+        * In "Add new action", select "Deliver to S3 bucket"
+        * S3 bucket: Select "Create S3 bucket", and select a name like "fxrelay-emails-myusername"
+        * Object key prefix: emails
+        * Message encryption: De-select Enable (default)
+        * SNS topic: Select your existing SNS topic
+        * Click Next
+    - Review:
+        * Step 3 now shows "S3Action" for Action type
+        * Click "Save changes"
 
 ### Configure the new AWS S3 Bucket
 
@@ -263,58 +261,56 @@ contains a fake email saying that SES is delivering to this S3 bucket.
 
 These changes needed to line up with other deployments:
 
-- Properties - enable server-side encryption
-- Permissions - disabled public access
-- Management - delete after 3 days
+* Properties - enable server-side encryption
+* Permissions - disabled public access
+* Management - delete after 3 days
 
 [s3-buckets-page]: https://s3.console.aws.amazon.com/s3/buckets?region=us-east-1
 
 #### Update Properties - Enable encryption
-
 On the **Properties** tab:
 
-- In the "Default encryption" section, select "Edit":
-  - Server-side encryption: select Enable
-  - Encryption key type: AWS Key Management Service key (SSE-KMS)
-  - AWS KMS key: Choose from your AWS KMS keys, select the RelayKey
-  - Bucket Key: Enable
-  - Select "Save Changes"
+* In the "Default encryption" section, select "Edit":
+    - Server-side encryption: select Enable
+    - Encryption key type: AWS Key Management Service key (SSE-KMS)
+    - AWS KMS key: Choose from your AWS KMS keys, select the RelayKey
+    - Bucket Key: Enable
+    - Select "Save Changes"
 
 #### Update Permissions
 
 On the **Permissions** tab:
 
-- In the "Block public access (bucket settings), select "Edit":
-  - Select "Block _all_ public access"
-  - Select "Save Changes"
-  - Type "confirm" to confirm
+* In the "Block public access (bucket settings), select "Edit":
+    - Select "Block *all* public access"
+    - Select "Save Changes"
+    - Type "confirm" to confirm
 
 #### Update Management
 
 On the **Management** tab:
 
-- In the "Lifecycle rules" section (top), select "Create lifecycle rule"
-  - Lifecycle rule configuration
-    - Lifecycle rule name: `delete-expired`
-    - Choose a rule scope: Leave at "Limit the scope of this rule using one or more filters"
-    - Filter type - Prefix: `emails/`
-    - Leave with no tags, and no object size filters
-  - Lifecycle rule actions
-    - Select option 3, "Expire current versions of objects". For an
-      unversioned bucket, this deletes the object.
-  - Expire current versions of objects (this section appears after selecting the action)
-    - Days after object creation: 3
-  - Review transition and expiration actions (read-only, confirms settings)
-    - Current version actions:
-      - Day 0: Objects uploaded
-      - Day 3: Objects expire
-    - Noncurrent versions actions
-      - Day 0: No actions defined.
-  - Select "Create rule" to return to the Lifecycle Configuration details.
-  - Select the bucket name from the breadcrumbs to return to bucket details
+* In the "Lifecycle rules" section (top), select "Create lifecycle rule"
+    * Lifecycle rule configuration
+        * Lifecycle rule name: ``delete-expired``
+        * Choose a rule scope: Leave at "Limit the scope of this rule using one or more filters"
+        * Filter type - Prefix: ``emails/``
+        * Leave with no tags, and no object size filters
+    * Lifecycle rule actions
+        * Select option 3, "Expire current versions of objects". For an
+          unversioned bucket, this deletes the object.
+    * Expire current versions of objects (this section appears after selecting the action)
+        * Days after object creation: 3
+    * Review transition and expiration actions (read-only, confirms settings)
+        * Current version actions:
+            * Day 0: Objects uploaded
+            * Day 3: Objects expire
+        * Noncurrent versions actions
+            * Day 0: No actions defined.
+    * Select "Create rule" to return to the Lifecycle Configuration details.
+    * Select the bucket name from the breadcrumbs to return to bucket details
 
 ### Allow the app AWS user to manage the S3 bucket
-
 Starting at the [Identity and Access Management (IAM) Dashboard][iam-dashboard],
 add the full access policy to the AWS user that you use from the app:
 
@@ -330,9 +326,9 @@ GetObject
 DeleteObject
 ```
 
-You'll need the bucket permission (like `arn:aws:s3:::fxrelay-emails-myusername`)
-for `ListBucket`, and object permission (like
-`arn:aws:s3:::fxrelay-emails-myusername/*`) for `GetObject` and `DeleteObject`.
+You'll need the bucket permission (like ``arn:aws:s3:::fxrelay-emails-myusername``)
+for ``ListBucket``, and object permission (like
+``arn:aws:s3:::fxrelay-emails-myusername/*``) for ``GetObject`` and ``DeleteObject``.
 
 [iam-dashboard]: https://us-east-1.console.aws.amazon.com/iamv2/home#/home
 
@@ -341,13 +337,13 @@ for `ListBucket`, and object permission (like
 Same as before:
 
 1. Run your local Relay server and ngrok:
-   - `python manage.py runserver 127.0.0.1:8000`
-   - `ngrok http -subdomain=myrelay 127.0.0.1:8000`
+   * `python manage.py runserver 127.0.0.1:8000`
+   * `ngrok http -subdomain=myrelay 127.0.0.1:8000`
 2. Go to your favorite email address and send an email to the Relay alias you
    generated above.
 3. You should see a POST to `/emails/sns-inbound` in your `runserver` process!
 4. You should see the test email in the Inbox of the final destination/recipient of the alias!
-   - Note: the final destination/recipient address for the alias must be in your SES "verified identities" for SES to actually send it emails.
+   * Note: the final destination/recipient address for the alias must be in your SES "verified identities" for SES to actually send it emails. 
 
 One way to see the S3 object is to add a breakpoint to your local code,
 so that you can examine the object in the AWS console before it is deleted.
@@ -355,11 +351,12 @@ However, SNS will quickly try the request again, so be fast!
 
 ## <a name="convert-to-back-end-processing"></a> (Optional) Convert to back-end processing
 
-_Note: this change is not yet in production_
+*Note: this change is not yet in production*
 
 In Q2 2022, we are switching from handling email as a web request, POSTed via
 an SNS subscription, to a back-end process, pulling from a Simple Queue Service
 (SQS) queue.
+
 
 ```mermaid
 sequenceDiagram
@@ -374,43 +371,41 @@ sequenceDiagram
 
 To make this change:
 
-- (Optional) Add a dead-letter queue
-- Add an SQS queue
-- Enable the app user to read from the queue
-- Turn off the SNS push subscription
-- Subscribe to SNS topic
-- Run the email task
+* (Optional) Add a dead-letter queue
+* Add an SQS queue
+* Enable the app user to read from the queue
+* Turn off the SNS push subscription
+* Subscribe to SNS topic
+* Run the email task
 
 ### (Optional) Add a dead-letter queue
-
 In production, undeliverable SNS messages are sent to a dead-letter queue
 (DLQ). They can be undeliverable because the service is unavailable, or because
 the email is malformed, or processing is broken. An SQS queue can also have a
-dead-letter queue. If you have a SNS DLQ, you can use it for the SQS DLQ as
+dead-letter queue.  If you have a SNS DLQ, you can use it for the SQS DLQ as
 well. If not, you can create it.
 
 On the [SQS dashboard][sqs-dashboard], select "Create Queue":
 
-- Details
-  - Type: Standard
-  - Name: `fx-relay-emails-dlq`
-- Select "Create Queue" to accept other defaults.
+* Details
+    * Type: Standard
+    * Name: `fx-relay-emails-dlq`
+* Select "Create Queue" to accept other defaults.
 
 ### Add an SQS queue
 
 On the [SQS dashboard][sqs-dashboard], select "Create Queue":
 
-- Details
-  - Type: Standard
-  - Name: `fx-relay-emails`
-- Dead-letter queue - _Optional_ - If you created one in the previous step:
-  - Set this queue to receive undeliverable messages: Enabled
-  - Choose Queue: The ARN for `fx-relay-emails-dlq`
-  - Maximum receives: 3
-- Select "Create queue"
+* Details
+    * Type: Standard
+    * Name: `fx-relay-emails`
+* Dead-letter queue - *Optional* - If you created one in the previous step:
+    * Set this queue to receive undeliverable messages: Enabled
+    * Choose Queue: The ARN for `fx-relay-emails-dlq`
+    * Maximum receives: 3
+* Select "Create queue"
 
 ### Enable the app user to read from the queue
-
 Starting at the [Identity and Access Management (IAM) Dashboard][iam-dashboard],
 add the full access policy to the AWS user that you use from the app:
 
@@ -420,38 +415,38 @@ arn:aws:iam::aws:policy/AmazonSQSFullAccess
 
 or add the specific permissions needed by the app:
 
-- `sqs:ReceiveMessage` - Needed to read messages
-- `sqs:DeleteMessage` - Needed to removed messages
-- `sqs:ChangeMessageVisibility` - Needed to reserve a message when reading
-- `sqs:GetQueueAttributes` - Needed to get (approximate) queue sizes
+* ``sqs:ReceiveMessage`` - Needed to read messages
+* ``sqs:DeleteMessage`` - Needed to removed messages
+* ``sqs:ChangeMessageVisibility`` - Needed to reserve a message when reading
+* ``sqs:GetQueueAttributes`` - Needed to get (approximate) queue sizes
 
 ### Turn off the SNS push subscription
 
 On the [SNS Topics dashboard][sns-topic-panel]:
 
-- Select the relay topic
-- Select radio button to the left of the `/emails/sns-inbound` subscription
-- Select "Delete"
-- Confirm "Delete"
+* Select the relay topic
+* Select radio button to the left of the `/emails/sns-inbound` subscription
+* Select "Delete"
+* Confirm "Delete"
 
 ### Subscribe to SNS topic
 
 Back on the [SQS dashboard][sqs-dashboard], select the queue.
 In the "SNS Subscriptions" tab:
 
-- Select "Subscribe to Amazon SNS topic"
-- In the "Amazon SNS topic" panel, choose the relay topic
-- Select "Save"
+* Select "Subscribe to Amazon SNS topic"
+* In the "Amazon SNS topic" panel, choose the relay topic
+* Select "Save"
 
 ### Run the email task
 
 Set environment variables:
 
-- `AWS_ACCESS_KEY_ID`
-- `AWS_SECRET_ACCESS_KEY`
-- `AWS_SQS_EMAIL_QUEUE_URL`: The URL of the `fx-relay-emails` queue
-- `AWS_SQS_EMAIL_DLQ_URL`: The URL of the `fx-relay-emails-dlq` queue, if
-  configured, otherwise omit or set to an empty string (`""`)
+* `AWS_ACCESS_KEY_ID`
+* `AWS_SECRET_ACCESS_KEY`
+* `AWS_SQS_EMAIL_QUEUE_URL`: The URL of the `fx-relay-emails` queue
+* `AWS_SQS_EMAIL_DLQ_URL`: The URL of the `fx-relay-emails-dlq` queue, if
+  configured, otherwise omit or set to an empty string (``""``)
 
 These URLs can be found by starting at the [SQS dashboard][sqs-dashboard] and
 clicking on the queue name to view details.

--- a/docs/end-to-end-local-email-dev.md
+++ b/docs/end-to-end-local-email-dev.md
@@ -1,4 +1,5 @@
 # End-to-end Local Development
+
 Rather than operate SMTP directly, Relay uses AWS SES via HTTPS. So, a full
 local end-to-end setup works like this:
 
@@ -16,12 +17,13 @@ sequenceDiagram
 
 ## Requirements
 
-* Your own domain and the ability to publish MX and CNAME records to it
-* AWS account
-* (Suggested) [ngrok.io][ngrok] account
-* Enable Firefox Accounts authentication (see README)
+- Your own domain and the ability to publish MX and CNAME records to it
+- AWS account
+- (Suggested) [ngrok.io][ngrok] account
+- Enable Mozilla Accounts authentication (see README)
 
 ## Overview
+
 At a high level, you will need to:
 
 1. Publish an MX record at your domain pointing to AWS SES
@@ -33,20 +35,21 @@ At a high level, you will need to:
 7. (Optional) [Convert to back-end processing](#convert-to-back-end-processing)
 
 ### Publish MX at your domain
-When a sending Mail Transfer Agents (MTA) delivers email to a domain, it 
-queries that domain's DNS for an MX record. The MX record is the address of 
-the SMTP server to which the sending MTA can connect. For Relay, that SMTP 
+
+When a sending Mail Transfer Agents (MTA) delivers email to a domain, it
+queries that domain's DNS for an MX record. The MX record is the address of
+the SMTP server to which the sending MTA can connect. For Relay, that SMTP
 server is AWS. So:
 
 1. Go to your domain's DNS and add a new MX record pointing to your AWS
    region. E.g.:
-   * Hostname: `*`
-   * Priority: 10
-   * Server: inbound-smtp.us-east-1.amazonaws.com
-   * TTL: 15
-
+   - Hostname: `*`
+   - Priority: 10
+   - Server: inbound-smtp.us-east-1.amazonaws.com
+   - TTL: 15
 
 ### Set up your AWS SES to send emails TO your app via HTTPS
+
 Since AWS will accept SMTP traffic from MTAs sending email to your domain,
 you will need to verify your domain ownership for AWS. Then, configure
 SES to send all inbound email to your app (via SNS HTTPS subscription). A
@@ -54,6 +57,7 @@ helpful tool for this is [ngrok][ngrok], which can proxy a public domain to
 your 127.0.0.1 server.
 
 #### Verify your domain ownership
+
 AWS needs to verify you own the domain before it will send its email to you.
 
 1. [Create a new domain identity][create-new-identity] in your SES "Verified
@@ -63,6 +67,7 @@ AWS needs to verify you own the domain before it will send its email to you.
    SES generated for you.
 
 #### (Suggested) Use ngrok to make your local server available
+
 When SES sends email thru an SNS HTTPS subscription, it is helpful to have a
 permanent public domain that proxies your local server. [ngrok](ngrok) is a
 handy tool for this.
@@ -83,17 +88,18 @@ Forwarding      https://myrelay.ngrok.io -> 127.0.0.1:8000
 
 Add the ngrok.io domain to the allowed hosts:
 
-* `DJANGO_ALLOWED_HOST=127.0.0.1,myrelay.ngrok.io`
+- `DJANGO_ALLOWED_HOST=127.0.0.1,myrelay.ngrok.io`
 
 In a different console, run the development server. Ensure:
 
-* The destination host works, such as http://127.0.0.1:8000
-* The ngrok.io hostname works, such as https://myrelay.ngrok.io
+- The destination host works, such as http://127.0.0.1:8000
+- The ngrok.io hostname works, such as https://myrelay.ngrok.io
 
-Firefox Accounts authentication doesn't work with multiple domains. Most
+Mozilla Accounts authentication doesn't work with multiple domains. Most
 developers will continue to log in with FxA at http://127.0.0.1:8000
 
 #### Create SNS topic subscription that sends HTTPS POSTs to your local server
+
 To confirm an SNS HTTPS topic subscription, you need to receive and visit a
 confirmation link from AWS. But Relay also checks HTTPS POSTs are for the
 proper Topic ARN, so you need to do these steps in this order:
@@ -107,6 +113,7 @@ proper Topic ARN, so you need to do these steps in this order:
    url.
 
 #### Configure SES to send email to your SNS topic
+
 1. In your [SES Email Receiving][ses-email-receiving] panel, create a new rule
    set.
 2. In that rule set, create a rule "ses-all-inbound-to-sns"
@@ -115,45 +122,45 @@ proper Topic ARN, so you need to do these steps in this order:
 4. In [SES Email Receiving][ses-email-receiving], ensure the rule
    "ses-all-inbound-to-sns" is Active.
 
-
 ### Configure your app to accept emails addressed to your domain
+
 Django and our Relay code have checks to make sure the HTTPS POSTs are for the
 right domain. So, you'll need to set some environment variable values:
 
-* `MOZMAIL_DOMAIN=yourdomain.com`
-* `RELAY_FROM_ADDRESS=relay@yourdomain.com`
+- `MOZMAIL_DOMAIN=yourdomain.com`
+- `RELAY_FROM_ADDRESS=relay@yourdomain.com`
 
 Note again: These are NOT your ngrok.io domain.
 
 ### Set up your AWS SES to send emails FROM your app
+
 The last part of Relay is sending emails FROM the Relay app to the real email
 addresses of the owners of Relay aliases. You will need to create an AWS SES
 Configuration set for your local Relay server. And, while in SES "sandbox"
 mode, you need to add one of your own email addresses as a verified identity.
 
 1. [Create an SES configuration set][create-ses-config].
-   * (All defaults are fine)
+   - (All defaults are fine)
 2. Set the AWS env vars:
-   * `AWS_SES_CONFIGSET`
-   * `AWS_REGION`
-   * `AWS_ACCESS_KEY_ID` *Must be set in the environment, not just in .env*
-   * `AWS_SECRET_ACCESS_KEY` *Also must be set in the environment*
-2. [Create a new verified identity][create-new-identity] email address.
-   * AWS will send you a confirmation link to the address.
-3. Register a local Relay user with this email address.
-4. Create an alias with this Relay user.
+   - `AWS_SES_CONFIGSET`
+   - `AWS_REGION`
+   - `AWS_ACCESS_KEY_ID` _Must be set in the environment, not just in .env_
+   - `AWS_SECRET_ACCESS_KEY` _Also must be set in the environment_
+3. [Create a new verified identity][create-new-identity] email address.
+   - AWS will send you a confirmation link to the address.
+4. Register a local Relay user with this email address.
+5. Create an alias with this Relay user.
 
 ### Send a test email
 
 1. Run your local Relay server and ngrok:
-   * `python manage.py runserver 127.0.0.1:8000`
-   * `ngrok http -subdomain=myrelay 127.0.0.1:8000`
+   - `python manage.py runserver 127.0.0.1:8000`
+   - `ngrok http -subdomain=myrelay 127.0.0.1:8000`
 2. Go to your favorite email address and send an email to the Relay alias you
    generated above.
 3. You should see a POST to `/emails/sns-inbound` in your `runserver` process!
 4. You should see the test email in the Inbox of the final destination/recipient of the alias!
-   * Note: the final destination/recipient address for the alias must be in your SES "verified identities" for SES to actually send it emails. 
-
+   - Note: the final destination/recipient address for the alias must be in your SES "verified identities" for SES to actually send it emails.
 
 [create-new-identity]: https://console.aws.amazon.com/ses/home?region=us-east-1#/verified-identities/create
 [ses-email-receiving]: https://console.aws.amazon.com/ses/home?region=us-east-1#/email-receiving
@@ -161,7 +168,6 @@ mode, you need to add one of your own email addresses as a verified identity.
 [ngrok-custom-subdomain]: https://ngrok.com/docs#http-subdomain
 [sns-topic-panel]: https://console.aws.amazon.com/sns/v3/home?region=us-east-1#/topics
 [create-ses-config]: https://console.aws.amazon.com/ses/home?region=us-east-1#/configuration-sets/create
-
 
 ## <a name="convert-to-store-in-s3"></a> (Optional) Convert to store in S3
 
@@ -182,30 +188,30 @@ The steps to setup S3 transfer:
 By adding the encryption key first, the AWS console will be able to add
 permissions as we use it.
 
-* Load the [Customer managed keys][customer-managed-keys] page, and select "Create Key"
-    * Step 1: Configure key
-        * Key type: Symmetric
-        * Advanced options: defaults are OK:
-            - Key material origin: KMS
-            - Regionality: Single-Region key
-        * Click "Next"
-    * Step 2: Add labels
-        * Alias: RelayKey or similar
-        * Description: This key is used to encrypt incoming SES messages processed by SNS, SQS, and S3.
-        * Tags: *None*
-        * Click "Next"
-    * Step 3: Define key administrative permissions
-        * Key administrators: Add your login user, if applicable
-        * Key deletion: Select Allow key administrators to delete this key (default)
-        * Click "Next"
-    * Step 4: Define key usage permissions
-        * This account: Add the app key user, if applicable
-        * Other AWS accounts: *None*
-    * Step 5: Review
-        * Add the statement below to the key policy
-        * Click "Finish"
+- Load the [Customer managed keys][customer-managed-keys] page, and select "Create Key"
+  - Step 1: Configure key
+    - Key type: Symmetric
+    - Advanced options: defaults are OK:
+      - Key material origin: KMS
+      - Regionality: Single-Region key
+    - Click "Next"
+  - Step 2: Add labels
+    - Alias: RelayKey or similar
+    - Description: This key is used to encrypt incoming SES messages processed by SNS, SQS, and S3.
+    - Tags: _None_
+    - Click "Next"
+  - Step 3: Define key administrative permissions
+    - Key administrators: Add your login user, if applicable
+    - Key deletion: Select Allow key administrators to delete this key (default)
+    - Click "Next"
+  - Step 4: Define key usage permissions
+    - This account: Add the app key user, if applicable
+    - Other AWS accounts: _None_
+  - Step 5: Review
+    - Add the statement below to the key policy
+    - Click "Finish"
 
-This Key Policy statement (change ``111122223333`` to your account number)
+This Key Policy statement (change `111122223333` to your account number)
 allows SES to access the key. Add it to key policy with the other statements:
 
 ```json
@@ -213,17 +219,13 @@ allows SES to access the key. Add it to key policy with the other statements:
   "Sid": "AllowSESToEncryptMessagesBelongingToThisAccount",
   "Effect": "Allow",
   "Principal": {
-    "Service":"ses.amazonaws.com"
+    "Service": "ses.amazonaws.com"
   },
-  "Action": [
-    "kms:GenerateDataKey*",
-    "kms:Encrypt",
-    "kms:Decrypt"
-  ],
+  "Action": ["kms:GenerateDataKey*", "kms:Encrypt", "kms:Decrypt"],
   "Resource": "*",
-  "Condition":{
-    "StringEquals":{
-      "AWS:SourceAccount":"111122223333"
+  "Condition": {
+    "StringEquals": {
+      "AWS:SourceAccount": "111122223333"
     },
     "StringLike": {
       "AWS:SourceArn": "arn:aws:ses:*"
@@ -237,20 +239,20 @@ allows SES to access the key. Add it to key policy with the other statements:
 ### Convert AWS SES to store emails in a new S3 bucket
 
 1. Go to [SES Email Receiving][ses-email-receiving].
-2. Select the ruleset ``ses-all-inbound-to-sns``
-3. Select the rule ``ses-all-inbound-to-sns``
+2. Select the ruleset `ses-all-inbound-to-sns`
+3. Select the rule `ses-all-inbound-to-sns`
 4. Select the "Actions" tab, and the "Edit"
-    - Step 3: Add actions:
-        * Click "Remove" to remove "Publish to Amazon SNS topic"
-        * In "Add new action", select "Deliver to S3 bucket"
-        * S3 bucket: Select "Create S3 bucket", and select a name like "fxrelay-emails-myusername"
-        * Object key prefix: emails
-        * Message encryption: De-select Enable (default)
-        * SNS topic: Select your existing SNS topic
-        * Click Next
-    - Review:
-        * Step 3 now shows "S3Action" for Action type
-        * Click "Save changes"
+   - Step 3: Add actions:
+     - Click "Remove" to remove "Publish to Amazon SNS topic"
+     - In "Add new action", select "Deliver to S3 bucket"
+     - S3 bucket: Select "Create S3 bucket", and select a name like "fxrelay-emails-myusername"
+     - Object key prefix: emails
+     - Message encryption: De-select Enable (default)
+     - SNS topic: Select your existing SNS topic
+     - Click Next
+   - Review:
+     - Step 3 now shows "S3Action" for Action type
+     - Click "Save changes"
 
 ### Configure the new AWS S3 Bucket
 
@@ -261,56 +263,58 @@ contains a fake email saying that SES is delivering to this S3 bucket.
 
 These changes needed to line up with other deployments:
 
-* Properties - enable server-side encryption
-* Permissions - disabled public access
-* Management - delete after 3 days
+- Properties - enable server-side encryption
+- Permissions - disabled public access
+- Management - delete after 3 days
 
 [s3-buckets-page]: https://s3.console.aws.amazon.com/s3/buckets?region=us-east-1
 
 #### Update Properties - Enable encryption
+
 On the **Properties** tab:
 
-* In the "Default encryption" section, select "Edit":
-    - Server-side encryption: select Enable
-    - Encryption key type: AWS Key Management Service key (SSE-KMS)
-    - AWS KMS key: Choose from your AWS KMS keys, select the RelayKey
-    - Bucket Key: Enable
-    - Select "Save Changes"
+- In the "Default encryption" section, select "Edit":
+  - Server-side encryption: select Enable
+  - Encryption key type: AWS Key Management Service key (SSE-KMS)
+  - AWS KMS key: Choose from your AWS KMS keys, select the RelayKey
+  - Bucket Key: Enable
+  - Select "Save Changes"
 
 #### Update Permissions
 
 On the **Permissions** tab:
 
-* In the "Block public access (bucket settings), select "Edit":
-    - Select "Block *all* public access"
-    - Select "Save Changes"
-    - Type "confirm" to confirm
+- In the "Block public access (bucket settings), select "Edit":
+  - Select "Block _all_ public access"
+  - Select "Save Changes"
+  - Type "confirm" to confirm
 
 #### Update Management
 
 On the **Management** tab:
 
-* In the "Lifecycle rules" section (top), select "Create lifecycle rule"
-    * Lifecycle rule configuration
-        * Lifecycle rule name: ``delete-expired``
-        * Choose a rule scope: Leave at "Limit the scope of this rule using one or more filters"
-        * Filter type - Prefix: ``emails/``
-        * Leave with no tags, and no object size filters
-    * Lifecycle rule actions
-        * Select option 3, "Expire current versions of objects". For an
-          unversioned bucket, this deletes the object.
-    * Expire current versions of objects (this section appears after selecting the action)
-        * Days after object creation: 3
-    * Review transition and expiration actions (read-only, confirms settings)
-        * Current version actions:
-            * Day 0: Objects uploaded
-            * Day 3: Objects expire
-        * Noncurrent versions actions
-            * Day 0: No actions defined.
-    * Select "Create rule" to return to the Lifecycle Configuration details.
-    * Select the bucket name from the breadcrumbs to return to bucket details
+- In the "Lifecycle rules" section (top), select "Create lifecycle rule"
+  - Lifecycle rule configuration
+    - Lifecycle rule name: `delete-expired`
+    - Choose a rule scope: Leave at "Limit the scope of this rule using one or more filters"
+    - Filter type - Prefix: `emails/`
+    - Leave with no tags, and no object size filters
+  - Lifecycle rule actions
+    - Select option 3, "Expire current versions of objects". For an
+      unversioned bucket, this deletes the object.
+  - Expire current versions of objects (this section appears after selecting the action)
+    - Days after object creation: 3
+  - Review transition and expiration actions (read-only, confirms settings)
+    - Current version actions:
+      - Day 0: Objects uploaded
+      - Day 3: Objects expire
+    - Noncurrent versions actions
+      - Day 0: No actions defined.
+  - Select "Create rule" to return to the Lifecycle Configuration details.
+  - Select the bucket name from the breadcrumbs to return to bucket details
 
 ### Allow the app AWS user to manage the S3 bucket
+
 Starting at the [Identity and Access Management (IAM) Dashboard][iam-dashboard],
 add the full access policy to the AWS user that you use from the app:
 
@@ -326,9 +330,9 @@ GetObject
 DeleteObject
 ```
 
-You'll need the bucket permission (like ``arn:aws:s3:::fxrelay-emails-myusername``)
-for ``ListBucket``, and object permission (like
-``arn:aws:s3:::fxrelay-emails-myusername/*``) for ``GetObject`` and ``DeleteObject``.
+You'll need the bucket permission (like `arn:aws:s3:::fxrelay-emails-myusername`)
+for `ListBucket`, and object permission (like
+`arn:aws:s3:::fxrelay-emails-myusername/*`) for `GetObject` and `DeleteObject`.
 
 [iam-dashboard]: https://us-east-1.console.aws.amazon.com/iamv2/home#/home
 
@@ -337,13 +341,13 @@ for ``ListBucket``, and object permission (like
 Same as before:
 
 1. Run your local Relay server and ngrok:
-   * `python manage.py runserver 127.0.0.1:8000`
-   * `ngrok http -subdomain=myrelay 127.0.0.1:8000`
+   - `python manage.py runserver 127.0.0.1:8000`
+   - `ngrok http -subdomain=myrelay 127.0.0.1:8000`
 2. Go to your favorite email address and send an email to the Relay alias you
    generated above.
 3. You should see a POST to `/emails/sns-inbound` in your `runserver` process!
 4. You should see the test email in the Inbox of the final destination/recipient of the alias!
-   * Note: the final destination/recipient address for the alias must be in your SES "verified identities" for SES to actually send it emails. 
+   - Note: the final destination/recipient address for the alias must be in your SES "verified identities" for SES to actually send it emails.
 
 One way to see the S3 object is to add a breakpoint to your local code,
 so that you can examine the object in the AWS console before it is deleted.
@@ -351,12 +355,11 @@ However, SNS will quickly try the request again, so be fast!
 
 ## <a name="convert-to-back-end-processing"></a> (Optional) Convert to back-end processing
 
-*Note: this change is not yet in production*
+_Note: this change is not yet in production_
 
 In Q2 2022, we are switching from handling email as a web request, POSTed via
 an SNS subscription, to a back-end process, pulling from a Simple Queue Service
 (SQS) queue.
-
 
 ```mermaid
 sequenceDiagram
@@ -371,41 +374,43 @@ sequenceDiagram
 
 To make this change:
 
-* (Optional) Add a dead-letter queue
-* Add an SQS queue
-* Enable the app user to read from the queue
-* Turn off the SNS push subscription
-* Subscribe to SNS topic
-* Run the email task
+- (Optional) Add a dead-letter queue
+- Add an SQS queue
+- Enable the app user to read from the queue
+- Turn off the SNS push subscription
+- Subscribe to SNS topic
+- Run the email task
 
 ### (Optional) Add a dead-letter queue
+
 In production, undeliverable SNS messages are sent to a dead-letter queue
 (DLQ). They can be undeliverable because the service is unavailable, or because
 the email is malformed, or processing is broken. An SQS queue can also have a
-dead-letter queue.  If you have a SNS DLQ, you can use it for the SQS DLQ as
+dead-letter queue. If you have a SNS DLQ, you can use it for the SQS DLQ as
 well. If not, you can create it.
 
 On the [SQS dashboard][sqs-dashboard], select "Create Queue":
 
-* Details
-    * Type: Standard
-    * Name: `fx-relay-emails-dlq`
-* Select "Create Queue" to accept other defaults.
+- Details
+  - Type: Standard
+  - Name: `fx-relay-emails-dlq`
+- Select "Create Queue" to accept other defaults.
 
 ### Add an SQS queue
 
 On the [SQS dashboard][sqs-dashboard], select "Create Queue":
 
-* Details
-    * Type: Standard
-    * Name: `fx-relay-emails`
-* Dead-letter queue - *Optional* - If you created one in the previous step:
-    * Set this queue to receive undeliverable messages: Enabled
-    * Choose Queue: The ARN for `fx-relay-emails-dlq`
-    * Maximum receives: 3
-* Select "Create queue"
+- Details
+  - Type: Standard
+  - Name: `fx-relay-emails`
+- Dead-letter queue - _Optional_ - If you created one in the previous step:
+  - Set this queue to receive undeliverable messages: Enabled
+  - Choose Queue: The ARN for `fx-relay-emails-dlq`
+  - Maximum receives: 3
+- Select "Create queue"
 
 ### Enable the app user to read from the queue
+
 Starting at the [Identity and Access Management (IAM) Dashboard][iam-dashboard],
 add the full access policy to the AWS user that you use from the app:
 
@@ -415,38 +420,38 @@ arn:aws:iam::aws:policy/AmazonSQSFullAccess
 
 or add the specific permissions needed by the app:
 
-* ``sqs:ReceiveMessage`` - Needed to read messages
-* ``sqs:DeleteMessage`` - Needed to removed messages
-* ``sqs:ChangeMessageVisibility`` - Needed to reserve a message when reading
-* ``sqs:GetQueueAttributes`` - Needed to get (approximate) queue sizes
+- `sqs:ReceiveMessage` - Needed to read messages
+- `sqs:DeleteMessage` - Needed to removed messages
+- `sqs:ChangeMessageVisibility` - Needed to reserve a message when reading
+- `sqs:GetQueueAttributes` - Needed to get (approximate) queue sizes
 
 ### Turn off the SNS push subscription
 
 On the [SNS Topics dashboard][sns-topic-panel]:
 
-* Select the relay topic
-* Select radio button to the left of the `/emails/sns-inbound` subscription
-* Select "Delete"
-* Confirm "Delete"
+- Select the relay topic
+- Select radio button to the left of the `/emails/sns-inbound` subscription
+- Select "Delete"
+- Confirm "Delete"
 
 ### Subscribe to SNS topic
 
 Back on the [SQS dashboard][sqs-dashboard], select the queue.
 In the "SNS Subscriptions" tab:
 
-* Select "Subscribe to Amazon SNS topic"
-* In the "Amazon SNS topic" panel, choose the relay topic
-* Select "Save"
+- Select "Subscribe to Amazon SNS topic"
+- In the "Amazon SNS topic" panel, choose the relay topic
+- Select "Save"
 
 ### Run the email task
 
 Set environment variables:
 
-* `AWS_ACCESS_KEY_ID`
-* `AWS_SECRET_ACCESS_KEY`
-* `AWS_SQS_EMAIL_QUEUE_URL`: The URL of the `fx-relay-emails` queue
-* `AWS_SQS_EMAIL_DLQ_URL`: The URL of the `fx-relay-emails-dlq` queue, if
-  configured, otherwise omit or set to an empty string (``""``)
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_SQS_EMAIL_QUEUE_URL`: The URL of the `fx-relay-emails` queue
+- `AWS_SQS_EMAIL_DLQ_URL`: The URL of the `fx-relay-emails-dlq` queue, if
+  configured, otherwise omit or set to an empty string (`""`)
 
 These URLs can be found by starting at the [SQS dashboard][sqs-dashboard] and
 clicking on the queue name to view details.

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -84,14 +84,14 @@ different sets of data are defined for different user IDs, defined in the
 (IDs are inspired by [the nine states of design](https://medium.com/swlh/the-nine-states-of-design-5bfe9b3d6d85)):
 
 - `empty`: A user that just signed up for Relay, but has not created any aliases
-           yet, nor have they upgraded to Premium.
+  yet, nor have they upgraded to Premium.
 - `onboarding`: A user that has just upgraded to Premium, but hasn't completed
-                the Premium onboarding flow yet.
+  the Premium onboarding flow yet.
 - `some`: A user that has an account that has seen some use: they've upgraded to
-          Premium, and have created some aliases.
+  Premium, and have created some aliases.
 - `full`: A user that has utilised most of the features of Relay. They have
-          Premium, set up a custom domain, have both random and custom aliases,
-          and have experienced an email bounce.
+  Premium, set up a custom domain, have both random and custom aliases,
+  and have experienced an email bounce.
 
 If you append `?mockId=<mockId>` (e.g. `?mockId=some`) to the URL, it will
 automatically log in as that mocked user. This is useful to quickly showcase a
@@ -122,7 +122,7 @@ happen in either direction, there are four situations to consider:
 This is mainly to tell the add-on which user is currently logged in, and data
 about them. (There are also plans to minimise this to only share the API key
 with the add-on, which can then fetch the rest of the data from the API
-directly, and even to have the add-on authenticate against Firefox Accounts
+directly, and even to have the add-on authenticate against Mozilla Accounts
 directly and then being able to communicate with the API without even needing to
 interact with the website.)
 

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -84,14 +84,14 @@ different sets of data are defined for different user IDs, defined in the
 (IDs are inspired by [the nine states of design](https://medium.com/swlh/the-nine-states-of-design-5bfe9b3d6d85)):
 
 - `empty`: A user that just signed up for Relay, but has not created any aliases
-  yet, nor have they upgraded to Premium.
+           yet, nor have they upgraded to Premium.
 - `onboarding`: A user that has just upgraded to Premium, but hasn't completed
-  the Premium onboarding flow yet.
+                the Premium onboarding flow yet.
 - `some`: A user that has an account that has seen some use: they've upgraded to
-  Premium, and have created some aliases.
+          Premium, and have created some aliases.
 - `full`: A user that has utilised most of the features of Relay. They have
-  Premium, set up a custom domain, have both random and custom aliases,
-  and have experienced an email bounce.
+          Premium, set up a custom domain, have both random and custom aliases,
+          and have experienced an email bounce.
 
 If you append `?mockId=<mockId>` (e.g. `?mockId=some`) to the URL, it will
 automatically log in as that mocked user. This is useful to quickly showcase a

--- a/docs/fx-integration.md
+++ b/docs/fx-integration.md
@@ -20,7 +20,7 @@ Firefox users signed into the browser with their FxA.
 ## Firefox users sign into their browsers with their FxA
 
 Relay has to forward emails to someone's existing email address. So, to use Relay, users
-create a [Firefox Account][sumo-fxa], which requires and verifies an existing email address.
+create a [Mozilla Account][sumo-fxa], which requires and verifies an existing email address.
 
 TODO: Link to tech doc for Firefox/FxA integration.
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,5 +1,4 @@
 # Translation and Localization
-
 Translations are maintained in separate repositories that are managed by the
 [Mozilla Localization Team](https://github.com/mozilla-l10n). There is a
 Pontoon project for the

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,4 +1,5 @@
 # Translation and Localization
+
 Translations are maintained in separate repositories that are managed by the
 [Mozilla Localization Team](https://github.com/mozilla-l10n). There is a
 Pontoon project for the
@@ -21,7 +22,7 @@ are also embedded in the JavaScript during the build process, so that the
 website text is translated.
 
 The user's desired language is parsed from the `Accept-Language` header,
-provided by their browser. When the user signs up for a Firefox Account, their
+provided by their browser. When the user signs up for a Mozilla Account, their
 `Accept-Language` header is captured, and this is used for translated headers in
 forwarded emails. When a user visits the Relay website or uses the add-on,
 their current `Accept-Language` header is used.

--- a/e2e-tests/specs/relay-e2e.spec.ts
+++ b/e2e-tests/specs/relay-e2e.spec.ts
@@ -15,7 +15,7 @@ test.describe('Relay e2e function email forwarding', () => {
       dashboardPage,
       page
     }) => {
-        // This tests creates a new Firefox Account with a new mask, to have
+        // This tests creates a new Mozilla Account with a new mask, to have
         // the signup confirmation email show up in the forwarded email count.
         // This is a pretty slow process:
         test.slow()

--- a/emails/models.py
+++ b/emails/models.py
@@ -171,7 +171,7 @@ class Profile(models.Model):
                     continue
         return "en"
 
-    # This method returns whether the locale associated with the user's Firefox account
+    # This method returns whether the locale associated with the user's Mozilla account
     # includes a country code from a Premium country. This is less accurate than using
     # get_countries_info_from_request_and_mapping(), which can use a GeoIP lookup, so
     # prefer using that if a request context is available. In other contexts, for

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -35,3 +35,12 @@ profile-label-set-your-custom-domain-free-user = Get your own email domain with 
 
 tooltip-email-domain-explanation-title-free = Get your own { -brand-name-relay } email domain
 tooltip-email-domain-explanation-part-one-free = With { -brand-name-premium }, you can create unlimited, custom { -brand-name-relay } masks on the go using a unique { -brand-name-relay } email domain — you won’t even have to generate them here first.
+
+nav-profile-manage-fxa-v2 = Manage your { -brand-name-mozilla-account(capitalization: "uppercase") }
+nav-profile-image-alt-v2 = { -brand-name-mozilla-account(capitalization: "uppercase") } Avatar
+faq-question-acceptable-use-answer-measure-account-v2 = Requiring a { -brand-name-mozilla-account(capitalization: "uppercase") } with a verified email address
+-brand-name-mozilla-account =
+    { $capitalization ->
+       *[lowercase] Mozilla account
+        [uppercase] Mozilla Account
+    } 

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -36,11 +36,6 @@ profile-label-set-your-custom-domain-free-user = Get your own email domain with 
 tooltip-email-domain-explanation-title-free = Get your own { -brand-name-relay } email domain
 tooltip-email-domain-explanation-part-one-free = With { -brand-name-premium }, you can create unlimited, custom { -brand-name-relay } masks on the go using a unique { -brand-name-relay } email domain — you won’t even have to generate them here first.
 
-nav-profile-manage-fxa-v2 = Manage your { -brand-name-mozilla-account(capitalization: "uppercase") }
-nav-profile-image-alt-v2 = { -brand-name-mozilla-account(capitalization: "uppercase") } Avatar
-faq-question-acceptable-use-answer-measure-account-v2 = Requiring a { -brand-name-mozilla-account(capitalization: "uppercase") } with a verified email address
--brand-name-mozilla-account =
-    { $capitalization ->
-       *[lowercase] Mozilla account
-        [uppercase] Mozilla Account
-    } 
+nav-profile-manage-fxa-v2 = Manage your account
+nav-profile-image-alt-v2 = account avatar
+faq-question-acceptable-use-answer-measure-account-v2 = Requiring an account with a verified email address

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -36,6 +36,6 @@ profile-label-set-your-custom-domain-free-user = Get your own email domain with 
 tooltip-email-domain-explanation-title-free = Get your own { -brand-name-relay } email domain
 tooltip-email-domain-explanation-part-one-free = With { -brand-name-premium }, you can create unlimited, custom { -brand-name-relay } masks on the go using a unique { -brand-name-relay } email domain — you won’t even have to generate them here first.
 
-nav-profile-manage-fxa-v2 = Manage your account
+nav-profile-manage-account = Manage your account
 nav-profile-image-alt-v2 = account avatar
 faq-question-acceptable-use-answer-measure-account-v2 = Requiring an account with a verified email address

--- a/frontend/src/components/layout/navigation/MobileNavigation.tsx
+++ b/frontend/src/components/layout/navigation/MobileNavigation.tsx
@@ -96,7 +96,11 @@ export const MobileNavigation = (props: Props) => {
                 rel="noopener noreferrer"
                 className={styles["settings-link"]}
               >
-                {l10n.getString(isFlagActive(runtimeData.data, "firefox_account_rebrand") ? "nav-profile-manage-fxa" : "nav-profile-manage-fxa-v2")}
+                {l10n.getString(
+                  isFlagActive(runtimeData.data, "firefox_account_rebrand")
+                    ? "nav-profile-manage-fxa"
+                    : "nav-profile-manage-fxa-v2",
+                )}
                 <NewTabIcon width={12} height={18} viewBox="0 0 16 18" alt="" />
               </a>
             </span>

--- a/frontend/src/components/layout/navigation/MobileNavigation.tsx
+++ b/frontend/src/components/layout/navigation/MobileNavigation.tsx
@@ -16,7 +16,6 @@ import { useRuntimeData } from "../../../hooks/api/runtimeData";
 import { getRuntimeConfig } from "../../../config";
 import { getCsrfToken } from "../../../functions/cookies";
 import { useL10n } from "../../../hooks/l10n";
-import { isFlagActive } from "../../../functions/waffle";
 
 export type MenuItem = {
   url: string;
@@ -96,11 +95,7 @@ export const MobileNavigation = (props: Props) => {
                 rel="noopener noreferrer"
                 className={styles["settings-link"]}
               >
-                {l10n.getString(
-                  isFlagActive(runtimeData.data, "firefox_account_rebrand")
-                    ? "nav-profile-manage-fxa"
-                    : "nav-profile-manage-fxa-v2",
-                )}
+                {l10n.getString("nav-profile-manage-fxa-v2")}
                 <NewTabIcon width={12} height={18} viewBox="0 0 16 18" alt="" />
               </a>
             </span>

--- a/frontend/src/components/layout/navigation/MobileNavigation.tsx
+++ b/frontend/src/components/layout/navigation/MobileNavigation.tsx
@@ -96,7 +96,7 @@ export const MobileNavigation = (props: Props) => {
                 rel="noopener noreferrer"
                 className={styles["settings-link"]}
               >
-                {l10n.getString(isFlagActive(runtimeData.data, "firefox-account-rebrand") ? "nav-profile-manage-fxa" : "nav-profile-manage-fxa-v2")}
+                {l10n.getString(isFlagActive(runtimeData.data, "firefox_account_rebrand") ? "nav-profile-manage-fxa" : "nav-profile-manage-fxa-v2")}
                 <NewTabIcon width={12} height={18} viewBox="0 0 16 18" alt="" />
               </a>
             </span>

--- a/frontend/src/components/layout/navigation/MobileNavigation.tsx
+++ b/frontend/src/components/layout/navigation/MobileNavigation.tsx
@@ -16,6 +16,7 @@ import { useRuntimeData } from "../../../hooks/api/runtimeData";
 import { getRuntimeConfig } from "../../../config";
 import { getCsrfToken } from "../../../functions/cookies";
 import { useL10n } from "../../../hooks/l10n";
+import { isFlagActive } from "../../../functions/waffle";
 
 export type MenuItem = {
   url: string;
@@ -95,7 +96,7 @@ export const MobileNavigation = (props: Props) => {
                 rel="noopener noreferrer"
                 className={styles["settings-link"]}
               >
-                {l10n.getString("nav-profile-manage-fxa")}
+                {l10n.getString(isFlagActive(runtimeData.data, "firefox-account-rebrand") ? "nav-profile-manage-fxa" : "nav-profile-manage-fxa-v2")}
                 <NewTabIcon width={12} height={18} viewBox="0 0 16 18" alt="" />
               </a>
             </span>

--- a/frontend/src/components/layout/navigation/MobileNavigation.tsx
+++ b/frontend/src/components/layout/navigation/MobileNavigation.tsx
@@ -95,7 +95,7 @@ export const MobileNavigation = (props: Props) => {
                 rel="noopener noreferrer"
                 className={styles["settings-link"]}
               >
-                {l10n.getString("nav-profile-manage-fxa-v2")}
+                {l10n.getString("nav-profile-manage-account")}
                 <NewTabIcon width={12} height={18} viewBox="0 0 16 18" alt="" />
               </a>
             </span>

--- a/frontend/src/hooks/api/profile.ts
+++ b/frontend/src/hooks/api/profile.ts
@@ -104,7 +104,7 @@ export function useProfiles(): SWRResponse<ProfilesData, unknown> & {
 /**
  * Instead of using the `fetcher` from `api.ts`, this fetcher is specific to the profiles API.
  * The reason that it's needed is that we have to tell the back-end to re-fetch data from
- * Firefox Accounts if the user was sent back here after trying to subscribe to Premium.
+ * Mozilla Accounts if the user was sent back here after trying to subscribe to Premium.
  */
 const profileFetcher = async (
   url: string,

--- a/frontend/src/hooks/api/runtimeData.ts
+++ b/frontend/src/hooks/api/runtimeData.ts
@@ -11,6 +11,7 @@ export type FlagNames =
   | "multi_replies"
   | "firefox_integration"
   | "mailing_list_announcement"
+  | "firefox-account-rebrand"
   | "premium_promo_banners"
   | "mask_redesign"
   | "mobile_app";

--- a/frontend/src/hooks/api/runtimeData.ts
+++ b/frontend/src/hooks/api/runtimeData.ts
@@ -11,7 +11,6 @@ export type FlagNames =
   | "multi_replies"
   | "firefox_integration"
   | "mailing_list_announcement"
-  | "firefox_account_rebrand"
   | "premium_promo_banners"
   | "mask_redesign"
   | "mobile_app";

--- a/frontend/src/hooks/api/runtimeData.ts
+++ b/frontend/src/hooks/api/runtimeData.ts
@@ -11,7 +11,7 @@ export type FlagNames =
   | "multi_replies"
   | "firefox_integration"
   | "mailing_list_announcement"
-  | "firefox-account-rebrand"
+  | "firefox_account_rebrand"
   | "premium_promo_banners"
   | "mask_redesign"
   | "mobile_app";

--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -440,7 +440,7 @@ const Faq: NextPage = () => {
                 </Localized>
                 <ul>
                   <li>
-                    {l10n.getString( isFlagActive(runtimeData.data, "firefox-account-rebrand") ?
+                    {l10n.getString( isFlagActive(runtimeData.data, "firefox_account_rebrand") ?
                       "faq-question-acceptable-use-answer-measure-account" : "faq-question-acceptable-use-answer-measure-account-v2",
                     )}
                   </li>

--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -441,9 +441,7 @@ const Faq: NextPage = () => {
                 <ul>
                   <li>
                     {l10n.getString(
-                      isFlagActive(runtimeData.data, "firefox_account_rebrand")
-                        ? "faq-question-acceptable-use-answer-measure-account"
-                        : "faq-question-acceptable-use-answer-measure-account-v2",
+                      "faq-question-acceptable-use-answer-measure-account-v2",
                     )}
                   </li>
                   <li>

--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -440,8 +440,10 @@ const Faq: NextPage = () => {
                 </Localized>
                 <ul>
                   <li>
-                    {l10n.getString( isFlagActive(runtimeData.data, "firefox_account_rebrand") ?
-                      "faq-question-acceptable-use-answer-measure-account" : "faq-question-acceptable-use-answer-measure-account-v2",
+                    {l10n.getString(
+                      isFlagActive(runtimeData.data, "firefox_account_rebrand")
+                        ? "faq-question-acceptable-use-answer-measure-account"
+                        : "faq-question-acceptable-use-answer-measure-account-v2",
                     )}
                   </li>
                   <li>

--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -440,8 +440,8 @@ const Faq: NextPage = () => {
                 </Localized>
                 <ul>
                   <li>
-                    {l10n.getString(
-                      "faq-question-acceptable-use-answer-measure-account",
+                    {l10n.getString( isFlagActive(runtimeData.data, "firefox-account-rebrand") ?
+                      "faq-question-acceptable-use-answer-measure-account" : "faq-question-acceptable-use-answer-measure-account-v2",
                     )}
                   </li>
                   <li>

--- a/frontend/src/pages/vpn-relay-welcome.page.tsx
+++ b/frontend/src/pages/vpn-relay-welcome.page.tsx
@@ -21,7 +21,7 @@ const VpnRelayWelcome: NextPage = () => {
 
   useEffect(() => {
     // Tell the backend that there will probably be new subscriptions.
-    // It will then ask Firefox Accounts for up-to-date subscription information,
+    // It will then ask Mozilla Accounts for up-to-date subscription information,
     // and have that ready for the next request to `/profiles`.
     authenticatedFetch("/accounts/profile/refresh");
   }, []);

--- a/privaterelay/management/commands/sync_phone_related_dates_on_profile.py
+++ b/privaterelay/management/commands/sync_phone_related_dates_on_profile.py
@@ -65,7 +65,7 @@ def sync_phone_related_dates_on_profile(group: str) -> int:
 
 
 class Command(BaseCommand):
-    help = "Sync date_subscribed_phone, date_phone_limits_reset, date_phone_subscription_end fields on Profile by syncing with Firefox Accounts data"
+    help = "Sync date_subscribed_phone, date_phone_limits_reset, date_phone_subscription_end fields on Profile by syncing with Mozilla Accounts data"
 
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -332,7 +332,7 @@ def get_fxa_event_jwt(
     iat_skew: int = 0,
 ) -> str:
     """
-    Return valid Firefox Accounts relying party event JWT
+    Return valid Mozilla Accounts relying party event JWT
 
     See https://github.com/mozilla/fxa/tree/main/packages/fxa-event-broker
     """

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -233,7 +233,7 @@ def guess_country_from_accept_lang(accept_lang: str) -> str:
     If an issue is detected, a AcceptLanguageError is raised.
 
     The header may come directly from a web request, or may be the header
-    captured by Firefox Accounts (FxA) at signup.
+    captured by Mozilla Accounts (FxA) at signup.
 
     Even with all this logic and special casing, it is still more accurate to
     use a GeoIP lookup or a country code provided by the infrastructure.


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3243

L10N: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/158

# New feature description

As a account customer on Firefox Relay, seeing consistent branding of accounts across Mozilla surfaces helps me trust the authentication experience, and not feel confused about the services I use. 

Rewrite Firefox Account(s) to Mozilla Account(s)

Comments, documentation updated - not behind a flag. 

# Screenshot (if applicable)

![image](https://github.com/mozilla/fx-private-relay/assets/3924990/35689f3a-d1f5-4163-89e9-471eaa413386)

![image](https://github.com/mozilla/fx-private-relay/assets/3924990/4efbb33c-48c7-4cf5-b362-b1a0146bc43a)

# How to test

Any and all instances of Firefox Account(s) should be rewritten to Mozilla Account(s)

User facing strings are behind a flag -> `firefox_account_rebrand`

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
