### PR TITLE
MPP-3434: Handle an empty JSON for account profile

### DIFF
--- a/api/tests/authentication_tests.py
+++ b/api/tests/authentication_tests.py
@@ -26,6 +26,11 @@ from ..authentication import (
 MOCK_BASE = "api.authentication"
 
 
+# TODO MPP-3527 - Many tests mock FxA responses. This one should specify that it is
+# mocking the introspection URL. It could also be refactored to a pytest fixture, or a
+# nullable.
+
+
 def _setup_fxa_response(status_code: int, json: dict | str):
     responses.add(
         responses.POST,

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -475,9 +475,8 @@ class TermsAcceptedUserViewTest(TestCase):
         _setup_fxa_response(200, {"active": True, "sub": self.uid, "exp": exp_time})
         # FxA profile server is down
         responses.add(responses.GET, FXA_PROFILE_URL, status=502, body="")
-
-        # get fxa response with 201 response for new user and profile created
         response = self.client.post(self.path)
+
         assert response.status_code == 500
         assert response.json()["detail"] == (
             "Did not receive a 200 response for account profile."

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -466,6 +466,23 @@ class TermsAcceptedUserViewTest(TestCase):
         assert responses.assert_call_count(self.fxa_verify_path, 2) is True
         assert responses.assert_call_count(FXA_PROFILE_URL, 1) is True
 
+    @responses.activate()
+    def test_failed_profile_fetch_for_new_user_returns_500(self):
+        user_token = "user-123"
+        self._setup_client(user_token)
+        now_time = int(datetime.now().timestamp())
+        exp_time = (now_time + 60 * 60) * 1000
+        _setup_fxa_response(200, {"active": True, "sub": self.uid, "exp": exp_time})
+        # FxA profile server is down
+        responses.add(responses.GET, FXA_PROFILE_URL, status=502, body="")
+
+        # get fxa response with 201 response for new user and profile created
+        response = self.client.post(self.path)
+        assert response.status_code == 500
+        assert response.json()["detail"] == (
+            "Did not receive a 200 response for account profile."
+        )
+
     def test_no_authorization_header_returns_400(self):
         client = APIClient()
         response = client.post(self.path)

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -230,6 +230,18 @@ def terms_accepted_user(request):
         fxa_profile_resp = requests.get(
             FXA_PROFILE_URL, headers={"Authorization": f"Bearer {token}"}
         )
+        if not (fxa_profile_resp.ok and fxa_profile_resp.content):
+            logger.error(
+                "terms_accepted_user: bad account profile response",
+                extra={
+                    "status_code": fxa_profile_resp.status_code,
+                    "content": fxa_profile_resp.content,
+                },
+            )
+            return response.Response(
+                data={"detail": "Did not receive a 200 response for account profile."},
+                status=500,
+            )
 
         # this is not exactly the request object that FirefoxAccountsProvider expects, but
         # it has all of the necssary attributes to initiatlize the Provider

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -1,3 +1,13 @@
+"""
+API views for emails and accounts
+
+TODO: Move these functions to mirror the Django apps
+
+Email stuff should be in api/views/emails.py
+Runtime data should be in api/views/privaterelay.py
+Profile stuff is strange - model is in emails, but probably should be in privaterelay.
+"""
+
 import json
 import logging
 from django.urls.exceptions import NoReverseMatch

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -8,7 +8,6 @@ Runtime data should be in api/views/privaterelay.py
 Profile stuff is strange - model is in emails, but probably should be in privaterelay.
 """
 
-import json
 import logging
 from django.urls.exceptions import NoReverseMatch
 import requests
@@ -238,7 +237,7 @@ def terms_accepted_user(request):
         # This may not save the new user that was created
         # https://github.com/pennersr/django-allauth/blob/77368a84903d32283f07a260819893ec15df78fb/allauth/socialaccount/providers/base/provider.py#L44
         social_login = provider.sociallogin_from_response(
-            request, json.loads(fxa_profile_resp.content)
+            request, fxa_profile_resp.json()
         )
         # Complete social login is called by callback
         # (see https://github.com/pennersr/django-allauth/blob/77368a84903d32283f07a260819893ec15df78fb/allauth/socialaccount/providers/oauth/views.py#L118)


### PR DESCRIPTION
When creating a user from a `POST` to `/api/v1/terms_accepter_user`, we request the user's profile. If this call fails, then log the profile request status code and text and return 500. Previously, an empty response was returned, and the call failed due to a JSON decode error.

Also:

* Add a TODO to split up this file. This can be done after the "first_forwarded_email" endpoint is merged.
* Use [.json() from the requests library](https://requests.readthedocs.io/en/latest/user/quickstart/#json-response-content) to parse the profile JSON

## How to test:

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
