### PR TITLE
MPP-3284: Log country determination

### DIFF
--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -58,7 +58,9 @@ class AddDetectedCountryToRequestAndResponseHeaders:
 def _get_metric_view_name(request):
     if request.resolver_match:
         view = request.resolver_match.func
-        return f"{view.__module__}.{view.view_class.__name__}"
+        if hasattr(view, "view_class"):
+            return f"{view.__module__}.{view.view_class.__name__}"
+        return f"{view.__module__}.{view.__name__}"
     return "<unknown_view>"
 
 

--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -58,7 +58,7 @@ class AddDetectedCountryToRequestAndResponseHeaders:
 def _get_metric_view_name(request):
     if request.resolver_match:
         view = request.resolver_match.func
-        return f"{view.__module__}.{view.__name__}"
+        return f"{view.__module__}.{view.view_class.__name__}"
     return "<unknown_view>"
 
 

--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timezone
 from typing import Callable
-import logging
 import time
 
 import markus
@@ -13,7 +12,6 @@ from whitenoise.middleware import WhiteNoiseMiddleware
 
 
 metrics = markus.get_metrics("fx-private-relay")
-info_logger = logging.getLogger("eventsinfo")
 
 
 class RedirectRootIfLoggedIn:
@@ -70,7 +68,6 @@ class ResponseMetrics:
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         start_time = time.time()
-        setattr(request, "region_details", {})
         response = self.get_response(request)
         delta = time.time() - start_time
 
@@ -85,14 +82,6 @@ class ResponseMetrics:
                 f"method:{request.method}",
             ],
         )
-
-        response_extra = {
-            "status_code": response.status_code,
-            "view_name": view_name,
-            "method": request.method,
-            "time_s": round(delta, 3),
-        }
-        info_logger.info("response", extra=response_extra)
 
         return response
 

--- a/privaterelay/tests/middleware_tests.py
+++ b/privaterelay/tests/middleware_tests.py
@@ -9,7 +9,7 @@ from pytest_django.fixtures import SettingsWrapper
 
 
 @pytest.mark.django_db
-def test_response_metrics(settings: SettingsWrapper, client: Client) -> None:
+def test_response_metrics_api_view(settings: SettingsWrapper, client: Client) -> None:
     settings.MIDDLEWARE = ["privaterelay.middleware.ResponseMetrics"]
     settings.DJANGO_STATSD_ENABLED = True
 
