### PR TITLE
Free user onboarding changes from readiness meeting

### DIFF
--- a/frontend/src/components/dashboard/FreeOnboarding.tsx
+++ b/frontend/src/components/dashboard/FreeOnboarding.tsx
@@ -212,7 +212,8 @@ export const FreeOnboarding = (props: Props) => {
     };
 
     const finish = () => {
-      props.onNextStep(3);
+      // this will trigger confetti in the dashboard
+      props.onNextStep(4);
       gaEvent({
         category: "Free Onboarding",
         action: "Engage",

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -249,15 +249,18 @@ const Profile: NextPage = () => {
 
   // Determine if the user is part of the target audience for onboarding
   // This checks if the user does not have a premium account and has not completed all onboarding steps
-  const isTargetAudience =
-    !profile.has_premium &&
+  const isOnboarding =
     profile.onboarding_free_state <
-      getRuntimeConfig().maxOnboardingFreeAvailable;
+    getRuntimeConfig().maxOnboardingFreeAvailable;
+  const isTargetAudience = !profile.has_premium && isOnboarding;
 
-  // Conditions: onboarding is active, UTM parameters are valid, and the user is part of the target audience
+  // Conditions: onboarding is active, UTM parameters are valid OR the user has less than or equal to 
+  // 2 masks (if in onboarding process, up to 3), and the user is part of the target audience
   if (
     isFreeUserOnboardingActive &&
-    (isValidUtmParameters || allAliases.length <= 2) &&
+    (isValidUtmParameters ||
+      allAliases.length <= 2 ||
+      (profile.onboarding_free_state > 0 && allAliases.length <= 3)) &&
     isTargetAudience
   ) {
     const onNextStep = (step: number) => {

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -255,7 +255,11 @@ const Profile: NextPage = () => {
       getRuntimeConfig().maxOnboardingFreeAvailable;
 
   // Conditions: onboarding is active, UTM parameters are valid, and the user is part of the target audience
-  if (isFreeUserOnboardingActive && isValidUtmParameters && isTargetAudience) {
+  if (
+    isFreeUserOnboardingActive &&
+    (isValidUtmParameters || allAliases.length <= 2) &&
+    isTargetAudience
+  ) {
     const onNextStep = (step: number) => {
       profileData.update(profile.id, {
         onboarding_free_state: step,
@@ -543,7 +547,7 @@ const Profile: NextPage = () => {
       {/* Show confetti animation when user completes last step. */}
       {isFlagActive(runtimeData.data, "free_user_onboarding") &&
         !profile.has_premium &&
-        profile.onboarding_free_state === 3 && (
+        profile.onboarding_free_state === 4 && (
           <Confetti
             tweenDuration={5000}
             gravity={0.2}
@@ -551,7 +555,7 @@ const Profile: NextPage = () => {
             onConfettiComplete={() => {
               // Update onboarding step to 4 - prevents animation from displaying again.
               profileData.update(profile.id, {
-                onboarding_free_state: 4,
+                onboarding_free_state: 5,
               });
             }}
           />

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -254,7 +254,7 @@ const Profile: NextPage = () => {
     getRuntimeConfig().maxOnboardingFreeAvailable;
   const isTargetAudience = !profile.has_premium && isOnboarding;
 
-  // Conditions: onboarding is active, UTM parameters are valid OR the user has less than or equal to 
+  // Conditions: onboarding is active, UTM parameters are valid OR the user has less than or equal to
   // 2 masks (if in onboarding process, up to 3), and the user is part of the target audience
   if (
     isFreeUserOnboardingActive &&


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR addresses questions that came out of our readiness review meeting today. 
 
# New feature description

1. Modifies trigger to show onboarding experience - either the user has the UTM params OR less than or equal to 2 masks
2. Confetti only shows for users that press the 'finish' button. 

# Screenshot (if applicable)


https://github.com/mozilla/fx-private-relay/assets/3924990/60a2c6cf-1bbb-48c5-8edd-0a75b603e109



# How to test

See video

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
