### PR TITLE
MPP-3545: Styling updates to email banners

### DIFF
--- a/emails/templates/emails/reply_requires_premium.html
+++ b/emails/templates/emails/reply_requires_premium.html
@@ -45,6 +45,13 @@
           font-size: 14px;
         }
 
+        @media screen and (max-width: 1024px) {
+            .footer-block a {
+                display: block;
+                margin-right: 0 !important;
+            }
+        }
+
         @media screen and (max-width: 768px) {
             .footer-block {
                 display: block;
@@ -122,6 +129,13 @@
             display: none;
         }
 
+        @media screen and (max-width: 1024px) {
+            .footer-block a {
+                display: block;
+                margin-right: 0 !important;
+            }
+        }
+        
         @media screen and (max-width: 768px) {
             .footer-block {
                 display: block;
@@ -163,7 +177,7 @@
     
     <table role="presentation" border="0" cellpadding="0" cellspacing="10px" style="padding: 60px 30px 120px 30px;" align="center">
         <tr>
-            <td style="padding-top: 0px; padding-bottom: 0px; text-align: center;">
+            <td style="max-width:850px; padding-top: 0px; padding-bottom: 0px; text-align: center;">
                 <h2 style="font-family: inter medium, Arial, system-ui, sans-serif;"> 
                     <img width="18" src="{{ SITE_ORIGIN }}/static/images/email-images/warning.png" style="margin: 0 5px;" alt="warning icon"/>
                     {% if forwarded == True %}

--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -76,15 +76,17 @@
         width: 300px;
       }
     }
-
+    @media screen and (max-width: 1024px) {
+        .relay-trackers-removed {
+          /* Avoid margin when header-block-right content overflows */
+          display: block !important;
+          margin-right: 0 !important;
+        }
+    }
     @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-      }
-      .relay-trackers-removed {
-        display: block !important;
-        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {

--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -33,6 +33,7 @@
       font-family: 'inter', Arial, sans-serif;
       color: #FFFFFF;
       font-size: 12px;
+      line-height: 140% !important;
     }
 
     a.container-link {
@@ -62,50 +63,52 @@
       vertical-align: bottom;
     }
 
-    @media screen and (max-width: 768px) {
-      .footer-block {
-        display: block;
-        width: 100%;
-        text-align: center;
-      }
-
-      .footer-block .container-link img {
-        height: 45px;
-        width: auto;
-      }
-
-      .header-block-left,
-      .header-block-right {
-        display: block;
-        width: 100%;
-        text-align: left;
-      }
-
-      .header-block-right {
-        margin-left: 40px;
-      }
-
-      .relay-trackers-removed,
-      .relay-mask {
-        width: 100%;
-        display: block;
-      }
-    }
     /* this deals with long email addresses */
     .forwarded-from-email {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
         width: 500px;
-      }
+    }
+
     @media screen and (max-width: 1200px) {
       .forwarded-from-email {
         width: 300px;
       }
     }
+
     @media screen and (max-width: 768px){
+      .footer-block {
+        display: block;
+        width: 100%;
+      }
+      .relay-trackers-removed {
+        display: block !important;
+        margin-right: 0 !important;
+      }
+      .header-block-left,
+      .header-block-right {
+        display: block;
+        width: 100%;
+        text-align: left;
+      }
+      .header-block-right {
+        margin-top: 4px;
+      }
+      .relay-trackers-removed,
+      .relay-mask {
+        width: 100%;
+        display: block;
+      }
       .forwarded-from-email {
         width: 250px;
+      }
+      .footer-block {
+        display: block;
+        text-align: left !important;
+      }
+      .footer-block .container-link.dashboard {
+        margin-left: 5px !important;
       }
     }
     @media screen and (max-width: 425px) {
@@ -117,31 +120,31 @@
   </head>
   <body id="relay-email" style="padding: 0; margin: 0;">
     <!-- Header -->
-    <table id="relay-email-header" width="100%" bgcolor="#3D3D3D" style="background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom: 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align="center">
+    <table id="relay-email-header" width="100%" bgcolor="#3D3D3D" style="background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align="center">
       <tr>
-        <td class="header-block-left" width="50%" align="left" style="padding-top: 5px;">
+        <td class="relay-logo-img" style="width: 30px; vertical-align: top;" >
           <img width="30" src="{{ SITE_ORIGIN }}/static/images/email-images/relay-icon.png" style="margin-right: 5px; display: inline-block; vertical-align: top;" alt="relay icon"/>
-
-          <p style="margin-top: 0; margin-bottom: 5px; display: inline-block;">
+        </td>
+        <td class="header-block-left" style="vertical-align: bottom;" width="50%" align="left" style="padding-top: 5px;">
+          <p style="margin-top: 0; margin-bottom: 0; vertical-align: middle; display: inline-block;">
             <span class="forwarded-from-email" style="display: block; color: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
             {% with display_email|striptags|urlencode as mask_url %}
             {% ftlmsg 'relay-email-forwarded-from-html' url=SITE_ORIGIN|add:'/accounts/profile/#'|add:mask_url attrs='class="container-link" style="margin-right: 30px;color: #FFFFFF;font-size: 12px;"' email_address=display_email|striptags %}
             {% endwith %}
             </span>
 
-          <span style="margin-top: 0; margin-bottom: 5px; display: block;color: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
-            {% if has_premium %}
-              {% ftlmsg 'relay-email-premium-byline-html' url=SITE_ORIGIN|add:'/accounts/profile/' attrs='class="container-link" style="margin-right: 30px;color: #FFFFFF;font-size: 12px;"' %}
-            {% else %}
-              {% ftlmsg 'relay-email-byline-html' url=SITE_ORIGIN|add:'/accounts/profile/' attrs='class="container-link" style="margin-right: 30px;color: #FFFFFF;font-size: 12px;"' %}
-            {% endif %}
-          </span>
+            <span style="margin-top: 0; color: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
+              {% if has_premium %}
+                {% ftlmsg 'relay-email-premium-byline-html' url=SITE_ORIGIN|add:'/accounts/profile/' attrs='class="container-link" style="margin-right: 30px;color: #FFFFFF;font-size: 12px;"' %}
+              {% else %}
+                {% ftlmsg 'relay-email-byline-html' url=SITE_ORIGIN|add:'/accounts/profile/' attrs='class="container-link" style="margin-right: 30px;color: #FFFFFF;font-size: 12px;"' %}
+              {% endif %}
+            </span>
           </p>
 
         </td>
-        <td class="header-block-right" width="50%" align="right">
-          <p class="relay-trackers-removed" style="margin: 0 30px 0 0; display: inline-block; color: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
-            <img class="email-trackers-removed-icon" width="15" src="{{ SITE_ORIGIN }}/static/images/email-images/email-trackers-removed-icon.png" alt="email trackers removed icon"/>
+        <td class="header-block-right" style="vertical-align: bottom;" width="50%" align="right">
+          <p class="relay-trackers-removed" style="margin: 0 16px 0 0; vertical-align: bottom; display: inline-block; color: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
             {% comment %}
               Create this as a link if we have a report link to show
             {% endcomment %}
@@ -186,15 +189,15 @@
     </table>
 
     <!-- Footer -->
-    <table id="relay-email-footer" width="100%" bgcolor="#3D3D3D" style="background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom: 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align="center">
+    <table id="relay-email-footer" width="100%" bgcolor="#3D3D3D" style="background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align="center">
       <tr>
         <td class="footer-block" width="50%" align="left">
           <a class="container-link" href="{{ SITE_ORIGIN }}">
-            <img width="110" src="{{ SITE_ORIGIN }}/static/images/email-images/relay-logo-emails-dark-bg.png" style="margin: 0;" alt="relay logo"/>
+            <img width="130" src="{{ SITE_ORIGIN }}/static/images/email-images/relay-logo-emails-dark-bg.png" style="margin: 0;" alt="relay logo"/>
           </a>
         </td>
         <td class="footer-block" width="50%" align="right">
-          <a class="container-link" href="{{ SITE_ORIGIN }}/accounts/profile" style="color: #FFFFFF;">{% ftlmsg 'relay-email-your-dashboard' %}</a>
+          <a class="container-link dashboard" href="{{ SITE_ORIGIN }}/accounts/profile" style="color: #FFFFFF;">{% ftlmsg 'relay-email-your-dashboard' %}</a>
         </td>
       </tr>
     </table>

--- a/emails/tests/fixtures/domain_recipient_expected.email
+++ b/emails/tests/fixtures/domain_recipient_expected.email
@@ -56,6 +56,7 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       font-family: 'inter', Arial, sans-serif;
       color: #FFFFFF;
       font-size: 12px;
+      line-height: 140% !important;
     }
     a.container-link {
       transition: all 0.2s ease;
@@ -79,15 +80,26 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       margin-right: 5px;
       vertical-align: bottom;
     }
