### PR TITLE
Update Django from 3.2.20 to 3.2.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.28.62
 codetiming==1.4.0
 cryptography==41.0.4
-Django==3.2.20
+Django==3.2.22
 dj-database-url==2.1.0
 django-allauth==0.54.0
 django-cors-headers==4.2.0


### PR DESCRIPTION
This update Django to the latest in the 3.2 series. It appears Dependabot is no longer suggesting 3.2 updates, which is another reason to update to 4.2 as soon as possible (#3126)

[Django 3.2.21](https://docs.djangoproject.com/en/3.2/releases/3.2.21/) was released September 4, 2023. It fixes a denial-of-service vulnerability with `django.utils.encoding.uri_to_iri()`.

**I do not believe we are vulnerable to this issue**, because our code does not use `uri_to_iri()`, and Django code does not appear to use it either.

[Django 3.2.22](https://docs.djangoproject.com/en/3.2/releases/3.2.22/) was released October 4, 2023. It fixed a denial-of-service vulnerability with `django.utils.text.Truncator`’s `chars()` and `words()` methods with `html=True`. 

**I do not believe we are vulnerable to this issue**, because we do not use the HTML mode. We use `Truncator` to create our `From` header for forwarded emails:

https://github.com/mozilla/fx-private-relay/blob/8041a14c6d958c05ae21b5d9e25451ef3b93519d/emails/utils.py#L298

We do not use the affected template filters `truncatechars_html` or `truncatewords_html`

## How to test

I believe the continuous integration tests should be sufficient to validate this update.