### PR TITLE
Add test on upsell banner

### DIFF
--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -119,7 +119,12 @@ export const ProfileBanners = (props: Props) => {
     // Only show updated Premium Banners to users in US/CAN
     {
       isPhonesAvailableInCountry(props.runtimeData)
-        ? banners.push(<PremiumPromoBanners showFirstPremiumBanner={true} />)
+        ? banners.push(
+            <PremiumPromoBanners
+              key="premium-banner"
+              showFirstPremiumBanner={true}
+            />,
+          )
         : banners.push(
             <LoyalistPremiumBanner
               key="premium-banner"


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #3797

# How to test
- [x] Are we showing free users a similar welcome and metrics like premium users see that include (email masks used, emails blocked, emails forwarded, and trackers removed) `This is already tested on the file by previous commiter`
- [X] When a user hits their 5 mask limit, are we showing the upsell header
- [ ] The header cannot be dismissed `need advice how to test this, because i can't see any element or property about dismissed option`
- [X] Upgrade to premium CTA takes user to premium price plans
- [X] Are we providing US users the right experience (correct banners, links, etc.)
- [X] Are we providing non-US users the right experience (correct banners, links, etc.)
- [X] Are we showing a tooltip when the user hovers over the number of masks they have after they reach the limit?

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.

Note: Currently i'm enrolled on hactoberfest program, if you don't mind could you please add tag `hacktoberfest-accepted` before merging this PR? Thank you 