### PR TITLE
MPP-2389: Fix for overflow on phones upsell page

### DIFF
--- a/frontend/src/components/phones/onboarding/PurchasePhonesPlan.module.scss
+++ b/frontend/src/components/phones/onboarding/PurchasePhonesPlan.module.scss
@@ -10,6 +10,7 @@
   margin: 0 auto;
   padding: $spacing-2xl $spacing-lg;
   width: 100%;
+  overflow-x: hidden;
 
   h2 {
     @include text-title-xs;
@@ -73,6 +74,10 @@
     padding: $spacing-lg $spacing-2xl;
     border-radius: $border-radius-md;
     box-shadow: $box-shadow-sm;
+
+    @media screen and (max-width: $screen-sm) {
+      padding: $spacing-lg;
+    }
 
     h3 {
       @include text-body-md;

--- a/frontend/src/components/phones/onboarding/PurchasePhonesPlan.module.scss
+++ b/frontend/src/components/phones/onboarding/PurchasePhonesPlan.module.scss
@@ -75,10 +75,6 @@
     border-radius: $border-radius-md;
     box-shadow: $box-shadow-sm;
 
-    @media screen and (max-width: $screen-sm) {
-      padding: $spacing-lg;
-    }
-
     h3 {
       @include text-body-md;
       font-family: $font-stack-firefox;
@@ -90,6 +86,7 @@
       display: flex;
       flex-direction: column;
       gap: $spacing-sm;
+      width: 100%; // Ensures responsiveness of container, and that the purchase tabpanel has a static width when toggling.
 
       .pricing-toggle {
         display: flex;
@@ -124,7 +121,6 @@
           padding-top: $spacing-sm;
           display: block;
           font-weight: 700;
-          width: $content-xs;
 
           > span {
             @include text-body-sm;


### PR DESCRIPTION
This PR fixes MPP-2389.

# Bug description

The phone masking upsell page sizing does not fit on small screens. This can be observed by going to https://relay.firefox.com/phone/ and setting the page width to 360px via inspector.

# Screenshot of fix 

~Decreased the padding of the container on small screens,~ Changed the parent width to 100%, to ensure that toggling between the purchase tabs stays static, and that the entire container remains responsive while decreasing the page width (this was not the case previously). Made the overflow hidden incase it goes off the page.

https://github.com/mozilla/fx-private-relay/assets/59676643/b4199c88-01c5-42ca-a484-800949d1b285

# How to test

1. On an account without a phones flag, go to the phones upsell page (/phone).
2. Open the inspector. 
3. Set the width to 360px or pick a phone with approximately that width.
4. [Acceptance criteria] Observe that you cannot scroll horizontally on the page and that the page fits correctly.

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
