### PR TITLE
MPP-3621: Handle mask generation error for free onboarding

### DIFF
--- a/frontend/src/components/dashboard/FreeOnboarding.tsx
+++ b/frontend/src/components/dashboard/FreeOnboarding.tsx
@@ -30,12 +30,13 @@ export type Props = {
   profile: ProfileData;
   onNextStep: (step: number) => void;
   onPickSubdomain: (subdomain: string) => void;
-  generateNewMask: () => void;
+  generateNewMask: (options: { mask_type: "random" }) => Promise<void>;
   hasReachedFreeMaskLimit: boolean;
   aliases: AliasData[];
   user: UserData;
   runtimeData?: RuntimeData;
   onUpdate: (alias: AliasData, updatedFields: Partial<AliasData>) => void;
+  hasAtleastOneMask: boolean;
 };
 
 /**
@@ -86,15 +87,27 @@ export const FreeOnboarding = (props: Props) => {
       });
     };
 
-    const createNewMask = () => {
-      props.generateNewMask();
-      props.onNextStep(1);
-      gaEvent({
-        category: "Free Onboarding",
-        action: "Engage",
-        label: "onboarding-step-1-create-random-mask",
-        value: 1,
-      });
+    const createNewMask = async () => {
+      let moveToNextStep = true;
+
+      try {
+        await props.generateNewMask({ mask_type: "random" });
+      } catch (e) {
+        // On error, we can only move to the next step if the user has atleast 1 mask.
+        if (!props.hasAtleastOneMask) {
+          moveToNextStep = false;
+        }
+      }
+
+      if (moveToNextStep) {
+        props.onNextStep(1);
+        gaEvent({
+          category: "Free Onboarding",
+          action: "Engage",
+          label: "onboarding-step-1-create-random-mask",
+          value: 1,
+        });
+      }
     };
 
     step = <StepOne />;

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -184,10 +184,13 @@ const Profile: NextPage = () => {
       }
       addonData.sendEvent("aliasListUpdate");
     } catch (error) {
+      // TODO: Refactor CustomAddressGenerationModal to remove the setAliasGeneratedState callback, and instead use a try catch block.
       setAliasGeneratedState
         ? setAliasGeneratedState(false)
         : toast(l10n.getString("error-mask-create-failed"), { type: "error" });
 
+      // This is so we can catch the error when calling createAlias asynchronously and apply
+      // more logic to handle when generating a mask fails.
       return Promise.reject("Mask generation failed");
     }
   };

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -187,6 +187,8 @@ const Profile: NextPage = () => {
       setAliasGeneratedState
         ? setAliasGeneratedState(false)
         : toast(l10n.getString("error-mask-create-failed"), { type: "error" });
+
+      return Promise.reject("Mask generation failed");
     }
   };
 
@@ -281,11 +283,12 @@ const Profile: NextPage = () => {
             onNextStep={onNextStep}
             onPickSubdomain={setCustomSubdomain}
             aliases={allAliases}
-            generateNewMask={() => createAlias({ mask_type: "random" })}
+            generateNewMask={createAlias}
             hasReachedFreeMaskLimit={freeMaskLimitReached}
             user={user}
             runtimeData={runtimeData.data}
             onUpdate={updateAlias}
+            hasAtleastOneMask={allAliases.length >= 1}
           />
         </Layout>
       </>


### PR DESCRIPTION
This PR fixes MPP-3621.

<!-- When adding a new feature: -->

# Bug description

When “Generate new mask” fails and the user has zero masks, they are brought to the second step of onboarding with empty containers, when instead they should be able to retry the mask generation button (see attached video in MPP-3621)

In this case where the user has 1 or more masks and “Generate mask” fails, we can move them forward as the containers will populate.

# Demo of fix

First part shows that a user with atleast 1 mask will move forward to the next step on error.

Second part shows that a user with zero masks will not move forward to the next step, and will need to retry (this is to handle the main bug, seen in MPP-3621).

https://github.com/mozilla/fx-private-relay/assets/59676643/d654004a-41cd-47d1-8e2b-f0a5c1595cf3

# How to test
Change this, https://github.com/mozilla/fx-private-relay/blob/075cc76d9c650604ec70e365d439e345a10c8253/frontend/src/pages/accounts/profile.page.tsx#L176
to `const response = await aliasData.create({ mask_type: "custom", address: "addict", blockPromotionals: false });` in order to force an error (addict is treated as a bad word) 

1. Sign in to a free user with onboarding_free_state = 0, and with zero masks.
2. Go to accounts/profile/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email
3. Click on “Generate new mask”
4. [Acceptance criteria] 
i) You should see an error modal
ii) You should not move on to the next step.
5. Sign in to a free user with onboarding_free_state = 0, and with atleast 1 mask.
6. Go to accounts/profile/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email
7. Click on “Generate new mask” 
8. [Acceptance criteria] 
i) You should see an error modal. 
ii) You should move onto the next step, because you have a mask that can populate this step.

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
