### PR TITLE
MPP-3518: Updated support link to remove trailing slash

### DIFF
--- a/frontend/src/components/dashboard/tips/Tips.tsx
+++ b/frontend/src/components/dashboard/tips/Tips.tsx
@@ -150,7 +150,7 @@ export const Tips = (props: Props) => {
           </li>
           <li>
             <a
-              href={`https://support.mozilla.org/products/relay/?utm_source=${
+              href={`https://support.mozilla.org/products/relay?utm_source=${
                 getRuntimeConfig().frontendOrigin
               }`}
               target="_blank"


### PR DESCRIPTION
This PR fixes MPP-3518.

# New feature description

Removed the trailing slash, I'm assuming some browsers were not parsing it correctly. Link sends me to the correct page now.

# Screenshot (if applicable)

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/809108c3-1774-497b-8042-150888335cba)


# How to test

1. Login in to Relay https://relay.firefox.com/accounts/profile/
2. Click your avatar on the top right
3. Click "Help and support"
4. Observe that you are taken to the correct page.

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
