### PR TITLE
Add GA Ping for holiday promo news item

### DIFF
--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -381,7 +381,7 @@ export const WhatsNewMenu = (props: Props) => {
     announcementDate: {
       year: 2023,
       month: 11,
-      day: 26,
+      day: 29,
     },
   };
 

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -344,7 +344,7 @@ export const WhatsNewMenu = (props: Props) => {
       ? getPeriodicalPremiumSubscribeLink(props.runtimeData, "yearly")
       : undefined;
 
-  const yearlyPlanRefWithCoupon = `${yearlyPlanLink}&coupon=HOLIDAY20&utm_source=fx-relay&utm_medium=announcement&utm_campaign=holiday-promo-2023`;
+  const yearlyPlanRefWithCoupon = `${yearlyPlanLink}&coupon=HOLIDAY20`;
 
   const holidayPromo2023: WhatsNewEntry = {
     title: l10n.getString("whatsnew-holiday-promo-2023-news-heading"),
@@ -357,7 +357,16 @@ export const WhatsNewMenu = (props: Props) => {
         heading={l10n.getString("whatsnew-holiday-promo-2023-news-heading")}
         image={HolidayPromo2023Hero}
         cta={
-          <Link href={yearlyPlanRefWithCoupon} legacyBehavior>
+          <Link
+            href={yearlyPlanRefWithCoupon}
+            onClick={() => {
+              gaEvent({
+                category: "Holiday Promo News CTA",
+                action: "Engage",
+                label: "holiday-promo-2023-news-cta",
+              });
+            }}
+          >
             <span className={styles.cta}>
               {l10n.getString("whatsnew-holiday-promo-2023-cta")}
             </span>
@@ -372,7 +381,7 @@ export const WhatsNewMenu = (props: Props) => {
     announcementDate: {
       year: 2023,
       month: 11,
-      day: 29,
+      day: 26,
     },
   };
 

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -344,7 +344,7 @@ export const WhatsNewMenu = (props: Props) => {
       ? getPeriodicalPremiumSubscribeLink(props.runtimeData, "yearly")
       : undefined;
 
-  const yearlyPlanRefWithCoupon = `${yearlyPlanLink}&coupon=HOLIDAY20`;
+  const yearlyPlanRefWithCoupon = `${yearlyPlanLink}&coupon=HOLIDAY20&utm_source=fx-relay&utm_medium=announcement&utm_campaign=holiday-promo-2023`;
 
   const holidayPromo2023: WhatsNewEntry = {
     title: l10n.getString("whatsnew-holiday-promo-2023-news-heading"),


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This addresses the Holiday Coupon telemetry. 
 
<!-- When adding a new feature: -->

# New feature description

Add UTM parameters for the holiday coupon work.

We added `&utm_source=fx-relay&utm_medium=announcement&utm_campaign=holiday-promo-2023`

# Screenshot (if applicable)

Not applicable.

# How to test

View links in new news item for holiday promo.



# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
