### PR TITLE
MPP-3500: Log header values that raise exceptions

### DIFF
--- a/emails/types.py
+++ b/emails/types.py
@@ -27,6 +27,7 @@ class EmailHeaderExceptionOnReadIssue(TypedDict):
 
 class EmailHeaderExceptionOnWriteIssue(TypedDict):
     exception_on_write: str
+    value: str
 
 
 class EmailHeaderDefectIssue(TypedDict):

--- a/emails/views.py
+++ b/emails/views.py
@@ -942,7 +942,7 @@ def _replace_headers(
         try:
             email[header] = value
         except Exception as e:
-            issues["outgoing"][header] = {"exception_on_write": str(e)}
+            issues["outgoing"][header] = {"exception_on_write": str(e), "value": value}
             continue
         try:
             parsed_value = email[header]


### PR DESCRIPTION
When writing a header value raises an exception, log the problematic header value. This will help diagnose [MPP-3500](https://mozilla-hub.atlassian.net/browse/MPP-3500).

I can see that writing `Subject` is causing "Header values may not contain linefeed or carriage return characters", but I'm curious if AWS is parsing a multi-line subject with linefeeds, or if there are shenanigans.

[MPP-3500]: https://mozilla-hub.atlassian.net/browse/MPP-3500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