### PR TITLE
e2e fix needed after the playwright version bump

### DIFF
--- a/e2e-tests/pages/dashboardPage.ts
+++ b/e2e-tests/pages/dashboardPage.ts
@@ -119,7 +119,7 @@ export class DashboardPage {
 
     async upgrade(){
         await Promise.all([
-            this.page.waitForNavigation(),
+            this.page.waitForURL("**/accounts/profile/"),
             this.upgradeButton.click()
         ]);
     }

--- a/e2e-tests/specs/relay-premium-upgrade.spec.ts
+++ b/e2e-tests/specs/relay-premium-upgrade.spec.ts
@@ -5,6 +5,8 @@ import { checkAuthState, defaultScreenshotOpts } from '../e2eTestUtils/helpers';
 test.use({ storageState: 'state.json' })
 test.describe.configure({ mode: 'parallel' });
 test.describe('Premium Relay - Purchase Premium Flow, Desktop', () => {
+  test.skip(({ browserName }) => browserName === 'firefox', 'FxA Issue with with authenication');
+
   test.beforeEach(async ({ dashboardPage, page }) => {
     await dashboardPage.open()
     await checkAuthState(page)


### PR DESCRIPTION
Fix for the relay e2e failure that appeared after the version bump. This is a temporally fix as it doesn't address the root problem with nightly and playwright just yet.
