### PR TITLE
fix MPP-3634: add provider argument to SocialAccount.objects.get

### DIFF
--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -279,7 +279,7 @@ def _verify_jwt_with_fxa_key(
 
 def _get_account_from_jwt(authentic_jwt: FxAEvent) -> SocialAccount:
     social_account_uid = authentic_jwt["sub"]
-    return SocialAccount.objects.get(uid=social_account_uid)
+    return SocialAccount.objects.get(uid=social_account_uid, provider="fxa")
 
 
 def _get_event_keys_from_jwt(authentic_jwt: FxAEvent) -> Iterable[str]:


### PR DESCRIPTION
This PR fixes MPP-3634.

How to test:

* [ ] Verify all tests are still passing
* [ ] 

Checklist:
- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).