### PR TITLE
MPP-3701: Fix for stage bug (2024.01.17) where multiple delete modals open

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.tsx
@@ -8,8 +8,8 @@ import {
   usePreventScroll,
   AriaOverlayProps,
 } from "react-aria";
-import { OverlayTriggerState } from "react-stately";
-import { ReactElement, ReactNode, useRef } from "react";
+import { useOverlayTriggerState } from "react-stately";
+import { ReactElement, ReactNode, useEffect, useRef } from "react";
 import styles from "./AliasDeletionButtonPermanent.module.scss";
 import { Button } from "../../Button";
 import { AliasData, getFullAddress } from "../../../hooks/api/aliases";
@@ -19,7 +19,7 @@ import { ErrorTriangleIcon } from "../../Icons";
 export type Props = {
   alias: AliasData;
   onDelete: () => void;
-  modalState?: OverlayTriggerState;
+  setModalOpenedState?: (state: boolean) => void;
 };
 
 /**
@@ -52,10 +52,21 @@ export const AliasDeletionButtonPermanent = (props: Props) => {
     confirmButtonRef,
   );
 
-  if (!props.modalState) {
-    return;
-  }
-  const modalState = props.modalState;
+  const modalState = useOverlayTriggerState({});
+  useEffect(() => {
+    if (props.setModalOpenedState === undefined) {
+      return;
+    }
+
+    if (modalState.isOpen) {
+      props.setModalOpenedState(true);
+      return;
+    }
+
+    props.setModalOpenedState(false);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modalState.isOpen]);
 
   const dialog = modalState.isOpen ? (
     <OverlayContainer>

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -16,7 +16,6 @@ import { Localized } from "../../Localized";
 import { VisuallyHidden } from "../../VisuallyHidden";
 import { MaskCard } from "./MaskCard";
 import { isFlagActive } from "../../../functions/waffle";
-import { OverlayTriggerState } from "react-stately";
 
 export type Props = {
   aliases: AliasData[];
@@ -32,7 +31,7 @@ export type Props = {
   onDelete: (alias: AliasData) => void;
   onboarding?: boolean;
   children?: React.ReactNode;
-  deleteMaskModalState?: OverlayTriggerState;
+  setModalOpenedState?: (state: boolean) => void;
 };
 
 /**
@@ -164,7 +163,7 @@ export const AliasList = (props: Props) => {
             runtimeData={props.runtimeData}
             isOnboarding={onboarding}
             copyAfterMaskGeneration={generatedAlias?.id === alias.id}
-            deleteMaskModalState={props.deleteMaskModalState}
+            setModalOpenedState={props.setModalOpenedState}
           >
             {props.children}
           </MaskCard>

--- a/frontend/src/components/dashboard/aliases/CustomAddressGenerationModal.module.scss
+++ b/frontend/src/components/dashboard/aliases/CustomAddressGenerationModal.module.scss
@@ -260,6 +260,8 @@
       p {
         font-weight: 700;
         color: $color-purple-60;
+        width: 100%;
+        text-align: center;
 
         @include text-body-lg;
       }

--- a/frontend/src/components/dashboard/aliases/MaskCard.tsx
+++ b/frontend/src/components/dashboard/aliases/MaskCard.tsx
@@ -10,7 +10,6 @@ import {
   useState,
 } from "react";
 import {
-  OverlayTriggerState,
   RadioGroupProps,
   RadioGroupState,
   useRadioGroupState,
@@ -61,7 +60,7 @@ export type Props = {
   isOnboarding?: boolean;
   children?: ReactNode;
   copyAfterMaskGeneration: boolean;
-  deleteMaskModalState?: OverlayTriggerState;
+  setModalOpenedState?: (state: boolean) => void;
 };
 
 export const MaskCard = (props: Props) => {
@@ -391,7 +390,7 @@ export const MaskCard = (props: Props) => {
                     "custom_domain_management_redesign",
                   ) ? (
                     <AliasDeletionButtonPermanent
-                      modalState={props.deleteMaskModalState}
+                      setModalOpenedState={props.setModalOpenedState}
                       onDelete={props.onDelete}
                       alias={props.mask}
                     />

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -32,14 +32,13 @@ import { isPhonesAvailableInCountry } from "../../functions/getPlan";
 import { useL10n } from "../../hooks/l10n";
 import { HolidayPromoBanner } from "./topmessage/HolidayPromoBanner";
 import { isFlagActive } from "../../functions/waffle";
-import { OverlayTriggerState } from "react-stately";
 
 export type Props = {
   children: ReactNode;
   // Plain page used for pages without the typical header bag, e.g. tracker report page
   theme?: "free" | "premium" | "plain";
   runtimeData?: RuntimeData;
-  deleteMaskModalState?: OverlayTriggerState;
+  isModalOpen?: boolean;
 };
 
 /**
@@ -137,10 +136,11 @@ export const Layout = (props: Props) => {
   const [pointerEventsNone, setPointerEventsNone] = useState(false);
 
   useEffect(() => {
-    const modalState = props.deleteMaskModalState;
-
+    if (props.isModalOpen === undefined) {
+      return;
+    }
     // When the modal is closed, we schedule a callback with 0 ms to enable pointer events.
-    if (!modalState?.isOpen) {
+    if (!props.isModalOpen) {
       setTimeout(() => {
         setPointerEventsNone(false);
       }, 0);
@@ -149,11 +149,7 @@ export const Layout = (props: Props) => {
     }
     // When the modal is open, pointer events is disabled for the layout wrapper.
     setPointerEventsNone(true);
-  }, [
-    props.deleteMaskModalState?.isOpen,
-    props.deleteMaskModalState,
-    pointerEventsNone,
-  ]);
+  }, [props.isModalOpen]);
 
   return (
     <>

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -6,6 +6,7 @@ import {
   ReactNode,
   RefObject,
   useRef,
+  useState,
 } from "react";
 import {
   FocusScope,
@@ -18,11 +19,7 @@ import {
   useTooltipTrigger,
 } from "react-aria";
 import { event as gaEvent } from "react-ga";
-import {
-  useMenuTriggerState,
-  useOverlayTriggerState,
-  useTooltipTriggerState,
-} from "react-stately";
+import { useMenuTriggerState, useTooltipTriggerState } from "react-stately";
 import { toast } from "react-toastify";
 import styles from "./profile.module.scss";
 import UpsellBannerUs from "./images/upsell-banner-us.svg";
@@ -85,7 +82,7 @@ const Profile: NextPage = () => {
     clearCookie("profile-location-hash");
   }
   usePurchaseTracker(profileData.data?.[0]);
-  const deleteMaskModalState = useOverlayTriggerState({});
+  const [modalOpened, setModalOpenedState] = useState(false);
 
   if (!userData.isValidating && userData.error) {
     if (document.location.hash) {
@@ -569,10 +566,7 @@ const Profile: NextPage = () => {
             }}
           />
         )}
-      <Layout
-        deleteMaskModalState={deleteMaskModalState}
-        runtimeData={runtimeData.data}
-      >
+      <Layout isModalOpen={modalOpened} runtimeData={runtimeData.data}>
         {/* If free user has reached their free mask limit and 
         premium is available in their country, show upsell banner */}
         {freeMaskLimitReached &&
@@ -598,7 +592,7 @@ const Profile: NextPage = () => {
               profile={profile}
               user={user}
               runtimeData={runtimeData.data}
-              deleteMaskModalState={deleteMaskModalState}
+              setModalOpenedState={setModalOpenedState}
             />
             <p className={styles["size-information"]}>
               {l10n.getString("profile-supports-email-forwarding", {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3701 stage bug 2024.01.17.


# Bug description

Upon clicking a delete mask modal, multiple modals open. 

To fix this, we need to make the modal states indepedent per mask card.

# How to test
* Go to the relay dashboard.
* Click on a mask, and click the "delete" button.
* Verify that the behavior is normal, only one modal is open, and the background is not black.

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
