### PR TITLE
Remove @next/bundle-analyzer

### DIFF
--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -96,19 +96,6 @@ bundling the website. To spot-check this update, open the Preview deployment to
 verify that the website was put together successfully, and that you can navigate
 between different pages (e.g. from the home to the FAQ) without issues.
 
-### `@next/bundle-analyzer`
-
-We use this package to investigate if any of our dependencies take up an
-inordinate amount of bytes in our payload. To verify that this still runs
-successfully, run
-
-    ANALYZE=true npm run build
-
-in the `frontend` directory locally, after installing the updated dependency. It
-should create an overview of the client bundle in
-`/frontend/.next/analyze/client.html`, which should look similar to the same
-output in the `main` branch.
-
 ### `swr` and `msw`
 
 [SWR](https://swr.vercel.app/) is responsible for making requests to the

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -49,21 +49,6 @@ runtimeConfigs.apimock = {
   fxaLogoutUrl: "/mock/logout",
 };
 
-/** @type {(config: import('next').NextConfig) => import('next').NextConfig} */
-const withBundleAnalyzer = (nextConfig) => {
-  if (process.env.ANALYZE !== "true") {
-    return nextConfig;
-  }
-  // This file is only loaded at build time, so we don't care about tree shaking
-  // being made impossible by a `require` call:
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const getAnalyzerWrapper = require("@next/bundle-analyzer");
-  const withAnalyzer = getAnalyzerWrapper({
-    enabled: process.env.ANALYZE === "true",
-  });
-  return withAnalyzer(nextConfig);
-};
-
 let applicableConfig = "production";
 if (process.env.NEXT_PUBLIC_MOCK_API === "true") {
   applicableConfig = "apimock";
@@ -73,7 +58,7 @@ if (process.env.NODE_ENV === "development") {
 }
 
 /** @type {import('next').NextConfig} */
-module.exports = withBundleAnalyzer({
+module.exports = {
   reactStrictMode: true,
   // This custom value for `pageExtensions` ensures that
   // test files are not picked up as pages to render by Next.js.
@@ -129,4 +114,4 @@ module.exports = withBundleAnalyzer({
 
     return config;
   },
-});
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,6 @@
     "swr": "^2.2.4"
   },
   "devDependencies": {
-    "@next/bundle-analyzer": "^14.0.4",
     "@next/eslint-plugin-next": "^14.0.4",
     "@testing-library/dom": "^9.3.3",
     "@testing-library/jest-dom": "^6.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "swr": "^2.2.4"
       },
       "devDependencies": {
-        "@next/bundle-analyzer": "^14.0.4",
         "@next/eslint-plugin-next": "^14.0.4",
         "@testing-library/dom": "^9.3.3",
         "@testing-library/jest-dom": "^6.1.5",
@@ -1762,15 +1761,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@next/bundle-analyzer": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-14.0.4.tgz",
-      "integrity": "sha512-Nn2PiCkFBJBlVmpSGVNItpISws0fuc9E8AkCafBz/moRv1cfASOpFBBVzSRfWLP9BPdAhfDkb6TafN0rvs2IJQ==",
-      "dev": true,
-      "dependencies": {
-        "webpack-bundle-analyzer": "4.7.0"
-      }
-    },
     "node_modules/@next/env": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.0.3.tgz",
@@ -2014,11 +2004,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/@polka/url": {
-      "version": "1.0.0-next.21",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@react-aria/breadcrumbs": {
       "version": "3.5.8",
@@ -6033,11 +6018,6 @@
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.284",
       "dev": true,
@@ -7495,20 +7475,6 @@
       "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/gzip-size": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/hard-rejection": {
@@ -11694,14 +11660,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mrmime": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "dev": true,
@@ -12197,14 +12155,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/opener": {
-      "version": "1.5.2",
-      "dev": true,
-      "license": "(WTFPL OR MIT)",
-      "bin": {
-        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -13563,19 +13513,6 @@
       "version": "3.0.7",
       "license": "ISC"
     },
-    "node_modules/sirv": {
-      "version": "1.0.19",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@polka/url": "^1.0.0-next.20",
-        "mrmime": "^1.0.0",
-        "totalist": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -14429,14 +14366,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/totalist": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tough-cookie": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
@@ -14820,120 +14749,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer": {
-      "version": "4.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.0.4",
-        "acorn-walk": "^8.0.0",
-        "chalk": "^4.1.0",
-        "commander": "^7.2.0",
-        "gzip-size": "^6.0.0",
-        "lodash": "^4.17.20",
-        "opener": "^1.5.2",
-        "sirv": "^1.0.7",
-        "ws": "^7.3.1"
-      },
-      "bin": {
-        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
-      "version": "7.5.9",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/whatwg-encoding": {
@@ -16552,15 +16367,6 @@
         "strict-event-emitter": "^0.5.1"
       }
     },
-    "@next/bundle-analyzer": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-14.0.4.tgz",
-      "integrity": "sha512-Nn2PiCkFBJBlVmpSGVNItpISws0fuc9E8AkCafBz/moRv1cfASOpFBBVzSRfWLP9BPdAhfDkb6TafN0rvs2IJQ==",
-      "dev": true,
-      "requires": {
-        "webpack-bundle-analyzer": "4.7.0"
-      }
-    },
     "@next/env": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.0.3.tgz",
@@ -16698,10 +16504,6 @@
       "requires": {
         "playwright": "1.38.1"
       }
-    },
-    "@polka/url": {
-      "version": "1.0.0-next.21",
-      "dev": true
     },
     "@react-aria/breadcrumbs": {
       "version": "3.5.8",
@@ -19559,10 +19361,6 @@
       "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
       "dev": true
     },