@@ -18,5 +18,21 @@ def test_response_metrics(settings: SettingsWrapper, client: Client) -> None:
     mm.assert_timing_once(
         "fx.private.relay.response",
         tags=["status:200", "view:api.views.runtime_data", "method:GET"],
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_response_metrics_django_view(
+    settings: SettingsWrapper, client: Client
+) -> None:
+    settings.MIDDLEWARE = ["privaterelay.middleware.ResponseMetrics"]
+    settings.DJANGO_STATSD_ENABLED = True
+
+    with MetricsMock() as mm:
+        response = client.get("/__heartbeat__")
+    mm.assert_timing_once(
+        "fx.private.relay.response",
+        tags=["status:200", "view:privaterelay.views.heartbeat", "method:GET"],
     )
     assert response.status_code == 200

--- a/privaterelay/tests/middleware_tests.py
+++ b/privaterelay/tests/middleware_tests.py
@@ -4,15 +4,12 @@ import pytest
 
 from django.test import Client
 
-from _pytest.logging import LogCaptureFixture
 from markus.testing import MetricsMock
 from pytest_django.fixtures import SettingsWrapper
 
 
 @pytest.mark.django_db
-def test_response_metrics(
-    settings: SettingsWrapper, client: Client, caplog: LogCaptureFixture
-) -> None:
+def test_response_metrics(settings: SettingsWrapper, client: Client) -> None:
     settings.MIDDLEWARE = ["privaterelay.middleware.ResponseMetrics"]
     settings.DJANGO_STATSD_ENABLED = True
 
@@ -23,8 +20,3 @@ def test_response_metrics(
         tags=["status:200", "view:api.views.runtime_data", "method:GET"],
     )
     assert response.status_code == 200
-    record = caplog.records[-1]
-    assert getattr(record, "status_code") == 200
-    assert getattr(record, "view_name") == "api.views.runtime_data"
-    assert getattr(record, "method") == "GET"
-    assert 0.0 <= getattr(record, "time_s") <= 1.0

--- a/privaterelay/tests/middleware_tests.py
+++ b/privaterelay/tests/middleware_tests.py
@@ -14,7 +14,7 @@ def test_response_metrics(settings: SettingsWrapper, client: Client) -> None:
     settings.DJANGO_STATSD_ENABLED = True
 
     with MetricsMock() as mm:
-        response = client.get("/api/v1/runtime_data")
+        response = client.get("/api/v1/runtime_data/")
     mm.assert_timing_once(
         "fx.private.relay.response",
         tags=["status:200", "view:api.views.runtime_data", "method:GET"],

--- a/privaterelay/tests/middleware_tests.py
+++ b/privaterelay/tests/middleware_tests.py
@@ -1,0 +1,22 @@
+"""Tests for privaterelay/middleware.py"""
+
+import pytest
+
+from django.test import Client
+
+from markus.testing import MetricsMock
+from pytest_django.fixtures import SettingsWrapper
+
+
+@pytest.mark.django_db
+def test_response_metrics(settings: SettingsWrapper, client: Client) -> None:
+    settings.MIDDLEWARE = ["privaterelay.middleware.ResponseMetrics"]
+    settings.DJANGO_STATSD_ENABLED = True
+
+    with MetricsMock() as mm:
+        response = client.get("/api/v1/runtime_data")
+    mm.assert_timing_once(
+        "fx.private.relay.response",
+        tags=["status:200", "view:api.views.runtime_data", "method:GET"],
+    )
+    assert response.status_code == 200

--- a/privaterelay/tests/middleware_tests.py
+++ b/privaterelay/tests/middleware_tests.py
@@ -4,12 +4,15 @@ import pytest
 
 from django.test import Client
 
+from _pytest.logging import LogCaptureFixture
 from markus.testing import MetricsMock
 from pytest_django.fixtures import SettingsWrapper
 
 
 @pytest.mark.django_db
-def test_response_metrics(settings: SettingsWrapper, client: Client) -> None:
+def test_response_metrics(
+    settings: SettingsWrapper, client: Client, caplog: LogCaptureFixture
+) -> None:
     settings.MIDDLEWARE = ["privaterelay.middleware.ResponseMetrics"]
     settings.DJANGO_STATSD_ENABLED = True
 
@@ -20,3 +23,8 @@ def test_response_metrics(settings: SettingsWrapper, client: Client) -> None:
         tags=["status:200", "view:api.views.runtime_data", "method:GET"],
     )
     assert response.status_code == 200
+    record = caplog.records[-1]
+    assert getattr(record, "status_code") == 200
+    assert getattr(record, "view_name") == "api.views.runtime_data"
+    assert getattr(record, "method") == "GET"
+    assert 0.0 <= getattr(record, "time_s") <= 1.0

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -4,6 +4,7 @@ import logging
 
 from django.contrib.auth.models import AbstractBaseUser, Group, User
 from django.core.cache.backends.base import BaseCache
+from django.test import RequestFactory
 
 from _pytest.fixtures import SubRequest
 from _pytest.logging import LogCaptureFixture
@@ -304,7 +305,9 @@ def test_guess_country_from_accept_lang_short_primary_lang_fails(accept_lang) ->
     assert exc_info.value.accept_lang == accept_lang
 
 
-def test_get_countries_info_bad_accept_language(rf) -> None:
+def test_get_countries_info_bad_accept_language(
+    rf: RequestFactory, caplog: LogCaptureFixture
+) -> None:
     request = rf.get("/api/v1/runtime_data", HTTP_ACCEPT_LANGUAGE="xx")
     mapping = get_premium_country_language_mapping()
     result = get_countries_info_from_request_and_mapping(request, mapping)
@@ -314,9 +317,17 @@ def test_get_countries_info_bad_accept_language(rf) -> None:
         "available_in_country": False,
         "plan_country_lang_mapping": mapping,
     }
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert getattr(record, "selected") == "accept_lang"
+    assert not hasattr(record, "cdn_region")
+    assert getattr(record, "accept_lang_region") == ""
+    assert getattr(record, "region") == ""
 
 
-def test_get_countries_info_cdn_language(rf) -> None:
+def test_get_countries_info_cdn_language(
+    rf: RequestFactory, caplog: LogCaptureFixture
+) -> None:
     request = rf.get("/api/v1/runtime_data", HTTP_X_CLIENT_REGION="DE")
     mapping = get_premium_country_language_mapping()
     result = get_countries_info_from_request_and_mapping(request, mapping)
