### PR TITLE
MPP-3583: Test header read exception, allow multiple headers with same name

### DIFF
--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -1902,6 +1902,8 @@ def test_replace_headers_read_error_is_handled() -> None:
     with patch.object(EmailMessage, "__getitem__", getitem_raise_on_x_fail):
         issues = _replace_headers(email, new_headers)
 
-    assert issues == {"incoming": {"X-Fail": {"exception_on_read": "I failed."}}}
+    assert issues == {
+        "incoming": {"X-Fail": {"exception_on_read": "RuntimeError('I failed.')"}}
+    }
     for name, value in new_headers.items():
         assert email[name] == value

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -749,19 +749,22 @@ class SNSNotificationTest(TestCase):
         _, _, _, mail = self.get_details_from_mock_send_raw_email()
         assert_email_equals(mail, "emperor_norton", replace_mime_boundaries=True)
         expected_header_errors = {
-            "incoming": {
-                "From": {
-                    "defect_count": 4,
-                    "parsed_value": (
-                        '"Norton I.", Emperor of the United States'
-                        " <norton@sf.us.example.com>"
-                    ),
-                    "unstructured_value": (
-                        "Norton I., Emperor of the United States"
-                        " <norton@sf.us.example.com>"
-                    ),
-                }
-            }
+            "incoming": [
+                (
+                    "From",
+                    {
+                        "defect_count": 4,
+                        "parsed_value": (
+                            '"Norton I.", Emperor of the United States'
+                            " <norton@sf.us.example.com>"
+                        ),
+                        "unstructured_value": (
+                            "Norton I., Emperor of the United States"
+                            " <norton@sf.us.example.com>"
+                        ),
+                    },
+                )
+            ]
         }
         mock_logger.warning.assert_called_once_with(
             "_handle_received: forwarding issues",
@@ -809,17 +812,20 @@ class SNSNotificationTest(TestCase):
             email, "message_id_in_brackets", replace_mime_boundaries=True
         )
         expected_header_errors = {
-            "incoming": {
-                "Message-ID": {
-                    "defect_count": 1,
-                    "parsed_value": (
-                        "<[d7c5838b5ab944f89e3f0c1b85674aef====@example.com]>"
-                    ),
-                    "unstructured_value": (
-                        "<[d7c5838b5ab944f89e3f0c1b85674aef====@example.com]>"
-                    ),
-                }
-            }
+            "incoming": [
+                (
+                    "Message-ID",
+                    {
+                        "defect_count": 1,
+                        "parsed_value": (
+                            "<[d7c5838b5ab944f89e3f0c1b85674aef====@example.com]>"
+                        ),
+                        "unstructured_value": (
+                            "<[d7c5838b5ab944f89e3f0c1b85674aef====@example.com]>"
+                        ),
+                    },
+                )
+            ]
         }
         mock_logger.warning.assert_called_once_with(
             "_handle_received: forwarding issues",
@@ -1903,7 +1909,7 @@ def test_replace_headers_read_error_is_handled() -> None:
         issues = _replace_headers(email, new_headers)
 
     assert issues == {
-        "incoming": {"X-Fail": {"exception_on_read": "RuntimeError('I failed.')"}}
+        "incoming": [("X-Fail", {"exception_on_read": "RuntimeError('I failed.')"})]
     }
     for name, value in new_headers.items():
         assert email[name] == value

--- a/emails/types.py
+++ b/emails/types.py
@@ -42,6 +42,8 @@ EmailHeaderIssue = (
     | EmailHeaderDefectIssue
 )
 
-EmailHeaderIssues = dict[Literal["incoming", "outgoing"], dict[str, EmailHeaderIssue]]
+EmailHeaderIssues = dict[
+    Literal["incoming", "outgoing"], list[tuple[str, EmailHeaderIssue]]
+]
 
 EmailForwardingIssues = dict[Literal["headers"], EmailHeaderIssues]

--- a/emails/views.py
+++ b/emails/views.py
@@ -913,7 +913,7 @@ def _replace_headers(
         try:
             value = email[header]
         except Exception as e:
-            issues["incoming"][header] = {"exception_on_read": str(e)}
+            issues["incoming"][header] = {"exception_on_read": repr(e)}
             value = None
         if getattr(value, "defects", None):
             issues["incoming"][header] = {
@@ -942,12 +942,12 @@ def _replace_headers(
         try:
             email[header] = value
         except Exception as e:
-            issues["outgoing"][header] = {"exception_on_write": str(e), "value": value}
+            issues["outgoing"][header] = {"exception_on_write": repr(e), "value": value}
             continue
         try:
             parsed_value = email[header]
         except Exception as e:
-            issues["outgoing"][header] = {"exception_on_read": str(e)}
+            issues["outgoing"][header] = {"exception_on_read": repr(e)}
             continue
         if parsed_value.defects:
             issues["outgoing"][header] = {

--- a/emails/views.py
+++ b/emails/views.py
@@ -906,21 +906,26 @@ def _replace_headers(
     # Look for headers to drop
     to_drop: list[str] = []
     replacements: set[str] = set(_k.lower() for _k in headers.keys())
-    issues: EmailHeaderIssues = defaultdict(dict)
+    issues: EmailHeaderIssues = defaultdict(list)
 
     # Detect non-compliant headers in incoming emails
     for header in email.keys():
         try:
             value = email[header]
         except Exception as e:
-            issues["incoming"][header] = {"exception_on_read": repr(e)}
+            issues["incoming"].append((header, {"exception_on_read": repr(e)}))
             value = None
         if getattr(value, "defects", None):
-            issues["incoming"][header] = {
-                "defect_count": len(value.defects),
-                "parsed_value": str(value),
-                "unstructured_value": str(value.as_unstructured),
-            }
+            issues["incoming"].append(
+                (
+                    header,
+                    {
+                        "defect_count": len(value.defects),
+                        "parsed_value": str(value),
+                        "unstructured_value": str(value.as_unstructured),
+                    },
+                )
+            )
 
     # Collect headers that will not be forwarded
     for header in email.keys():
@@ -942,19 +947,26 @@ def _replace_headers(
         try:
             email[header] = value
         except Exception as e:
-            issues["outgoing"][header] = {"exception_on_write": repr(e), "value": value}
+            issues["outgoing"].append(
+                (header, {"exception_on_write": repr(e), "value": value})
+            )
             continue
         try:
             parsed_value = email[header]
         except Exception as e:
-            issues["outgoing"][header] = {"exception_on_read": repr(e)}
+            issues["outgoing"].append((header, {"exception_on_read": repr(e)}))
             continue
         if parsed_value.defects:
-            issues["outgoing"][header] = {
-                "defect_count": len(parsed_value.defects),
-                "parsed_value": str(parsed_value),
-                "unstructured_value": str(parsed_value.as_unstructured),
-            }
+            issues["outgoing"].append(
+                (
+                    header,
+                    {
+                        "defect_count": len(parsed_value.defects),
+                        "parsed_value": str(parsed_value),
+                        "unstructured_value": str(parsed_value.as_unstructured),
+                    },
+                )
+            )
 
     return dict(issues)
 


### PR DESCRIPTION
PR #4059 did not actually fix the problem. I still can't write a text how I'd like, because I don't know what causes the issue, but `Mock` can raise the exception as needed.

While I'm touching the code, I ~added some new bug~ adjusted the output:

* Use `repr(exception)`, which includes the exception name
* Use a list of (name, issue) pairs instead of a dict of name → issue, so that if multiple headers with the same name have problems we capture them all.

## How to test:
- [x] I've added a unit test to test for potential regressions of this bug.
