### PR TITLE
MPP-3636: Fix domain address conflict handling

### DIFF
--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -25,7 +25,38 @@ class ErrorData(OptionalErrorData):
 
 
 class RelayAPIException(APIException):
-    """Base class for exceptions that may be returned through API"""
+    """
+    Base class for exceptions that may be returned through the API.
+
+    Derived classes should set `default_code` to a unique string identifying the
+    exception. There should be a matching Fluent string with an `api-error-`
+    prefix. For example, the Fluent string "api-error-free-tier-limit" matches
+    the exception class with the default_code "free-tier-limit". These Fluent
+    strings are in misc.ftl.
+
+    Derived classes can set `default_detail` to a human-readable string, or they
+    can set `default_detail_template` to dynamically create the string from extra
+    context. When using default_detail_template, the Fluent string should use the same
+    variable names.
+
+    Derived classes can set `status_code` to the HTTP status code, or accept the
+    APIException default of 500 for a Server Error.
+    """
+
+    default_code: str
+    default_detail: str
+    status_code: int
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Check that derived classes have set the required data."""
+        assert isinstance(self.default_code, str)
+        assert isinstance(self.status_code, int)
+        if hasattr(self, "default_detail_template"):
+            context = self.error_context()
+            assert context
+            self.default_detail = self.default_detail_template.format(**context)
+        assert isinstance(self.default_detail, str)
+        super().__init__(*args, **kwargs)
 
     def error_context(self) -> ErrorContextType:
         """Return context variables for client-side translation."""
@@ -34,7 +65,7 @@ class RelayAPIException(APIException):
     def error_data(self) -> ErrorData:
         """Return extra data for API error responses."""
 
-        # For RelayAPIException classes, this should always be a string
+        # For RelayAPIException classes, this is the default_code and is a string
         error_code = self.get_codes()
         assert isinstance(error_code, str)
 

--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -1,7 +1,9 @@
-from typing import Union
+from typing import Any, TypedDict
 
 from rest_framework import status
 from rest_framework.exceptions import APIException
+
+from privaterelay.ftl_bundles import main as ftl_bundle
 
 
 class ConflictError(APIException):
@@ -10,7 +12,16 @@ class ConflictError(APIException):
     default_code = "conflict_error"
 
 
-ErrorContextType = dict[str, Union[int, str]]
+ErrorContextType = dict[str, int | str]
+
+
+class OptionalErrorData(TypedDict, total=False):
+    error_context: ErrorContextType
+
+
+class ErrorData(OptionalErrorData):
+    detail: str
+    error_code: str | list[Any] | dict[str, Any] | None
 
 
 class RelayAPIException(APIException):
@@ -19,3 +30,24 @@ class RelayAPIException(APIException):
     def error_context(self) -> ErrorContextType:
         """Return context variables for client-side translation."""
         return {}
+
+    def error_data(self) -> ErrorData:
+        """Return extra data for API error responses."""
+
+        # For RelayAPIException classes, this should always be a string
+        error_code = self.get_codes()
+        assert isinstance(error_code, str)
+
+        # Build the Fluent error ID
+        ftl_id_sub = "api-error-"
+        ftl_id_error = error_code.replace("_", "-")
+        ftl_id = ftl_id_sub + ftl_id_error
+
+        # Replace the default message with the translated Fluent string
+        error_context = self.error_context()
+        translated_detail = ftl_bundle.format(ftl_id, error_context)
+
+        error_data = ErrorData(detail=translated_detail, error_code=error_code)
+        if error_context:
+            error_data["error_context"] = error_context
+        return error_data

--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -10,17 +10,6 @@ class ConflictError(APIException):
     default_code = "conflict_error"
 
 
-class DomainAddressConflictError(ConflictError):
-    default_detail = "This domain address already exists."
-
-    def __init__(
-        self, existing_id: int | None = None, existing_address: str | None = None
-    ) -> None:
-        self.existing_id = existing_id
-        self.existing_address = existing_address
-        super().__init__()
-
-
 ErrorContextType = dict[str, Union[int, str]]
 
 

--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -10,6 +10,17 @@ class ConflictError(APIException):
     default_code = "conflict_error"
 
 
+class DomainAddressConflictError(ConflictError):
+    default_detail = "This domain address already exists."
+
+    def __init__(
+        self, existing_id: int | None = None, existing_address: str | None = None
+    ) -> None:
+        self.existing_id = existing_id
+        self.existing_address = existing_address
+        super().__init__()
+
+
 ErrorContextType = dict[str, Union[int, str]]
 
 

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -140,10 +140,13 @@ def test_patch_premium_user_subdomain_cannot_be_changed(
 
 def test_patch_profile_fields_are_read_only_by_default(premium_user, prem_api_client):
     """
