### PR TITLE
MPP-3441: add first_forwarded_email API endpoint

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -241,3 +241,7 @@ class WebcompatIssueSerializer(serializers.Serializer):
     add_on_visual_issue = serializers.BooleanField(required=False, default=False)
     email_not_received = serializers.BooleanField(required=False, default=False)
     other_issue = serializers.CharField(required=False, default="", allow_blank=True)
+
+
+class FirstForwardedEmailSerializer(serializers.Serializer):
+    mask = serializers.EmailField(required=True)

--- a/api/urls.py
+++ b/api/urls.py
@@ -15,6 +15,7 @@ from .views import (
     ProfileViewSet,
     UserViewSet,
     FlagViewSet,
+    first_forwarded_email,
     report_webcompat_issue,
     runtime_data,
     terms_accepted_user,
@@ -82,6 +83,11 @@ urlpatterns = [
             SpectacularRedocView.as_view(url_name="schema")
         ),
         name="schema-redoc-ui",
+    ),
+    path(
+        "v1/first-forwarded-email/",
+        first_forwarded_email,
+        name="first_forwarded_email",
     ),
 ]
 

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from django.core.exceptions import ObjectDoesNotExist
 from django.template.loader import render_to_string
 from django.urls.exceptions import NoReverseMatch
 import requests
@@ -380,7 +381,7 @@ def first_forwarded_email(request):
         try:
             address = _get_address(mask)
             RelayAddress.objects.get(user=user, address=address)
-        except RelayAddress.DoesNotExist:
+        except ObjectDoesNotExist:
             return response.Response(
                 f"{mask} does not exist for user.", status=status.HTTP_404_NOT_FOUND
             )

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -369,7 +369,9 @@ def first_forwarded_email(request):
         translated_subject = ftl_bundle.format("first-forwarded-email-subject")
     first_forwarded_email_html = render_to_string(
         "emails/first_forwarded_email.html",
-        {},
+        {
+            "SITE_ORIGIN": settings.SITE_ORIGIN,
+        },
     )
     wrapped_email = wrap_html_email(
         first_forwarded_email_html,

--- a/emails/management/commands/send_welcome_emails.py
+++ b/emails/management/commands/send_welcome_emails.py
@@ -13,7 +13,7 @@ import django_ftl
 
 from emails.apps import EmailsConfig
 from emails.models import Profile
-from emails.utils import get_welcome_email
+from emails.utils import get_welcome_email, ses_message_props
 from privaterelay.ftl_bundles import main as ftl_bundle
 
 logger = logging.getLogger("eventsinfo.send_welcome_emails")
@@ -54,10 +54,10 @@ def send_welcome_email(profile: Profile, **kwargs):
             },
             Source=settings.RELAY_FROM_ADDRESS,
             Message={
-                "Subject": _ses_message_props(translated_subject),
+                "Subject": ses_message_props(translated_subject),
                 "Body": {
-                    "Html": _ses_message_props(get_welcome_email(user, "html")),
-                    "Text": _ses_message_props(get_welcome_email(user, "txt")),
+                    "Html": ses_message_props(get_welcome_email(user, "html")),
+                    "Text": ses_message_props(get_welcome_email(user, "txt")),
                 },
             },
         )

--- a/emails/templates/emails/first_forwarded_email.html
+++ b/emails/templates/emails/first_forwarded_email.html
@@ -87,44 +87,17 @@ See privaterelay/ftl_bundles.py.
       color: #000000;
     }
 
-    #our-promise-section {
-      display: block;
-      /* provides extra outer padding for the gradient container */
-      width: 100%;
-      margin: 0;
-      position: relative;
-      box-sizing: border-box;
-      background-clip: padding-box;
-    }
-
-    #our-promise-section:before {
-      content: '';
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      /* sets order for clipped background */
-      z-index: -1;
-      /* set to the same width of the border for clipping */
-      margin: -2px;
-      border-radius: inherit;
-      background: radial-gradient(100% 100% at 100% 0%, #B833E1 0%, #9059FF 33.33%, #B833E1 60.42%, #073072 100%);
-      opacity: 90%;
-    }
-
     #what-you-can-do-with-relay {
