### PR TITLE
fix MPP-3700: empty DomainAddress.used_on|description fields when pro…

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -162,6 +162,8 @@ class Profile(models.Model):
         if not self.server_storage:
             relay_addresses = RelayAddress.objects.filter(user=self.user)
             relay_addresses.update(description="", generated_for="", used_on="")
+            domain_addresses = DomainAddress.objects.filter(user=self.user)
+            domain_addresses.update(description="", used_on="")
         if settings.PHONES_ENABLED:
             # any time a profile is saved with store_phone_log False, delete the
             # appropriate server-stored InboundContact records
@@ -831,10 +833,11 @@ class DomainAddress(models.Model):
             self.block_list_emails = False
             if update_fields:
                 update_fields = {"block_list_emails"}.union(update_fields)
-        if (not user_profile.server_storage) and self.description:
+        if (not user_profile.server_storage) and (self.description or self.used_on):
             self.description = ""
+            self.used_on = ""
             if update_fields:
-                update_fields = {"description"}.union(update_fields)
+                update_fields = {"description", "used_on"}.union(update_fields)
         super().save(
             force_insert=force_insert,
             force_update=force_update,


### PR DESCRIPTION
…file.server_storage=False

The ServerStorageCleaner task cleans this data out, but this change means the task has less work to do each time it runs.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3700.

## How to test:
1. `pytest`
4. Go to http://127.0.0.1:8000/api/v1/docs/#/domainaddresses/domainaddresses_create
5. Make a domain address with values in `description` and `used_on` fields. E.g.:
    ```
    {
      "enabled": true,
      "description": "some description",
      "block_list_emails": true,
      "used_on": "some_description.com",
      "address": "somedesc"
    }
    ```
   * [ ] You should receive a `201` response
6. Go to http://127.0.0.1:8000/accounts/settings/
7. UNCHECK the "Enable account names for email masks" setting
8. Click "Save"
9. Go to http://127.0.0.1:8000/accounts/profile/
   * [ ] The label/description value from Step 5 should be gone
10. Go to http://127.0.0.1:8000/api/v1/domainaddresses/
   * [ ] Both the `description` and `used_on` values from Step 5 should be gone

## Checklist
- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).