-    A field in the Profile model should be read only by default, and return a 400 response code
-    (see StrictReadOnlyFieldsMixin in api/serializers/__init__.py), if it is not mentioned in the ProfileSerializer class fields.
+    A field in the Profile model should be read only by default, and return a 400
+    response code (see StrictReadOnlyFieldsMixin in api/serializers/__init__.py), if it
+    is not mentioned in the ProfileSerializer class fields.
 
-    Two fields were tested, num_address_deleted, and sent_welcome_email to see if the behavior matches what is described here: https://www.django-rest-framework.org/api-guide/serializers/#specifying-read-only-fields
+    Two fields were tested, num_address_deleted, and sent_welcome_email to see if the
+    behavior matches what is described here:
+    https://www.django-rest-framework.org/api-guide/serializers/#specifying-read-only-fields
     """
     premium_profile = premium_user.profile
     expected_num_address_deleted = premium_profile.num_address_deleted
@@ -172,7 +175,8 @@ def test_profile_non_read_only_fields_update_correctly(premium_user, prem_api_cl
     """
     A field that is not read only should update correctly on a patch request.
 
-    "Not read only" meaning that it was defined in the serializers fields, but not read_only_fields.
+    "Not read only" meaning that it was defined in the serializers fields, but not
+    read_only_fields.
     """
     premium_profile = premium_user.profile
     old_onboarding_state = premium_profile.onboarding_state
@@ -244,7 +248,10 @@ def test_profile_patch_with_non_read_only_and_read_only_fields(
 
 
 def test_profile_patch_fields_that_dont_exist(premium_user, prem_api_client):
-    """A request sent with only fields that don't exist give a 200 response (this is the default behavior django provides, we decided to leave it as is)"""
+    """
+    A request sent with only fields that don't exist give a 200 response (this is the
+    default behavior django provides, we decided to leave it as is)
+    """
     response = prem_api_client.patch(
         reverse(viewname="profiles-detail", args=[premium_user.profile.id]),
         data={
@@ -287,10 +294,13 @@ def test_post_domainaddress_bad_address_error(prem_api_client) -> None:
 
     assert response.status_code == 400
     ret_data = response.json()
-    # Add unicode characters to get around Fluent.js using unicode isolation.
-    # See https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation for more info
+    # Add unicode characters to get around Fluent.js using unicode isolation. See:
+    # https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation
     assert ret_data == {
-        "detail": "“\u2068myNewAlias\u2069” could not be created. Please try again with a different mask name.",
+        "detail": (
+            "“\u2068myNewAlias\u2069” could not be created."
+            " Please try again with a different mask name."
+        ),
         "error_code": "address_unavailable",
         "error_context": {"unavailable_address": "myNewAlias"},
     }
@@ -304,10 +314,13 @@ def test_post_domainaddress_free_user_error(free_api_client):
 
     assert response.status_code == 403
     ret_data = response.json()
-    # Add unicode characters to get around Fluent.js using unicode isolation.
-    # See https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation for more info
+    # Add unicode characters to get around Fluent.js using unicode isolation. See:
+    # https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation
     assert ret_data == {
-        "detail": "Your free account does not include custom subdomains for masks. To create custom masks, upgrade to \u2068Relay Premium\u2069.",
+        "detail": (
+            "Your free account does not include custom subdomains for masks."
+            " To create custom masks, upgrade to \u2068Relay Premium\u2069."
+        ),
         "error_code": "free_tier_no_subdomain_masks",
     }
 
@@ -334,13 +347,15 @@ def test_post_relayaddress_free_mask_email_limit_error(
 
     assert response.status_code == 403
     ret_data = response.json()
-    # Add unicode characters to get around Fluent.js using unicode isolation.
-    # See https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation for more info
+    # Add unicode characters to get around Fluent.js using unicode isolation. See:
+    # https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation
 
     assert ret_data == {
         "detail": (
             "You’ve used all"
-            f" \u2068{settings.MAX_NUM_FREE_ALIASES}\u2069 email masks included with your free account. You can reuse an existing mask, but using a unique mask for each account is the most secure option."
+            f" \u2068{settings.MAX_NUM_FREE_ALIASES}\u2069 email masks included with"
+            " your free account. You can reuse an existing mask, but using a unique"
+            " mask for each account is the most secure option."
         ),
         "error_code": "free_tier_limit",
         "error_context": {"free_tier_limit": 5},

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -333,7 +333,14 @@ def test_post_domainaddress_conflict_existing(prem_api_client, premium_user):
     ret_data = response.json()
     # Add unicode characters to get around Fluent.js using unicode isolation. See:
     # https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation
-    assert ret_data == {"detail": "This domain address already exists."}
+    assert ret_data == {
+        "detail": (
+            "“\u2068my-new-alias\u2069” already exists."
+            " Please try again with a different mask name."
+        ),
+        "error_code": "duplicate_address",
+        "error_context": {"duplicate_address": "my-new-alias"},
+    }
 
 
 @pytest.mark.django_db(transaction=True)

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -5,20 +5,16 @@ import pytest
 from model_bakery import baker
 import responses
 
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.core.cache import cache
-from django.test import (
-    override_settings,
-    RequestFactory,
-    TestCase,
-)
+from django.test import RequestFactory, TestCase
 from django.utils import timezone
 from django.urls import reverse
 from rest_framework.test import APIClient
 
 from allauth.socialaccount.models import SocialAccount, SocialApp
+from waffle.testutils import override_flag
 
 from api.authentication import get_cache_key, INTROSPECT_TOKEN_URL
 from api.tests.authentication_tests import (
@@ -26,7 +22,7 @@ from api.tests.authentication_tests import (
     _setup_fxa_response_no_json,
 )
 from api.views import FXA_PROFILE_URL
-from emails.models import Profile, RelayAddress
+from emails.models import Profile, RelayAddress, DomainAddress
 from emails.tests.models_tests import make_free_test_user, make_premium_test_user
 from privaterelay.tests.utils import log_extra
 
@@ -325,7 +321,46 @@ def test_post_domainaddress_free_user_error(free_api_client):
     }
 
 
-def test_post_relayaddress_success(settings, free_api_client) -> None:
+@pytest.mark.django_db(transaction=True)
+def test_post_domainaddress_conflict_existing(prem_api_client, premium_user):
+    """A user can not create a duplicate domain address."""
+    DomainAddress.objects.create(user=premium_user, address="my-new-alias")
+    response = prem_api_client.post(
+        reverse("domainaddress-list"), data={"address": "my-new-alias"}, format="json"
+    )
+
+    assert response.status_code == 409
+    ret_data = response.json()
+    # Add unicode characters to get around Fluent.js using unicode isolation. See:
+    # https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation
+    assert ret_data == {"detail": "This domain address already exists."}
+
+
+@pytest.mark.django_db(transaction=True)
+@override_flag("custom_domain_management_redesign", active=True)
+def test_post_domainaddress_conflict_deleted(prem_api_client, premium_user):
+    """A user can not create a domain address that matches a deleted address."""
+    existing = DomainAddress.objects.create(user=premium_user, address="my-new-alias")
+    existing.delete()
+    response = prem_api_client.post(
+        reverse("domainaddress-list"), data={"address": "my-new-alias"}, format="json"
+    )
+
+    assert response.status_code == 400
+    ret_data = response.json()
+    # Add unicode characters to get around Fluent.js using unicode isolation. See:
+    # https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation
+    assert ret_data == {
+        "detail": (
+            "“\u2068my-new-alias\u2069” could not be created."
+            " Please try again with a different mask name."
+        ),
+        "error_code": "address_unavailable",
+        "error_context": {"unavailable_address": "my-new-alias"},
+    }
+
+
+def test_post_relayaddress_success(free_api_client, free_user, caplog) -> None:
     """A free user is able to create a random address."""
     response = free_api_client.post(
         reverse("relayaddress-list"), data={}, format="json"

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -190,10 +190,15 @@ class UserViewSet(viewsets.ModelViewSet):
             description="Accepted; returned when user already exists."
         ),
         400: OpenApiResponse(
-            description="Bad request; returned when request is missing Authorization: Bearer header or token value."
+            description=(
+                "Bad request; returned when request is missing Authorization: Bearer"
+                " header or token value."
+            )
         ),
         401: OpenApiResponse(
-            description="Unauthorized; returned when the FXA token is invalid or expired."
+            description=(
+                "Unauthorized; returned when the FXA token is invalid or expired."
+            )
         ),
     },
 )
@@ -207,7 +212,7 @@ def terms_accepted_user(request):
     See [API Auth doc][api-auth-doc] for details.
 
     [api-auth-doc]: https://github.com/mozilla/fx-private-relay/blob/main/docs/api_auth.md#firefox-oauth-token-authentication-and-accept-terms-of-service
-    """
+    """  # noqa: E501
     # Setting authentication_classes to empty due to
     # authentication still happening despite permissions being set to allowany
     # https://forum.djangoproject.com/t/solved-allowany-override-does-not-work-on-apiview/9754
@@ -223,8 +228,8 @@ def terms_accepted_user(request):
         fxa_uid = get_fxa_uid_from_oauth_token(token, use_cache=False)
     except AuthenticationFailed as e:
         # AuthenticationFailed exception returns 403 instead of 401 because we are not
-        # using the proper config that comes with the authentication_classes
-        # Read more: https://www.django-rest-framework.org/api-guide/authentication/#custom-authentication
+        # using the proper config that comes with the authentication_classes. See:
+        # https://www.django-rest-framework.org/api-guide/authentication/#custom-authentication
         return response.Response(
             data={"detail": e.detail.title()}, status=e.status_code
         )
@@ -251,25 +256,26 @@ def terms_accepted_user(request):
                 status=500,
             )
 
-        # this is not exactly the request object that FirefoxAccountsProvider expects, but
-        # it has all of the necssary attributes to initiatlize the Provider
+        # This is not exactly the request object that FirefoxAccountsProvider expects,
+        # but it has all of the necessary attributes to initialize the Provider
         provider = get_social_adapter().get_provider(request, "fxa")
         # This may not save the new user that was created
         # https://github.com/pennersr/django-allauth/blob/77368a84903d32283f07a260819893ec15df78fb/allauth/socialaccount/providers/base/provider.py#L44
         social_login = provider.sociallogin_from_response(
             request, fxa_profile_resp.json()
         )
-        # Complete social login is called by callback
-        # (see https://github.com/pennersr/django-allauth/blob/77368a84903d32283f07a260819893ec15df78fb/allauth/socialaccount/providers/oauth/views.py#L118)
-        # which is what we are mimicking to
-        # create new SocialAccount, User, and Profile for the new Relay user from Firefox
-        # Since this is a Resource Provider/Server flow and are NOT a Relying Party (RP) of FXA
-        # No social token information is stored (no Social Token object created).
+        # Complete social login is called by callback, see
+        # https://github.com/pennersr/django-allauth/blob/77368a84903d32283f07a260819893ec15df78fb/allauth/socialaccount/providers/oauth/views.py#L118
+        # for what we are mimicking to create new SocialAccount, User, and Profile for
+        # the new Relay user from Firefox Since this is a Resource Provider/Server flow
+        # and are NOT a Relying Party (RP) of FXA No social token information is stored
+        # (no Social Token object created).
         try:
             complete_social_login(request, social_login)
-            # complete_social_login writes ['account_verified_email', 'user_created', '_auth_user_id', '_auth_user_backend', '_auth_user_hash']
-            # on request.session which sets the cookie because complete_social_login does the "login"
-            # The user did not actually log in, logout to clear the session
+            # complete_social_login writes ['account_verified_email', 'user_created',
+            # '_auth_user_id', '_auth_user_backend', '_auth_user_hash'] on
+            # request.session which sets the cookie because complete_social_login does
+            # the "login" The user did not actually log in, logout to clear the session
             if request.user.is_authenticated:
                 get_account_adapter(request).logout(request)
         except NoReverseMatch as e:
@@ -454,7 +460,8 @@ def relay_exception_handler(
     Add error information to response data.
 
     When the error is a RelayAPIException, these additional fields may be present and
-    the information will be translated if an Accept-Language header is added to the request:
+    the information will be translated if an Accept-Language header is added to the
+    request:
 
     error_code - A string identifying the error, for client-side translation
     error_context - Additional data needed for client-side translation

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -28,6 +28,7 @@ from rest_framework.exceptions import (
     ParseError,
 )
 from rest_framework.response import Response
+from rest_framework.serializers import BaseSerializer
 from rest_framework.views import exception_handler
 
 from allauth.account.adapter import get_adapter as get_account_adapter
@@ -63,7 +64,7 @@ from emails.models import (
 )
 
 from ..authentication import get_fxa_uid_from_oauth_token
-from ..exceptions import ConflictError, RelayAPIException
+from ..exceptions import DomainAddressConflictError, RelayAPIException
 from ..permissions import IsOwner, CanManageFlags
 from ..serializers import (
     DomainAddressSerializer,
@@ -153,16 +154,19 @@ class DomainAddressViewSet(SaveToRequestUser, viewsets.ModelViewSet):
     def get_queryset(self):
         return DomainAddress.objects.filter(user=self.request.user)
 
-    def perform_create(self, serializer):
+    def perform_create(self, serializer: BaseSerializer[DomainAddress]) -> None:
         try:
             serializer.save(user=self.request.user)
         except IntegrityError:
+            assert isinstance(self.request.user, User)
             domain_address = DomainAddress.objects.filter(
                 user=self.request.user, address=serializer.validated_data.get("address")
             ).first()
-            raise ConflictError(
-                {"id": domain_address.id, "full_address": domain_address.full_address}
-            )
+            existing_id = existing_address = None
+            if domain_address:
+                existing_id = domain_address.id
+                existing_address = domain_address.full_address
+            raise DomainAddressConflictError(existing_id, existing_address)
 
 
 class ProfileViewSet(viewsets.ModelViewSet):

--- a/emails/models.py
+++ b/emails/models.py
@@ -70,7 +70,8 @@ def valid_available_subdomain(subdomain, *args, **kwargs):
     return True
 
 
-# This historical function is referenced in migration 0029_profile_add_deleted_metric_and_changeserver_storage_default
+# This historical function is referenced in migration
+# 0029_profile_add_deleted_metric_and_changeserver_storage_default
 def default_server_storage():
     return True
 
@@ -87,7 +88,8 @@ class Profile(models.Model):
     num_address_deleted = models.PositiveIntegerField(default=0)
     date_subscribed = models.DateTimeField(blank=True, null=True)
     date_subscribed_phone = models.DateTimeField(blank=True, null=True)
-    # TODO: delete date_phone_subscription_checked in favor of date_phone_subscription_next_reset
+    # TODO MPP-2972: delete date_phone_subscription_checked in favor of
+    # date_phone_subscription_next_reset
     date_phone_subscription_checked = models.DateTimeField(blank=True, null=True)
     date_phone_subscription_start = models.DateTimeField(blank=True, null=True)
     date_phone_subscription_reset = models.DateTimeField(blank=True, null=True)
@@ -395,8 +397,9 @@ class Profile(models.Model):
         if self.subdomain is not None:
             raise CannotMakeSubdomainException("error-premium-cannot-change-subdomain")
         self.subdomain = subdomain
-        # The validator defined in the subdomain field does not get run in full_clean() when self.subdomain is "" or None
-        # So we need to run the validator again to catch these cases.
+        # The validator defined in the subdomain field does not get run in full_clean()
+        # when self.subdomain is "" or None, so we need to run the validator again to
+        # catch these cases.
         valid_available_subdomain(subdomain)
         self.full_clean()
         self.save()
@@ -411,7 +414,9 @@ class Profile(models.Model):
         email_forwarded=False,
         forwarded_email_size=0,
     ):
-        #  TODO: this should be wrapped in atomic to ensure race conditions are properly handled
+        # TODO MPP-3720: This should be wrapped in atomic or select_for_update to ensure
+        # race conditions are properly handled.
+
         # look for abuse metrics created on the same UTC date, regardless of time.
         midnight_utc_today = datetime.combine(
             datetime.now(timezone.utc).date(), datetime.min.time()
@@ -582,7 +587,8 @@ class RelayAddrFreeTierLimitException(CannotMakeAddressException):
     default_code = "free_tier_limit"
     default_detail_template = (
         "You’ve used all {free_tier_limit} email masks included with your free account."
-        "You can reuse an existing mask, but using a unique mask for each account is the most secure option."
+        " You can reuse an existing mask, but using a unique mask for each account is"
+        " the most secure option."
     )
     status_code = 403
 
@@ -599,7 +605,10 @@ class RelayAddrFreeTierLimitException(CannotMakeAddressException):
 
 class DomainAddrFreeTierException(CannotMakeAddressException):
     default_code = "free_tier_no_subdomain_masks"
-    default_detail = "Your free account does not include custom subdomains for masks. To create custom masks, upgrade to Relay Premium."
+    default_detail = (
+        "Your free account does not include custom subdomains for masks."
+        " To create custom masks, upgrade to Relay Premium."
+    )
     status_code = 403
 
 
@@ -611,7 +620,10 @@ class DomainAddrNeedSubdomainException(CannotMakeAddressException):
 
 class DomainAddrUnavailableException(CannotMakeAddressException):
     default_code = "address_unavailable"
-    default_detail_template = "“{unavailable_address}” could not be created. Please try again with a different mask name."
+    default_detail_template = (
+        "“{unavailable_address}” could not be created."
+        " Please try again with a different mask name."
+    )
     status_code = 400
 
     def __init__(self, unavailable_address: str, *args, **kwargs):
@@ -857,7 +869,6 @@ class DomainAddress(models.Model):
     ) -> "DomainAddress":
         check_user_can_make_domain_address(user_profile)
 
-        address_contains_badword = False
         if not address:
             # FIXME: if the alias is randomly generated and has bad words
             # we should retry like make_relay_address does
@@ -954,7 +965,7 @@ class AbuseMetrics(models.Model):
     num_replies_per_day = models.PositiveSmallIntegerField(default=0)
     # Values from 0 to 32767 are safe in all databases supported by Django.
     num_email_forwarded_per_day = models.PositiveSmallIntegerField(default=0)
-    # Values from 0 to 9223372036854775807 are safe in all databases supported by Django.
+    # Values from 0 to 9.2 exabytes are safe in all databases supported by Django.
     forwarded_email_size_per_day = models.PositiveBigIntegerField(default=0)
 
     class Meta:

--- a/emails/models.py
+++ b/emails/models.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from datetime import datetime, timedelta, timezone
 from hashlib import sha256
-from typing import Optional, Iterable
+from typing import Iterable
 import logging
 import random
 import re
@@ -592,11 +592,8 @@ class RelayAddrFreeTierLimitException(CannotMakeAddressException):
     )
     status_code = 403
 
-    def __init__(self, free_tier_limit: Optional[int] = None, *args, **kwargs):
+    def __init__(self, free_tier_limit: int | None = None, *args, **kwargs):
         self.free_tier_limit = free_tier_limit or settings.MAX_NUM_FREE_ALIASES
-        self.default_detail = self.default_detail_template.format(
-            free_tier_limit=self.free_tier_limit
-        )
         super().__init__(*args, **kwargs)
 
     def error_context(self) -> ErrorContextType:
@@ -628,9 +625,6 @@ class DomainAddrUnavailableException(CannotMakeAddressException):
 
     def __init__(self, unavailable_address: str, *args, **kwargs):
         self.unavailable_address = unavailable_address
-        self.default_detail = self.default_detail_template.format(
-            unavailable_address=self.unavailable_address
-        )
         super().__init__(*args, **kwargs)
 
     def error_context(self) -> ErrorContextType:
@@ -647,9 +641,6 @@ class DomainAddrDuplicateException(CannotMakeAddressException):
 
     def __init__(self, duplicate_address: str, *args, **kwargs):
         self.duplicate_address = duplicate_address
-        self.default_detail = self.default_detail_template.format(
-            duplicate_address=duplicate_address
-        )
         super().__init__(*args, **kwargs)
 
     def error_context(self) -> ErrorContextType:

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -1377,7 +1377,7 @@ class DomainAddressTest(TestCase):
         domain_address = DomainAddress.objects.create(
             user=self.storageless_user, address="no-storage"
         )
-        assert domain_address.used_on == None
+        assert domain_address.used_on is None
         assert domain_address.description == ""
 
         # Use QuerySet.update to avoid model save method

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.db import IntegrityError
 from django.test import override_settings, TestCase
 
 from allauth.socialaccount.models import SocialAccount
@@ -23,6 +22,7 @@ from ..models import (
     CannotMakeSubdomainException,
     DeletedAddress,
     DomainAddress,
+    DomainAddrDuplicateException,
     DomainAddrUnavailableException,
     emails_config,
     get_domain_numerical,
@@ -1238,8 +1238,9 @@ class DomainAddressTest(TestCase):
     def test_make_domain_address_dupe_of_existing_raises(self):
         address = "same-address"
         DomainAddress.make_domain_address(self.user_profile, address=address)
-        with pytest.raises(IntegrityError):
+        with pytest.raises(DomainAddrDuplicateException) as exc_info:
             DomainAddress.make_domain_address(self.user_profile, address=address)
+        assert exc_info.value.get_codes() == "duplicate_address"
 
     @override_flag("custom_domain_management_redesign", active=False)
     def test_make_domain_address_can_make_dupe_of_deleted(self):

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.db import IntegrityError
 from django.test import override_settings, TestCase
 
 from allauth.socialaccount.models import SocialAccount
@@ -1233,6 +1234,12 @@ class DomainAddressTest(TestCase):
         with pytest.raises(CannotMakeAddressException) as exc_info:
             DomainAddress.make_domain_address(user_profile, "test-nosubdomain")
         assert exc_info.value.get_codes() == "need_subdomain"
+
+    def test_make_domain_address_dupe_of_existing_raises(self):
+        address = "same-address"
+        DomainAddress.make_domain_address(self.user_profile, address=address)
+        with pytest.raises(IntegrityError):
+            DomainAddress.make_domain_address(self.user_profile, address=address)
 
     @override_flag("custom_domain_management_redesign", active=False)
     def test_make_domain_address_can_make_dupe_of_deleted(self):

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -3,3 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # This is the Django equivalent of frontend/pendingTranslations.ftl
+
+# Variables:
+#   $duplicate_address (string) - User-set email address that already exists
+api-error-duplicate-address = “{ $duplicate_address }” already exists. Please try again with a different mask name.


### PR DESCRIPTION
This code was extracted from PR #4320. The `DomainAddressViewSet` has special handling for -re-creating a domain address via the API, and turning it into a `409 Conflict` response. However, it passed a `dict` to the exception rather than an exception method, and was untested. This PR adds tests ~and returns a proper exception~, checks for a duplicate in the `save()` method, and returns a translated exception. It also wraps comments and other lines that exceed the 88 character limit.

## How to test:

- ~[ ] l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- ~[ ] I've added or updated relevant docs in the docs/ directory.~
- ~[ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
