### PR TITLE
MPP-2530, MPP-3487: Test Python 3.11, 3.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -681,6 +681,24 @@ workflows:
           filters: *default_filters
 
       - python_job:
+          name: python 3.11 test
+          python_version: "3.11"
+          command: pytest
+          pytest_fail_fast: true
+          test_results_filename: pytest-python-3-11.xml
+          allow_fail: true
+          filters: *default_filters
+
+      - python_job:
+          name: python 3.12 test
+          python_version: "3.12"
+          command: pytest
+          pytest_fail_fast: true
+          test_results_filename: pytest-python-3-12.xml
+          allow_fail: true
+          filters: *default_filters
+
+      - python_job:
           name: python test iq enabled
           command: pytest
           pytest_phones_backend: iq


### PR DESCRIPTION
Test future Python versions in CircleCI, with `pytest` allowed to fail quickly.

* MPP-2530 / Issue #2731 - Python 3.11
* MPP-3487 / Issue #3982 - Python 3.12