### PR TITLE
MPP-3579: Welcome email cta button string update

### DIFF
--- a/emails/templates/emails/first_time_user.html
+++ b/emails/templates/emails/first_time_user.html
@@ -253,7 +253,7 @@
                   <p style="color: #321C64; font-size: 18px; font-family: metropolis medium, system-ui, sans-serif;">{% ftlmsg 'first-time-user-email-hero-primary-text' %}</p> 
                   <p style="color: #321C64; font-size: 18px; font-family: metropolis medium, system-ui, sans-serif;margin-top: 20px;">{% ftlmsg 'first-time-user-email-hero-secondary-text' %}</p>
 
-                  <a href="{{ SITE_ORIGIN }}/accounts/profile/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=hero-cta" target="_blank" class="button" style="margin-top: 30px; color: #FFFFFF;" rel="noreferrer">{% ftlmsg 'first-time-user-email-hero-cta' %}</a>
+                  <a href="{{ SITE_ORIGIN }}/accounts/profile/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email&utm_content=hero-cta" target="_blank" class="button" style="margin-top: 30px; color: #FFFFFF;" rel="noreferrer">{% ftlmsg 'first-time-user-email-cta-dashboard-button' %}</a>
 
                 </td>
               </tr>

--- a/emails/tests/mgmt_send_welcome_emails_tests.py
+++ b/emails/tests/mgmt_send_welcome_emails_tests.py
@@ -71,7 +71,7 @@ def test_send_welcome_emails(
     assert source == settings.RELAY_FROM_ADDRESS
     with django_ftl.override(user.profile.language):
         expected_subject = ftl_bundle.format("first-time-user-email-welcome")
-        expected_cta = ftl_bundle.format("first-time-user-email-hero-cta")
+        expected_cta = ftl_bundle.format("first-time-user-email-cta-dashboard-button")
     assert subject == expected_subject
     assert expected_cta in body_html
 


### PR DESCRIPTION
This PR fixes MPP-3579.

<!-- When adding a new feature: -->

# New feature description

String has changed to "Learn to use Relay", which is apart of the free onboarding work being done. 

l10n: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/163

This PR is currently blocked due to a failing test which requires the string "Learn to use Relay" to be translated into german. Once this is done, we can merge this PR.

# Screenshot (if applicable)

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/0cf430cf-149b-44e2-9a2f-895199c15cec)


# How to test
* Go to http://127.0.0.1:8000/emails/first_time_user_test and verify that the button has the string "Learn to use Relay"

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
