### PR TITLE
MPP-3480: Delete mask modal update

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -106,3 +106,9 @@ holiday-promo-banner-code-desc = Take 20% off { -brand-name-relay-premium }
 holiday-promo-banner-code-usage = Use code <coupon>{ $couponCode }</coupon> at checkout
 holiday-promo-banner-cta-button = Get 1 year of { -brand-name-premium }
 holiday-promo-banner-promo-expiry = offer ends Dec 31, 2023
+
+## Updated mask deletion strings
+
+mask-deletion-header = Delete this email mask?
+mask-deletion-warning-no-recovery = Once you delete this mask, it cannot be recovered. You will no longer receive any emails sent to it.
+mask-deletion-warning-sign-ins = If you use this mask to sign in to any accounts, you should change those account emails before deleting this mask.

--- a/frontend/src/components/dashboard/aliases/Alias.tsx
+++ b/frontend/src/components/dashboard/aliases/Alias.tsx
@@ -29,6 +29,8 @@ import { isPeriodicalPremiumAvailableInCountry } from "../../../functions/getPla
 import { useL10n } from "../../../hooks/l10n";
 import { Localized } from "../../Localized";
 
+// Deprecated, flag "mask_redesign" is in use and uses <MaskCard/> instead of <Alias/>
+
 export type Props = {
   alias: AliasData;
   user: UserData;

--- a/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.module.scss
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.module.scss
@@ -1,0 +1,141 @@
+@import "../../../styles/tokens.scss";
+@import "~@mozilla-protocol/core/protocol/css/includes/lib";
+@import "~@mozilla-protocol/core/protocol/css/includes/forms/lib";
+
+.deletion-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  background-color: transparent;
+  padding: $spacing-sm $spacing-md;
+  border-radius: $border-radius-sm;
+  font-weight: 600;
+  border: 2px solid transparent;
+  // Keep some space for the focus outline
+  margin: 2px;
+  color: $color-red-60;
+  line-height: 1.25;
+
+  @include text-body-md;
+
+  &:hover {
+    background-color: $color-red-70;
+    color: $color-white;
+  }
+}
+
+.underlay {
+  position: fixed;
+  background-color: rgba($color-black, 0.4);
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .dialog-wrapper {
+    background: $color-white;
+    width: calc((#{$content-sm} + #{$content-md}) / 2); // 560px
+    max-width: 90%;
+    border-radius: $border-radius-md;
+    box-shadow: $box-shadow-sm;
+    padding: $spacing-md;
+    overflow-wrap: break-word;
+
+    hr {
+      border: 1px solid $color-grey-10;
+      margin-top: $spacing-2xl;
+    }
+
+    .hero {
+      @include text-title-3xs;
+      font-family: $font-stack-firefox;
+      font-weight: 700;
+      text-align: center;
+      border-radius: $border-radius-md;
+      background-color: $color-light-gray-10;
+      padding: $spacing-lg $spacing-md;
+    }
+
+    .alias-to-delete {
+      @include text-title-3xs;
+      font-weight: 700;
+      font-family: $font-stack-firefox;
+      display: block;
+      text-align: center;
+      padding: $spacing-lg $spacing-lg $spacing-sm;
+      color: $color-grey-50;
+      margin-bottom: $spacing-sm;
+    }
+
+    .permanence-warning {
+      @include text-body-sm;
+      font-weight: 600;
+      text-align: center;
+      padding: $spacing-sm $spacing-lg;
+      color: $color-grey-50;
+      margin: 0 auto $spacing-2xl auto;
+
+      @media screen and #{$mq-md} {
+        width: 75%;
+      }
+    }
+
+    .buttons {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding-top: $spacing-xl;
+      .delete-btn {
+        width: calc($layout-xl + $layout-lg);
+      }
+      .cancel-button {
+        border-style: none;
+        background-color: transparent;
+        cursor: pointer;
+        border-radius: $border-radius-sm;
+        color: $color-blue-50;
+        padding: $spacing-sm $spacing-md;
+
+        &:hover {
+          color: $color-link-hover;
+        }
+
+        &:focus {
+          color: $color-blue-50;
+        }
+      }
+    }
+
+    .warning-wrapper {
+      position: relative;
+      display: flex;
+      border-left: $border-radius-xs solid color $color-error;
+      align-items: center;
+      padding-left: $spacing-sm;
+      background-color: #fff;
+      gap: $spacing-md;
+      width: 90%;
+      margin: 0 auto;
+
+      .left-content {
+        display: flex;
+        align-self: self-start;
+        gap: $spacing-sm;
+
+        p {
+          @include text-body-sm;
+          color: $color-grey-50;
+        }
+      }
+
+      .prefix-error-icon {
+        flex: 0 0 auto; // Avoid shrinkage of svg icons
+      }
+    }
+  }
+}

--- a/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
@@ -1,0 +1,151 @@
+import {
+  OverlayContainer,
+  FocusScope,
+  useButton,
+  useDialog,
+  useModal,
+  useOverlay,
+  usePreventScroll,
+  AriaOverlayProps,
+} from "react-aria";
+import { useOverlayTriggerState } from "react-stately";
+import { FormEventHandler, ReactElement, ReactNode, useRef } from "react";
+import styles from "./AliasDeletionButtonPermanent.module.scss";
+import { Button } from "../../Button";
+import { AliasData, getFullAddress } from "../../../hooks/api/aliases";
+import { useL10n } from "../../../hooks/l10n";
+import { ErrorTriangleIcon } from "../../Icons";
+
+export type Props = {
+  alias: AliasData;
+  onDelete: () => void;
+};
+
+/**
+ * A button to delete a given alias, which will pop up a confirmation modal before deleting.
+ */
+export const AliasDeletionButtonPermanent = (props: Props) => {
+  const l10n = useL10n();
+
+  const openModalButtonRef = useRef<HTMLButtonElement>(null);
+  const openModalButtonProps = useButton(
+    {
+      onPress: () => modalState.open(),
+    },
+    openModalButtonRef,
+  ).buttonProps;
+
+  const modalState = useOverlayTriggerState({});
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+  const cancelButton = useButton(
+    { onPress: () => modalState.close() },
+    cancelButtonRef,
+  );
+
+  const onConfirm: FormEventHandler = (event) => {
+    event.preventDefault();
+
+    props.onDelete();
+    modalState.close();
+  };
+
+  const dialog = modalState.isOpen ? (
+    <OverlayContainer>
+      <ConfirmationDialog
+        title={l10n.getString("mask-deletion-header")}
+        onClose={() => modalState.close()}
+        isOpen={modalState.isOpen}
+        isDismissable={true}
+      >
+        <samp className={styles["alias-to-delete"]}>
+          {getFullAddress(props.alias)}
+        </samp>
+
+        <p className={styles["permanence-warning"]}>
+          {l10n.getString("mask-deletion-warning-no-recovery")}
+        </p>
+        <WarningBanner />
+        <hr />
+        <form onSubmit={onConfirm} className={styles.confirm}>
+          <div className={styles.buttons}>
+            <button
+              {...cancelButton.buttonProps}
+              ref={cancelButtonRef}
+              className={styles["cancel-button"]}
+            >
+              {l10n.getString("profile-label-cancel")}
+            </button>
+            <Button
+              type="submit"
+              variant="destructive"
+              className={styles["delete-btn"]}
+            >
+              {l10n.getString("profile-label-delete")}
+            </Button>
+          </div>
+        </form>
+      </ConfirmationDialog>
+    </OverlayContainer>
+  ) : null;
+
+  return (
+    <>
+      <button
+        {...openModalButtonProps}
+        className={styles["deletion-button"]}
+        ref={openModalButtonRef}
+      >
+        {l10n.getString("profile-label-delete")}
+      </button>
+      {dialog}
+    </>
+  );
+};
+
+const WarningBanner = () => {
+  const l10n = useL10n();
+
+  return (
+    <div className={styles["warning-wrapper"]}>
+      <div className={styles["left-content"]}>
+        <ErrorTriangleIcon alt="" className={styles["prefix-error-icon"]} />
+        <p>{l10n.getString("mask-deletion-warning-sign-ins")}</p>
+      </div>
+    </div>
+  );
+};
+
+type ConfirmationDialogProps = {
+  title: string | ReactElement;
+  children: ReactNode;
+  isOpen: boolean;
+  onClose?: () => void;
+};
+const ConfirmationDialog = (
+  props: ConfirmationDialogProps & AriaOverlayProps,
+) => {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const { overlayProps, underlayProps } = useOverlay(props, wrapperRef);
+  usePreventScroll();
+  const { modalProps } = useModal();
+  const { dialogProps, titleProps } = useDialog({}, wrapperRef);
+
+  return (
+    <div className={styles.underlay} {...underlayProps}>
+      <FocusScope contain restoreFocus autoFocus>
+        <div
+          className={styles["dialog-wrapper"]}
+          {...overlayProps}
+          {...dialogProps}
+          {...modalProps}
+          ref={wrapperRef}
+        >
+          <div className={styles.hero}>
+            <h3 {...titleProps}>{props.title}</h3>
+          </div>
+          {props.children}
+        </div>
+      </FocusScope>
+    </div>
+  );
+};

--- a/frontend/src/components/dashboard/aliases/MaskCard.tsx
+++ b/frontend/src/components/dashboard/aliases/MaskCard.tsx
@@ -44,6 +44,7 @@ import { renderDate } from "../../../functions/renderDate";
 import { AliasDeletionButton } from "./AliasDeletionButton";
 import { VisuallyHidden } from "./../../VisuallyHidden";
 import HorizontalArrow from "./../images/free-onboarding-horizontal-arrow.svg";
+import { AliasDeletionButtonPermanent } from "./AliasDeletionButtonPermanent";
 
 export type Props = {
   mask: AliasData;
@@ -383,10 +384,20 @@ export const MaskCard = (props: Props) => {
               </dl>
               {!props.isOnboarding && (
                 <div className={styles["deletion-button-wrapper"]}>
-                  <AliasDeletionButton
-                    onDelete={props.onDelete}
-                    alias={props.mask}
-                  />
+                  {isFlagActive(
+                    props.runtimeData,
+                    "custom_domain_management_redesign",
+                  ) ? (
+                    <AliasDeletionButtonPermanent
+                      onDelete={props.onDelete}
+                      alias={props.mask}
+                    />
+                  ) : (
+                    <AliasDeletionButton
+                      onDelete={props.onDelete}
+                      alias={props.mask}
+                    />
+                  )}
                 </div>
               )}
             </div>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3480.
<!-- When adding a new feature: -->

# New feature description

New deletion modal for uniform deletions between premium and free masks.

@say-yawn Will be implementing the backend in MPP-3482. Assuming no changes on client-side are needed, and that she will update the existing api.

This work is under the flag `custom_domain_management_redesign`. 
# Screenshot (if applicable)

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/bb30acd8-f71d-4150-87ba-9e0b5e257603)

# How to test
1. Give yourself the `custom_domain_management_redesign` flag.
2. Verify that the delete modal matches the designs in the figma file.

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