-      padding: 0 48px 32px 48px;
+      padding: 32px 48px 32px 48px;
+      width: 95%;
       display: block;
-      /* provides extra outer padding for the gradient container */
-      width: calc(100% - 20px);
       position: relative;
-      box-sizing: border-box;
-      color: #FFFFFF;
-      background: #FFFFFF;
-      background-clip: padding-box;
       border: solid 3px transparent;
       border-radius: 8px;
+      background: radial-gradient(#FFFFFF, #FFFFFF), 
+        radial-gradient(100% 100% at 100% 0%, #9D62FC 0%, #FD3296 100%);
+      background-origin: border-box;
+      background-clip: padding-box, border-box;
     }
 
     #what-you-can-do-with-relay p {
@@ -136,21 +109,6 @@ See privaterelay/ftl_bundles.py.
 
     #what-you-can-do-with-relay p:first-child {
       margin-bottom: 8px;
-    }
-
-    #what-you-can-do-with-relay:before {
-      content: '';
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      /* sets order for clipped background */
-      z-index: -1;
-      /* set to the same width of the border for clipping */
-      margin: -3px;
-      border-radius: inherit;
-      background: radial-gradient(100% 100% at 100% 0%, #9D62FC 0%, #FD3296 100%);
     }
 
     #relay-email-footer {
@@ -245,19 +203,18 @@ See privaterelay/ftl_bundles.py.
   <table style="vertical-align: top;min-width: 320px;margin: 0 auto;width:100%" cellpadding="0" cellspacing="0">
     <tbody>
       <tr style="vertical-align: top">
-        <td style="word-break: break-word;border-collapse: collapse ;vertical-align: top">
+        <td style="word-break: break-word;border-collapse: collapse;vertical-align: top">
           <!-- Hero section -->
-          <table id="hero" style="max-width:850px;margin:48px auto 64px auto;" cellpadding="0"
+          <table id="hero" style="max-width:850px;margin:0 auto 48px auto;" cellpadding="0"
             cellspacing="0" width="100%" border="0">
             <tbody>
               <tr>
-                <td align="right">
+                <td style="vertical-align: top;" align="right">
                   <img class="arrow-img" align="center" border="0"
                   src="{{ SITE_ORIGIN }}/static/images/email-images/first-time-forwarded/arrow-up.png" alt=""
-                  title="" style="display: inline-block;border: none; height: auto; width: 126px; position:absolute; top: 120px;" />
-                
+                  title="" style="display: inline-block;border: none; height: auto; max-width: 126px;" />  
                 </td>
-                <td id="hero-desc" style="padding-left: 120px;max-width: 280px; height: auto;" align="left">
+                <td id="hero-desc" style="padding-top: 40px; max-width: 280px; height: auto;" align="left">
                   <h1 style="margin-top: 0;text-align: left; word-wrap: break-word; font-size: 38px; color: #321C64;">
                     {% ftlmsg 'forwarded-email-hero-header' %}
                   </h1>
@@ -265,7 +222,7 @@ See privaterelay/ftl_bundles.py.
                     {% ftlmsg 'forwarded-email-hero-desc' %}
                   </p>
                 </td>
-                <td id="hero-mask-img" style="padding-right:90px;" align="right">
+                <td id="hero-mask-img" style="vertical-align: top; padding-top: 40px;" align="left">
                   <img align="center" border="0"
                   src="{{ SITE_ORIGIN }}/static/images/email-images/first-time-forwarded/privacy-illustration.png" alt=""
                   title="" style="display: inline-block;border: none; height: auto; max-width: 250px;" />
@@ -275,16 +232,14 @@ See privaterelay/ftl_bundles.py.
           </table>
 
           <!-- What you can do with relay -->
-          <table id="what-you-can-do-with-relay" style="max-width: 850px; display: block; margin: 0 auto;"
+          <table id="what-you-can-do-with-relay"  style="max-width: 850px; display: block; margin: 0 auto;"
             cellpadding="0" cellspacing="0" width="100%" border="0">
             <tbody>
               <tr>
