### PR TITLE
MPP-3578 - Make FF banner dismissible

### DIFF
--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -101,7 +101,9 @@ export const ProfileBanners = (props: Props) => {
     // This pushes a banner promoting the add-on - detecting the add-on
     // and determining whether to show it based on that is a bit slow,
     // so we'll just let the add-on hide it:
-    banners.push(<NoAddonBanner key="addon-banner" />);
+    banners.push(
+      <NoAddonBanner profileData={props.profile} key="addon-banner" />,
+    );
   }
 
   if (supportsChromeExtension() && isLargeScreen) {
@@ -200,7 +202,11 @@ const NoFirefoxBanner = () => {
   );
 };
 
-const NoAddonBanner = () => {
+type NoAddonBannerProps = {
+  profileData: ProfileData;
+};
+
+const NoAddonBanner = (props: NoAddonBannerProps) => {
   const l10n = useL10n();
 
   return (
@@ -226,6 +232,9 @@ const NoAddonBanner = () => {
             label: "profile-banner-download-firefox-extension",
           });
         },
+      }}
+      dismissal={{
+        key: `firefox-extension-banner-${props.profileData.id}`,
       }}
       hiddenWithAddon={true}
     >


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3578  

# New feature description

Makes FF banner dismissible

# Screenshot (if applicable)
 
![image](https://github.com/mozilla/fx-private-relay/assets/3924990/4f400801-5f14-4747-8903-bcfb657d48ed)
 
# How to test

Login to account from FF and check if banner is dismissible. 

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