@@ -326,9 +337,17 @@ def test_get_countries_info_cdn_language(rf) -> None:
         "available_in_country": True,
         "plan_country_lang_mapping": mapping,
     }
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert getattr(record, "selected") == "cdn"
+    assert getattr(record, "cdn_region", "DE")
+    assert not hasattr(record, "accept_language_region")
+    assert getattr(record, "region") == "DE"
 
 
-def test_get_countries_info_no_language(rf) -> None:
+def test_get_countries_info_no_language(
+    rf: RequestFactory, caplog: LogCaptureFixture
+) -> None:
     request = rf.get("/api/v1/runtime_data")
     mapping = get_premium_country_language_mapping()
     result = get_countries_info_from_request_and_mapping(request, mapping)
@@ -338,6 +357,12 @@ def test_get_countries_info_no_language(rf) -> None:
         "available_in_country": True,
         "plan_country_lang_mapping": mapping,
     }
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert getattr(record, "selected") == "fallback"
+    assert not hasattr(record, "cdn_region")
+    assert not hasattr(record, "accept_language_region")
+    assert getattr(record, "region") == "US"
 
 
 #


### PR DESCRIPTION
This PR addresses MPP-3284. It updates `_get_cc_from_request` in `privaterelay/utils.py` to log the details of the user's country code selection. The details are extra fields on the "eventsinfo" log message "region_details":
    - selected - which method was selected, one of "cdn", "accept_lang", "fallback" (US)
    - region - the region code returned from the function
    - cdn_region - The region code returned from the `X-Client-Region` header, or omitted if none
    - accept_lang_region - The region code determined from the `Accept-Language` header, or omitted if none

This log message is omitted once per request, by adding a flag on the request.

I originally wanted to do this logging in the `ResponseMetrics` middleware, by adding the region details as an attribute of the `HttpRequest` object. However, Django REST Framework doesn't use the original request, but recreates it as [its own Request](https://www.django-rest-framework.org/api-guide/requests/), losing any attributes it doesn't know about. I've addressed this issue on past projects, but didn't want to add that to this PR. I did retain the test and type annotations for `ResponseMetrics`. 

## How to test:

Optional test steps to see the log message and metrics:

* Add to `.env`:
   ```sh
   DJANGO_STATSD_ENABLED=True
   STATSD_DEBUG=True
   ```
* Run `./manage.py runserver`
* Visit http://127.0.0.1:8000/api/v1/runtime_data/ . Among others, you'll see a log entry like:
   ```json
  {"Timestamp": 1696881837835036928, "Type": "eventsinfo", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.local", "EnvVersion": "2.0", "Severity": 6, "Pid": 58553, "Fields": {"accept_lang_region": "US", "selected": "accept_lang", "region": "US", "msg": "region_details"}}
   ```
