### PR TITLE
MPP-3687 - Delete mask confirmation update

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
@@ -28,13 +28,6 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
   const l10n = useL10n();
 
   const openModalButtonRef = useRef<HTMLButtonElement>(null);
-  const openModalButtonProps = useButton(
-    {
-      onPress: () => modalState.open(),
-    },
-    openModalButtonRef,
-  ).buttonProps;
-
   const modalState = useOverlayTriggerState({});
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const cancelButton = useButton(
@@ -92,7 +85,9 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
   return (
     <>
       <button
-        {...openModalButtonProps}
+        onClick={() => {
+          modalState.open();
+        }}
         className={styles["deletion-button"]}
         ref={openModalButtonRef}
       >

--- a/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
@@ -9,7 +9,7 @@ import {
   AriaOverlayProps,
 } from "react-aria";
 import { useOverlayTriggerState } from "react-stately";
-import { FormEventHandler, ReactElement, ReactNode, useRef } from "react";
+import { ReactElement, ReactNode, useRef } from "react";
 import styles from "./AliasDeletionButtonPermanent.module.scss";
 import { Button } from "../../Button";
 import { AliasData, getFullAddress } from "../../../hooks/api/aliases";
@@ -28,28 +28,12 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
   const l10n = useL10n();
 
   const openModalButtonRef = useRef<HTMLButtonElement>(null);
-  const openModalButtonProps = useButton(
-    {
-      onPress: () => modalState.open(),
-    },
-    openModalButtonRef,
-  ).buttonProps;
-
   const modalState = useOverlayTriggerState({});
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const cancelButton = useButton(
     { onPress: () => modalState.close() },
     cancelButtonRef,
   );
-
-  const onConfirm: FormEventHandler = (event) => {
-    event.preventDefault();
-
-    if (modalState.isOpen) {
-      props.onDelete();
-      modalState.close();
-    }
-  };
 
   const dialog = modalState.isOpen ? (
     <OverlayContainer>
@@ -68,7 +52,7 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
         </p>
         <WarningBanner />
         <hr />
-        <form onSubmit={onConfirm} className={styles.confirm}>
+        <form className={styles.confirm}>
           <div className={styles.buttons}>
             <button
               {...cancelButton.buttonProps}
@@ -78,7 +62,11 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
               {l10n.getString("profile-label-cancel")}
             </button>
             <Button
-              type="submit"
+              onClick={() => {
+                props.onDelete();
+                modalState.close();
+              }}
+              type="button"
               variant="destructive"
               className={styles["delete-btn"]}
             >
@@ -93,7 +81,9 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
   return (
     <>
       <button
-        {...openModalButtonProps}
+        onClick={() => {
+          modalState.open();
+        }}
         className={styles["deletion-button"]}
         ref={openModalButtonRef}
       >

--- a/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
@@ -9,7 +9,7 @@ import {
   AriaOverlayProps,
 } from "react-aria";
 import { useOverlayTriggerState } from "react-stately";
-import { FormEventHandler, ReactElement, ReactNode, useRef } from "react";
+import { ReactElement, ReactNode, useRef } from "react";
 import styles from "./AliasDeletionButtonPermanent.module.scss";
 import { Button } from "../../Button";
 import { AliasData, getFullAddress } from "../../../hooks/api/aliases";
@@ -59,6 +59,7 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
         <hr />
         <div className={styles.confirm}>
           <div className={styles.buttons}>
+            {/* cancel button */}
             <button
               {...cancelButton.buttonProps}
               ref={cancelButtonRef}
@@ -66,6 +67,7 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
             >
               {l10n.getString("profile-label-cancel")}
             </button>
+            {/* confirm deletion button */}
             <Button
               onClick={() => {
                 onConfirm();
@@ -84,6 +86,7 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
 
   return (
     <>
+      {/* delete mask button - opens confirmation modal */}
       <button
         onClick={() => {
           modalState.open();

--- a/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
@@ -9,7 +9,7 @@ import {
   AriaOverlayProps,
 } from "react-aria";
 import { useOverlayTriggerState } from "react-stately";
-import { ReactElement, ReactNode, useRef } from "react";
+import { FormEventHandler, ReactElement, ReactNode, useRef } from "react";
 import styles from "./AliasDeletionButtonPermanent.module.scss";
 import { Button } from "../../Button";
 import { AliasData, getFullAddress } from "../../../hooks/api/aliases";
@@ -28,12 +28,24 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
   const l10n = useL10n();
 
   const openModalButtonRef = useRef<HTMLButtonElement>(null);
+  const openModalButtonProps = useButton(
+    {
+      onPress: () => modalState.open(),
+    },
+    openModalButtonRef,
+  ).buttonProps;
+
   const modalState = useOverlayTriggerState({});
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const cancelButton = useButton(
     { onPress: () => modalState.close() },
     cancelButtonRef,
   );
+
+  const onConfirm = () => {
+    props.onDelete();
+    modalState.close();
+  };
 
   const dialog = modalState.isOpen ? (
     <OverlayContainer>
@@ -52,7 +64,7 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
         </p>
         <WarningBanner />
         <hr />
-        <form className={styles.confirm}>
+        <div className={styles.confirm}>
           <div className={styles.buttons}>
             <button
               {...cancelButton.buttonProps}
@@ -63,8 +75,7 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
             </button>
             <Button
               onClick={() => {
-                props.onDelete();
-                modalState.close();
+                onConfirm();
               }}
               type="button"
               variant="destructive"
@@ -73,7 +84,7 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
               {l10n.getString("profile-label-delete")}
             </Button>
           </div>
-        </form>
+        </div>
       </ConfirmationDialog>
     </OverlayContainer>
   ) : null;
@@ -81,9 +92,7 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
   return (
     <>
       <button
-        onClick={() => {
-          modalState.open();
-        }}
+        {...openModalButtonProps}
         className={styles["deletion-button"]}
         ref={openModalButtonRef}
       >


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3687
 

# New feature description

This PR addresses the issue where spam deleting masks sometimes allows you to delete masks without confirmation. 

# Screenshot (if applicable)

![image](https://github.com/mozilla/fx-private-relay/assets/3924990/b2375813-d194-495e-9c53-80744b219620)


# How to test

From the ticket on Jira: 

**Platforms affected:**
Android 13;

**Browsers affected:**
Firefox, latest version;
Chrome, latest version;


**Prerequisites:**
Be signed into a Relay account;

**Steps to reproduce:**

1. Navigate to the Relay email mask dashboard;
2. Generate a new email mask;
3. Delete the email mask;
4. Repeat steps 2-3 a few times and observe behaviour;


**Expected result:**
The delete mask modal appears whenever a user tries to delete a mask;

**Actual result:**
Intermittently, the modal does not appear and the mask is deleted instantly;

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
