### PR TITLE
MPP-3701: Patch for Android modal dismissal clickthrough

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
@@ -8,7 +8,7 @@ import {
   usePreventScroll,
   AriaOverlayProps,
 } from "react-aria";
-import { useOverlayTriggerState } from "react-stately";
+import { OverlayTriggerState } from "react-stately";
 import { ReactElement, ReactNode, useRef } from "react";
 import styles from "./AliasDeletionButtonPermanent.module.scss";
 import { Button } from "../../Button";
@@ -19,6 +19,7 @@ import { ErrorTriangleIcon } from "../../Icons";
 export type Props = {
   alias: AliasData;
   onDelete: () => void;
+  modalState?: OverlayTriggerState;
 };
 
 /**
@@ -34,8 +35,6 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
     },
     openModalButtonRef,
   ).buttonProps;
-
-  const modalState = useOverlayTriggerState({});
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const cancelButton = useButton(
     { onPress: () => modalState.close() },
@@ -52,6 +51,11 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
     },
     confirmButtonRef,
   );
+
+  if (!props.modalState) {
+    return;
+  }
+  const modalState = props.modalState;
 
   const dialog = modalState.isOpen ? (
     <OverlayContainer>

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -16,6 +16,7 @@ import { Localized } from "../../Localized";
 import { VisuallyHidden } from "../../VisuallyHidden";
 import { MaskCard } from "./MaskCard";
 import { isFlagActive } from "../../../functions/waffle";
+import { OverlayTriggerState } from "react-stately";
 
 export type Props = {
   aliases: AliasData[];
@@ -31,6 +32,7 @@ export type Props = {
   onDelete: (alias: AliasData) => void;
   onboarding?: boolean;
   children?: React.ReactNode;
+  deleteMaskModalState?: OverlayTriggerState;
 };
 
 /**
@@ -162,6 +164,7 @@ export const AliasList = (props: Props) => {
             runtimeData={props.runtimeData}
             isOnboarding={onboarding}
             copyAfterMaskGeneration={generatedAlias?.id === alias.id}
+            deleteMaskModalState={props.deleteMaskModalState}
           >
             {props.children}
           </MaskCard>

--- a/frontend/src/components/dashboard/aliases/MaskCard.tsx
+++ b/frontend/src/components/dashboard/aliases/MaskCard.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from "react";
 import {
+  OverlayTriggerState,
   RadioGroupProps,
   RadioGroupState,
   useRadioGroupState,
@@ -60,6 +61,7 @@ export type Props = {
   isOnboarding?: boolean;
   children?: ReactNode;
   copyAfterMaskGeneration: boolean;
+  deleteMaskModalState?: OverlayTriggerState;
 };
 
 export const MaskCard = (props: Props) => {
@@ -389,6 +391,7 @@ export const MaskCard = (props: Props) => {
                     "custom_domain_management_redesign",
                   ) ? (
                     <AliasDeletionButtonPermanent
+                      modalState={props.deleteMaskModalState}
                       onDelete={props.onDelete}
                       alias={props.mask}
                     />

--- a/frontend/src/components/layout/Layout.module.scss
+++ b/frontend/src/components/layout/Layout.module.scss
@@ -1,6 +1,10 @@
 @import "../../styles/tokens.scss";
 @import "~@mozilla-protocol/core/protocol/css/includes/lib";
 
+.patch3701 {
+  pointer-events: none;
+}
+
 .wrapper {
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -18,7 +18,11 @@ import {
   useTooltipTrigger,
 } from "react-aria";
 import { event as gaEvent } from "react-ga";
-import { useMenuTriggerState, useTooltipTriggerState } from "react-stately";
+import {
+  useMenuTriggerState,
+  useOverlayTriggerState,
+  useTooltipTriggerState,
+} from "react-stately";
 import { toast } from "react-toastify";
 import styles from "./profile.module.scss";
 import UpsellBannerUs from "./images/upsell-banner-us.svg";
@@ -81,6 +85,7 @@ const Profile: NextPage = () => {
     clearCookie("profile-location-hash");
   }
   usePurchaseTracker(profileData.data?.[0]);
+  const deleteMaskModalState = useOverlayTriggerState({});
 
   if (!userData.isValidating && userData.error) {
     if (document.location.hash) {
@@ -564,7 +569,10 @@ const Profile: NextPage = () => {
             }}
           />
         )}
-      <Layout runtimeData={runtimeData.data}>
+      <Layout
+        deleteMaskModalState={deleteMaskModalState}
+        runtimeData={runtimeData.data}
+      >
         {/* If free user has reached their free mask limit and 
         premium is available in their country, show upsell banner */}
         {freeMaskLimitReached &&
@@ -590,6 +598,7 @@ const Profile: NextPage = () => {
               profile={profile}
               user={user}
               runtimeData={runtimeData.data}
+              deleteMaskModalState={deleteMaskModalState}
             />
             <p className={styles["size-information"]}>
               {l10n.getString("profile-supports-email-forwarding", {


### PR DESCRIPTION
This PR fixes MPP-3701.


# Bug description

When closing the delete mask modal on Android by either clicking outside of the modal, clicking the cancel button, or the delete button, a clickthrough occurs and elements under the modal have a chance of being clicked depending on the alignment (such as anchor tags in the footer).

Noting here that this issue occurs for all our modals (ex. Generate new mask modal, the modal when setting up a premium domain), and this patch is only for the delete mask modal. 

This patch disables pointer events for the Layout component when the modal is open, and uses a timeout to schedule a callback which keeps pointer-events disabled on our Layout component for close to 0 ms when the modal gets closed, which seems to solve the issue.

# Demo of fix 

Upon clicking the cancel button, or outside of the dialog, the anchor tags in the footer are not being clicked through anymore.

https://github.com/mozilla/fx-private-relay/assets/59676643/5708fa0f-4193-4914-ad8f-47ae62f83c4c

# How to test
1. Navigate to the Relay dashboard;
2. Open a mask card and open its delete modal;
3. Observe where the Cancel option is displayed, or observe the outside of the dialog;
4. Close the delete modal, then position the page so that where you click to dismiss the modal (by clicking Cancel, or outside of the dialog) is displayed over one of the following: a mask card’s label field, a mask card’s mask address, the site footer’s Mozilla logo;
5. Open the delete modal again and tap on the Cancel option;
6. Observe behaviour (repeat if necessary);

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
