### PR TITLE
MPP-3568: Added tracker removal argument for first forwarded email onboarding

### DIFF
--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -429,6 +429,7 @@ def first_forwarded_email(request):
         profile.language,
         profile.has_premium,
         from_address,
+        0,
     )
     ses_client.send_email(
         Destination={

--- a/emails/views.py
+++ b/emails/views.py
@@ -138,14 +138,22 @@ def reply_requires_premium_test(request):
 
 def first_forwarded_email_test(request: HttpRequest) -> HttpResponse:
     # TO DO: Update with correct context when trigger is created
-    email_context = {
-        "sender": "test@example.com",
-        "display_email": "test@example.com",
-        "SITE_ORIGIN": settings.SITE_ORIGIN,
-        "has_premium": True,
-        "num_level_one_email_trackers_removed": 100,
-    }
-    return render(request, "emails/first_forwarded_email.html", email_context)
+    first_forwarded_email_html = render_to_string(
+        "emails/first_forwarded_email.html",
+        {
+            "SITE_ORIGIN": settings.SITE_ORIGIN,
+        },
+    )
+
+    wrapped_email = wrap_html_email(
+        first_forwarded_email_html,
+        "en-us",
+        True,
+        "test@example.com",
+        0,
+    )
+
+    return HttpResponse(wrapped_email)
 
 
 def wrap_html_email(


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3568.

<!-- When adding a new feature: -->

# Bug description

Trackers were being displayed as "number" instead of "0" on the email banner which gets sent from api/v1/first-forwarded-email (more info https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/api/v1/docs/#/first-forwarded-email/first_forwarded_email_create). Now, it displays "0" (this email is being sent from us during free user onboarding, hence there are no trackers being removed).

# Screenshot (if applicable)
![image](https://github.com/mozilla/fx-private-relay/assets/59676643/91550454-81e8-43b0-bde9-1d2c536fa557)

# How to test
1. Check http://127.0.0.1:8000/emails/first_forwarded_email to verify that the test includes "0 email trackers removed" in the top banner.

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
