### PR TITLE
MPP-3107: get PHONE_RATE_LIMIT value from environment

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -614,9 +614,11 @@ SPECTACULAR_SETTINGS = {
     "SERVE_INCLUDE_SCHEMA": False,
 }
 
-PHONE_RATE_LIMIT = "5/minute"
 if IN_PYTEST or RELAY_CHANNEL in ["local", "dev"]:
-    PHONE_RATE_LIMIT = "1000/minute"
+    _DEFAULT_PHONE_RATE_LIMIT = "1000/minute"
+else:
+    _DEFAULT_PHONE_RATE_LIMIT = "5/minute"
+PHONE_RATE_LIMIT = config("PHONE_RATE_LIMIT", _DEFAULT_PHONE_RATE_LIMIT)
 
 # Turn on logging out on GET in development.
 # This allows `/mock/logout/` in the front-end to clear the


### PR DESCRIPTION
This PR is for #MPP-3107.

How to test:
1. `RELAY_CHANNEL="prod" PHONE_RATE_LIMIT="20/minute" python manage.py shell`
2. `from django.conf import settings`
3. `settings.PHONE_RATE_LIMIT`
   * [x] Should return `'20/minute'`
      * Note: On `main` branch this returns `'5/minute'`

<img width="1362" alt="image" src="https://github.com/mozilla/fx-private-relay/assets/71928/242da734-031a-471c-995c-e3c50505169c">

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).