* Visit http://127.0.0.1:800/ , log in. Amoung others, you'll see log entries like:
   ```json
   {"Timestamp": 1696884254750748928, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 60055, "Fields": {"msg": "METRICS|2023-10-09 20:44:14|timing|fx.private.relay.response|372.32184410095215|#status:200,view:api.views.RelayAddressViewSet,method:GET"}}
   {"Timestamp": 1696884254761412096, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 60055, "Fields": {"msg": "METRICS|2023-10-09 20:44:14|timing|fx.private.relay.response|391.8941020965576|#status:200,view:api.views.runtime_data,method:GET"}}
   {"Timestamp": 1696884254762234880, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 60055, "Fields": {"msg": "METRICS|2023-10-09 20:44:14|timing|fx.private.relay.response|372.3020553588867|#status:200,view:api.views.DomainAddressViewSet,method:GET"}}
   {"Timestamp": 1696884254762557952, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 60055, "Fields": {"msg": "METRICS|2023-10-09 20:44:14|timing|fx.private.relay.response|387.8509998321533|#status:200,view:api.views.UserViewSet,method:GET"}}
   {"Timestamp": 1696884254795787008, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 60055, "Fields": {"msg": "METRICS|2023-10-09 20:44:14|timing|fx.private.relay.response|424.10993576049805|#status:200,view:api.views.ProfileViewSet,method:GET"}}
   ```
   The important part is the metrics tag `view`, which has a value like `view:api.views.RelayAddressViewSet`
* Visit http://127.0.0.1:8000/emails/wrapped_email_test . You should get log entries like:
   ```json
   {"Timestamp": 1696884594150611968, "Type": "request.summary", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 60157, "Fields": {"errno": 0, "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0", "lang": "en-US,en;q=0.5", "method": "GET", "path": "/emails/wrapped_email_test", "uid": 25, "rid": "0e3b814c-c635-4089-9e88-d907d755ceea", "t": 337}}
   {"Timestamp": 1696884594197489920, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 60157, "Fields": {"msg": "METRICS|2023-10-09 20:49:54|timing|fx.private.relay.response|394.3328857421875|#status:200,view:emails.views.wrapped_email_test,method:GET"}}
   {"Timestamp": 1696884594276588032, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 60157, "Fields": {"msg": "METRICS|2023-10-09 20:49:54|timing|fx.private.relay.response|31.200170516967773|#status:304,view:<unknown_view>,method:GET"}}
   {"Timestamp": 1696884594277666048, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 60157, "Fields": {"msg": "METRICS|2023-10-09 20:49:54|timing|fx.private.relay.response|32.5169563293457|#status:304,view:<unknown_view>,method:GET"}}
   {"Timestamp": 1696884594366545920, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 60157, "Fields": {"msg": "METRICS|2023-10-09 20:49:54|timing|fx.private.relay.response|86.52710914611816|#status:304,view:<unknown_view>,method:GET"}}
   {"Timestamp": 1696884594368954880, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 60157, "Fields": {"msg": "METRICS|2023-10-09 20:49:54|timing|fx.private.relay.response|86.11607551574707|#status:304,view:<unknown_view>,method:GET"}}
   {"Timestamp": 1696884594369138944, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 60157, "Fields": {"msg": "METRICS|2023-10-09 20:49:54|timing|fx.private.relay.response|89.82300758361816|#status:304,view:<unknown_view>,method:GET"}}
   {"Timestamp": 1696884594369462016, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 60157, "Fields": {"msg": "METRICS|2023-10-09 20:49:54|timing|fx.private.relay.response|89.41984176635742|#status:304,view:<unknown_view>,method:GET"}}
   {"Timestamp": 1696884594373288960, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 60157, "Fields": {"msg": "METRICS|2023-10-09 20:49:54|timing|fx.private.relay.response|89.8282527923584|#status:304,view:<unknown_view>,method:GET"}}
   ```
   The important part is the metrics tag `view:emails.views.wrapped_email_test`. Assets like Django Debug Toolbar CSS appears with the metrics tag `view:<unknown_view>`.
* Comment out or remove in `.env`:
   ```sh
   # DJANGO_STATSD_ENABLED=True
   # STATSD_DEBUG=True
   ```
   These settings cause tests to fail, because some expect them both to be `False`.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
