### PR TITLE
MPP-3594: Fix long masks overflow in free onboarding

### DIFF
--- a/frontend/src/components/dashboard/FreeOnboarding.module.scss
+++ b/frontend/src/components/dashboard/FreeOnboarding.module.scss
@@ -22,8 +22,6 @@
 }
 
 .step.step-copy-mask {
-  max-width: $content-lg;
-
   .copy-mask-header {
     margin-bottom: $spacing-lg;
 

--- a/frontend/src/components/dashboard/aliases/MaskCard.module.scss
+++ b/frontend/src/components/dashboard/aliases/MaskCard.module.scss
@@ -81,6 +81,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
 
+        // Magic numbers: Stops long mask domains from overflowing, and enforces an ellipsis.
         @media screen and #{$mq-sm} {
           max-width: 350px; // Flex items wrap on smaller screens, hence there is more space
         }
@@ -90,9 +91,11 @@
         @media screen and (min-width: $content-lg) {
           max-width: 400px;
         }
-        // Stops long mask domain from cutting into the "Block promotions label"
+        // Note: Since the mask card is being used in a container (.main-wrapper) with a max-width of $content-xl,
+        // this will work. But if we use a mask card where the max-width of the parent container is < $content-xl,
+        // this formatting will break and could cause overflow (ex. MPP-3594). It could be worthwhile to do a re-design of the mask card CSS as whole.
         @media screen and (min-width: $content-xl) {
-          max-width: calc($content-md - 100px);
+          max-width: calc($content-md - 140px);
         }
       }
 


### PR DESCRIPTION
This PR fixes MPP-3594.

<!-- When adding a new feature: -->

# New feature description

Fix for masks overflowing into the "Forwarding all emails label".

# Screenshot of fix (if applicable)

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/f5f69439-fb45-41b2-9d41-578fa90c1c5a)

# How to test

* Sign in to a free user , set the onboarding_free_state to 0 if the user has already onboarded.
* Go to /accounts/profile/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email
* In step 2 of the onboarding, verify that there is no overflow by manually updating atleast 63 chars for the mask mask (if it is not long enough).

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