-    "duplexer": {
-      "version": "0.1.2",
-      "dev": true
-    },
     "electron-to-chromium": {
       "version": "1.4.284",
       "dev": true
@@ -20369,7 +20167,6 @@
         "@fluent/langneg": "^0.7.0",
         "@fluent/react": "^0.15.2",
         "@mozilla-protocol/core": "^17.0.1",
-        "@next/bundle-analyzer": "^14.0.4",
         "@next/eslint-plugin-next": "^14.0.4",
         "@stripe/stripe-js": "^2.2.0",
         "@testing-library/dom": "^9.3.3",
@@ -20603,13 +20400,6 @@
       "version": "16.8.1",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
       "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw=="
-    },
-    "gzip-size": {
-      "version": "6.0.0",
-      "dev": true,
-      "requires": {
-        "duplexer": "^0.1.2"
-      }
     },
     "hard-rejection": {
       "version": "2.1.0",
@@ -23446,10 +23236,6 @@
       "version": "1.0.4",
       "dev": true
     },
-    "mrmime": {
-      "version": "1.0.1",
-      "dev": true
-    },
     "ms": {
       "version": "2.1.2",
       "dev": true
@@ -23760,10 +23546,6 @@
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0"
       }
-    },
-    "opener": {
-      "version": "1.5.2",
-      "dev": true
     },
     "optionator": {
       "version": "0.9.3",
@@ -24619,15 +24401,6 @@
     "signal-exit": {
       "version": "3.0.7"
     },
-    "sirv": {
-      "version": "1.0.19",
-      "dev": true,
-      "requires": {
-        "@polka/url": "^1.0.0-next.20",
-        "mrmime": "^1.0.0",
-        "totalist": "^1.0.0"
-      }
-    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -25221,10 +24994,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "totalist": {
-      "version": "1.1.0",
-      "dev": true
-    },
     "tough-cookie": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
@@ -25484,69 +25253,6 @@
     "webidl-conversions": {
       "version": "7.0.0",
       "dev": true
-    },
-    "webpack-bundle-analyzer": {
-      "version": "4.7.0",
-      "dev": true,
-      "requires": {
-        "acorn": "^8.0.4",
-        "acorn-walk": "^8.0.0",
-        "chalk": "^4.1.0",
-        "commander": "^7.2.0",
-        "gzip-size": "^6.0.0",
-        "lodash": "^4.17.20",
-        "opener": "^1.5.2",
-        "sirv": "^1.0.7",
-        "ws": "^7.3.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "dev": true
-        },
-        "commander": {
-          "version": "7.2.0",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "ws": {
-          "version": "7.5.9",
-          "dev": true,
-          "requires": {}
-        }
-      }
     },
     "whatwg-encoding": {
       "version": "2.0.0",


### PR DESCRIPTION
We spend more time managing dependency updates (that, as far as I know, hardly ever actually change how `@next/bundle-analyzer` works), than that we actually look at the analysis - let alone act on it. Thus, it probably makes more sense to just re-add it when we do feel the need to analyse the make-up of our frontend bundles.
