### PR TITLE
MPP-3390: Set test database name with TEST_DB_NAME

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -411,6 +411,11 @@ DATABASES = {
         default="sqlite:///%s" % os.path.join(BASE_DIR, "db.sqlite3")
     )
 }
+# Optionally set a test database name.
+# This is useful for forcing an on-disk database for SQLite.
+TEST_DB_NAME = config("TEST_DB_NAME", "")
+if TEST_DB_NAME:
+    DATABASES["default"]["TEST"] = {"NAME": TEST_DB_NAME}
 
 REDIS_URL = config("REDIS_URL", "", cast=str)
 if REDIS_URL:


### PR DESCRIPTION
Optionally set the name of the test database. This is most useful for sqlite3 and reusing the database. When setting
`TEST_DB_NAME=test.sqlite3`, tests will populate `test.sqlite3`. Without setting `TEST_DB_NAME`, we get the current default of running tests in an in-memory sqlite3 database.

The new migrations checks for MPP-3390 will run the code in production against the branch migrations. This means this change needs to ship to production before updating to the new migrations checks.

# How to test:

- Run `TEST_DB_NAME='test.sqlite3' pytest --reuse-db .`
  * [ ] Tests pass
  * [ ] `test.sqlite3` is created
  * [ ]  `sqlite3 test.sqlite3 .schema` shows the Relay schema
* Run `sqlite3 test.sqlite3 "UPDATE sqlite_sequence SET seq=1 WHERE name='auth_user';` to get the user and profile IDs out of sync
- Run `TEST_DB_NAME='test.sqlite3' pytest --reuse-db .` again
  * [ ] Profile API patch tests fail (see PR #4174)
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

*Note 1*: Fixed command, it used to be `DATABASE_URL= TEST_DB_NAME='test.sqlite3' --reuse-db pytest .`
