### PR TITLE
MPP-3284: Log details of region determination

### DIFF
--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -319,7 +319,7 @@ def test_get_countries_info_bad_accept_language(
     }
     assert len(caplog.records) == 1
     record = caplog.records[0]
-    assert getattr(record, "selected") == "accept_lang"
+    assert getattr(record, "region_method") == "accept_lang"
     assert not hasattr(record, "cdn_region")
     assert getattr(record, "accept_lang") == "xx"
     assert getattr(record, "accept_lang_region") == ""
@@ -340,7 +340,7 @@ def test_get_countries_info_cdn_language(
     }
     assert len(caplog.records) == 1
     record = caplog.records[0]
-    assert getattr(record, "selected") == "cdn"
+    assert getattr(record, "region_method") == "cdn"
     assert getattr(record, "cdn_region", "DE")
     assert not hasattr(record, "accept_lang")
     assert not hasattr(record, "accept_lang_region")
@@ -361,7 +361,7 @@ def test_get_countries_info_no_language(
     }
     assert len(caplog.records) == 1
     record = caplog.records[0]
-    assert getattr(record, "selected") == "fallback"
+    assert getattr(record, "region_method") == "fallback"
     assert not hasattr(record, "cdn_region")
     assert not hasattr(record, "accept_lang")
     assert not hasattr(record, "accept_lang_region")

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from functools import wraps
 from string import ascii_uppercase
 from typing import Callable, TypedDict
+import logging
 import random
 
 from django.conf import settings
@@ -17,6 +18,8 @@ from waffle.utils import (
 )
 
 from .plans import PlanCountryLangMapping, CountryStr
+
+info_logger = logging.getLogger("eventsinfo")
 
 
 class CountryInfo(TypedDict):
@@ -55,11 +58,37 @@ def get_countries_info_from_lang_and_mapping(
 
 
 def _get_cc_from_request(request: HttpRequest) -> str:
+    """Determine the user's region / country code."""
+
+    log_data: dict[str, str] = {}
+    cdn_region = None
+    region = None
     if "X-Client-Region" in request.headers:
-        return request.headers["X-Client-Region"].upper()
+        cdn_region = region = request.headers["X-Client-Region"].upper()
+        log_data["cdn_region"] = cdn_region
+        log_data["selected"] = "cdn"
+
+    accept_language_region = None
     if "Accept-Language" in request.headers:
-        return _get_cc_from_lang(request.headers["Accept-Language"])
-    return "US"
+        log_data["accept_lang"] = request.headers["Accept-Language"]
+        accept_language_region = _get_cc_from_lang(request.headers["Accept-Language"])
+        log_data["accept_lang_region"] = accept_language_region
+        if region is None:
+            region = accept_language_region
+            log_data["selected"] = "accept_lang"
+
+    if region is None:
+        region = "US"
+        log_data["selected"] = "fallback"
+    log_data["region"] = region
+
+    # MPP-3284: Log details of region selection. Only log once per request, since some
+    # endpoints, like /api/v1/runtime_data, call this multiple times.
+    if not getattr(request, "_logged_region_details", False):
+        setattr(request, "_logged_region_details", True)
+        info_logger.info("region_details", extra=log_data)
+
+    return region
 
 
 def _get_cc_from_lang(accept_lang: str) -> str:

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -66,7 +66,7 @@ def _get_cc_from_request(request: HttpRequest) -> str:
     if "X-Client-Region" in request.headers:
         cdn_region = region = request.headers["X-Client-Region"].upper()
         log_data["cdn_region"] = cdn_region
-        log_data["selected"] = "cdn"
+        log_data["region_method"] = "cdn"
 
     accept_language_region = None
     if "Accept-Language" in request.headers:
@@ -75,11 +75,11 @@ def _get_cc_from_request(request: HttpRequest) -> str:
         log_data["accept_lang_region"] = accept_language_region
         if region is None:
             region = accept_language_region
-            log_data["selected"] = "accept_lang"
+            log_data["region_method"] = "accept_lang"
 
     if region is None:
         region = "US"
-        log_data["selected"] = "fallback"
+        log_data["region_method"] = "fallback"
     log_data["region"] = region
 
     # MPP-3284: Log details of region selection. Only log once per request, since some


### PR DESCRIPTION
This PR addresses MPP-3284. It updates `_get_cc_from_request` in `privaterelay/utils.py` to log the details of the user's country code selection. The details are extra fields on the "eventsinfo" log message "region_details":
    - ~`selected`~ `region_method` - which method was selected, one of "cdn", "accept_lang", "fallback" (US)
    - `region` - the region code returned from the function
    - `cdn_region` - The region code returned from the `X-Client-Region` header, or omitted if none
    - `accept_lang` - The user's `Accept-Language` header
    - `accept_lang_region` - The region code determined from the `Accept-Language` header, or omitted if none

This log message is omitted once per request, by adding a flag on the request.

I originally wanted to do this logging in the `ResponseMetrics` middleware, but that had some problems. See PR #3983. I may pick up that idea again in the future.

## How to test:

Optional test steps to see the log message:

* Run `./manage.py runserver`
* Visit http://127.0.0.1:8000/api/v1/runtime_data/ . Among others, you'll see a log entry like:
   ```json
  {"Timestamp": 1696881837835036928, "Type": "eventsinfo", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.local", "EnvVersion": "2.0", "Severity": 6, "Pid": 58553, "Fields": {"accept_lang": "en-US, en", "accept_lang_region": "US", "region_method": "accept_lang", "region": "US", "msg": "region_details"}}
   ```

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
