### PR TITLE
MPP-3624: Remove invisible container in second step of free onboarding on mobile screens

### DIFF
--- a/frontend/src/components/dashboard/FreeOnboarding.module.scss
+++ b/frontend/src/components/dashboard/FreeOnboarding.module.scss
@@ -62,19 +62,19 @@
   width: 100px;
   height: 100px;
   margin: 0 auto;
+  display: none;
+
+  @media screen and #{$mq-lg} {
+    display: block;
+  }
 
   img {
-    display: none;
     position: absolute;
     width: $layout-xl;
     height: 125px;
     /* both calculations below deal with alignment of custom art element - vertical arrow */
     bottom: -30px;
     right: -86px;
-
-    @media screen and #{$mq-lg} {
-      display: block;
-    }
   }
 }
 


### PR DESCRIPTION
This PR fixes MPP-3624.

<!-- When adding a new feature: -->

# New feature description
Removes invisible container in second step of free onboarding on mobile screens as seen in the screenshot in MPP-3624.

# Screenshot of fix (if applicable)

<img src='https://github.com/mozilla/fx-private-relay/assets/59676643/644481b1-7994-4f7f-a9d7-b1db79565bb4' height='500'/>


# How to test
As a free user with the free_user_onboarding flag, and with onboarding_free_state = 0,

1. Go to accounts/profile/?utm_campaign=relay-onboarding&utm_source=relay-onboarding&utm_medium=email
2. Proceed to the second step of free onboarding.
3. In devtools, pick any mobile view.
4. Verify that there is no empty container.

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
