### PR TITLE
MPP-3477: Handle value=None

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -901,7 +901,7 @@ def _replace_headers(
         except Exception as e:
             issues["incoming"][header] = {"exception_on_read": str(e)}
             value = None
-        if value.defects:
+        if getattr(value, "defects"):
             issues["incoming"][header] = {
                 "defect_count": len(value.defects),
                 "parsed_value": str(value),


### PR DESCRIPTION
If the exception handler sets the value to `None`, it will not have the defects parameter.

This bug was introduced by PR #4035, but the only header I know that triggers an exception on reading was `Message-ID`, before the fix that was also in PR #4035.