-    @media screen and (max-width: 768px) {
+    /* this deals with long email addresses */
+    .forwarded-from-email {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 500px;
+    }
+    @media screen and (max-width: 1200px) {
+      .forwarded-from-email {
+        width: 300px;
+      }
+    }
+    @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-        text-align: center;
       }
-      .footer-block .container-link img {
-        height: 45px;
-        width: auto;
+      .relay-trackers-removed {
+        display: block !important;
+        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {
@@ -96,29 +108,22 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         text-align: left;
       }
       .header-block-right {
-        margin-left: 40px;
+        margin-top: 4px;
       }
       .relay-trackers-removed,
       .relay-mask {
         width: 100%;
         display: block;
       }
-    }
-    /* this deals with long email addresses */
-    .forwarded-from-email {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        width: 500px;
-      }
-    @media screen and (max-width: 1200px) {
-      .forwarded-from-email {
-        width: 300px;
-      }
-    }
-    @media screen and (max-width: 768px){
       .forwarded-from-email {
         width: 250px;
+      }
+      .footer-block {
+        display: block;
+        text-align: left !important;
+      }
+      .footer-block .container-link.dashboard {
+        margin-left: 5px !important;
       }
     }
     @media screen and (max-width: 425px) {
@@ -131,37 +136,38 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
   <body id=3D"relay-email" style=3D"padding: 0; margin: 0;">
     <!-- Header -->
     <table id=3D"relay-email-header" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
-        <td class=3D"header-block-left" width=3D"50%" align=3D"left" style=3D=
-"padding-top: 5px;">
+        <td class=3D"relay-logo-img" style=3D"width: 30px; vertical-align: to=
+p;" >
           <img width=3D"30" src=3D"http://127.0.0.1:8000/static/images/email-=
 images/relay-icon.png" style=3D"margin-right: 5px; display: inline-block; ver=
 tical-align: top;" alt=3D"relay icon"/>
-          <p style=3D"margin-top: 0; margin-bottom: 5px; display: inline-bloc=
-k;">
+        </td>
+        <td class=3D"header-block-left" style=3D"vertical-align: bottom;" wid=
+th=3D"50%" align=3D"left" style=3D"padding-top: 5px;">
+          <p style=3D"margin-top: 0; margin-bottom: 0; vertical-align: middle=
+; display: inline-block;">
             <span class=3D"forwarded-from-email" style=3D"display: block; col=
 or: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
             Forwarded from <a href=3D"http://127.0.0.1:8000/accounts/profile/=
 #wildcard%40subdomain.test.com" class=3D"container-link" style=3D"margin-righ=
 t: 30px;color: #FFFFFF;font-size: 12px;">wildcard@subdomain.test.com</a>
             </span>
-          <span style=3D"margin-top: 0; margin-bottom: 5px; display: block;co=
-lor: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
-              by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=3D=
-"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12px;"=
->Firefox Relay Premium</a>
-          </span>
+            <span style=3D"margin-top: 0; color: #FFFFFF; font-family: 'inter=
+', Arial, sans-serif; font-size: 12px;">
+                by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=
+=3D"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12p=
+x;">Firefox Relay Premium</a>
+            </span>
           </p>
         </td>
-        <td class=3D"header-block-right" width=3D"50%" align=3D"right">
-          <p class=3D"relay-trackers-removed" style=3D"margin: 0 30px 0 0; di=
-splay: inline-block; color: #FFFFFF; font-family: 'inter', Arial, sans-serif;=
- font-size: 12px;">
-            <img class=3D"email-trackers-removed-icon" width=3D"15" src=3D"ht=
-tp://127.0.0.1:8000/static/images/email-images/email-trackers-removed-icon.pn=
-g" alt=3D"email trackers removed icon"/>
+        <td class=3D"header-block-right" style=3D"vertical-align: bottom;" wi=
+dth=3D"50%" align=3D"right">
+          <p class=3D"relay-trackers-removed" style=3D"margin: 0 16px 0 0; ve=
+rtical-align: bottom; display: inline-block; color: #FFFFFF; font-family: 'in=
+ter', Arial, sans-serif; font-size: 12px;">
               <span dir=3D"auto">0</span> email trackers removed
           </p>
           <p class=3D"relay-mask" style=3D"margin: 0; display: inline-block;">
@@ -192,19 +198,19 @@ l.</div></div></div><div style=3D"font-family: arial; font-size: 14px;"><br><=
     </table>
     <!-- Footer -->
     <table id=3D"relay-email-footer" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
         <td class=3D"footer-block" width=3D"50%" align=3D"left">
           <a class=3D"container-link" href=3D"http://127.0.0.1:8000">
-            <img width=3D"110" src=3D"http://127.0.0.1:8000/static/images/ema=
+            <img width=3D"130" src=3D"http://127.0.0.1:8000/static/images/ema=
 il-images/relay-logo-emails-dark-bg.png" style=3D"margin: 0;" alt=3D"relay lo=
 go"/>
           </a>
         </td>
         <td class=3D"footer-block" width=3D"50%" align=3D"right">
-          <a class=3D"container-link" href=3D"http://127.0.0.1:8000/accounts/=
-profile" style=3D"color: #FFFFFF;">Your dashboard</a>
+          <a class=3D"container-link dashboard" href=3D"http://127.0.0.1:8000=
+/accounts/profile" style=3D"color: #FFFFFF;">Your dashboard</a>
         </td>
       </tr>
     </table>

--- a/emails/tests/fixtures/domain_recipient_expected.email
+++ b/emails/tests/fixtures/domain_recipient_expected.email
@@ -92,14 +92,17 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         width: 300px;
       }
     }
+    @media screen and (max-width: 1024px) {
+        .relay-trackers-removed {
+          /* Avoid margin when header-block-right content overflows */
+          display: block !important;
+          margin-right: 0 !important;
+        }
+    }
     @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-      }
-      .relay-trackers-removed {
-        display: block !important;
-        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {

--- a/emails/tests/fixtures/emperor_norton_expected.email
+++ b/emails/tests/fixtures/emperor_norton_expected.email
@@ -63,6 +63,7 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       font-family: 'inter', Arial, sans-serif;
       color: #FFFFFF;
       font-size: 12px;
+      line-height: 140% !important;
     }
     a.container-link {
       transition: all 0.2s ease;
@@ -86,15 +87,26 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       margin-right: 5px;
       vertical-align: bottom;
     }
-    @media screen and (max-width: 768px) {
+    /* this deals with long email addresses */
+    .forwarded-from-email {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 500px;
+    }
+    @media screen and (max-width: 1200px) {
+      .forwarded-from-email {
+        width: 300px;
+      }
+    }
+    @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-        text-align: center;
       }
-      .footer-block .container-link img {
-        height: 45px;
-        width: auto;
+      .relay-trackers-removed {
+        display: block !important;
+        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {
@@ -103,29 +115,22 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         text-align: left;
       }
       .header-block-right {
-        margin-left: 40px;
+        margin-top: 4px;
       }
       .relay-trackers-removed,
       .relay-mask {
         width: 100%;
         display: block;
       }
-    }
-    /* this deals with long email addresses */
-    .forwarded-from-email {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        width: 500px;
-      }
-    @media screen and (max-width: 1200px) {
-      .forwarded-from-email {
-        width: 300px;
-      }
-    }
-    @media screen and (max-width: 768px){
       .forwarded-from-email {
         width: 250px;
+      }
+      .footer-block {
+        display: block;
+        text-align: left !important;
+      }
+      .footer-block .container-link.dashboard {
+        margin-left: 5px !important;
       }
     }
     @media screen and (max-width: 425px) {
@@ -138,37 +143,38 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
   <body id=3D"relay-email" style=3D"padding: 0; margin: 0;">
     <!-- Header -->
     <table id=3D"relay-email-header" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
-        <td class=3D"header-block-left" width=3D"50%" align=3D"left" style=3D=
-"padding-top: 5px;">
+        <td class=3D"relay-logo-img" style=3D"width: 30px; vertical-align: to=
+p;" >
           <img width=3D"30" src=3D"http://127.0.0.1:8000/static/images/email-=
 images/relay-icon.png" style=3D"margin-right: 5px; display: inline-block; ver=
 tical-align: top;" alt=3D"relay icon"/>
-          <p style=3D"margin-top: 0; margin-bottom: 5px; display: inline-bloc=
-k;">
+        </td>
+        <td class=3D"header-block-left" style=3D"vertical-align: bottom;" wid=
+th=3D"50%" align=3D"left" style=3D"padding-top: 5px;">
+          <p style=3D"margin-top: 0; margin-bottom: 0; vertical-align: middle=
+; display: inline-block;">
             <span class=3D"forwarded-from-email" style=3D"display: block; col=
 or: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
             Forwarded from <a href=3D"http://127.0.0.1:8000/accounts/profile/=
 #ebsbdsan7%40test.com" class=3D"container-link" style=3D"margin-right: 30px;c=
 olor: #FFFFFF;font-size: 12px;">ebsbdsan7@test.com</a>
             </span>
-          <span style=3D"margin-top: 0; margin-bottom: 5px; display: block;co=
-lor: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
-              by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=3D=
-"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12px;"=
->Firefox Relay</a>
-          </span>
+            <span style=3D"margin-top: 0; color: #FFFFFF; font-family: 'inter=
+', Arial, sans-serif; font-size: 12px;">
+                by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=
+=3D"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12p=
+x;">Firefox Relay</a>
+            </span>
           </p>
         </td>
-        <td class=3D"header-block-right" width=3D"50%" align=3D"right">
-          <p class=3D"relay-trackers-removed" style=3D"margin: 0 30px 0 0; di=
-splay: inline-block; color: #FFFFFF; font-family: 'inter', Arial, sans-serif;=
- font-size: 12px;">
-            <img class=3D"email-trackers-removed-icon" width=3D"15" src=3D"ht=
-tp://127.0.0.1:8000/static/images/email-images/email-trackers-removed-icon.pn=
-g" alt=3D"email trackers removed icon"/>
+        <td class=3D"header-block-right" style=3D"vertical-align: bottom;" wi=
+dth=3D"50%" align=3D"right">
+          <p class=3D"relay-trackers-removed" style=3D"margin: 0 16px 0 0; ve=
+rtical-align: bottom; display: inline-block; color: #FFFFFF; font-family: 'in=
+ter', Arial, sans-serif; font-size: 12px;">
               <span dir=3D"auto">0</span> email trackers removed
           </p>
           <p class=3D"relay-mask" style=3D"margin: 0; display: inline-block;">
@@ -202,19 +208,19 @@ r, 1859<br>
     </table>
     <!-- Footer -->
     <table id=3D"relay-email-footer" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
         <td class=3D"footer-block" width=3D"50%" align=3D"left">
           <a class=3D"container-link" href=3D"http://127.0.0.1:8000">
-            <img width=3D"110" src=3D"http://127.0.0.1:8000/static/images/ema=
+            <img width=3D"130" src=3D"http://127.0.0.1:8000/static/images/ema=
 il-images/relay-logo-emails-dark-bg.png" style=3D"margin: 0;" alt=3D"relay lo=
 go"/>
           </a>
         </td>
         <td class=3D"footer-block" width=3D"50%" align=3D"right">
-          <a class=3D"container-link" href=3D"http://127.0.0.1:8000/accounts/=
-profile" style=3D"color: #FFFFFF;">Your dashboard</a>
+          <a class=3D"container-link dashboard" href=3D"http://127.0.0.1:8000=
+/accounts/profile" style=3D"color: #FFFFFF;">Your dashboard</a>
         </td>
       </tr>
     </table>

--- a/emails/tests/fixtures/emperor_norton_expected.email
+++ b/emails/tests/fixtures/emperor_norton_expected.email
@@ -99,14 +99,17 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         width: 300px;
       }
     }
+    @media screen and (max-width: 1024px) {
+        .relay-trackers-removed {
+          /* Avoid margin when header-block-right content overflows */
+          display: block !important;
+          margin-right: 0 !important;
+        }
+    }
     @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-      }
