### PR TITLE
MPP-3597: Fix mobile sizing of step two in free user onboarding

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasList.module.scss
+++ b/frontend/src/components/dashboard/aliases/AliasList.module.scss
@@ -2,6 +2,11 @@
 @import "~@mozilla-protocol/core/protocol/css/includes/lib";
 @import "~@mozilla-protocol/core/protocol/css/includes/forms/lib";
 
+// Resolves mobile extra spacing issues for 2nd step of updated free onboarding (MPP-3597).
+.alias-list-container {
+  width: 100%;
+}
+
 .controls {
   display: grid;
   grid-template-columns: auto 1fr auto;

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -228,7 +228,7 @@ export const AliasList = (props: Props) => {
   };
 
   return (
-    <section>
+    <section className={styles["alias-list-container"]}>
       {isFlagActive(props.runtimeData, "free_user_onboarding") &&
       onboarding ? null : (
         <div className={styles.controls}>


### PR DESCRIPTION
This PR fixes MPP-3597.

<!-- When adding a new feature: -->

# Bug description

See the picture below
<img src='https://github.com/mozilla/fx-private-relay/assets/59676643/ebd8e27d-8b57-4d80-8bb7-488673773ddb' width='400'>

# Screenshot of fix

<img src='https://github.com/mozilla/fx-private-relay/assets/59676643/7dc61a24-bb75-4b43-9830-1b774dc24bc2' width='400'>

# How to test

* Sign in to a free user with onboarding_free_state = 0.
* Go to /accounts/profile?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email
* Go to the second step of this onboarding by clicking generate new mask.
* Using devtools, click on mobile view and set the width to 360px.
* Verify that there is no extra space by scrolling horizontally to the right.


# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
