### PR TITLE
MPP-3061: On filter resets, visually reset checkboxes

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -38,6 +38,7 @@ export const AliasList = (props: Props) => {
   const l10n = useL10n();
   const [stringFilterInput, setStringFilterInput] = useState("");
   const [stringFilterVisible, setStringFilterVisible] = useState(false);
+  const [resetCheckBoxes, setCheckboxes] = useState(false);
   const [categoryFilters, setCategoryFilters] = useState<SelectedFilters>({});
   const [localLabels, storeLocalLabel] = useLocalLabels();
   // When <AliasList> gets added to the page, if there's an anchor link in the
@@ -178,6 +179,8 @@ export const AliasList = (props: Props) => {
       <CategoryFilter
         onChange={setCategoryFilters}
         selectedFilters={categoryFilters}
+        resetChecks={resetCheckBoxes}
+        setCheckboxes={setCheckboxes}
       />
     </div>
   ) : null;
@@ -191,6 +194,7 @@ export const AliasList = (props: Props) => {
             <button
               onClick={() => {
                 setCategoryFilters({});
+                setCheckboxes(true);
                 setStringFilterInput("");
               }}
               className={styles["clear-filters-button"]}

--- a/frontend/src/components/dashboard/aliases/CategoryFilter.tsx
+++ b/frontend/src/components/dashboard/aliases/CategoryFilter.tsx
@@ -5,6 +5,7 @@ import {
   RefObject,
   useRef,
   useState,
+  useEffect,
 } from "react";
 import {
   FocusScope,
@@ -30,6 +31,8 @@ export type SelectedFilters = {
 export type Props = {
   selectedFilters: SelectedFilters;
   onChange: (selected: SelectedFilters) => void;
+  resetChecks: boolean;
+  setCheckboxes: (isReset: boolean) => void;
 };
 
 type OnCloseParams = {
@@ -93,6 +96,8 @@ export const CategoryFilter = (props: Props) => {
           isOpen={menuState.isOpen}
           selectedFilters={props.selectedFilters}
           onClose={onClose}
+          resetChecks={props.resetChecks}
+          setCheckboxes={props.setCheckboxes}
         />
       </OverlayContainer>
     </>
@@ -103,10 +108,19 @@ type FilterMenuProps = HTMLAttributes<HTMLDivElement> & {
   selectedFilters: SelectedFilters;
   onClose: (onCloseParams: OnCloseParams) => void;
   isOpen: boolean;
+  resetChecks: boolean;
+  setCheckboxes: (isReset: boolean) => void;
 };
 const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
   function FilterMenuWithForwardedRef(
-    { selectedFilters, onClose, isOpen, ...otherProps },
+    {
+      selectedFilters,
+      onClose,
+      isOpen,
+      resetChecks,
+      setCheckboxes,
+      ...otherProps
+    },
     overlayRef,
   ) {
     const l10n = useL10n();
@@ -123,6 +137,8 @@ const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
       onClose({ selectedFilters: { domainType, status }, saveFilters: false });
     };
     const resetAndClose = () => {
+      setDomainType(undefined);
+      setStatus(undefined);
       onClose({
         selectedFilters: { domainType: undefined, status: undefined },
       });
@@ -147,6 +163,14 @@ const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
     };
 
     const mergedOverlayProps = mergeProps(overlayProps, otherProps);
+
+    // This is for the empty state message, where a user's filters return no alias'
+    // When they click "Clear all filters", the checkboxes should be reset.
+    useEffect(() => {
+      setDomainType(undefined);
+      setStatus(undefined);
+      setCheckboxes(false); // Finished reset, toggle back to false
+    }, [resetChecks, setCheckboxes]);
 
     return (
       <FocusScope contain restoreFocus autoFocus>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3061.

<!-- When adding a new feature: -->

# Bug description

Resetting the mask filters from the dashboard does not visually clear the checkmarks within  the checkboxes.

# Screenshot of fix (if applicable)

https://github.com/mozilla/fx-private-relay/assets/59676643/e4284206-ea33-41d8-98a3-449bc12f847f

# How to test
1. From the email masks dashboard, open the mask filter menu;

2. Check any checkbox and click “Apply”;

3. Open the mask filter menu and click “Reset”;

4. Open the mask filter menu again and observe that the checkmarks have been reset.

5. Open the mask filter menu.

6. Filter so that no masks will match your selected criteria.

7. Click "Clear all filters"

8. Open the mask filter menu again and observe that the checkmarks have been reset.


# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