-      .relay-trackers-removed {
-        display: block !important;
-        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {

--- a/emails/tests/fixtures/inline_image_expected.email
+++ b/emails/tests/fixtures/inline_image_expected.email
@@ -94,14 +94,17 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         width: 300px;
       }
     }
+    @media screen and (max-width: 1024px) {
+        .relay-trackers-removed {
+          /* Avoid margin when header-block-right content overflows */
+          display: block !important;
+          margin-right: 0 !important;
+        }
+    }
     @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-      }
-      .relay-trackers-removed {
-        display: block !important;
-        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {

--- a/emails/tests/fixtures/inline_image_expected.email
+++ b/emails/tests/fixtures/inline_image_expected.email
@@ -58,6 +58,7 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       font-family: 'inter', Arial, sans-serif;
       color: #FFFFFF;
       font-size: 12px;
+      line-height: 140% !important;
     }
     a.container-link {
       transition: all 0.2s ease;
@@ -81,15 +82,26 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       margin-right: 5px;
       vertical-align: bottom;
     }
-    @media screen and (max-width: 768px) {
+    /* this deals with long email addresses */
+    .forwarded-from-email {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 500px;
+    }
+    @media screen and (max-width: 1200px) {
+      .forwarded-from-email {
+        width: 300px;
+      }
+    }
+    @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-        text-align: center;
       }
-      .footer-block .container-link img {
-        height: 45px;
-        width: auto;
+      .relay-trackers-removed {
+        display: block !important;
+        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {
@@ -98,29 +110,22 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         text-align: left;
       }
       .header-block-right {
-        margin-left: 40px;
+        margin-top: 4px;
       }
       .relay-trackers-removed,
       .relay-mask {
         width: 100%;
         display: block;
       }
-    }
-    /* this deals with long email addresses */
-    .forwarded-from-email {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        width: 500px;
-      }
-    @media screen and (max-width: 1200px) {
-      .forwarded-from-email {
-        width: 300px;
-      }
-    }
-    @media screen and (max-width: 768px){
       .forwarded-from-email {
         width: 250px;
+      }
+      .footer-block {
+        display: block;
+        text-align: left !important;
+      }
+      .footer-block .container-link.dashboard {
+        margin-left: 5px !important;
       }
     }
     @media screen and (max-width: 425px) {
@@ -133,37 +138,38 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
   <body id=3D"relay-email" style=3D"padding: 0; margin: 0;">
     <!-- Header -->
     <table id=3D"relay-email-header" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
-        <td class=3D"header-block-left" width=3D"50%" align=3D"left" style=3D=
-"padding-top: 5px;">
+        <td class=3D"relay-logo-img" style=3D"width: 30px; vertical-align: to=
+p;" >
           <img width=3D"30" src=3D"http://127.0.0.1:8000/static/images/email-=
 images/relay-icon.png" style=3D"margin-right: 5px; display: inline-block; ver=
 tical-align: top;" alt=3D"relay icon"/>
-          <p style=3D"margin-top: 0; margin-bottom: 5px; display: inline-bloc=
-k;">
+        </td>
+        <td class=3D"header-block-left" style=3D"vertical-align: bottom;" wid=
+th=3D"50%" align=3D"left" style=3D"padding-top: 5px;">
+          <p style=3D"margin-top: 0; margin-bottom: 0; vertical-align: middle=
+; display: inline-block;">
             <span class=3D"forwarded-from-email" style=3D"display: block; col=
 or: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
             Forwarded from <a href=3D"http://127.0.0.1:8000/accounts/profile/=
 #ebsbdsan7%40test.com" class=3D"container-link" style=3D"margin-right: 30px;c=
 olor: #FFFFFF;font-size: 12px;">ebsbdsan7@test.com</a>
             </span>
-          <span style=3D"margin-top: 0; margin-bottom: 5px; display: block;co=
-lor: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
-              by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=3D=
-"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12px;"=
->Firefox Relay</a>
-          </span>
+            <span style=3D"margin-top: 0; color: #FFFFFF; font-family: 'inter=
+', Arial, sans-serif; font-size: 12px;">
+                by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=
+=3D"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12p=
+x;">Firefox Relay</a>
+            </span>
           </p>
         </td>
-        <td class=3D"header-block-right" width=3D"50%" align=3D"right">
-          <p class=3D"relay-trackers-removed" style=3D"margin: 0 30px 0 0; di=
-splay: inline-block; color: #FFFFFF; font-family: 'inter', Arial, sans-serif;=
- font-size: 12px;">
-            <img class=3D"email-trackers-removed-icon" width=3D"15" src=3D"ht=
-tp://127.0.0.1:8000/static/images/email-images/email-trackers-removed-icon.pn=
-g" alt=3D"email trackers removed icon"/>
+        <td class=3D"header-block-right" style=3D"vertical-align: bottom;" wi=
+dth=3D"50%" align=3D"right">
+          <p class=3D"relay-trackers-removed" style=3D"margin: 0 16px 0 0; ve=
+rtical-align: bottom; display: inline-block; color: #FFFFFF; font-family: 'in=
+ter', Arial, sans-serif; font-size: 12px;">
               <span dir=3D"auto">0</span> email trackers removed
           </p>
           <p class=3D"relay-mask" style=3D"margin: 0; display: inline-block;">
@@ -190,19 +196,19 @@ dir=3D"ltr"><li>Your Friend</li></ul></div></div></body></html>
     </table>
     <!-- Footer -->
     <table id=3D"relay-email-footer" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
         <td class=3D"footer-block" width=3D"50%" align=3D"left">
           <a class=3D"container-link" href=3D"http://127.0.0.1:8000">
-            <img width=3D"110" src=3D"http://127.0.0.1:8000/static/images/ema=
+            <img width=3D"130" src=3D"http://127.0.0.1:8000/static/images/ema=
 il-images/relay-logo-emails-dark-bg.png" style=3D"margin: 0;" alt=3D"relay lo=
 go"/>
           </a>
         </td>
         <td class=3D"footer-block" width=3D"50%" align=3D"right">
-          <a class=3D"container-link" href=3D"http://127.0.0.1:8000/accounts/=
-profile" style=3D"color: #FFFFFF;">Your dashboard</a>
+          <a class=3D"container-link dashboard" href=3D"http://127.0.0.1:8000=
+/accounts/profile" style=3D"color: #FFFFFF;">Your dashboard</a>
         </td>
       </tr>
     </table>

--- a/emails/tests/fixtures/message_id_in_brackets_expected.email
+++ b/emails/tests/fixtures/message_id_in_brackets_expected.email
@@ -56,6 +56,7 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       font-family: 'inter', Arial, sans-serif;
       color: #FFFFFF;
       font-size: 12px;
+      line-height: 140% !important;
     }
     a.container-link {
       transition: all 0.2s ease;
@@ -79,15 +80,26 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       margin-right: 5px;
       vertical-align: bottom;
     }
-    @media screen and (max-width: 768px) {
+    /* this deals with long email addresses */
+    .forwarded-from-email {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 500px;
+    }
+    @media screen and (max-width: 1200px) {
+      .forwarded-from-email {
+        width: 300px;
+      }
+    }
+    @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-        text-align: center;
       }
-      .footer-block .container-link img {
-        height: 45px;
-        width: auto;
+      .relay-trackers-removed {
+        display: block !important;
+        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {
@@ -96,29 +108,22 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         text-align: left;
       }
       .header-block-right {
-        margin-left: 40px;
+        margin-top: 4px;
       }
       .relay-trackers-removed,
       .relay-mask {
         width: 100%;
         display: block;
       }
-    }
-    /* this deals with long email addresses */
-    .forwarded-from-email {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        width: 500px;
-      }
-    @media screen and (max-width: 1200px) {
-      .forwarded-from-email {
-        width: 300px;
-      }
-    }
-    @media screen and (max-width: 768px){
       .forwarded-from-email {
         width: 250px;
+      }
+      .footer-block {
+        display: block;
+        text-align: left !important;
+      }
+      .footer-block .container-link.dashboard {
+        margin-left: 5px !important;
       }
     }
     @media screen and (max-width: 425px) {
@@ -131,37 +136,38 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
   <body id=3D"relay-email" style=3D"padding: 0; margin: 0;">
     <!-- Header -->
     <table id=3D"relay-email-header" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
-        <td class=3D"header-block-left" width=3D"50%" align=3D"left" style=3D=
-"padding-top: 5px;">
+        <td class=3D"relay-logo-img" style=3D"width: 30px; vertical-align: to=
+p;" >
           <img width=3D"30" src=3D"http://127.0.0.1:8000/static/images/email-=
 images/relay-icon.png" style=3D"margin-right: 5px; display: inline-block; ver=
 tical-align: top;" alt=3D"relay icon"/>
-          <p style=3D"margin-top: 0; margin-bottom: 5px; display: inline-bloc=
-k;">
+        </td>
+        <td class=3D"header-block-left" style=3D"vertical-align: bottom;" wid=
+th=3D"50%" align=3D"left" style=3D"padding-top: 5px;">
+          <p style=3D"margin-top: 0; margin-bottom: 0; vertical-align: middle=
+; display: inline-block;">
             <span class=3D"forwarded-from-email" style=3D"display: block; col=
 or: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
             Forwarded from <a href=3D"http://127.0.0.1:8000/accounts/profile/=
 #ebsbdsan7%40test.com" class=3D"container-link" style=3D"margin-right: 30px;c=
 olor: #FFFFFF;font-size: 12px;">ebsbdsan7@test.com</a>
             </span>
-          <span style=3D"margin-top: 0; margin-bottom: 5px; display: block;co=
-lor: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
-              by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=3D=
-"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12px;"=
->Firefox Relay</a>
-          </span>
+            <span style=3D"margin-top: 0; color: #FFFFFF; font-family: 'inter=
+', Arial, sans-serif; font-size: 12px;">
+                by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=
+=3D"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12p=
+x;">Firefox Relay</a>
+            </span>
           </p>
         </td>
-        <td class=3D"header-block-right" width=3D"50%" align=3D"right">
-          <p class=3D"relay-trackers-removed" style=3D"margin: 0 30px 0 0; di=
-splay: inline-block; color: #FFFFFF; font-family: 'inter', Arial, sans-serif;=
- font-size: 12px;">
-            <img class=3D"email-trackers-removed-icon" width=3D"15" src=3D"ht=
-tp://127.0.0.1:8000/static/images/email-images/email-trackers-removed-icon.pn=
-g" alt=3D"email trackers removed icon"/>
+        <td class=3D"header-block-right" style=3D"vertical-align: bottom;" wi=
+dth=3D"50%" align=3D"right">
+          <p class=3D"relay-trackers-removed" style=3D"margin: 0 16px 0 0; ve=
+rtical-align: bottom; display: inline-block; color: #FFFFFF; font-family: 'in=
+ter', Arial, sans-serif; font-size: 12px;">
               <span dir=3D"auto">0</span> email trackers removed
           </p>
           <p class=3D"relay-mask" style=3D"margin: 0; display: inline-block;">
@@ -188,19 +194,19 @@ t;<br><br>So maybe there was an ID that was omitted...<br>
     </table>
     <!-- Footer -->
     <table id=3D"relay-email-footer" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
         <td class=3D"footer-block" width=3D"50%" align=3D"left">
           <a class=3D"container-link" href=3D"http://127.0.0.1:8000">
-            <img width=3D"110" src=3D"http://127.0.0.1:8000/static/images/ema=
+            <img width=3D"130" src=3D"http://127.0.0.1:8000/static/images/ema=
 il-images/relay-logo-emails-dark-bg.png" style=3D"margin: 0;" alt=3D"relay lo=
 go"/>
           </a>
         </td>
         <td class=3D"footer-block" width=3D"50%" align=3D"right">
-          <a class=3D"container-link" href=3D"http://127.0.0.1:8000/accounts/=
-profile" style=3D"color: #FFFFFF;">Your dashboard</a>
+          <a class=3D"container-link dashboard" href=3D"http://127.0.0.1:8000=
+/accounts/profile" style=3D"color: #FFFFFF;">Your dashboard</a>
         </td>
       </tr>
     </table>

--- a/emails/tests/fixtures/message_id_in_brackets_expected.email
+++ b/emails/tests/fixtures/message_id_in_brackets_expected.email
@@ -92,14 +92,17 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         width: 300px;
       }
     }
+    @media screen and (max-width: 1024px) {
+        .relay-trackers-removed {
+          /* Avoid margin when header-block-right content overflows */
+          display: block !important;
+          margin-right: 0 !important;
+        }
+    }
     @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-      }
-      .relay-trackers-removed {
-        display: block !important;
-        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {

--- a/emails/tests/fixtures/plain_text_expected.email
+++ b/emails/tests/fixtures/plain_text_expected.email
@@ -87,14 +87,17 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         width: 300px;
       }
     }
+    @media screen and (max-width: 1024px) {
+        .relay-trackers-removed {
+          /* Avoid margin when header-block-right content overflows */
+          display: block !important;
+          margin-right: 0 !important;
+        }
+    }
     @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-      }