-                <td style="overflow-wrap:break-word;word-break:break-word;padding:10px;" align="left">
-
+                <td style="overflow-wrap:break-word;word-break:break-word;" align="left">
                   <h1
                     style="line-height: 140%; text-align: center; word-wrap: break-word; font-size: 24px; color: #321C64;">
                     {% ftlmsg 'what-can-you-do-with-relay-title' %}</h1>
-
                 </td>
               </tr>
 
@@ -350,7 +305,7 @@ See privaterelay/ftl_bundles.py.
               </tr>
             </tbody>
           </table>
-
+        
           <!-- View your dashboard button -->
           <table id="view-your-dashboard" style="max-width: 850px;margin:32px auto 64px auto;" cellpadding="0"
             cellspacing="0" width="100%" border="0">
@@ -361,27 +316,27 @@ See privaterelay/ftl_bundles.py.
                     target="_blank" class="button" style="color: #FFFFFF;" rel="noreferrer">
                     {% ftlmsg 'first-time-user-email-hero-cta' %}
                   </a>
-                  <img class="arrow-img-two" align="" border="0"
-                  src="{{ SITE_ORIGIN }}/static/images/email-images/first-time-forwarded/arrow-down.png" alt=""
-                  title="" style="position:absolute; height: auto; width: 122px; margin-top: -66px;" />
                 </td>
               </tr>
             </tbody>
           </table>
 
           <!-- Our promise -->
