### PR TITLE
Restore overlay bug workaround for news menu

### DIFF
--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -69,6 +69,7 @@ import Link from "next/link";
 import { GiftIcon } from "../../../Icons";
 import { useL10n } from "../../../../hooks/l10n";
 import { VisuallyHidden } from "../../../VisuallyHidden";
+import { useOverlayBugWorkaround } from "../../../../hooks/overlayBugWorkaround";
 
 export type WhatsNewEntry = {
   title: string;
@@ -660,6 +661,7 @@ export const WhatsNewMenu = (props: Props) => {
     offset: 10,
     isOpen: triggerState.isOpen,
   }).overlayProps;
+  const overlayBugWorkaround = useOverlayBugWorkaround(triggerState);
 
   const { buttonProps } = useButton(triggerProps, triggerRef);
 
@@ -681,6 +683,7 @@ export const WhatsNewMenu = (props: Props) => {
 
   return (
     <>
+      {overlayBugWorkaround}
       <button
         {...buttonProps}
         ref={triggerRef}
@@ -697,7 +700,7 @@ export const WhatsNewMenu = (props: Props) => {
         </span>
         {pill}
       </button>
-      {
+      {triggerState.isOpen && (
         <OverlayContainer>
           <WhatsNewPopover
             {...overlayProps}
@@ -714,7 +717,7 @@ export const WhatsNewMenu = (props: Props) => {
             />
           </WhatsNewPopover>
         </OverlayContainer>
-      }
+      )}
     </>
   );
 };
@@ -756,10 +759,6 @@ const WhatsNewPopover = forwardRef<HTMLDivElement, PopoverProps>(
           {...mergedOverlayProps}
           ref={ref}
           className={styles["popover-wrapper"]}
-          style={{
-            ...mergedOverlayProps.style,
-            display: !isOpen ? "none" : mergedOverlayProps.style?.display,
-          }}
         >
           <VisuallyHidden>
             <h2 {...titleProps}>{title}</h2>

--- a/frontend/src/hooks/overlayBugWorkaround.tsx
+++ b/frontend/src/hooks/overlayBugWorkaround.tsx
@@ -1,0 +1,42 @@
+import { Fragment, useEffect, useReducer } from "react";
+import { OverlayTriggerState } from "react-stately";
+
+/**
+ * Work around a bug that prevents overlay menus from opening
+ *
+ * This hook is a workaround for this weird bug:
+ * https://github.com/adobe/react-spectrum/issues/3517
+ *
+ * Since the bug presumably exists somewhere in the interplay between Next.js
+ * and React Aria, it is hard for either project to fix. And of course, our glue
+ * code might be at fault as well.
+ *
+ * The bug is that `useOverlayPosition` usually looks at the position of the
+ * overlay trigger, and then updates the style properties that it returns with
+ * the values needed to position the overlay. However, that update does not
+ * happen by itself. Hence, this hook returns an invisible element that you can
+ * include in your view, and that will trigger a re-render whenever the menu
+ * opens or closes.
+ *
+ * @param state The OverlayTriggerState controlling your overlay (i.e. whose `isOpen` property you pass to `useOverlayPosition`)
+ * @returns An invisible element to include next to your overlay trigger
+ */
+export const useOverlayBugWorkaround = (state: OverlayTriggerState) => {
+  const [renderCount, triggerRerender] = useReducer(
+    (renders) => renders + 1,
+    0,
+  );
+
+  useEffect(() => {
+    // Not doing anything, just triggering a re-render if the menu opens to
+    // work around
+    // https://github.com/adobe/react-spectrum/issues/3517
+    setTimeout(() => triggerRerender());
+  }, [state.isOpen]);
+
+  // An invisible element that gets re-rendered every time the menu opens
+  const elementToRender = (
+    <Fragment key={`overlayBugWorkaroundRender${renderCount}`} />
+  );
+  return elementToRender;
+};


### PR DESCRIPTION
So... This is a bit embarrassing. I was just trying to inspect something in the accessibility inspector, only to find out I couldn't reach it. It turned out that the <OverlayProvider> set aria-hidden by default, and git bisect turned up the following commit as the culprit: 44d2e15cf94c05c58ebb5e20b79dd4880a7e56d1.

Thus, this partially reverts that commit.

How to test: On `main`, if you're on a page that displays the News menu, and you right-click and select "Inspect Accessibility Properties", you'll find that you can't really select anything, and the accessibility tree is suspiciously short:

![image](https://github.com/mozilla/fx-private-relay/assets/4251/91918f19-41f0-4db1-96a2-adba6e0b5d3a)

Then in the regular inspector, you'll see that the `div` with ID `overlayProvider` has `aria-hidden="true"`:

![image](https://github.com/mozilla/fx-private-relay/assets/4251/6d3391a1-ee09-4d0c-bd84-14109a25c57d)

In this branch, everything should be accessible again.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
