### PR TITLE
Avoid distortion in app logos, using object-fit

### DIFF
--- a/frontend/src/components/layout/navigation/AppPicker.module.scss
+++ b/frontend/src/components/layout/navigation/AppPicker.module.scss
@@ -110,6 +110,7 @@
         width: fit-content;
         box-sizing: content-box;
         border-radius: $border-radius-md;
+        object-fit: contain;
       }
 
       &:hover {


### PR DESCRIPTION
This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1863049 .

Before this commit, some of the app logos in Relay's top-right app-picker-menu were distorted, due to displaying a rectangular image file in a square img element.  "object-fit: contain" (added here) lets us preserve the image's aspect ratio when displaying it via an img element.