### PR TITLE
MPP-3652 - Update monitor branding

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -122,4 +122,5 @@ upsell-banner-4-masks-us-description = { -brand-name-relay-premium } gives you a
 upsell-banner-4-masks-non-us-description = { -brand-name-relay-premium } gives you unlimited email masks, spam blocking, a custom { -brand-name-relay } email domain, and the ability to reply to forwarded messages.
 upsell-banner-4-masks-us-cta = Upgrade to { -brand-name-relay-premium }
 
+-brand-name-mozilla-monitor = Mozilla Monitor
 moz-monitor = { -brand-name-mozilla-monitor }

--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -121,3 +121,5 @@ upsell-banner-4-masks-non-us-heading = Get maximum email protection
 upsell-banner-4-masks-us-description = { -brand-name-relay-premium } gives you a phone mask to protect your real number, plus unlimited email masks and the ability to block promotional emails.
 upsell-banner-4-masks-non-us-description = { -brand-name-relay-premium } gives you unlimited email masks, spam blocking, a custom { -brand-name-relay } email domain, and the ability to reply to forwarded messages.
 upsell-banner-4-masks-us-cta = Upgrade to { -brand-name-relay-premium }
+
+moz-monitor = { -brand-name-mozilla-monitor }

--- a/frontend/src/components/layout/navigation/AppPicker.tsx
+++ b/frontend/src/components/layout/navigation/AppPicker.tsx
@@ -48,7 +48,7 @@ const getProducts = (referringSiteUrl: string) => ({
     url: `https://monitor.firefox.com/?utm_source=${encodeURIComponent(
       referringSiteUrl,
     )}&utm_medium=referral&utm_campaign=bento&utm_content=desktop`,
-    gaLabel: "fx-monitor",
+    gaLabel: "moz-monitor",
   },
   pocket: {
     id: "pocket",
@@ -146,7 +146,7 @@ export const AppPicker = (props: Props) => {
           {l10n.getString("fx-vpn")}
         </a>
       </Item>
-      <Item key={products.monitor.id} textValue={l10n.getString("fx-monitor")}>
+      <Item key={products.monitor.id} textValue={l10n.getString("moz-monitor")}>
         <a
           ref={linkRefs.monitor}
           href={products.monitor.url}
@@ -155,7 +155,7 @@ export const AppPicker = (props: Props) => {
           rel="noopener noreferrer"
         >
           <Image src={MonitorLogo} alt="" width={16} height={16} />
-          {l10n.getString("fx-monitor")}
+          {l10n.getString("moz-monitor")}
         </a>
       </Item>
       <Item key={products.pocket.id} textValue={l10n.getString("fx-pocket")}>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->
L10N PR: https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/168
This PR fixes addresses MPP-3652 
<!-- When adding a new feature: -->

# New feature description

Updates Firefox Monitor to Mozilla Monitor strings found in Bento Box component. 

# Screenshot (if applicable)

Not applicable.

# How to test

Open the bento component and verify that it reads Mozilla Monitor rather than Firefox Monitor

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] Customer Experience team has seen or waived a demo of functionality.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