-          <table id="our-promise-section" style="max-width: 850px; display: block;margin:0 auto;" cellpadding="0"
-            cellspacing="0" width="100%" border="0">
+          <!-- bgcolor for fallback, as outlook does not support gradient backgrounds -->
+          <table id="our-promise-section" bgcolor="#45278D" style="max-width: 850px; display:block;margin:0 auto;width:100%; background-clip: padding-box; box-sizing: border-box; position: relative;
+          background: radial-gradient(100% 100% at 100% 0%, #B833E1 0%, #9059FF 33.33%, #B833E1 60.42%, #073072 100%);
+          opacity:90%;" cellpadding="0" cellspacing="0" width="100%" border="0">
             <tbody>
               <tr>
                 <td style="overflow-wrap:break-word;word-break:break-word;padding: 32px 48px 48px 48px;" align="center">
                   <img align="center" border="0"
                     src="{{ SITE_ORIGIN }}/static/images/email-images/first-time-forwarded/lock-illustration.png" alt=""
-                    title="" style="display: inline-block;border: none;height: auto; max-width: 90px;" />
-
-                  <p class="title"
-                    style="font-size: 24px; font-family: metropolis bold, system-ui, sans-serif; color: #ffffff; margin-top: 8px;">
-                    {% ftlmsg 'our-promise-header' %}</p>
+                    title="" style="display: inline-block;border: none;height: auto;max-height:90px;max-width: 90px;" />
+                  <strong>
+                    <p class="title"
+                      style="font-size: 24px; font-family: metropolis bold, system-ui, sans-serif; color: #ffffff; margin-top: 8px;">
+                      {% ftlmsg 'our-promise-header' %}</p>
+                  </strong>
                   <p class="text"
                     style="font-size: 18px; line-height:20px; font-family: metropolis medium, system-ui, sans-serif; color: #ffffff; word-wrap: break-word; margin-top: 24px; ">
                     {% ftlmsg 'our-promise-content' %}</p>
@@ -455,7 +410,6 @@ See privaterelay/ftl_bundles.py.
               </tr>
             </tbody>
           </table>
-
         </td>
       </tr>
     </tbody>

--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -177,7 +177,7 @@
     </table>
 
     <!-- Email Body -->
-    <table id="relay-email-body" width="100%" style="padding: 0; max-width:700px;" align="center">
+    <table id="relay-email-body" width="100%" style="padding: 0; max-width:850px;" align="center">
       <tr>
         <td width="100%" style="padding-left: 15px; padding-right: 15px;">
           {{ original_html|safe }}

--- a/emails/tests/fixtures/emperor_norton_expected.email
+++ b/emails/tests/fixtures/emperor_norton_expected.email
@@ -1,28 +1,35 @@
+Subject: Declaration and Meeting of the Union
+From: "norton@sf.us.example.com [via Relay]" <ebsbdsan7@test.com>
+To: user@example.com
+Reply-To: replies@default.com
+Resent-From: norton@sf.us.example.com
 MIME-Version: 1.0
 Content-Type: multipart/alternative;
- boundary="b1_1tMoOzirX5rNUK0QIqMdSQB8hwcBeFGHtIfEtmvEG0k"
-Subject: localized email header + footer
-From: "fxastage@protonmail.com [via Relay]" <wildcard@subdomain.test.com>
-To: premium@email.com
-Reply-To: replies@default.com
-Resent-From: fxastage@protonmail.com
+ boundary="==[BOUNDARY0]=="
 
-This is a multi-part message in MIME format.
-
---b1_1tMoOzirX5rNUK0QIqMdSQB8hwcBeFGHtIfEtmvEG0k
+--==[BOUNDARY0]==
 Content-Type: text/plain; charset="utf-8"
 Content-Transfer-Encoding: quoted-printable
-MIME-Version: 1.0
 
-This email was sent to your alias wildcard@subdomain.test.com. To stop receiv=
-ing emails sent to this alias, update the forwarding settings in your dashboa=
-rd.
+This email was sent to your alias ebsbdsan7@test.com. To stop receiving email=
+s sent to this alias, update the forwarding settings in your dashboard.
 ---Begin Email---
-should work
+At the peremptory request and desire of a large majority of the citizens of
+these United States, I, Joshua Norton, formerly of Algoa Bay, Cape of Good
+Hope, and now for the last 9 years and 10 months past of San Francisco,
+California, declare and proclaim myself Emperor of these United States; and in
+virtue of the authority thereby in me vested, do hereby order and direct the
+representatives of the different States of the Union to assemble in Musical
+Hall, of this city, on the 1st day of February next, then and there to make
+such alterations in the existing laws of the Union as may ameliorate the evils
+under which the country is laboring, and thereby cause confidence to exist,
+both at home and abroad, in our stability and integrity.
 
-Sent with [ProtonMail](https://protonmail.com/) Secure Email.
+NORTON I.,
+Emperor of the United States.
+17th September, 1859
 
---b1_1tMoOzirX5rNUK0QIqMdSQB8hwcBeFGHtIfEtmvEG0k
+--==[BOUNDARY0]==
 Content-Type: text/html; charset="utf-8"
 Content-Transfer-Encoding: quoted-printable
 MIME-Version: 1.0
@@ -144,14 +151,14 @@ k;">
             <span class=3D"forwarded-from-email" style=3D"display: block; col=
 or: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
             Forwarded from <a href=3D"http://127.0.0.1:8000/accounts/profile/=
-#wildcard%40subdomain.test.com" class=3D"container-link" style=3D"margin-righ=
-t: 30px;color: #FFFFFF;font-size: 12px;">wildcard@subdomain.test.com</a>
+#ebsbdsan7%40test.com" class=3D"container-link" style=3D"margin-right: 30px;c=
+olor: #FFFFFF;font-size: 12px;">ebsbdsan7@test.com</a>
             </span>
           <span style=3D"margin-top: 0; margin-bottom: 5px; display: block;co=
 lor: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
               by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=3D=
 "container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12px;"=
->Firefox Relay Premium</a>
+>Firefox Relay</a>
           </span>
           </p>
         </td>
@@ -165,9 +172,9 @@ g" alt=3D"email trackers removed icon"/>
               <span dir=3D"auto">0</span> email trackers removed
           </p>
           <p class=3D"relay-mask" style=3D"margin: 0; display: inline-block;">
-              <a class=3D"container-link" href=3D"http://127.0.0.1:8000/accou=
-nts/profile/#wildcard%40subdomain.test.com" style=3D"color: #FFFFFF;">
-                Manage this mask
+              <a class=3D"container-link" href=3D"http://127.0.0.1:8000/premi=
+um" style=3D"color: #FFFFFF;">
+                Upgrade for more protection
               </a>
           </p>
         </td>
@@ -178,15 +185,18 @@ nts/profile/#wildcard%40subdomain.test.com" style=3D"color: #FFFFFF;">
 dth:850px;" align=3D"center">
       <tr>
         <td width=3D"100%" style=3D"padding-left: 15px; padding-right: 15px;">
-          <div style=3D"font-family: arial; font-size: 14px;"><div style=3D"f=
-ont-family: arial; font-size: 14px;">should work<br></div><div style=3D"font-=
-family: arial; font-size: 14px;"><br></div><div style=3D"font-family: arial; =
-font-size: 14px;" class=3D"protonmail_signature_block"><div class=3D"protonma=
-il_signature_block-user protonmail_signature_block-empty"></div><div class=3D=
-"protonmail_signature_block-proton">Sent with <a rel=3D"noopener noreferrer" =
-href=3D"https://protonmail.com/" target=3D"_blank">ProtonMail</a> Secure Emai=
-l.</div></div></div><div style=3D"font-family: arial; font-size: 14px;"><br><=
-/div>
+          At the peremptory request and desire of a large majority of the cit=
+izens of<br>these United States, I, Joshua Norton, formerly of Algoa Bay, Cap=
+e of Good<br>Hope, and now for the last 9 years and 10 months past of San Fra=
+ncisco,<br>California, declare and proclaim myself Emperor of these United St=
+ates; and in<br>virtue of the authority thereby in me vested, do hereby order=
+ and direct the<br>representatives of the different States of the Union to as=
+semble in Musical<br>Hall, of this city, on the 1st day of February next, the=
+n and there to make<br>such alterations in the existing laws of the Union as =
+may ameliorate the evils<br>under which the country is laboring, and thereby =
+cause confidence to exist,<br>both at home and abroad, in our stability and i=
+ntegrity.<br><br>NORTON I.,<br>Emperor of the United States.<br>17th Septembe=
+r, 1859<br>
         </td>
       </tr>
     </table>
@@ -211,5 +221,4 @@ profile" style=3D"color: #FFFFFF;">Your dashboard</a>
   </body>
 </html>
 
---b1_1tMoOzirX5rNUK0QIqMdSQB8hwcBeFGHtIfEtmvEG0k--
-
+--==[BOUNDARY0]==--

--- a/emails/tests/fixtures/inline_image_expected.email
+++ b/emails/tests/fixtures/inline_image_expected.email
@@ -177,7 +177,7 @@ um" style=3D"color: #FFFFFF;">
     </table>
     <!-- Email Body -->
     <table id=3D"relay-email-body" width=3D"100%" style=3D"padding: 0; max-wi=
-dth:700px;" align=3D"center">
+dth:850px;" align=3D"center">
       <tr>
         <td width=3D"100%" style=3D"padding-left: 15px; padding-right: 15px;">
           <!doctype html><html><body><div dir=3D"ltr">Here is an inline image=

--- a/emails/tests/fixtures/plain_text_expected.email
+++ b/emails/tests/fixtures/plain_text_expected.email
@@ -170,7 +170,7 @@ um" style=3D"color: #FFFFFF;">
     </table>
     <!-- Email Body -->
     <table id=3D"relay-email-body" width=3D"100%" style=3D"padding: 0; max-wi=
-dth:700px;" align=3D"center">
+dth:850px;" align=3D"center">
       <tr>
         <td width=3D"100%" style=3D"padding-left: 15px; padding-right: 15px;">
           This is a text-only email.<br>See <a href=3D"https://text.example.c=

--- a/emails/tests/fixtures/russian_spam_expected.email
+++ b/emails/tests/fixtures/russian_spam_expected.email
@@ -179,7 +179,7 @@ um" style=3D"color: #FFFFFF;">
     </table>
     <!-- Email Body -->
     <table id=3D"relay-email-body" width=3D"100%" style=3D"padding: 0; max-wi=
-dth:700px;" align=3D"center">
+dth:850px;" align=3D"center">
       <tr>
         <td width=3D"100%" style=3D"padding-left: 15px; padding-right: 15px;">
 <!DOCTYPE html>

--- a/emails/tests/fixtures/single_recipient_expected.email
+++ b/emails/tests/fixtures/single_recipient_expected.email
@@ -174,7 +174,7 @@ um" style=3D"color: #FFFFFF;">
     </table>
     <!-- Email Body -->
     <table id=3D"relay-email-body" width=3D"100%" style=3D"padding: 0; max-wi=
-dth:700px;" align=3D"center">
+dth:850px;" align=3D"center">
       <tr>
         <td width=3D"100%" style=3D"padding-left: 15px; padding-right: 15px;">
           <div style=3D"font-family: arial; font-size: 14px;"><div style=3D"f=

--- a/emails/tests/fixtures/single_recipient_fr_expected.email
+++ b/emails/tests/fixtures/single_recipient_fr_expected.email
@@ -175,7 +175,7 @@ um" style=3D"color: #FFFFFF;">
     </table>
     <!-- Email Body -->
     <table id=3D"relay-email-body" width=3D"100%" style=3D"padding: 0; max-wi=
-dth:700px;" align=3D"center">
+dth:850px;" align=3D"center">
       <tr>
         <td width=3D"100%" style=3D"padding-left: 15px; padding-right: 15px;">
           <div style=3D"font-family: arial; font-size: 14px;"><div style=3D"f=

--- a/emails/tests/fixtures/single_recipient_list_expected.email
+++ b/emails/tests/fixtures/single_recipient_list_expected.email
@@ -174,7 +174,7 @@ um" style=3D"color: #FFFFFF;">
     </table>
     <!-- Email Body -->
     <table id=3D"relay-email-body" width=3D"100%" style=3D"padding: 0; max-wi=
-dth:700px;" align=3D"center">
+dth:850px;" align=3D"center">
       <tr>
         <td width=3D"100%" style=3D"padding-left: 15px; padding-right: 15px;">
           <div style=3D"font-family: arial; font-size: 14px;"><div style=3D"f=

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -16,7 +16,7 @@ import requests
 from botocore.exceptions import ClientError
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDFExpand
-from mypy_boto3_ses.type_defs import SendRawEmailResponseTypeDef
+from mypy_boto3_ses.type_defs import ContentTypeDef, SendRawEmailResponseTypeDef
 import jwcrypto.jwe
 import jwcrypto.jwk
 import markus
@@ -54,6 +54,10 @@ shavar_prod_lists_url = (
 )
 EMAILS_FOLDER_PATH = pathlib.Path(__file__).parent
 TRACKER_FOLDER_PATH = EMAILS_FOLDER_PATH / "tracker_lists"
+
+
+def ses_message_props(data: str) -> ContentTypeDef:
+    return {"Charset": "UTF-8", "Data": data}
 
 
 def get_trackers(level):

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -586,6 +586,10 @@ if DEBUG and not IN_PYTEST:
         "rest_framework.renderers.BrowsableAPIRenderer",
     ]
 
+FIRST_EMAIL_RATE_LIMIT = config("FIRST_EMAIL_RATE_LIMIT", "5/minute")
+if IN_PYTEST or RELAY_CHANNEL in ["local", "dev"]:
+    FIRST_EMAIL_RATE_LIMIT = "1000/minute"
+
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "api.authentication.FxaTokenAuthentication",


### PR DESCRIPTION
This PR fixes #MPP-3441.
### Still TODO
* [x] Fix the `From` to be the mask email address

### How to test:
1. [Set up end-to-end local email](https://github.com/mozilla/fx-private-relay/blob/main/docs/end-to-end-local-email-dev.md) or push branch to dev server
2. Sign in and go to http://127.0.0.1:8000/api/v1/docs/#/first-forwarded-email
3. Expand the endpoint
4. Click "Try it out"
5. Enter a generated masks email as the value to "mask" in the request body.
6. Click "Execute"
   * [x] It should show a `201` response code
   * [x] It should send the first forwarded email

### Checklist
- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).