### PR TITLE
Revert "fix MPP-3634: add provider argument to SocialAccount.objects.…

### DIFF
--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -279,7 +279,7 @@ def _verify_jwt_with_fxa_key(
 
 def _get_account_from_jwt(authentic_jwt: FxAEvent) -> SocialAccount:
     social_account_uid = authentic_jwt["sub"]
-    return SocialAccount.objects.get(uid=social_account_uid, provider="fxa")
+    return SocialAccount.objects.get(uid=social_account_uid)
 
 
 def _get_event_keys_from_jwt(authentic_jwt: FxAEvent) -> Iterable[str]:


### PR DESCRIPTION
…get"

This reverts commit f4abd5b4ad3246e4bb6dda7e351784b00231f852.

This PR fixes https://mozilla.sentry.io/issues/4716503385/?environment=prod&project=4503976951152641&query=release%3A2023.12.08&referrer=release-issue-stream.