### PR TITLE
Fix responses decorator, update responses

### DIFF
--- a/api/tests/authentication_tests.py
+++ b/api/tests/authentication_tests.py
@@ -57,7 +57,7 @@ class AuthenticationMiscellaneous(TestCase):
     def tearDown(self):
         cache.clear()
 
-    @responses.activate()
+    @responses.activate
     def test_introspect_token_catches_JSONDecodeError_raises_AuthenticationFailed(self):
         _setup_fxa_response_no_json(200)
         invalid_token = "invalid-123"
@@ -70,7 +70,7 @@ class AuthenticationMiscellaneous(TestCase):
             return
         self.fail("Should have raised AuthenticationFailed")
 
-    @responses.activate()
+    @responses.activate
     def test_introspect_token_returns_fxa_introspect_response(self):
         now_time = int(datetime.now().timestamp())
         # Note: FXA iat and exp are timestamps in *milliseconds*
@@ -88,7 +88,7 @@ class AuthenticationMiscellaneous(TestCase):
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
         assert fxa_resp_data == expected_fxa_resp_data
 
-    @responses.activate()
+    @responses.activate
     def test_get_fxa_uid_from_oauth_token_returns_cached_response(self):
         user_token = "user-123"
         now_time = int(datetime.now().timestamp())
@@ -112,7 +112,7 @@ class AuthenticationMiscellaneous(TestCase):
         assert fxa_uid == self.uid
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
-    @responses.activate()
+    @responses.activate
     def test_get_fxa_uid_from_oauth_token_status_code_None_uses_cached_response_returns_error_response(
         self,
     ):
@@ -140,7 +140,7 @@ class AuthenticationMiscellaneous(TestCase):
             return
         self.fail("Should have raised APIException")
 
-    @responses.activate()
+    @responses.activate
     def test_get_fxa_uid_from_oauth_token_status_code_not_200_uses_cached_response_returns_error_response(
         self,
     ):
@@ -172,7 +172,7 @@ class AuthenticationMiscellaneous(TestCase):
             return
         self.fail("Should have raised APIException")
 
-    @responses.activate()
+    @responses.activate
     def test_get_fxa_uid_from_oauth_token_not_active_uses_cached_response_returns_error_response(
         self,
     ):
@@ -204,7 +204,7 @@ class AuthenticationMiscellaneous(TestCase):
             return
         self.fail("Should have raised AuthenticationFailed")
 
-    @responses.activate()
+    @responses.activate
     def test_get_fxa_uid_from_oauth_token_returns_fxa_response_with_no_fxa_uid(self):
         user_token = "user-123"
         now_time = int(datetime.now().timestamp())
@@ -260,7 +260,7 @@ class FxaTokenAuthenticationTest(TestCase):
         assert response.status_code == 400
         assert response.json()["detail"] == "Missing FXA Token after 'Bearer'."
 
-    @responses.activate()
+    @responses.activate
     def test_non_200_resp_from_fxa_raises_error_and_caches(self):
         fxa_response = _setup_fxa_response(401, {"error": "401"})
         not_found_token = "not-found-123"
@@ -280,7 +280,7 @@ class FxaTokenAuthenticationTest(TestCase):
         response = client.get("/api/v1/relayaddresses/")
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
-    @responses.activate()
+    @responses.activate
     def test_non_200_non_json_resp_from_fxa_raises_error_and_caches(self):
         fxa_response = _setup_fxa_response(503, "Bad Gateway")
         not_found_token = "fxa-gw-error"
@@ -299,7 +299,7 @@ class FxaTokenAuthenticationTest(TestCase):
         response = client.get("/api/v1/relayaddresses/")
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
-    @responses.activate()
+    @responses.activate
     def test_inactive_token_responds_with_401(self):
         fxa_response = _setup_fxa_response(200, {"active": False})
         inactive_token = "inactive-123"
