### PR TITLE
MPP-3598: Avoid iOS autozooming on input focus

### DIFF
--- a/frontend/src/components/dashboard/EmailForwardingModal.module.scss
+++ b/frontend/src/components/dashboard/EmailForwardingModal.module.scss
@@ -100,7 +100,8 @@
   font-weight: 100;
   padding: $spacing-sm $spacing-md;
 
-  @include text-body-sm;
+  // Inputs should be atleast 16px if we want to avoid iOS auto-zooming (MPP-3598)
+  @include text-body-md;
   color: $color-grey-40;
   width: 100%;
 }

--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.module.scss
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.module.scss
@@ -110,7 +110,7 @@
           color: $color-grey-40;
           font-family: $font-stack-base;
 
-          @include text-body-sm;
+          @include text-body-md;
         }
       }
 

--- a/frontend/src/components/dashboard/aliases/CustomAddressGenerationModal.module.scss
+++ b/frontend/src/components/dashboard/aliases/CustomAddressGenerationModal.module.scss
@@ -166,8 +166,7 @@
           color: $color-grey-40;
           font-family: $font-stack-base;
 
-          @include text-body-sm;
-
+          @include text-body-md;
           &.invalid-prefix:focus {
             outline: 5px solid $color-red-10;
             border: 2px solid $color-error;


### PR DESCRIPTION
This PR fixes MPP-3598.

<!-- When adding a new feature: -->

# New feature description

Fix auto-zooming into inputs for modals on iOS.

Reference: https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone

# Screenshot (if applicable)

https://github.com/mozilla/fx-private-relay/assets/59676643/471bfbe1-7c3a-45d8-adfd-8cb211932af4

# How to test
* Push this branch to our dev server
* Give yourself the flags in the heroku console 
* i) For a free user: ./manage.py waffle_flag --append free_user_onboarding --user <username\>
* As a free user with the flag, go to accounts/profile/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email
* Proceed to the second step and click "See how forwarding works" 
* Verify that the page does not zoom.

* Sign in to the premium user.
* Open the premium domain creation modal.
* Verify that no auto zoom occurs.

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
