### PR TITLE
fix MPP-3420: handle and log NoReverseMatch error

### DIFF
--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from django.urls.exceptions import NoReverseMatch
 import requests
 from typing import Mapping, Optional
 
@@ -59,6 +60,7 @@ from ..serializers import (
 
 from privaterelay.ftl_bundles import main as ftl_bundle
 
+logger = logging.getLogger("events")
 info_logger = logging.getLogger("eventsinfo")
 FXA_PROFILE_URL = (
     f"{settings.SOCIALACCOUNT_PROVIDERS['fxa']['PROFILE_ENDPOINT']}/profile"
@@ -234,12 +236,27 @@ def terms_accepted_user(request):
         # create new SocialAccount, User, and Profile for the new Relay user from Firefox
         # Since this is a Resource Provider/Server flow and are NOT a Relying Party (RP) of FXA
         # No social token information is stored (no Social Token object created).
-        complete_social_login(request, social_login)
-        # complete_social_login writes ['account_verified_email', 'user_created', '_auth_user_id', '_auth_user_backend', '_auth_user_hash']
-        # on request.session which sets the cookie because complete_social_login does the "login"
-        # The user did not actually log in, logout to clear the session
-        if request.user.is_authenticated:
-            get_account_adapter(request).logout(request)
+        try:
+            complete_social_login(request, social_login)
+            # complete_social_login writes ['account_verified_email', 'user_created', '_auth_user_id', '_auth_user_backend', '_auth_user_hash']
+            # on request.session which sets the cookie because complete_social_login does the "login"
+            # The user did not actually log in, logout to clear the session
+            if request.user.is_authenticated:
+                get_account_adapter(request).logout(request)
+        except NoReverseMatch as e:
+            # TODO: use this logging to fix the underlying issue
+            # https://mozilla-hub.atlassian.net/browse/MPP-3473
+            if "socialaccount_signup" in e.args[0]:
+                logger.error(
+                    "socialaccount_signup_error",
+                    extra={
+                        "exception": str(e),
+                        "fxa_uid": fxa_uid,
+                        "social_login_state": social_login.state,
+                    },
+                )
+                return response.Response(status=500)
+            raise e
         sa = SocialAccount.objects.get(uid=fxa_uid, provider="fxa")
         # Indicate profile was created from the resource flow
         profile = sa.user.profile

--- a/emails/tests/mgmt_process_emails_from_sqs_tests.py
+++ b/emails/tests/mgmt_process_emails_from_sqs_tests.py
@@ -13,6 +13,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 
 from emails.tests.views_tests import EMAIL_SNS_BODIES
+from privaterelay.tests.utils import log_extra
 
 
 COMMAND_NAME = "process_emails_from_sqs"
@@ -152,40 +153,6 @@ def make_client_error(message="Unknown", code="Unknown", operation_name="Unknown
     """Create a minimal botocore.exceptions.ClientError"""
     err_response = {"Error": {"Message": message, "Code": code}}
     return ClientError(err_response, operation_name)
-
-
-def log_extra(log_record):
-    """Reconstruct the "extra" argument to the log call"""
-    omit_log_record_keys = set(
-        (
-            "args",
-            "created",
-            "exc_info",
-            "exc_text",
-            "filename",
-            "funcName",
-            "levelname",
-            "levelno",
-            "lineno",
-            "message",
-            "module",
-            "msecs",
-            "msg",
-            "name",
-            "pathname",
-            "process",
-            "processName",
-            "relativeCreated",
-            "stack_info",
-            "thread",
-            "threadName",
-        )
-    )
-    return {
-        key: val
-        for key, val in log_record.__dict__.items()
-        if key not in omit_log_record_keys
-    }
 
 
 def summary_from_exit_log(caplog_fixture):

--- a/privaterelay/allauth.py
+++ b/privaterelay/allauth.py
@@ -1,7 +1,17 @@
 from urllib.parse import urlencode
-from django.shortcuts import resolve_url
+import logging
+
+
+from django.shortcuts import redirect, resolve_url
+from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
 
 from allauth.account.adapter import DefaultAccountAdapter
+
+from . import urls
+
+
+logger = logging.getLogger("events")
 
 
 class AccountAdapter(DefaultAccountAdapter):
@@ -14,3 +24,11 @@ class AccountAdapter(DefaultAccountAdapter):
         utm_params = {k: v for k, v in request.GET.items() if k.startswith("utm")}
         url += urlencode(utm_params)
         return resolve_url(url)
+
+    def is_safe_url(self, url):
+        try:
+            reverse(url, urls)
+            return True
+        except NoReverseMatch:
+            logger.error("NoReverseMatch for %s", url)
+        redirect("/")

--- a/privaterelay/tests/allauth_tests.py
+++ b/privaterelay/tests/allauth_tests.py
@@ -1,0 +1,20 @@
+import pytest
+
+from ..allauth import AccountAdapter
+
+
+def test_account_adapter_is_safe_url_noreversematch_logs_error(
+    caplog: pytest.LogCaptureFixture,
+):
+    adapter = AccountAdapter()
+    return_value = adapter.is_safe_url("fuzzymcfuzzface")
+    assert return_value is None
+    (rec1,) = caplog.records
+    assert rec1.levelname == "ERROR"
+    assert rec1.getMessage() == "NoReverseMatch for fuzzymcfuzzface"
+
+
+def test_account_adapter_is_safe_url_redirects():
+    adapter = AccountAdapter()
+    return_value = adapter.is_safe_url("account_logout")
+    assert return_value is True

--- a/privaterelay/tests/utils.py
+++ b/privaterelay/tests/utils.py
@@ -1,0 +1,32 @@
+def log_extra(log_record):
+    """Reconstruct the "extra" argument to the log call"""
+    omit_log_record_keys = set(
+        (
+            "args",
+            "created",
+            "exc_info",
+            "exc_text",
+            "filename",
+            "funcName",
+            "levelname",
+            "levelno",
+            "lineno",
+            "message",
+            "module",
+            "msecs",
+            "msg",
+            "name",
+            "pathname",
+            "process",
+            "processName",
+            "relativeCreated",
+            "stack_info",
+            "thread",
+            "threadName",
+        )
+    )
+    return {
+        key: val
+        for key, val in log_record.__dict__.items()
+        if key not in omit_log_record_keys
+    }


### PR DESCRIPTION
This PR fixes #MPP-3420.

How to test:
1. Run `pytest`
   * [ ] All tests should pass
2. Go to http://127.0.0.1:8000/accounts/logout/?next=fuzzymcfuzzface
   * [ ] No error; it should redirect to the home page
   * [ ] Check the `runserver` output for an error message in the log

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).