### PR TITLE
MPP-1810: Update to dockerflow 2024.1.0, remove unused views

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -801,5 +801,8 @@ PROCESS_EMAIL_HEALTHCHECK_MAX_AGE = config(
 # Django 3.2 switches default to BigAutoField
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
+# python-dockerflow settings
+DOCKERFLOW_VERSION_CALLBACK = "privaterelay.utils.get_version_info"
+
 # Patching for django-types
 django_stubs_ext.monkeypatch()

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -803,6 +803,12 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # python-dockerflow settings
 DOCKERFLOW_VERSION_CALLBACK = "privaterelay.utils.get_version_info"
+DOCKERFLOW_CHECKS = [
+    "dockerflow.django.checks.check_database_connected",
+    "dockerflow.django.checks.check_migrations_applied",
+]
+if REDIS_URL:
+    DOCKERFLOW_CHECKS.append("dockerflow.django.checks.check_redis_connected")
 
 # Patching for django-types
 django_stubs_ext.monkeypatch()

--- a/privaterelay/tests/conftest.py
+++ b/privaterelay/tests/conftest.py
@@ -3,13 +3,14 @@
 from pathlib import Path
 from typing import Iterator
 
+from pytest_django.fixtures import SettingsWrapper
 import pytest
 
 from privaterelay.utils import get_version_info
 
 
 @pytest.fixture
-def version_json_path(tmp_path, settings) -> Iterator[Path]:
+def version_json_path(tmp_path: Path, settings: SettingsWrapper) -> Iterator[Path]:
     """Create testing version.json file, cleanup after test."""
     get_version_info.cache_clear()
     settings.BASE_DIR = tmp_path

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -591,7 +591,7 @@ def test_flag_is_active_for_task_override_existing_to_inactive(
 def test_get_version_info_bad_contents(version_json_path, content: str | None) -> None:
     if content is not None:
         version_json_path.write_text(content)
-    info = get_version_info(version_json_path)
+    info = get_version_info()
     assert info == {
         "source": "https://github.com/mozilla/fx-private-relay",
         "version": "unknown",

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -545,3 +545,16 @@ def test_version_view(client, version_json_path) -> None:
     version_json_path.write_text(json.dumps(version_info))
     response = client.get("/__version__")
     assert response.json() == version_info
+
+
+@pytest.mark.django_db
+def test_heartbeat_view(client) -> None:
+    response = client.get("/__heartbeat__")
+    assert response.status_code in (200, 500)
+    assert "status" in response.json()
+
+
+def test_lbheartbeat_view(client) -> None:
+    response = client.get("/__lbheartbeat__")
+    assert response.status_code == 200
+    assert response.content == b""

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -550,7 +550,7 @@ def test_version_view(client, version_json_path) -> None:
 @pytest.mark.django_db
 def test_heartbeat_view(client) -> None:
     response = client.get("/__heartbeat__")
-    assert response.status_code in (200, 500)
+    assert response.status_code == 200
     assert "status" in response.json()
 
 

--- a/privaterelay/urls.py
+++ b/privaterelay/urls.py
@@ -23,10 +23,6 @@ from allauth.socialaccount.providers.fxa import views as fxa_views
 from . import views
 
 urlpatterns = [
-    # Dockerflow endpoint
-    path("__version__", views.version),
-    path("__heartbeat__", views.heartbeat),
-    path("__lbheartbeat__", views.lbheartbeat),
     # FXA endpoints
     path("fxa-rp-events", views.fxa_rp_events),
     path("metrics-event", views.metrics_event),
@@ -50,8 +46,6 @@ if settings.DEBUG:
         path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     ]
 if settings.USE_SILK:
-    import silk
-
     urlpatterns.append(path("silk/", include("silk.urls", namespace="silk")))
 
 if settings.ADMIN_ENABLED:

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -488,9 +488,13 @@ class VersionInfo(TypedDict):
 
 
 @cache
-def get_version_info(version_json_path: Path | None = None) -> VersionInfo:
+def get_version_info(base_dir: str | Path | None = None) -> VersionInfo:
     """Return version information written by build process."""
-    version_json_path = version_json_path or (Path(settings.BASE_DIR) / "version.json")
+    if base_dir is None:
+        base_path = Path(settings.BASE_DIR)
+    else:
+        base_path = Path(base_dir)
+    version_json_path = base_path / "version.json"
     info = {}
     if version_json_path.exists():
         with version_json_path.open() as version_file:

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -7,7 +7,7 @@ import logging
 
 from django.apps import apps
 from django.conf import settings
-from django.db import IntegrityError, connections, transaction
+from django.db import IntegrityError, transaction
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -35,7 +35,6 @@ from emails.utils import incr_if_enabled
 
 from .apps import PrivateRelayConfig
 from .fxa_utils import _get_oauth2_session, NoSocialToken
-from .utils import get_version_info
 
 
 FXA_PROFILE_CHANGE_EVENT = "https://schemas.accounts.firefox.com/event/profile-change"
@@ -94,20 +93,6 @@ def profile_subdomain(request):
             )
     except CannotMakeSubdomainException as e:
         return JsonResponse({"message": e.message, "subdomain": subdomain}, status=400)
-
-
-def version(request):
-    return JsonResponse(get_version_info())
-
-
-def heartbeat(request):
-    db_conn = connections["default"]
-    assert db_conn.cursor()
-    return HttpResponse("200 OK", status=200)
-
-
-def lbheartbeat(request):
-    return HttpResponse("200 OK", status=200)
 
 
 @csrf_exempt

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-ftl==0.14
 django-referrer-policy==1.0
 djangorestframework==3.14.0
 django-waffle==4.1.0
-dockerflow==2022.8.0
+dockerflow==2024.1.0
 drf-spectacular==0.27.1
 drf-spectacular-sidecar==2024.1.1
 google-measurement-protocol==1.1.0


### PR DESCRIPTION
This expands on PR #4309 to use dockerflow 2024.1.0

* Use our `privaterelay.utils.get_version_info`, which provides caching and a default response when `version.json` is not present.
* Enable the Redis check if `REDIS_URL` is set
* MPP-1810: Remove the `/__version__`, `/__heartbeat`, and `/__lbheartbeat__` views, since [DockerflowMiddleware](https://github.com/mozilla-services/python-dockerflow/blob/997f481093dc5932462746f6f9fce7e8aa564552/src/dockerflow/django/middleware.py#L17-L21) handles these before we see them.
 
# How to test:

Load in local development, and try:

* <http://127.0.0.1:8000/__heartbeat__>
* <http://127.0.0.1:8000/__lbheartbeat__>
* <http://127.0.0.1:8000/__version__>

- ~[ ] l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- ~[ ] I've added or updated relevant docs in the docs/ directory.~
- ~[ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).