### PR TITLE
fix MPP-3329: add bitwarden EU domains to CORS

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -625,16 +625,34 @@ if IN_PYTEST or RELAY_CHANNEL in ["local", "dev"]:
 # an auth token:
 ACCOUNT_LOGOUT_ON_GET = DEBUG
 
+# TODO: introduce an environment variable to control CORS_ALLOWED_ORIGINS
+# https://mozilla-hub.atlassian.net/browse/MPP-3468
 CORS_URLS_REGEX = r"^/api/"
 CORS_ALLOWED_ORIGINS = [
     "https://vault.bitwarden.com",
+    "https://vault.bitwarden.eu",
 ]
 if RELAY_CHANNEL in ["dev", "stage"]:
-    CORS_ALLOWED_ORIGINS += ["https://vault.qa.bitwarden.pw"]
+    CORS_ALLOWED_ORIGINS += [
+        "https://vault.qa.bitwarden.pw",
+        "https://vault.euqa.bitwarden.pw",
+    ]
+# Allow origins for each environment to help debug cors headers
 if RELAY_CHANNEL == "local":
     # In local dev, next runs on localhost and makes requests to /accounts/
-    CORS_ALLOWED_ORIGINS += ["http://localhost:3000"]
+    CORS_ALLOWED_ORIGINS += [
+        "http://localhost:3000",
+        "http://127.0.0.1:8000",
+    ]
     CORS_URLS_REGEX = r"^/(api|accounts)/"
+if RELAY_CHANNEL == "dev":
+    CORS_ALLOWED_ORIGINS += [
+        "https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net",
+    ]
+if RELAY_CHANNEL == "stage":
+    CORS_ALLOWED_ORIGINS += [
+        "https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net",
+    ]
 
 CSRF_TRUSTED_ORIGINS = []
 if RELAY_CHANNEL == "local":


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #MPP-3329.

How to test:
1. Push this branch to heroku
2. Go to https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/accounts/settings/ to get your API key for dev server
3. `curl -I -H "Origin: https://vault.euqa.bitwarden.pw" -H "Authorization: Token <your-api-key>" https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/api/v1/`
   * [ ] You should see `Access-Control-Allow-Origin: https://vault.euqa.bitwarden.pw` in the response headers

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).