### PR TITLE
MPP-3390: Auto-verify emails

### DIFF
--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -604,7 +604,7 @@ def test_duplicate_email_logs_details_for_debugging(caplog: pytest.LogCaptureFix
     caplog.set_level(logging.ERROR)
     uid = "relay-user-fxa-uid"
     email = "user@email.com"
-    baker.make(EmailAddress, email=email)
+    baker.make(EmailAddress, email=email, verified=True)
     user_token = "user-123"
     client = _setup_client(user_token)
     now_time = int(datetime.now().timestamp())

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -517,6 +517,7 @@ SOCIALACCOUNT_PROVIDERS = {
         "PROFILE_ENDPOINT": config(
             "FXA_PROFILE_ENDPOINT", "https://profile.accounts.firefox.com/v1"
         ),
+        "VERIFIED_EMAIL": True,  # Assume FxA primary email is verified
     }
 }
 

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -114,11 +114,13 @@ class UpdateExtraDataAndEmailTest(TestCase):
         extra_data = json.loads('{"test": "test"}')
 
         user = baker.make(User, email="user@example.com")
-        baker.make(EmailAddress, user=user, email="user@example.com")
+        baker.make(EmailAddress, user=user, email="user@example.com", verified=True)
         baker.make(SocialAccount, user=user, provider="fxa", extra_data=extra_data)
 
         user2 = baker.make(User, email="user2@example.com")
-        ea2 = baker.make(EmailAddress, user=user2, email="user2@example.com")
+        ea2 = baker.make(
+            EmailAddress, user=user2, email="user2@example.com", verified=True
+        )
         sa2 = baker.make(
             SocialAccount, user=user2, provider="fxa", extra_data=extra_data
         )


### PR DESCRIPTION
`django-allauth` 0.55.0 changes the unique index on emails to a unique index on emails where `verified=True`. Our code relies on unique emails, so we need to start marking emails coming from Mozilla accounts as verified.

Upgrading to `django-allauth` 0.55.0 and later will require two steps over two production pushes.

* **Step 1** (This PR) - Mark emails as verified going forward.
* **Step 2** - Mark existing emails as verified

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).