### PR TITLE
Switch from pycopg2 2.9.9 to psycopg 3.1.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ gunicorn==21.2.0
 jwcrypto==1.5.1
 markus[datadog]==4.2.0
 pem==23.1.0
-psycopg2==2.9.9
+psycopg[c]==3.1.17
 PyJWT==2.8.0
 python-decouple==3.8
 pyOpenSSL==23.3.0


### PR DESCRIPTION
Django 4.2 supports [psycopg 3](https://www.psycopg.org/psycopg3/), a new implementation of the PostgreSQL adapter. Django [recommends it](https://docs.djangoproject.com/en/5.0/ref/databases/#postgresql-notes), and says psycopg2 may be deprecated in the future.

The features of Psycopg 3:

* A new asyncio-based interface
* Asynchronous communication with both Python and the database
* Rich and flexible adaptation system, optionally using binary format for efficient data transfer
* High performance data loading using COPY directly from Python objects

It is unclear how many of these will be supported by the Django postgresql backend. However, Django continues to add [async support](https://docs.djangoproject.com/en/5.0/topics/async/) with each release. When they add async ORM support, I expect psycopg2 to be deprecated. Until then, I assume Django is using the traditional interfaces, so we should see no changes.

## How to test:

- [x] CircleCI tests pass without warnings.