-      .relay-trackers-removed {
-        display: block !important;
-        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {

--- a/emails/tests/fixtures/plain_text_expected.email
+++ b/emails/tests/fixtures/plain_text_expected.email
@@ -51,6 +51,7 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       font-family: 'inter', Arial, sans-serif;
       color: #FFFFFF;
       font-size: 12px;
+      line-height: 140% !important;
     }
     a.container-link {
       transition: all 0.2s ease;
@@ -74,15 +75,26 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       margin-right: 5px;
       vertical-align: bottom;
     }
-    @media screen and (max-width: 768px) {
+    /* this deals with long email addresses */
+    .forwarded-from-email {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 500px;
+    }
+    @media screen and (max-width: 1200px) {
+      .forwarded-from-email {
+        width: 300px;
+      }
+    }
+    @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-        text-align: center;
       }
-      .footer-block .container-link img {
-        height: 45px;
-        width: auto;
+      .relay-trackers-removed {
+        display: block !important;
+        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {
@@ -91,29 +103,22 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         text-align: left;
       }
       .header-block-right {
-        margin-left: 40px;
+        margin-top: 4px;
       }
       .relay-trackers-removed,
       .relay-mask {
         width: 100%;
         display: block;
       }
-    }
-    /* this deals with long email addresses */
-    .forwarded-from-email {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        width: 500px;
-      }
-    @media screen and (max-width: 1200px) {
-      .forwarded-from-email {
-        width: 300px;
-      }
-    }
-    @media screen and (max-width: 768px){
       .forwarded-from-email {
         width: 250px;
+      }
+      .footer-block {
+        display: block;
+        text-align: left !important;
+      }
+      .footer-block .container-link.dashboard {
+        margin-left: 5px !important;
       }
     }
     @media screen and (max-width: 425px) {
@@ -126,37 +131,38 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
   <body id=3D"relay-email" style=3D"padding: 0; margin: 0;">
     <!-- Header -->
     <table id=3D"relay-email-header" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
-        <td class=3D"header-block-left" width=3D"50%" align=3D"left" style=3D=
-"padding-top: 5px;">
+        <td class=3D"relay-logo-img" style=3D"width: 30px; vertical-align: to=
+p;" >
           <img width=3D"30" src=3D"http://127.0.0.1:8000/static/images/email-=
 images/relay-icon.png" style=3D"margin-right: 5px; display: inline-block; ver=
 tical-align: top;" alt=3D"relay icon"/>
-          <p style=3D"margin-top: 0; margin-bottom: 5px; display: inline-bloc=
-k;">
+        </td>
+        <td class=3D"header-block-left" style=3D"vertical-align: bottom;" wid=
+th=3D"50%" align=3D"left" style=3D"padding-top: 5px;">
+          <p style=3D"margin-top: 0; margin-bottom: 0; vertical-align: middle=
+; display: inline-block;">
             <span class=3D"forwarded-from-email" style=3D"display: block; col=
 or: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
             Forwarded from <a href=3D"http://127.0.0.1:8000/accounts/profile/=
 #ebsbdsan7%40test.com" class=3D"container-link" style=3D"margin-right: 30px;c=
 olor: #FFFFFF;font-size: 12px;">ebsbdsan7@test.com</a>
             </span>
-          <span style=3D"margin-top: 0; margin-bottom: 5px; display: block;co=
-lor: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
-              by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=3D=
-"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12px;"=
->Firefox Relay</a>
-          </span>
+            <span style=3D"margin-top: 0; color: #FFFFFF; font-family: 'inter=
+', Arial, sans-serif; font-size: 12px;">
+                by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=
+=3D"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12p=
+x;">Firefox Relay</a>
+            </span>
           </p>
         </td>
-        <td class=3D"header-block-right" width=3D"50%" align=3D"right">
-          <p class=3D"relay-trackers-removed" style=3D"margin: 0 30px 0 0; di=
-splay: inline-block; color: #FFFFFF; font-family: 'inter', Arial, sans-serif;=
- font-size: 12px;">
-            <img class=3D"email-trackers-removed-icon" width=3D"15" src=3D"ht=
-tp://127.0.0.1:8000/static/images/email-images/email-trackers-removed-icon.pn=
-g" alt=3D"email trackers removed icon"/>
+        <td class=3D"header-block-right" style=3D"vertical-align: bottom;" wi=
+dth=3D"50%" align=3D"right">
+          <p class=3D"relay-trackers-removed" style=3D"margin: 0 16px 0 0; ve=
+rtical-align: bottom; display: inline-block; color: #FFFFFF; font-family: 'in=
+ter', Arial, sans-serif; font-size: 12px;">
               <span dir=3D"auto">0</span> email trackers removed
           </p>
           <p class=3D"relay-mask" style=3D"margin: 0; display: inline-block;">
@@ -180,19 +186,19 @@ om" rel=3D"nofollow">https://text.example.com</a><br>
     </table>
     <!-- Footer -->
     <table id=3D"relay-email-footer" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
         <td class=3D"footer-block" width=3D"50%" align=3D"left">
           <a class=3D"container-link" href=3D"http://127.0.0.1:8000">
-            <img width=3D"110" src=3D"http://127.0.0.1:8000/static/images/ema=
+            <img width=3D"130" src=3D"http://127.0.0.1:8000/static/images/ema=
 il-images/relay-logo-emails-dark-bg.png" style=3D"margin: 0;" alt=3D"relay lo=
 go"/>
           </a>
         </td>
         <td class=3D"footer-block" width=3D"50%" align=3D"right">
-          <a class=3D"container-link" href=3D"http://127.0.0.1:8000/accounts/=
-profile" style=3D"color: #FFFFFF;">Your dashboard</a>
+          <a class=3D"container-link dashboard" href=3D"http://127.0.0.1:8000=
+/accounts/profile" style=3D"color: #FFFFFF;">Your dashboard</a>
         </td>
       </tr>
     </table>

--- a/emails/tests/fixtures/reply_requires_premium_first_expected.email
+++ b/emails/tests/fixtures/reply_requires_premium_first_expected.email
@@ -83,6 +83,13 @@ lay.firefox.com/fonts/Inter/Inter-Medium.027d14e7d35b.woff2?v=3D3.18) format(=
           font-size: 14px;
         }
 
+        @media screen and (max-width: 1024px) {
+            .footer-block a {
+                display: block;
+                margin-right: 0 !important;
+            }
+        }
+
         @media screen and (max-width: 768px) {
             .footer-block {
                 display: block;
@@ -164,6 +171,13 @@ lay.firefox.com/fonts/Inter/Inter-Medium.027d14e7d35b.woff2?v=3D3.18) format(=
             display: none;
         }
 
+        @media screen and (max-width: 1024px) {
+            .footer-block a {
+                display: block;
+                margin-right: 0 !important;
+            }
+        }
+       =20
         @media screen and (max-width: 768px) {
             .footer-block {
                 display: block;
@@ -213,8 +227,8 @@ ail" style=3D"color: white;">Upgrade for more protection</a>=20
     <table role=3D"presentation" border=3D"0" cellpadding=3D"0" cellspacing=
 =3D"10px" style=3D"padding: 60px 30px 120px 30px;" align=3D"center">
         <tr>
-            <td style=3D"max-width:850px; padding-top: 0px; padding-bottom: 0px; text-align: c=
-enter;">
+            <td style=3D"max-width:850px; padding-top: 0px; padding-bottom: 0=
+px; text-align: center;">
                 <h2 style=3D"font-family: inter medium, Arial, system-ui, san=
 s-serif;">=20
                     <img width=3D"18" src=3D"http://127.0.0.1:8000/static/ima=

--- a/emails/tests/fixtures/reply_requires_premium_first_expected.email
+++ b/emails/tests/fixtures/reply_requires_premium_first_expected.email
@@ -213,7 +213,7 @@ ail" style=3D"color: white;">Upgrade for more protection</a>=20
     <table role=3D"presentation" border=3D"0" cellpadding=3D"0" cellspacing=
 =3D"10px" style=3D"padding: 60px 30px 120px 30px;" align=3D"center">
         <tr>
-            <td style=3D"padding-top: 0px; padding-bottom: 0px; text-align: c=
+            <td style=3D"max-width:850px; padding-top: 0px; padding-bottom: 0px; text-align: c=
 enter;">
                 <h2 style=3D"font-family: inter medium, Arial, system-ui, san=
 s-serif;">=20

--- a/emails/tests/fixtures/reply_requires_premium_second_expected.email
+++ b/emails/tests/fixtures/reply_requires_premium_second_expected.email
@@ -212,7 +212,7 @@ ail" style=3D"color: white;">Upgrade for more protection</a>=20
     <table role=3D"presentation" border=3D"0" cellpadding=3D"0" cellspacing=
 =3D"10px" style=3D"padding: 60px 30px 120px 30px;" align=3D"center">
         <tr>
-            <td style=3D"padding-top: 0px; padding-bottom: 0px; text-align: c=
+            <td style=3D"max-width:850px; padding-top: 0px; padding-bottom: 0px; text-align: c=
 enter;">
                 <h2 style=3D"font-family: inter medium, Arial, system-ui, san=
 s-serif;">=20

--- a/emails/tests/fixtures/reply_requires_premium_second_expected.email
+++ b/emails/tests/fixtures/reply_requires_premium_second_expected.email
@@ -82,6 +82,13 @@ lay.firefox.com/fonts/Inter/Inter-Medium.027d14e7d35b.woff2?v=3D3.18) format(=
           font-size: 14px;
         }
 
+        @media screen and (max-width: 1024px) {
+            .footer-block a {
+                display: block;
+                margin-right: 0 !important;
+            }
+        }
+
         @media screen and (max-width: 768px) {
             .footer-block {
                 display: block;
@@ -163,6 +170,13 @@ lay.firefox.com/fonts/Inter/Inter-Medium.027d14e7d35b.woff2?v=3D3.18) format(=
             display: none;
         }
 
+        @media screen and (max-width: 1024px) {
+            .footer-block a {
+                display: block;
+                margin-right: 0 !important;
+            }
+        }
+       =20
         @media screen and (max-width: 768px) {
             .footer-block {
                 display: block;
@@ -212,8 +226,8 @@ ail" style=3D"color: white;">Upgrade for more protection</a>=20
     <table role=3D"presentation" border=3D"0" cellpadding=3D"0" cellspacing=
 =3D"10px" style=3D"padding: 60px 30px 120px 30px;" align=3D"center">
         <tr>
-            <td style=3D"max-width:850px; padding-top: 0px; padding-bottom: 0px; text-align: c=
-enter;">
+            <td style=3D"max-width:850px; padding-top: 0px; padding-bottom: 0=
+px; text-align: center;">
                 <h2 style=3D"font-family: inter medium, Arial, system-ui, san=
 s-serif;">=20
                     <img width=3D"18" src=3D"http://127.0.0.1:8000/static/ima=

--- a/emails/tests/fixtures/russian_spam_expected.email
+++ b/emails/tests/fixtures/russian_spam_expected.email
@@ -96,14 +96,17 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         width: 300px;
       }
     }
+    @media screen and (max-width: 1024px) {
+        .relay-trackers-removed {
+          /* Avoid margin when header-block-right content overflows */
+          display: block !important;
+          margin-right: 0 !important;
+        }
+    }
     @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-      }
-      .relay-trackers-removed {
-        display: block !important;
-        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {

--- a/emails/tests/fixtures/russian_spam_expected.email
+++ b/emails/tests/fixtures/russian_spam_expected.email
@@ -60,6 +60,7 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       font-family: 'inter', Arial, sans-serif;
       color: #FFFFFF;
       font-size: 12px;
+      line-height: 140% !important;
     }
     a.container-link {
       transition: all 0.2s ease;
@@ -83,15 +84,26 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       margin-right: 5px;
       vertical-align: bottom;
     }
-    @media screen and (max-width: 768px) {
+    /* this deals with long email addresses */
+    .forwarded-from-email {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 500px;
+    }
+    @media screen and (max-width: 1200px) {
+      .forwarded-from-email {
+        width: 300px;
+      }
+    }
+    @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-        text-align: center;
       }
-      .footer-block .container-link img {
-        height: 45px;
-        width: auto;
+      .relay-trackers-removed {
+        display: block !important;
+        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {
@@ -100,29 +112,22 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         text-align: left;
       }
       .header-block-right {
-        margin-left: 40px;
+        margin-top: 4px;
       }
       .relay-trackers-removed,
       .relay-mask {
         width: 100%;
         display: block;
       }
-    }
-    /* this deals with long email addresses */
-    .forwarded-from-email {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        width: 500px;
-      }
-    @media screen and (max-width: 1200px) {
-      .forwarded-from-email {
-        width: 300px;
-      }
-    }
-    @media screen and (max-width: 768px){
       .forwarded-from-email {
         width: 250px;
+      }
+      .footer-block {
+        display: block;
+        text-align: left !important;
+      }
+      .footer-block .container-link.dashboard {
+        margin-left: 5px !important;
       }
     }
     @media screen and (max-width: 425px) {
@@ -135,37 +140,38 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
   <body id=3D"relay-email" style=3D"padding: 0; margin: 0;">
     <!-- Header -->
     <table id=3D"relay-email-header" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
-        <td class=3D"header-block-left" width=3D"50%" align=3D"left" style=3D=
-"padding-top: 5px;">
+        <td class=3D"relay-logo-img" style=3D"width: 30px; vertical-align: to=
+p;" >
           <img width=3D"30" src=3D"http://127.0.0.1:8000/static/images/email-=
 images/relay-icon.png" style=3D"margin-right: 5px; display: inline-block; ver=
 tical-align: top;" alt=3D"relay icon"/>
-          <p style=3D"margin-top: 0; margin-bottom: 5px; display: inline-bloc=
-k;">
+        </td>
+        <td class=3D"header-block-left" style=3D"vertical-align: bottom;" wid=
+th=3D"50%" align=3D"left" style=3D"padding-top: 5px;">
+          <p style=3D"margin-top: 0; margin-bottom: 0; vertical-align: middle=
+; display: inline-block;">
             <span class=3D"forwarded-from-email" style=3D"display: block; col=
 or: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
             Forwarded from <a href=3D"http://127.0.0.1:8000/accounts/profile/=
 #ebsbdsan7%40test.com" class=3D"container-link" style=3D"margin-right: 30px;c=
 olor: #FFFFFF;font-size: 12px;">ebsbdsan7@test.com</a>
             </span>
-          <span style=3D"margin-top: 0; margin-bottom: 5px; display: block;co=
-lor: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
-              by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=3D=
-"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12px;"=
->Firefox Relay</a>
-          </span>
+            <span style=3D"margin-top: 0; color: #FFFFFF; font-family: 'inter=
+', Arial, sans-serif; font-size: 12px;">
+                by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=
+=3D"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12p=
+x;">Firefox Relay</a>
+            </span>
           </p>
         </td>
-        <td class=3D"header-block-right" width=3D"50%" align=3D"right">
-          <p class=3D"relay-trackers-removed" style=3D"margin: 0 30px 0 0; di=
-splay: inline-block; color: #FFFFFF; font-family: 'inter', Arial, sans-serif;=
- font-size: 12px;">
-            <img class=3D"email-trackers-removed-icon" width=3D"15" src=3D"ht=
-tp://127.0.0.1:8000/static/images/email-images/email-trackers-removed-icon.pn=
-g" alt=3D"email trackers removed icon"/>
+        <td class=3D"header-block-right" style=3D"vertical-align: bottom;" wi=
+dth=3D"50%" align=3D"right">
+          <p class=3D"relay-trackers-removed" style=3D"margin: 0 16px 0 0; ve=
+rtical-align: bottom; display: inline-block; color: #FFFFFF; font-family: 'in=
+ter', Arial, sans-serif; font-size: 12px;">
               <span dir=3D"auto">0</span> email trackers removed
           </p>
           <p class=3D"relay-mask" style=3D"margin: 0; display: inline-block;">
@@ -218,19 +224,19 @@ lank" style=3D"text-decoration: none; color: #9393a0;" rel=3D"noopener">=D0=
     </table>
     <!-- Footer -->
     <table id=3D"relay-email-footer" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
         <td class=3D"footer-block" width=3D"50%" align=3D"left">
           <a class=3D"container-link" href=3D"http://127.0.0.1:8000">
-            <img width=3D"110" src=3D"http://127.0.0.1:8000/static/images/ema=
+            <img width=3D"130" src=3D"http://127.0.0.1:8000/static/images/ema=
 il-images/relay-logo-emails-dark-bg.png" style=3D"margin: 0;" alt=3D"relay lo=
 go"/>
           </a>
         </td>
         <td class=3D"footer-block" width=3D"50%" align=3D"right">
-          <a class=3D"container-link" href=3D"http://127.0.0.1:8000/accounts/=
-profile" style=3D"color: #FFFFFF;">Your dashboard</a>
+          <a class=3D"container-link dashboard" href=3D"http://127.0.0.1:8000=
+/accounts/profile" style=3D"color: #FFFFFF;">Your dashboard</a>
         </td>
       </tr>
     </table>

--- a/emails/tests/fixtures/single_recipient_expected.email
+++ b/emails/tests/fixtures/single_recipient_expected.email
@@ -91,14 +91,17 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         width: 300px;
       }
     }
+    @media screen and (max-width: 1024px) {
+        .relay-trackers-removed {
+          /* Avoid margin when header-block-right content overflows */
+          display: block !important;
+          margin-right: 0 !important;
+        }
+    }
     @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-      }
-      .relay-trackers-removed {
-        display: block !important;
-        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {

--- a/emails/tests/fixtures/single_recipient_expected.email
+++ b/emails/tests/fixtures/single_recipient_expected.email
@@ -55,6 +55,7 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       font-family: 'inter', Arial, sans-serif;
       color: #FFFFFF;
       font-size: 12px;
+      line-height: 140% !important;
     }
     a.container-link {
       transition: all 0.2s ease;
@@ -78,15 +79,26 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       margin-right: 5px;
       vertical-align: bottom;
     }
-    @media screen and (max-width: 768px) {
+    /* this deals with long email addresses */
+    .forwarded-from-email {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 500px;
+    }
+    @media screen and (max-width: 1200px) {
+      .forwarded-from-email {
+        width: 300px;
+      }
+    }
+    @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-        text-align: center;
       }
-      .footer-block .container-link img {
-        height: 45px;
-        width: auto;
+      .relay-trackers-removed {
+        display: block !important;
+        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {
@@ -95,29 +107,22 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         text-align: left;
       }
       .header-block-right {
-        margin-left: 40px;
+        margin-top: 4px;
       }
       .relay-trackers-removed,
       .relay-mask {
         width: 100%;
         display: block;
       }
-    }
-    /* this deals with long email addresses */
-    .forwarded-from-email {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        width: 500px;
-      }
-    @media screen and (max-width: 1200px) {
-      .forwarded-from-email {
-        width: 300px;
-      }
-    }
-    @media screen and (max-width: 768px){
       .forwarded-from-email {
         width: 250px;
+      }
+      .footer-block {
+        display: block;
+        text-align: left !important;
+      }
+      .footer-block .container-link.dashboard {
+        margin-left: 5px !important;
       }
     }
     @media screen and (max-width: 425px) {
@@ -130,37 +135,38 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
   <body id=3D"relay-email" style=3D"padding: 0; margin: 0;">
     <!-- Header -->
     <table id=3D"relay-email-header" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
-        <td class=3D"header-block-left" width=3D"50%" align=3D"left" style=3D=
-"padding-top: 5px;">
+        <td class=3D"relay-logo-img" style=3D"width: 30px; vertical-align: to=
+p;" >
           <img width=3D"30" src=3D"http://127.0.0.1:8000/static/images/email-=
 images/relay-icon.png" style=3D"margin-right: 5px; display: inline-block; ver=
 tical-align: top;" alt=3D"relay icon"/>
-          <p style=3D"margin-top: 0; margin-bottom: 5px; display: inline-bloc=
-k;">
+        </td>
+        <td class=3D"header-block-left" style=3D"vertical-align: bottom;" wid=
+th=3D"50%" align=3D"left" style=3D"padding-top: 5px;">
+          <p style=3D"margin-top: 0; margin-bottom: 0; vertical-align: middle=
+; display: inline-block;">
             <span class=3D"forwarded-from-email" style=3D"display: block; col=
 or: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
             Forwarded from <a href=3D"http://127.0.0.1:8000/accounts/profile/=
 #ebsbdsan7%40test.com" class=3D"container-link" style=3D"margin-right: 30px;c=
 olor: #FFFFFF;font-size: 12px;">ebsbdsan7@test.com</a>
             </span>
-          <span style=3D"margin-top: 0; margin-bottom: 5px; display: block;co=
-lor: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
-              by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=3D=
-"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12px;"=
->Firefox Relay</a>
-          </span>
+            <span style=3D"margin-top: 0; color: #FFFFFF; font-family: 'inter=
+', Arial, sans-serif; font-size: 12px;">
+                by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=
+=3D"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12p=
+x;">Firefox Relay</a>
+            </span>
           </p>
         </td>
-        <td class=3D"header-block-right" width=3D"50%" align=3D"right">
-          <p class=3D"relay-trackers-removed" style=3D"margin: 0 30px 0 0; di=
-splay: inline-block; color: #FFFFFF; font-family: 'inter', Arial, sans-serif;=
- font-size: 12px;">
-            <img class=3D"email-trackers-removed-icon" width=3D"15" src=3D"ht=
-tp://127.0.0.1:8000/static/images/email-images/email-trackers-removed-icon.pn=
-g" alt=3D"email trackers removed icon"/>
+        <td class=3D"header-block-right" style=3D"vertical-align: bottom;" wi=
+dth=3D"50%" align=3D"right">
+          <p class=3D"relay-trackers-removed" style=3D"margin: 0 16px 0 0; ve=
+rtical-align: bottom; display: inline-block; color: #FFFFFF; font-family: 'in=
+ter', Arial, sans-serif; font-size: 12px;">
               <span dir=3D"auto">0</span> email trackers removed
           </p>
           <p class=3D"relay-mask" style=3D"margin: 0; display: inline-block;">
@@ -191,19 +197,19 @@ l.</div></div></div><div style=3D"font-family: arial; font-size: 14px;"><br><=
     </table>
     <!-- Footer -->
     <table id=3D"relay-email-footer" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
         <td class=3D"footer-block" width=3D"50%" align=3D"left">
           <a class=3D"container-link" href=3D"http://127.0.0.1:8000">
-            <img width=3D"110" src=3D"http://127.0.0.1:8000/static/images/ema=
+            <img width=3D"130" src=3D"http://127.0.0.1:8000/static/images/ema=
 il-images/relay-logo-emails-dark-bg.png" style=3D"margin: 0;" alt=3D"relay lo=
 go"/>
           </a>
         </td>
         <td class=3D"footer-block" width=3D"50%" align=3D"right">
-          <a class=3D"container-link" href=3D"http://127.0.0.1:8000/accounts/=
-profile" style=3D"color: #FFFFFF;">Your dashboard</a>
+          <a class=3D"container-link dashboard" href=3D"http://127.0.0.1:8000=
+/accounts/profile" style=3D"color: #FFFFFF;">Your dashboard</a>
         </td>
       </tr>
     </table>

--- a/emails/tests/fixtures/single_recipient_fr_expected.email
+++ b/emails/tests/fixtures/single_recipient_fr_expected.email
@@ -55,6 +55,7 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       font-family: 'inter', Arial, sans-serif;
       color: #FFFFFF;
       font-size: 12px;
+      line-height: 140% !important;
     }
     a.container-link {
       transition: all 0.2s ease;
@@ -78,15 +79,26 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       margin-right: 5px;
       vertical-align: bottom;
     }
-    @media screen and (max-width: 768px) {
+    /* this deals with long email addresses */
+    .forwarded-from-email {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 500px;
+    }
+    @media screen and (max-width: 1200px) {
+      .forwarded-from-email {
+        width: 300px;
+      }
+    }
+    @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-        text-align: center;
       }
-      .footer-block .container-link img {
-        height: 45px;
-        width: auto;
+      .relay-trackers-removed {
+        display: block !important;
+        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {
@@ -95,29 +107,22 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         text-align: left;
       }
       .header-block-right {
-        margin-left: 40px;
+        margin-top: 4px;
       }
       .relay-trackers-removed,
       .relay-mask {
         width: 100%;
         display: block;
       }
-    }
-    /* this deals with long email addresses */
-    .forwarded-from-email {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        width: 500px;
-      }
-    @media screen and (max-width: 1200px) {
-      .forwarded-from-email {
-        width: 300px;
-      }
-    }
-    @media screen and (max-width: 768px){
       .forwarded-from-email {
         width: 250px;
+      }
+      .footer-block {
+        display: block;
+        text-align: left !important;
+      }
+      .footer-block .container-link.dashboard {
+        margin-left: 5px !important;
       }
     }
     @media screen and (max-width: 425px) {
@@ -130,37 +135,38 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
   <body id=3D"relay-email" style=3D"padding: 0; margin: 0;">
     <!-- Header -->
     <table id=3D"relay-email-header" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
-        <td class=3D"header-block-left" width=3D"50%" align=3D"left" style=3D=
-"padding-top: 5px;">
+        <td class=3D"relay-logo-img" style=3D"width: 30px; vertical-align: to=
+p;" >
           <img width=3D"30" src=3D"http://127.0.0.1:8000/static/images/email-=
 images/relay-icon.png" style=3D"margin-right: 5px; display: inline-block; ver=
 tical-align: top;" alt=3D"relay icon"/>
-          <p style=3D"margin-top: 0; margin-bottom: 5px; display: inline-bloc=
-k;">
+        </td>
+        <td class=3D"header-block-left" style=3D"vertical-align: bottom;" wid=
+th=3D"50%" align=3D"left" style=3D"padding-top: 5px;">
+          <p style=3D"margin-top: 0; margin-bottom: 0; vertical-align: middle=
+; display: inline-block;">
             <span class=3D"forwarded-from-email" style=3D"display: block; col=
 or: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
             Transf=C3=A9r=C3=A9 depuis <a href=3D"http://127.0.0.1:8000/accou=
 nts/profile/#ebsbdsan7%40test.com" class=3D"container-link" style=3D"margin-r=
 ight: 30px;color: #FFFFFF;font-size: 12px;">ebsbdsan7@test.com</a>
             </span>
-          <span style=3D"margin-top: 0; margin-bottom: 5px; display: block;co=
-lor: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
-              par <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=
+            <span style=3D"margin-top: 0; color: #FFFFFF; font-family: 'inter=
+', Arial, sans-serif; font-size: 12px;">
+                par <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=
 =3D"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12p=
 x;">Firefox Relay</a>
-          </span>
+            </span>
           </p>
         </td>
-        <td class=3D"header-block-right" width=3D"50%" align=3D"right">
-          <p class=3D"relay-trackers-removed" style=3D"margin: 0 30px 0 0; di=
-splay: inline-block; color: #FFFFFF; font-family: 'inter', Arial, sans-serif;=
- font-size: 12px;">
-            <img class=3D"email-trackers-removed-icon" width=3D"15" src=3D"ht=
-tp://127.0.0.1:8000/static/images/email-images/email-trackers-removed-icon.pn=
-g" alt=3D"email trackers removed icon"/>
+        <td class=3D"header-block-right" style=3D"vertical-align: bottom;" wi=
+dth=3D"50%" align=3D"right">
+          <p class=3D"relay-trackers-removed" style=3D"margin: 0 16px 0 0; ve=
+rtical-align: bottom; display: inline-block; color: #FFFFFF; font-family: 'in=
+ter', Arial, sans-serif; font-size: 12px;">
               <span dir=3D"auto">0</span>=C2=A0traqueur d=E2=80=99e-mail supp=
 rim=C3=A9
           </p>
@@ -192,19 +198,19 @@ l.</div></div></div><div style=3D"font-family: arial; font-size: 14px;"><br><=
     </table>
     <!-- Footer -->
     <table id=3D"relay-email-footer" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
         <td class=3D"footer-block" width=3D"50%" align=3D"left">
           <a class=3D"container-link" href=3D"http://127.0.0.1:8000">
-            <img width=3D"110" src=3D"http://127.0.0.1:8000/static/images/ema=
+            <img width=3D"130" src=3D"http://127.0.0.1:8000/static/images/ema=
 il-images/relay-logo-emails-dark-bg.png" style=3D"margin: 0;" alt=3D"relay lo=
 go"/>
           </a>
         </td>
         <td class=3D"footer-block" width=3D"50%" align=3D"right">
-          <a class=3D"container-link" href=3D"http://127.0.0.1:8000/accounts/=
-profile" style=3D"color: #FFFFFF;">Votre tableau de bord</a>
+          <a class=3D"container-link dashboard" href=3D"http://127.0.0.1:8000=
+/accounts/profile" style=3D"color: #FFFFFF;">Votre tableau de bord</a>
         </td>
       </tr>
     </table>

--- a/emails/tests/fixtures/single_recipient_fr_expected.email
+++ b/emails/tests/fixtures/single_recipient_fr_expected.email
@@ -91,14 +91,17 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         width: 300px;
       }
     }
+    @media screen and (max-width: 1024px) {
+        .relay-trackers-removed {
+          /* Avoid margin when header-block-right content overflows */
+          display: block !important;
+          margin-right: 0 !important;
+        }
+    }
     @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-      }
-      .relay-trackers-removed {
-        display: block !important;
-        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {

--- a/emails/tests/fixtures/single_recipient_list_expected.email
+++ b/emails/tests/fixtures/single_recipient_list_expected.email
@@ -91,14 +91,17 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         width: 300px;
       }
     }
+    @media screen and (max-width: 1024px) {
+        .relay-trackers-removed {
+          /* Avoid margin when header-block-right content overflows */
+          display: block !important;
+          margin-right: 0 !important;
+        }
+    }
     @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-      }
-      .relay-trackers-removed {
-        display: block !important;
-        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {

--- a/emails/tests/fixtures/single_recipient_list_expected.email
+++ b/emails/tests/fixtures/single_recipient_list_expected.email
@@ -55,6 +55,7 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       font-family: 'inter', Arial, sans-serif;
       color: #FFFFFF;
       font-size: 12px;
+      line-height: 140% !important;
     }
     a.container-link {
       transition: all 0.2s ease;
@@ -78,15 +79,26 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
       margin-right: 5px;
       vertical-align: bottom;
     }
-    @media screen and (max-width: 768px) {
+    /* this deals with long email addresses */
+    .forwarded-from-email {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 500px;
+    }
+    @media screen and (max-width: 1200px) {
+      .forwarded-from-email {
+        width: 300px;
+      }
+    }
+    @media screen and (max-width: 768px){
       .footer-block {
         display: block;
         width: 100%;
-        text-align: center;
       }
-      .footer-block .container-link img {
-        height: 45px;
-        width: auto;
+      .relay-trackers-removed {
+        display: block !important;
+        margin-right: 0 !important;
       }
       .header-block-left,
       .header-block-right {
@@ -95,29 +107,22 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
         text-align: left;
       }
       .header-block-right {
-        margin-left: 40px;
+        margin-top: 4px;
       }
       .relay-trackers-removed,
       .relay-mask {
         width: 100%;
         display: block;
       }
-    }
-    /* this deals with long email addresses */
-    .forwarded-from-email {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        width: 500px;
-      }
-    @media screen and (max-width: 1200px) {
-      .forwarded-from-email {
-        width: 300px;
-      }
-    }
-    @media screen and (max-width: 768px){
       .forwarded-from-email {
         width: 250px;
+      }
+      .footer-block {
+        display: block;
+        text-align: left !important;
+      }
+      .footer-block .container-link.dashboard {
+        margin-left: 5px !important;
       }
     }
     @media screen and (max-width: 425px) {
@@ -130,37 +135,38 @@ refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
   <body id=3D"relay-email" style=3D"padding: 0; margin: 0;">
     <!-- Header -->
     <table id=3D"relay-email-header" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
-        <td class=3D"header-block-left" width=3D"50%" align=3D"left" style=3D=
-"padding-top: 5px;">
+        <td class=3D"relay-logo-img" style=3D"width: 30px; vertical-align: to=
+p;" >
           <img width=3D"30" src=3D"http://127.0.0.1:8000/static/images/email-=
 images/relay-icon.png" style=3D"margin-right: 5px; display: inline-block; ver=
 tical-align: top;" alt=3D"relay icon"/>
-          <p style=3D"margin-top: 0; margin-bottom: 5px; display: inline-bloc=
-k;">
+        </td>
+        <td class=3D"header-block-left" style=3D"vertical-align: bottom;" wid=
+th=3D"50%" align=3D"left" style=3D"padding-top: 5px;">
+          <p style=3D"margin-top: 0; margin-bottom: 0; vertical-align: middle=
+; display: inline-block;">
             <span class=3D"forwarded-from-email" style=3D"display: block; col=
 or: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
             Forwarded from <a href=3D"http://127.0.0.1:8000/accounts/profile/=
 #ebsbdsan7%40test.com" class=3D"container-link" style=3D"margin-right: 30px;c=
 olor: #FFFFFF;font-size: 12px;">ebsbdsan7@test.com</a>
             </span>
-          <span style=3D"margin-top: 0; margin-bottom: 5px; display: block;co=
-lor: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
-              by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=3D=
-"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12px;"=
->Firefox Relay</a>
-          </span>
+            <span style=3D"margin-top: 0; color: #FFFFFF; font-family: 'inter=
+', Arial, sans-serif; font-size: 12px;">
+                by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=
+=3D"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12p=
+x;">Firefox Relay</a>
+            </span>
           </p>
         </td>
-        <td class=3D"header-block-right" width=3D"50%" align=3D"right">
-          <p class=3D"relay-trackers-removed" style=3D"margin: 0 30px 0 0; di=
-splay: inline-block; color: #FFFFFF; font-family: 'inter', Arial, sans-serif;=
- font-size: 12px;">
-            <img class=3D"email-trackers-removed-icon" width=3D"15" src=3D"ht=
-tp://127.0.0.1:8000/static/images/email-images/email-trackers-removed-icon.pn=
-g" alt=3D"email trackers removed icon"/>
+        <td class=3D"header-block-right" style=3D"vertical-align: bottom;" wi=
+dth=3D"50%" align=3D"right">
+          <p class=3D"relay-trackers-removed" style=3D"margin: 0 16px 0 0; ve=
+rtical-align: bottom; display: inline-block; color: #FFFFFF; font-family: 'in=
+ter', Arial, sans-serif; font-size: 12px;">
               <span dir=3D"auto">0</span> email trackers removed
           </p>
           <p class=3D"relay-mask" style=3D"margin: 0; display: inline-block;">
@@ -191,19 +197,19 @@ l.</div></div></div><div style=3D"font-family: arial; font-size: 14px;"><br><=
     </table>
     <!-- Footer -->
     <table id=3D"relay-email-footer" width=3D"100%" bgcolor=3D"#3D3D3D" style=
-=3D"background: #3D3D3D; padding: 12px 25px; margin-top: 30px; margin-bottom:=
- 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
       <tr>
         <td class=3D"footer-block" width=3D"50%" align=3D"left">
           <a class=3D"container-link" href=3D"http://127.0.0.1:8000">
-            <img width=3D"110" src=3D"http://127.0.0.1:8000/static/images/ema=
+            <img width=3D"130" src=3D"http://127.0.0.1:8000/static/images/ema=
 il-images/relay-logo-emails-dark-bg.png" style=3D"margin: 0;" alt=3D"relay lo=
 go"/>
           </a>
         </td>
         <td class=3D"footer-block" width=3D"50%" align=3D"right">
-          <a class=3D"container-link" href=3D"http://127.0.0.1:8000/accounts/=
-profile" style=3D"color: #FFFFFF;">Your dashboard</a>
+          <a class=3D"container-link dashboard" href=3D"http://127.0.0.1:8000=
+/accounts/profile" style=3D"color: #FFFFFF;">Your dashboard</a>
         </td>
       </tr>
     </table>


### PR DESCRIPTION
This PR fixes MPP-3545.

<!-- When adding a new feature: -->
# New feature description
Wrapper email styling was updated. Also added a minor change to reply banner styling to remove the margin when there is overflow.

# Screenshot (if applicable)

https://github.com/mozilla/fx-private-relay/assets/59676643/56686e53-1c97-4475-bf9a-943e36e5a6c2

# How to test
* Go to emails/wrapped_email_test
* Verify that the top banner matches the screenshots in for desktop and mobile https://mozilla-hub.atlassian.net/browse/MPP-3545

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