@@ -318,7 +318,7 @@ class FxaTokenAuthenticationTest(TestCase):
         response = client.get("/api/v1/relayaddresses/")
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
-    @responses.activate()
+    @responses.activate
     def test_200_resp_from_fxa_no_matching_user_raises_APIException(self):
         fxa_response = _setup_fxa_response(
             200, {"active": True, "sub": "not-a-relay-user"}
@@ -341,7 +341,7 @@ class FxaTokenAuthenticationTest(TestCase):
         response = client.get("/api/v1/relayaddresses/")
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
-    @responses.activate()
+    @responses.activate
     def test_200_resp_from_fxa_for_user_returns_user_and_caches(self):
         self.sa = baker.make(SocialAccount, uid=self.uid, provider="fxa")
         user_token = "user-123"
@@ -372,7 +372,7 @@ class FxaTokenAuthenticationTest(TestCase):
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
         assert cache.get(get_cache_key(user_token)) == fxa_response
 
-    @responses.activate()
+    @responses.activate
     def test_write_requests_make_calls_to_fxa(self):
         self.sa = baker.make(SocialAccount, uid=self.uid, provider="fxa")
         user_token = "user-123"

--- a/api/tests/iq_views_tests.py
+++ b/api/tests/iq_views_tests.py
@@ -167,7 +167,7 @@ def test_iq_endpoint_disabled_number(phone_user):
 
 
 @pytest.mark.django_db(transaction=True)
-@responses.activate()
+@responses.activate
 def test_iq_endpoint_success(phone_user):
     _make_real_phone_with_mock_iq(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user, "inteliquent")
@@ -194,7 +194,7 @@ def test_iq_endpoint_success(phone_user):
 
 
 @pytest.mark.django_db(transaction=True)
-@responses.activate()
+@responses.activate
 def test_reply_with_no_remaining_texts(phone_user):
     real_phone = _make_real_phone_with_mock_iq(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user, "inteliquent")
@@ -224,7 +224,7 @@ def test_reply_with_no_remaining_texts(phone_user):
 
 
 @pytest.mark.django_db(transaction=True)
-@responses.activate()
+@responses.activate
 def test_reply_with_no_phone_capability(phone_user):
     real_phone = _make_real_phone_with_mock_iq(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user, "inteliquent")
@@ -253,7 +253,7 @@ def test_reply_with_no_phone_capability(phone_user):
 
 
 @pytest.mark.django_db(transaction=True)
-@responses.activate()
+@responses.activate
 def test_reply_without_previous_sender_error(phone_user):
     real_phone = _make_real_phone_with_mock_iq(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user, "inteliquent")
@@ -294,7 +294,7 @@ def test_reply_without_previous_sender_error(phone_user):
 
 
 @pytest.mark.django_db(transaction=True)
-@responses.activate()
+@responses.activate
 def test_reply_with_previous_sender_works(phone_user):
     real_phone = _make_real_phone_with_mock_iq(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user, "inteliquent")

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -414,7 +414,7 @@ class TermsAcceptedUserViewTest(TestCase):
     def tearDown(self):
         cache.clear()
 
-    @responses.activate()
+    @responses.activate
     def test_201_new_user_created_and_202_user_exists(
         self,
     ):
@@ -466,7 +466,7 @@ class TermsAcceptedUserViewTest(TestCase):
         assert responses.assert_call_count(self.fxa_verify_path, 2) is True
         assert responses.assert_call_count(FXA_PROFILE_URL, 1) is True
 
-    @responses.activate()
+    @responses.activate
     def test_failed_profile_fetch_for_new_user_returns_500(self):
         user_token = "user-123"
         self._setup_client(user_token)
@@ -497,7 +497,7 @@ class TermsAcceptedUserViewTest(TestCase):
         assert response.status_code == 400
         assert response.json()["detail"] == "Missing FXA Token after 'Bearer'."
 
-    @responses.activate()
+    @responses.activate
     def test_invalid_bearer_token_error_from_fxa_returns_500_and_cache_returns_500(
         self,
     ):
@@ -512,7 +512,7 @@ class TermsAcceptedUserViewTest(TestCase):
         assert response.json()["detail"] == "Did not receive a 200 response from FXA."
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
-    @responses.activate()
+    @responses.activate
     def test_jsondecodeerror_returns_401_and_cache_returns_500(
         self,
     ):
@@ -531,7 +531,7 @@ class TermsAcceptedUserViewTest(TestCase):
         )
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
-    @responses.activate()
+    @responses.activate
     def test_non_200_response_from_fxa_returns_500_and_cache_returns_500(
         self,
     ):
@@ -551,7 +551,7 @@ class TermsAcceptedUserViewTest(TestCase):
         assert response.json()["detail"] == "Did not receive a 200 response from FXA."
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
-    @responses.activate()
+    @responses.activate
     def test_inactive_fxa_oauth_token_returns_401_and_cache_returns_401(
         self,
     ):
@@ -573,7 +573,7 @@ class TermsAcceptedUserViewTest(TestCase):
         assert response.json()["detail"] == "Fxa Returned Active: False For Token."
         assert responses.assert_call_count(self.fxa_verify_path, 1) is True
 
-    @responses.activate()
+    @responses.activate
     def test_fxa_responds_with_no_fxa_uid_returns_404_and_cache_returns_404(self):
         user_token = "user-123"
         now_time = int(datetime.now().timestamp())
@@ -599,7 +599,7 @@ def _setup_client(token):
 
 
 @pytest.mark.django_db
-@responses.activate()
+@responses.activate
 def test_duplicate_email_logs_details_for_debugging(caplog: pytest.LogCaptureFixture):
     caplog.set_level(logging.ERROR)
     uid = "relay-user-fxa-uid"

--- a/phones/tests/models_tests.py
+++ b/phones/tests/models_tests.py
@@ -155,7 +155,7 @@ def test_create_realphone_creates_twilio_message(phone_user, mock_twilio_client)
 
 
 @override_settings(IQ_FOR_VERIFICATION=True)
-@responses.activate()
+@responses.activate
 @pytest.mark.skipif(not settings.IQ_ENABLED, reason="IQ_ENABLED is false")
 def test_create_realphone_creates_iq_message(phone_user):
     number = "+12223334444"

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,8 +38,8 @@ vobject==0.9.6.1
 coverage==7.3.2
 model-bakery==1.17.0
 pytest-cov==4.1.0
-pytest-django==4.5.2
-responses==0.23.3
+pytest-django==4.6.0
+responses==0.24.0
 
 # linting
 black==23.10.1


### PR DESCRIPTION
The update of responses 0.23.3 to 0.24.0 broken on `mypy` in PR #4080, because that release removed some overrides that handled calling `@responses.activate()` with no parameters. This may be fixed in the next version, but the syntax `@responses.activate` does the same thing and will work with 0.24.0