### PR TITLE
MPP-3495: Fix next URL check

### DIFF
--- a/privaterelay/tests/allauth_tests.py
+++ b/privaterelay/tests/allauth_tests.py
@@ -1,4 +1,5 @@
 from typing import Iterator
+from unittest.mock import patch, Mock
 import pytest
 
 from allauth.core.context import request_context
@@ -34,3 +35,36 @@ def test_account_adapter_is_safe_url_empty_does_not_log(
 ) -> None:
     assert not adapter.is_safe_url(path)
     assert len(caplog.records) == 0
+
+
+@pytest.mark.parametrize("found", (True, False))
+def test_account_adapter_is_safe_url_try_frontend_path(
+    adapter: AccountAdapter, caplog: pytest.LogCaptureFixture, found
+):
+    mock_instance = Mock()
+    mock_instance.find_file = Mock(return_value=found)
+    path = "/frontend/path/"
+    with patch(
+        "privaterelay.allauth.RelayStaticFilesMiddleware", return_value=mock_instance
+    ):
+        assert adapter.is_safe_url(path) == found
+    mock_instance.find_file.assert_called_once_with(path)
+    if found:
+        assert len(caplog.records) == 0
+    else:
+        (rec1,) = caplog.records
+        assert rec1.levelname == "ERROR"
+        assert rec1.getMessage() == f"No matching URL for '{path}'"
+
+
+def test_account_adapter_is_safe_url_frontend_not_built(
+    adapter: AccountAdapter, caplog: pytest.LogCaptureFixture
+):
+    with patch(
+        "privaterelay.allauth.RelayStaticFilesMiddleware",
+        side_effect=NotADirectoryError(),
+    ):
+        assert not adapter.is_safe_url("/faq/")
+    (rec1,) = caplog.records
+    assert rec1.levelname == "ERROR"
+    assert rec1.getMessage() == "No matching URL for '/faq/'"

--- a/privaterelay/tests/allauth_tests.py
+++ b/privaterelay/tests/allauth_tests.py
@@ -1,20 +1,36 @@
+from typing import Iterator
 import pytest
+
+from allauth.core.context import request_context
 
 from ..allauth import AccountAdapter
 
 
-def test_account_adapter_is_safe_url_noreversematch_logs_error(
-    caplog: pytest.LogCaptureFixture,
-):
-    adapter = AccountAdapter()
-    return_value = adapter.is_safe_url("fuzzymcfuzzface")
-    assert return_value is None
+@pytest.fixture
+def adapter(rf) -> Iterator[AccountAdapter]:
+    request = rf.get("/accounts/fxa/login/callback/?code=oauth_code")
+    with request_context(request):
+        yield AccountAdapter()
+
+
+def test_account_adapter_is_safe_url_invalid_path_logs_error(
+    caplog: pytest.LogCaptureFixture, adapter: AccountAdapter
+) -> None:
+    assert not adapter.is_safe_url("/fuzzymcfuzzface")
     (rec1,) = caplog.records
     assert rec1.levelname == "ERROR"
