### PR TITLE
Create epic_owners.md

### DIFF
--- a/docs/epic_owners.md
+++ b/docs/epic_owners.md
@@ -1,0 +1,4 @@
+# Epic Owner
+- [Epic Ownership Roles and Responsibilities][epic-owners]
+
+[epic-owners]: https://relay.firefox.com/](https://mozilla-hub.atlassian.net/wiki/spaces/SECPRV/pages/402751585/Roles+and+Responsibilities#Epic-Ownership)https://mozilla-hub.atlassian.net/wiki/spaces/SECPRV/pages/402751585/Roles+and+Responsibilities#Epic-Ownership

--- a/docs/epic_owners.md
+++ b/docs/epic_owners.md
@@ -1,4 +1,4 @@
 # Epic Owner
 - [Epic Ownership Roles and Responsibilities][epic-owners]
 
-[epic-owners]: https://relay.firefox.com/](https://mozilla-hub.atlassian.net/wiki/spaces/SECPRV/pages/402751585/Roles+and+Responsibilities#Epic-Ownership)https://mozilla-hub.atlassian.net/wiki/spaces/SECPRV/pages/402751585/Roles+and+Responsibilities#Epic-Ownership
+[epic-owners]: https://mozilla-hub.atlassian.net/wiki/spaces/SECPRV/pages/402751585/Roles+and+Responsibilities#Epic-Ownership


### PR DESCRIPTION
Doc to link back to epic owner definition in Confluence so team members can find the details from Github.

