### PR TITLE
Downgrade to Django 3.2.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.28.78
 codetiming==1.4.0
 cryptography==41.0.5
-Django==4.2.7
+Django==3.2.22
 dj-database-url==2.1.0
 django-allauth==0.54.0
 django-cors-headers==4.3.0


### PR DESCRIPTION
Try to fix CSP errors in production by downgrading Django from 4.2.7 to 3.2.22.