-    assert rec1.getMessage() == "NoReverseMatch for fuzzymcfuzzface"
+    assert rec1.getMessage() == "No matching URL for '/fuzzymcfuzzface'"
 
 
-def test_account_adapter_is_safe_url_redirects():
-    adapter = AccountAdapter()
-    return_value = adapter.is_safe_url("account_logout")
-    assert return_value is True
+def test_account_adapter_is_safe_url_valid_path(adapter: AccountAdapter) -> None:
+    assert adapter.is_safe_url("/accounts/logout/")
+
+
+@pytest.mark.parametrize("path", ("", None))
+def test_account_adapter_is_safe_url_empty_does_not_log(
+    caplog: pytest.LogCaptureFixture,
+    adapter: AccountAdapter,
+    path: str | None,
+) -> None:
+    assert not adapter.is_safe_url(path)
+    assert len(caplog.records) == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ django_settings_module = "privaterelay.settings"
 ignore_missing_imports = true
 module = [
     "allauth.account.*",
+    "allauth.core.*",
     "allauth.socialaccount.*",
     "boto3",
     "botocore.config",
@@ -86,7 +87,6 @@ module = [
     "emails.utils",
     "phones.models",
     "phones.tests.models_tests",
-    "privaterelay.allauth",
     "privaterelay.tests.fxa_utils_tests",
     "privaterelay.tests.mgmt_sync_phone_related_dates_on_profile_tests",
     "privaterelay.tests.mgmt_update_phone_remaining_stats_tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ strict = true
 # Disable these strict checks
 # Order is the recommended enabling order, from highest to lowest priority,
 # from mypy doc "Using mypy with an existing codebase"
-check_untyped_defs = false
 disallow_subclassing_any = false
 disallow_any_generics = false
 disallow_untyped_calls = false
@@ -61,4 +60,35 @@ module = [
 ignore_missing_imports = true
 module = [
     "silk",
+]
+
+[[tool.mypy.overrides]]
+# MPP-3698: Enumerate files where we still need this setting
+check_untyped_defs = false
+module = [
+    "api.authentication",
+    "api.serializers",
+    "api.tests.authentication_tests",
+    "api.tests.phones_views_tests",
+    "api.tests.views_tests",
+    "api.views",
+    "api.views.phones",
+    "emails.apps",
+    "emails.management.command_from_django_settings",
+    "emails.management.commands.check_health",
+    "emails.management.commands.process_emails_from_sqs",
+    "emails.models",
+    "emails.policy",
+    "emails.templatetags.email_extras",
+    "emails.tests.mgmt_process_emails_from_sqs_tests",
+    "emails.tests.models_tests",
+    "emails.tests.views_tests",
+    "emails.utils",
+    "phones.models",
+    "phones.tests.models_tests",
+    "privaterelay.allauth",
+    "privaterelay.tests.fxa_utils_tests",
+    "privaterelay.tests.mgmt_sync_phone_related_dates_on_profile_tests",
+    "privaterelay.tests.mgmt_update_phone_remaining_stats_tests",
+    "privaterelay.tests.views_tests",
 ]


### PR DESCRIPTION
The function `is_safe_url` in `privaterelay.allauth.AccountAdapter` checks if the provided next URL is safe. This was recently customized, but is broken.

For example, this URL:

https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net/accounts/fxa/login/?next=profile_refresh

will redirect the user after login to:

https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net/accounts/fxa/login/profile_refresh

Most URLs are not URL names, so most URLs will be identified as non-safe, and the user will redirect to `/accounts/profile/?`.

This PR fixes the function and improves it so that it will also redirect to next.js pages. Some things to try:

* Redirect to email test view:
  - Login URL: http://127.0.0.1:8000/accounts/fxa/login/?process=login&next=/emails/wrapped_email_test
  - Redirects to: http://127.0.0.1:8000/emails/wrapped_email_test
* Redirect to FAQ page:
  - Login URL: http://127.0.0.1:8000/accounts/fxa/login/?process=login&next=/faq/
  - Redirects to: http://127.0.0.1:8000/faq/
* Redirect to phones page with full URL:
  - Login URL: http://127.0.0.1:8000/accounts/fxa/login/?process=login&next=http://127.0.0.1:8000/phone/
  - Redirects to: http://127.0.0.1:8000/phone/
* Fail to Redirect to non-existent page
  - Login URL: http://127.0.0.1:8000/accounts/fxa/login/?process=login&next=/404-page
  - Redirects to: http://127.0.0.1:8000/accounts/profile/?
* Fail to Redirect to other domain
  - Login URL: http://127.0.0.1:8000/accounts/fxa/login/?process=login&next=https://monitor.mozilla.org/
  - Redirects to: http://127.0.0.1:8000/accounts/profile/? 
* Next URL after logout
  - Logout URL: http://127.0.0.1:8000/accounts/logout/?next=/faq/
  - Redirects to: http://127.0.0.1:8000/faq/

This issue was re-discovered while working on MPP-3698, which failed type checking with `mypy --check-untyped-defs privaterelay/allauth.py`. It now passes.