### PR TITLE
Avoid single tap being handled by both the deletion and confirmation button

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
@@ -9,7 +9,7 @@ import {
   AriaOverlayProps,
 } from "react-aria";
 import { useOverlayTriggerState } from "react-stately";
-import { FormEventHandler, ReactElement, ReactNode, useRef } from "react";
+import { ReactElement, ReactNode, useRef } from "react";
 import styles from "./AliasDeletionButtonPermanent.module.scss";
 import { Button } from "../../Button";
 import { AliasData, getFullAddress } from "../../../hooks/api/aliases";
@@ -42,14 +42,16 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
     cancelButtonRef,
   );
 
-  const onConfirm: FormEventHandler = (event) => {
-    event.preventDefault();
-
-    if (modalState.isOpen) {
-      props.onDelete();
-      modalState.close();
-    }
-  };
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+  const confirmButton = useButton(
+    {
+      onPress: () => {
+        props.onDelete();
+        modalState.close();
+      },
+    },
+    confirmButtonRef,
+  );
 
   const dialog = modalState.isOpen ? (
     <OverlayContainer>
@@ -68,7 +70,7 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
         </p>
         <WarningBanner />
         <hr />
-        <form onSubmit={onConfirm} className={styles.confirm}>
+        <div className={styles.confirm}>
           <div className={styles.buttons}>
             <button
               {...cancelButton.buttonProps}
@@ -81,11 +83,12 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
               type="submit"
               variant="destructive"
               className={styles["delete-btn"]}
+              {...confirmButton.buttonProps}
             >
               {l10n.getString("profile-label-delete")}
             </Button>
           </div>
-        </form>
+        </div>
       </ConfirmationDialog>
     </OverlayContainer>
   ) : null;


### PR DESCRIPTION
This makes React Aria handle touch events for the button (via `useButton`), making sure it doesn't handle touch events from before the dialog opens, resulting in the deletion of a mask without confirmation.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3687.

How to test: on an Android device, open a mask card, then tap "Delete". Take note where the confirmation button (the one that says "Delete" _in the dialog_, the button with the red background) is, and hover a finger over it. Then close the dialog, scroll the page so that the regular Delete button (i.e. the one _outside_ the dialog) is under your finger. Tap it.

Before this PR, the confirmation button would immediately be tapped as well, and the mask would disappear. With this PR, the dialog appears as usual.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug. - Handed over to external library and dependent on coordinates on screen, so hard to unit test.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
