### PR TITLE
MPP-3518: Remove trailing slash from support link, stage fix

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -7,7 +7,7 @@ const runtimeConfigs = {
     frontendOrigin: "",
     fxaLoginUrl: "/accounts/fxa/login/?process=login",
     fxaLogoutUrl: "/accounts/logout/",
-    supportUrl: "https://support.mozilla.org/products/relay/",
+    supportUrl: "https://support.mozilla.org/products/relay",
     emailSizeLimitNumber: 10,
     emailSizeLimitUnit: "MB",
     maxFreeAliases: 5,

--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -250,13 +250,13 @@ const Faq: NextPage = () => {
                 <Localized
                   id="faq-question-missing-emails-answer-support-site-html"
                   vars={{
-                    url: "https://support.mozilla.org/products/relay/",
+                    url: "https://support.mozilla.org/products/relay",
                     attrs: "",
                   }}
                   elems={{
                     a: (
                       <a
-                        href="https://support.mozilla.org/products/relay/"
+                        href="https://support.mozilla.org/products/relay"
                         target="_blank"
                         rel="noopener noreferrer"
                       />


### PR DESCRIPTION
This PR fixes MPP-3518.

# Description
In #4037 the trailing slash was only removed from the support link in the "Tips" component. With this PR, it was changed in the runtimeConfig file as well so that the link to "Help and Support" when clicking your account on the top right opens the correct link. 

# Screenshot (if applicable)
![image](https://github.com/mozilla/fx-private-relay/assets/59676643/042e9791-92b4-4ff6-a2c2-d722cae6c5d6)

# How to test
1. Login in to Relay
2. Click your avatar on the top right
3. Click "Help and support"
4. Observe that you are taken to "https://support.mozilla.org/en-US/products/relay?utm_source="
6. Go back to https://relay.firefox.com/accounts/profile/
7. Click "Help & Tips" on the bottom right
8. Click "Support"
9. Observe that you are taken to "https://support.mozilla.org/en-US/products/relay?utm_source="

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
