### PR TITLE
Add tests for upsell banner feature

### DIFF
--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -119,7 +119,12 @@ export const ProfileBanners = (props: Props) => {
     // Only show updated Premium Banners to users in US/CAN
     {
       isPhonesAvailableInCountry(props.runtimeData)
-        ? banners.push(<PremiumPromoBanners showFirstPremiumBanner={true} />)
+        ? banners.push(
+            <PremiumPromoBanners
+              key="premium-banner"
+              showFirstPremiumBanner={true}
+            />,
+          )
         : banners.push(
             <LoyalistPremiumBanner
               key="premium-banner"

--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -68,6 +68,21 @@ setMockRelayNumberData();
 setMockMinViewportWidth();
 setMockAddonData();
 
+function setupTestEnvironmentForUpsellBanner() {
+  setMockAliasesDataOnce({ random: [{ enabled: true, id: 42 }], custom: [] });
+  setMockProfileDataOnce({ has_premium: false });
+  setMockRuntimeDataOnce(getMockRuntimeDataWithPeriodicalPremium());
+  const mockedConfig = mockConfigModule.getRuntimeConfig();
+  // getRuntimeConfig() is called frequently, so mock its return value,
+  // then restore the original mock at the end of this test:
+  mockConfigModule.getRuntimeConfig.mockReturnValue({
+    ...mockedConfig,
+    maxFreeAliases: 1,
+  });
+
+  return mockedConfig;
+}
+
 describe("The dashboard", () => {
   describe("under axe accessibility testing", () => {
     it("passes axe accessibility testing", async () => {
@@ -451,16 +466,7 @@ describe("The dashboard", () => {
   });
 
   it("shows an upsell banner if user hits mask limit and Premium is available in their country", () => {
-    setMockAliasesDataOnce({ random: [{ enabled: true, id: 42 }], custom: [] });
-    setMockProfileDataOnce({ has_premium: false });
-    setMockRuntimeDataOnce(getMockRuntimeDataWithPeriodicalPremium());
-    const mockedConfig = mockConfigModule.getRuntimeConfig();
-    // getRuntimeConfig() is called frequently, so mock its return value,
-    // then restore the original mock at the end of this test:
-    mockConfigModule.getRuntimeConfig.mockReturnValue({
-      ...mockedConfig,
-      maxFreeAliases: 1,
-    });
+    const mockedConfig = setupTestEnvironmentForUpsellBanner();
 
     render(<Profile />);
 
@@ -472,7 +478,7 @@ describe("The dashboard", () => {
     mockConfigModule.getRuntimeConfig.mockReturnValue(mockedConfig);
   });
 
-  it("shows correct upsell banner for US country", () => {
+  it("shows correct upsell banner for phone countries", () => {
     setMockAliasesDataOnce({ random: [{ enabled: true, id: 42 }], custom: [] });
     setMockProfileDataOnce({ has_premium: false });
     setMockRuntimeDataOnce(getMockRuntimeDataWithPhones());
@@ -503,16 +509,7 @@ describe("The dashboard", () => {
   });
 
   it("shows correct upsell banner for non-US country", async () => {
-    setMockAliasesDataOnce({ random: [{ enabled: true, id: 42 }], custom: [] });
-    setMockProfileDataOnce({ has_premium: false });
-    setMockRuntimeDataOnce(getMockRuntimeDataWithPeriodicalPremium());
-    const mockedConfig = mockConfigModule.getRuntimeConfig();
-    // getRuntimeConfig() is called frequently, so mock its return value,
-    // then restore the original mock at the end of this test:
-    mockConfigModule.getRuntimeConfig.mockReturnValue({
-      ...mockedConfig,
-      maxFreeAliases: 1,
-    });
+    const mockedConfig = setupTestEnvironmentForUpsellBanner();
 
     render(<Profile />);
 
@@ -533,16 +530,7 @@ describe("The dashboard", () => {
   });
 
   it("shows tooltip when user hovers over the number of masks when user reach the limit", async () => {
-    setMockAliasesDataOnce({ random: [{ enabled: true, id: 42 }], custom: [] });
-    setMockProfileDataOnce({ has_premium: false });
-    setMockRuntimeDataOnce(getMockRuntimeDataWithPeriodicalPremium());
-    const mockedConfig = mockConfigModule.getRuntimeConfig();
-    // getRuntimeConfig() is called frequently, so mock its return value,
-    // then restore the original mock at the end of this test:
-    mockConfigModule.getRuntimeConfig.mockReturnValue({
-      ...mockedConfig,
-      maxFreeAliases: 1,
-    });
+    const mockedConfig = setupTestEnvironmentForUpsellBanner();
 
     render(<Profile />);
 
@@ -570,16 +558,7 @@ describe("The dashboard", () => {
   }, 10000);
 
   it("Upgrade to premium CTA takes user to premium price plans", async () => {
-    setMockAliasesDataOnce({ random: [{ enabled: true, id: 42 }], custom: [] });
-    setMockProfileDataOnce({ has_premium: false });
-    setMockRuntimeDataOnce(getMockRuntimeDataWithPeriodicalPremium());
-    const mockedConfig = mockConfigModule.getRuntimeConfig();
-    // getRuntimeConfig() is called frequently, so mock its return value,
-    // then restore the original mock at the end of this test:
-    mockConfigModule.getRuntimeConfig.mockReturnValue({
-      ...mockedConfig,
-      maxFreeAliases: 1,
-    });
+    const mockedConfig = setupTestEnvironmentForUpsellBanner();
 
     render(<Profile />);
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #3797 

# How to test
- [x] Are we showing free users a similar welcome and metrics like premium users see that include (email masks used, emails blocked, emails forwarded, and trackers removed) `This is already tested on the file by previous committer`
- [X] When a user hits their 5 mask limit, are we showing the upsell header 
- [X] Upgrade to premium CTA takes user to premium price plans
- [X] Are we providing US users the right experience (correct banners, links, etc.)
- [X] Are we providing non-US users the right experience (correct banners, links, etc.)
- [X] Are we showing a tooltip when the user hovers over the number of masks they have after they reach the limit?

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
 