### PR TITLE
Put permanent domain address delete logic behind flag

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -714,9 +714,13 @@ def valid_address_pattern(address):
 def valid_address(address: str, domain: str, subdomain: str | None = None) -> bool:
     address_pattern_valid = valid_address_pattern(address)
     address_contains_badword = has_bad_words(address)
-    address_already_deleted = DeletedAddress.objects.filter(
-        address_hash=address_hash(address, domain=domain, subdomain=subdomain)
-    ).count()
+    address_already_deleted = 0
+    if not subdomain or flag_is_active_in_task(
+        "custom_domain_management_redesign", None
+    ):
+        address_already_deleted = DeletedAddress.objects.filter(
+            address_hash=address_hash(address, domain=domain, subdomain=subdomain)
+        ).count()
     if (
         address_already_deleted > 0
         or address_contains_badword

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -176,21 +176,6 @@ class MiscEmailModelsTest(TestCase):
         assert not valid_address_pattern("foo bar")
         assert not valid_address_pattern("Foo")
 
-    @override_flag("custom_domain_management_redesign", active=True)
-    def test_valid_address_dupe_domain_address_of_deleted_is_not_valid(self):
-        user = make_premium_test_user()
-        user_profile = user.profile
-        user_profile.subdomain = "test"
-        user_profile.save()
-        address = "same-address"
-        domain_address = DomainAddress.make_domain_address(
-            user_profile, address=address
-        )
-        domain_address.delete()
-        assert not valid_address(
-            address, domain_address.domain_value, user_profile.subdomain
-        )
-
 
 class RelayAddressTest(TestCase):
     def setUp(self):
@@ -1143,6 +1128,17 @@ class DomainAddressTest(TestCase):
             DeletedAddress.objects.filter(address_hash=domain_address_hash).count() == 1
         )
         assert dupe_domain_address.full_address == domain_address.full_address
+
+    @override_flag("custom_domain_management_redesign", active=True)
+    def test_valid_address_dupe_domain_address_of_deleted_is_not_valid(self):
+        address = "same-address"
+        domain_address = DomainAddress.make_domain_address(
+            self.user_profile, address=address
+        )
+        domain_address.delete()
+        assert not valid_address(
+            address, domain_address.domain_value, self.user_profile.subdomain
+        )
 
     @override_flag("custom_domain_management_redesign", active=True)
     def test_make_domain_address_cannot_make_dupe_of_deleted(self):

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -10,6 +10,7 @@ from django.contrib.auth.models import User
 from django.test import override_settings, TestCase
 
 from allauth.socialaccount.models import SocialAccount
+from waffle.testutils import override_flag
 import pytest
 
 from model_bakery import baker
@@ -174,6 +175,21 @@ class MiscEmailModelsTest(TestCase):
         assert not valid_address_pattern("foo.")
         assert not valid_address_pattern("foo bar")
         assert not valid_address_pattern("Foo")
+
+    @override_flag("custom_domain_management_redesign", active=True)
+    def test_valid_address_dupe_domain_address_of_deleted_is_not_valid(self):
+        user = make_premium_test_user()
+        user_profile = user.profile
+        user_profile.subdomain = "test"
+        user_profile.save()
+        address = "same-address"
+        domain_address = DomainAddress.make_domain_address(
+            user_profile, address=address
+        )
+        domain_address.delete()
+        assert not valid_address(
+            address, domain_address.domain_value, user_profile.subdomain
+        )
 
 
 class RelayAddressTest(TestCase):
@@ -347,20 +363,6 @@ class RelayAddressTest(TestCase):
         relay_address = RelayAddress.objects.create(user=baker.make(User))
         relay_address.delete()
         assert not valid_address(relay_address.address, relay_address.domain_value)
-
-    def test_dupe_domain_address_of_deleted_invalid(self):
-        user = make_premium_test_user()
-        user_profile = user.profile
-        user_profile.subdomain = "test"
-        user_profile.save()
-        address = "same-address"
-        domain_address = DomainAddress.make_domain_address(
-            user_profile, address=address
-        )
-        domain_address.delete()
-        assert not valid_address(
-            address, domain_address.domain_value, user_profile.subdomain
-        )
 
     @patch.object(emails_config, "blocklist", ["blocked-word"])
     def test_address_contains_blocklist_invalid(self) -> None:
@@ -1122,6 +1124,27 @@ class DomainAddressTest(TestCase):
             DomainAddress.make_domain_address(user_profile, "test-nosubdomain")
         assert exc_info.value.get_codes() == "need_subdomain"
 
+    @override_flag("custom_domain_management_redesign", active=False)
+    def test_make_domain_address_can_make_dupe_of_deleted(self):
+        address = "same-address"
+        domain_address = DomainAddress.make_domain_address(
+            self.user_profile, address=address
+        )
+        domain_address_hash = address_hash(
+            domain_address.address,
+            domain_address.user_profile.subdomain,
+            domain_address.domain_value,
+        )
+        domain_address.delete()
+        dupe_domain_address = DomainAddress.make_domain_address(
+            self.user_profile, address=address
+        )
+        assert (
+            DeletedAddress.objects.filter(address_hash=domain_address_hash).count() == 1
+        )
+        assert dupe_domain_address.full_address == domain_address.full_address
+
+    @override_flag("custom_domain_management_redesign", active=True)
     def test_make_domain_address_cannot_make_dupe_of_deleted(self):
         address = "same-address"
         domain_address = DomainAddress.make_domain_address(


### PR DESCRIPTION
This PR supports MPP-3687. In order to ship the rest of the work in `2024.01.10` that is not improve mask experience, we want to put the permanent domain address delete behind the `custom_domain_management_redesign` flag.

Expected behavior
### When `custom_domain_management_redesign` is disabled the delete domain and create address work as it has
### When `custom_domain_management_redesign` is enabled the delete domain and create address works as newly defined in this [Figma](https://www.figma.com/file/zA6iEpjHkLYeloGQSHZSfX/Relay-Custom-Domain-Management?type=design&node-id=332-2640&mode=design&t=1E1uro0Qgj59l5A8-4)

How to test:
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

#
Using this for cleaner commits to `main` instead of #4296 since the React changes mentioned in the PR is no longer being used. See https://github.com/mozilla/fx-private-relay/pull/4293