### PR TITLE
Bump the typing-stubs group with 3 updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,11 +47,11 @@ responses==0.23.3
 black==23.9.1
 
 # type hinting
-boto3-stubs==1.28.53
-botocore-stubs==1.31.53
+boto3-stubs==1.28.57
+botocore-stubs==1.31.57
 django-stubs==4.2.4
 djangorestframework-stubs==3.14.2
 mypy-boto3-ses==1.28.36
 mypy==1.5.1
 types-pyOpenSSL==23.2.0.2
-types-requests==2.31.0.4
+types-requests==2.31.0.7


### PR DESCRIPTION
Replaces https://github.com/mozilla/fx-private-relay/pull/3938 which had this conflict:

```
The conflict is caused by:
    requests 2.31.0 depends on urllib3<3 and >=1.21.1
    sentry-sdk 1.31.0 depends on urllib3>=1.26.11; python_version >= "3.6"
    responses 0.23.3 depends on urllib3<3.0 and >=1.25.10
    types-requests 2.31.0.7 depends on urllib3>=2
    botocore 1.31.57 depends on urllib3<1.27 and >=1.25.4
```

I removed the version for `types-requests` to let `pip` try to resolve the conflict.

Bumps the typing-stubs group with 3 updates: [boto3-stubs](https://github.com/youtype/mypy_boto3_builder), [botocore-stubs](https://github.com/youtype/botocore-stubs) and [types-requests](https://github.com/python/typeshed).


Updates `boto3-stubs` from 1.28.53 to 1.28.57
- [Release notes](https://github.com/youtype/mypy_boto3_builder/releases)
- [Commits](https://github.com/youtype/mypy_boto3_builder/commits)

Updates `botocore-stubs` from 1.31.53 to 1.31.57
- [Release notes](https://github.com/youtype/botocore-stubs/releases)
- [Commits](https://github.com/youtype/botocore-stubs/commits)

Updates `types-requests` from 2.31.0.4 to 2.31.0.7
- [Commits](https://github.com/python/typeshed/commits)

---
updated-dependencies:
- dependency-name: boto3-stubs dependency-type: direct:production update-type: version-update:semver-patch dependency-group: typing-stubs
- dependency-name: botocore-stubs dependency-type: direct:production update-type: version-update:semver-patch dependency-group: typing-stubs
- dependency-name: types-requests dependency-type: direct:production update-type: version-update:semver-patch dependency-group: typing-stubs ...

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #<issue ID>.

How to test:

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description



# Screenshot (if applicable)

Not applicable.

# How to test



# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
