### PR TITLE
Translations doc: Stripe intervals, test card usage

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -727,10 +727,14 @@ A Relay user's payment method, such as a credit card, has a payment region. The
 user region detected by Relay may differ from the user's payment region. Relay may say a
 user can buy a plan, and then Stripe may reject payment.
 
-In development and stage, there are test prices connected to the [Stripe test mode][].
-One feature of test mode is fake credit cards. These cards allow testing without paying
-real money, and testing failure modes. A test visitor from the United States will get
-these prices. Other regions get the production prices.
+In development and stage, there are test prices connected to the [Stripe test mode][]. A
+test visitor from the United States will get these prices. Other regions get the
+production prices. One feature of test mode is [test credit cards][]. These cards allow
+testing without paying real money, testing failure modes, and testing payments linked to
+other countries. A test card associated with the United States or Canada can be used
+with the test price. A test card associated with a European or other region will be
+rejected with a message like "The currency of this subscription is not valid for the
+country associated with your payment".
 
 [/api/v1/runtime_data]: https://relay.firefox.com/api/v1/runtime_data
 [Stripe product]: https://stripe.com/docs/api/products
@@ -738,6 +742,7 @@ these prices. Other regions get the production prices.
 [Subscription Platform]: https://mozilla.github.io/ecosystem-platform/relying-parties/reference/sub-plat-features
 [does not confirm the user's region]: https://mozilla.github.io/ecosystem-platform/relying-parties/reference/sub-plat-features#geo-restrictions
 [markets and currencies]: https://mozilla-hub.atlassian.net/wiki/spaces/FJT/pages/173539548/Supported+Markets+and+Currencies
+[test credit cards]: https://stripe.com/docs/testing?testing-method=card-numbers#cards
 
 ## Terms
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -354,9 +354,9 @@ for the expansion effort**. This allows engineers to ship partial changes withou
 affecting current users.
 
 The Subscription Platform (version 2) uses [Stripe][] for paid services. A
-[Stripe Price][] tracks currency, taxes, and a subscription term. Relay
-subscription terms are monthly or yearly. There are usually two prices per region, one
-for each term. The Subscription Platform also uses the price to track language and region.
+[Stripe Price][] tracks currency, taxes, and a subscription interval. Relay
+subscription intervals are monthly or yearly. There are usually two prices per region, one
+for each interval. The Subscription Platform also uses the price to track language and region.
 The product details are in the selected language. The Localization team helps pick the
 region's primary language. The product reports use the price to segment purchases by
 region.
@@ -700,9 +700,9 @@ user's region.
 
 The [Subscription Platform][] (version 2) uses [Stripe][]. A [Stripe product][] represents
 each Relay plan, such as the premium email service. A [Stripe price][] represents how a
-user will pay. The price has an associated product, a currency, tax details, and a term.
-Many Relay plans have monthly and yearly subscription terms. The VPN bundle only has a
-yearly subscription term.
+user will pay. The price has an associated product, a currency, tax details, and a subscription interval.
+Many Relay plans have monthly and yearly subscription intervals. The VPN bundle only has a
+yearly subscription interval.
 
 The Subscription Platform associates a price with a region. Product reports may use this
 to segment purchasers by region. Relay detects the user's region and determines what


### PR DESCRIPTION
Update the translations documentation for suggestions from @StaberindeZA:

* Stripe uses [interval](https://stripe.com/docs/api/plans/object#plan_object-interval) for subscription payment intervals, instead of "term". Use this in the documentation as well.
* Link to the list of [Stripe test cards](https://stripe.com/docs/testing?testing-method=card-numbers#cards). Clarify that the card's associated country must match the allowed price country. US and Canada cards will work, other regions will fail.