### PR TITLE
MPP-3562 CSAT banner not showing every 90 days on website

### DIFF
--- a/frontend/src/components/layout/topmessage/CsatSurvey.tsx
+++ b/frontend/src/components/layout/topmessage/CsatSurvey.tsx
@@ -99,7 +99,7 @@ export const CsatSurvey = (props: Props) => {
         (firstSeen as Date);
     const daysSinceSubscription =
       (Date.now() - subscriptionDate.getTime()) / 1000 / 60 / 60 / 24;
-     if (daysSinceSubscription >= 90) {
+    if (daysSinceSubscription >= 90) {
       if (!premium90DaysDismissal.isDismissed) {
         reasonToShow = "premium90days";
       }

--- a/frontend/src/components/layout/topmessage/CsatSurvey.tsx
+++ b/frontend/src/components/layout/topmessage/CsatSurvey.tsx
@@ -99,7 +99,7 @@ export const CsatSurvey = (props: Props) => {
         (firstSeen as Date);
     const daysSinceSubscription =
       (Date.now() - subscriptionDate.getTime()) / 1000 / 60 / 60 / 24;
-    if (daysSinceSubscription >= 90) {
+     if (daysSinceSubscription >= 90) {
       if (!premium90DaysDismissal.isDismissed) {
         reasonToShow = "premium90days";
       }
@@ -143,7 +143,7 @@ export const CsatSurvey = (props: Props) => {
       free7DaysDismissal.dismiss(options);
     }
     if (reasonToShow === "free30days") {
-      free90DaysDismissal.dismiss(options);
+      free30DaysDismissal.dismiss(options);
     }
     if (reasonToShow === "free90days") {
       free90DaysDismissal.dismiss(options);


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3562

Problem: 

From Andrei: ...I ran into some issues making the website one work as well and I wasn’t able to make that re-appear for after 30 days and later…

For the website CSAT, modifying the cookie values does not help make the survey re-appear, but modifying the date of my computer does. I can go until around the middle December, and that should cover the 30 days re-appearance, but it just doesn’t come up, the latest cookie being the 30 days one. Going later than that end up in the website giving errors due to my PC’s date.

Going back in time with the date does not give any results.

I’ve dug a bit through the ticket where I tested the website banner, but I didn’t find any solutions. The last suggestion from Vincent there, for fixing the 30 days + re-appear issue, was to delete the previous cookie, but that doesn’t actually fix the situation. I just get the same cookie as the one deleted. Instead of getting the 90 days cookie I get back the 30 days one. :confused: 
 
# New feature description

The logic had a minor typo that had dismissal of the banner for 90days twice. This accounts for 30 day dismissal and fixes the flow for the CSAT banner on the website. 

# Screenshot (if applicable)

![image](https://github.com/mozilla/fx-private-relay/assets/3924990/161c1035-9b23-45a7-b614-80bdbd77f54d)

# How to test

You can test the dismissal of the banner, closing banner (with x) should not permanently remove it, but dismissing it intentionally should make it go away until the next cycle (90 days and every 90 days thereafter). To make it show up again, change your local time to 90 days in the future. You can dismiss it again and it shouldn't show up. Then change your date to 90 days in the future and it should work.

You can use these values to update first_seen cookie: 

7 days ago: 1698670807489
30 days ago: 1696190807489
90 days ago: 1690290807489
180 days ago: 1681490807489

These dates are relative to 11/6/23 

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
