### PR TITLE
MPP-3636: Refactor version loading

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -46,7 +46,7 @@ except ImportError:
     HAS_SILK = False
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR: str = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TMP_DIR = os.path.join(BASE_DIR, "tmp")
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 

--- a/privaterelay/tests/conftest.py
+++ b/privaterelay/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared fixtures for privaterelay tests"""
+
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from privaterelay.utils import get_version_info
+
+
+@pytest.fixture
+def version_json_path(tmp_path, settings) -> Iterator[Path]:
+    """Create testing version.json file, cleanup after test."""
+    get_version_info.cache_clear()
+    settings.BASE_DIR = tmp_path
+    path = settings.BASE_DIR / "version.json"
+    yield path
+    get_version_info.cache_clear()

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -588,11 +588,10 @@ def test_flag_is_active_for_task_override_existing_to_inactive(
     (None, "", "[]", '{"foo": "bar"}'),
     ids=("missing", "empty", "list", "other object"),
 )
-def test_get_version_info_bad_contents(tmp_path, content: str | None) -> None:
-    path = tmp_path / "bad.json"
+def test_get_version_info_bad_contents(version_json_path, content: str | None) -> None:
     if content is not None:
-        path.write_text(content)
-    info = get_version_info(path)
+        version_json_path.write_text(content)
+    info = get_version_info(version_json_path)
     assert info == {
         "source": "https://github.com/mozilla/fx-private-relay",
         "version": "unknown",
@@ -601,15 +600,13 @@ def test_get_version_info_bad_contents(tmp_path, content: str | None) -> None:
     }
 
 
-def test_get_version_info(tmp_path, settings) -> None:
-    settings.BASE_DIR = tmp_path
-    path = settings.BASE_DIR / "version.json"
+def test_get_version_info(version_json_path) -> None:
     build_info = {
         "commit": "the_commit_hash",
         "version": "2024.01.17",
         "source": "https://github.com/mozilla/fx-private-relay",
         "build": "https://circleci.com/gh/mozilla/fx-private-relay/100",
     }
-    path.write_text(json.dumps(build_info))
+    version_json_path.write_text(json.dumps(build_info))
     version_info = get_version_info()
     assert version_info == build_info

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -533,3 +533,15 @@ def test_fxa_rp_events_delete_user(
         da.address, da.user.profile.subdomain, da.domain_value
     )
     assert DeletedAddress.objects.filter(address_hash=da_address_hash).exists()
+
+
+def test_version_view(client, version_json_path) -> None:
+    version_info = {
+        "commit": "a_commit_hash",
+        "version": "2024.01.17.1",
+        "source": "https://github.com/mozilla/fx-private-relay",
+        "build": "https://circleci.com/gh/mozilla/fx-private-relay/200",
+    }
+    version_json_path.write_text(json.dumps(version_info))
+    response = client.get("/__version__")
+    assert response.json() == version_info

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -77,7 +77,10 @@ def get_subplat_upgrade_link_by_language(
     else:
         first_key = list(country_details.keys())[0]
         plan = country_details[first_key][period]
-    return f"{settings.FXA_BASE_ORIGIN}/subscriptions/products/{settings.PERIODICAL_PREMIUM_PROD_ID}?plan={plan['id']}"
+    return (
+        f"{settings.FXA_BASE_ORIGIN}/subscriptions/products/"
+        f"{settings.PERIODICAL_PREMIUM_PROD_ID}?plan={plan['id']}"
+    )
 
 
 def _get_cc_from_request(request: HttpRequest) -> str:

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -4,7 +4,6 @@ from hashlib import sha256
 from typing import Any, Iterable, Optional, TypedDict
 import json
 import logging
-import os
 
 from django.apps import apps
 from django.conf import settings
@@ -33,9 +32,10 @@ from emails.models import (
     valid_available_subdomain,
 )
 from emails.utils import incr_if_enabled
-from privaterelay.fxa_utils import _get_oauth2_session, NoSocialToken
 
 from .apps import PrivateRelayConfig
+from .fxa_utils import _get_oauth2_session, NoSocialToken
+from .utils import get_version_info
 
 
 FXA_PROFILE_CHANGE_EVENT = "https://schemas.accounts.firefox.com/event/profile-change"
@@ -97,27 +97,7 @@ def profile_subdomain(request):
 
 
 def version(request):
-    # If version.json is available (from Circle job), serve that
-    VERSION_JSON_PATH = os.path.join(settings.BASE_DIR, "version.json")
-    if os.path.isfile(VERSION_JSON_PATH):
-        with open(VERSION_JSON_PATH) as version_file:
-            return JsonResponse(json.load(version_file))
-
-    # Generate version.json contents
-    git_dir = os.path.join(settings.BASE_DIR, ".git")
-    with open(os.path.join(git_dir, "HEAD")) as head_file:
-        ref = head_file.readline().split(" ")[-1].strip()
-
-    with open(os.path.join(git_dir, ref)) as git_hash_file:
-        git_hash = git_hash_file.readline().strip()
-
-    version_data = {
-        "source": "https://github.com/groovecoder/private-relay",
-        "version": git_hash,
-        "commit": git_hash,
-        "build": "uri to CI build job",
-    }
-    return JsonResponse(version_data)
+    return JsonResponse(get_version_info())
 
 
 def heartbeat(request):


### PR DESCRIPTION
This is split from #4320. Glean pings include the release version, so we need a way to load that outside if the `__version__` view.

The version information comes from `version.json`, which is written by the CircleCI build system. This PR refactors loading this file into `privaterelay.utils.get_version_info`, along with tests, and then uses it in the view. In the future, other functions will be able to read this version info in tests and production code.

# How to test:

- ~[ ] l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- ~[ ] I've added or updated relevant docs in the docs/ directory.~
- ~[ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
