### PR TITLE
MPP-3644: Add Mozilla accounts opt-out property to Profile and API

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -183,6 +183,7 @@ class ProfileSerializer(StrictReadOnlyFieldsMixin, serializers.ModelSerializer):
             "remove_level_one_email_trackers",
             "total_masks",
             "at_mask_limit",
+            "metrics_enabled",
         ]
         read_only_fields = [
             "id",
@@ -202,6 +203,7 @@ class ProfileSerializer(StrictReadOnlyFieldsMixin, serializers.ModelSerializer):
             "level_one_trackers_blocked",
             "total_masks",
             "at_mask_limit",
+            "metrics_enabled",
         ]
 
 

--- a/emails/models.py
+++ b/emails/models.py
@@ -522,6 +522,15 @@ class Profile(models.Model):
 
     @property
     def metrics_enabled(self) -> bool:
+        """
+        Does the user allow us to record technical and interaction data?
+
+        This is based on the Mozilla accounts opt-out option, added around 2022. A user
+        can go to their Mozilla account profile settings, Data Collection and Use, and
+        deselect "Help improve Mozilla Account". This setting defaults to On, and is
+        sent as "metricsEnabled". Some older Relay accounts do not have
+        "metricsEnabled", and we default to On.
+        """
         if self.fxa:
             return bool(self.fxa.extra_data.get("metricsEnabled", True))
         return True

--- a/emails/models.py
+++ b/emails/models.py
@@ -520,6 +520,12 @@ class Profile(models.Model):
         # user was flagged and the premium feature pause period is not yet over
         return True
 
+    @property
+    def metrics_enabled(self) -> bool:
+        if self.fxa:
+            return bool(self.fxa.extra_data.get("metricsEnabled", True))
+        return True
+
 
 @receiver(models.signals.post_save, sender=Profile)
 def copy_auth_token(sender, instance=None, created=False, **kwargs):

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -1189,6 +1189,33 @@ class ProfileUpdateAbuseMetricTest(ProfileTestCase):
         assert self.profile.last_account_flagged == self.expected_now
 
 
+class ProfileMetricsEnabledTest(ProfileTestCase):
+
+    def test_no_fxa_means_metrics_enabled(self) -> None:
+        assert not self.profile.fxa
+        assert self.profile.metrics_enabled
+
+    def test_fxa_legacy_means_metrics_enabled(self) -> None:
+        self.get_or_create_social_account()
+        assert self.profile.fxa
+        assert "metricsEnabled" not in self.profile.fxa.extra_data
+        assert self.profile.metrics_enabled
+
+    def test_fxa_opt_in_means_metrics_enabled(self) -> None:
+        social_account = self.get_or_create_social_account()
+        social_account.extra_data["metricsEnabled"] = True
+        social_account.save()
+        assert self.profile.fxa
+        assert self.profile.metrics_enabled
+
+    def test_fxa_opt_out_means_metrics_disabled(self) -> None:
+        social_account = self.get_or_create_social_account()
+        social_account.extra_data["metricsEnabled"] = False
+        social_account.save()
+        assert self.profile.fxa
+        assert not self.profile.metrics_enabled
+
+
 class DomainAddressTest(TestCase):
     def setUp(self):
         self.subdomain = "test"

--- a/frontend/__mocks__/hooks/googleAnalytics.ts
+++ b/frontend/__mocks__/hooks/googleAnalytics.ts
@@ -1,0 +1,5 @@
+export const mockUseGoogleAnalyticsModule = {
+  useGoogleAnalytics: jest.fn(),
+  initGoogleAnalytics: jest.fn(),
+};
+mockUseGoogleAnalyticsModule.useGoogleAnalytics.mockReturnValue(true);

--- a/frontend/__mocks__/hooks/metrics.ts
+++ b/frontend/__mocks__/hooks/metrics.ts
@@ -1,4 +1,0 @@
-export const mockUseMetricsModule = {
-  useMetrics: jest.fn(),
-};
-mockUseMetricsModule.useMetrics.mockReturnValue(true);

--- a/frontend/__mocks__/hooks/metrics.ts
+++ b/frontend/__mocks__/hooks/metrics.ts
@@ -1,0 +1,4 @@
+export const mockUseMetricsModule = {
+  useMetrics: jest.fn(),
+};
+mockUseMetricsModule.useMetrics.mockReturnValue(true);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "react-ga": "^3.3.1",
     "react-intersection-observer": "^9.6.0",
     "react-qr-code": "^2.0.12",
+    "react-singleton-hook": "^4.0.1",
     "react-stately": "^3.29.1",
     "react-toastify": "^10.0.4",
     "swr": "^2.2.4"

--- a/frontend/src/apiMocks/mockData.ts
+++ b/frontend/src/apiMocks/mockData.ts
@@ -116,6 +116,7 @@ export const mockedProfiles: Record<(typeof mockIds)[number], ProfileData> = {
     emails_forwarded: 30,
     emails_replied: 0,
     level_one_trackers_blocked: 0,
+    metrics_enabled: true,
   },
   empty: {
     api_token: "empty",
@@ -138,6 +139,7 @@ export const mockedProfiles: Record<(typeof mockIds)[number], ProfileData> = {
     emails_forwarded: 0,
     emails_replied: 0,
     level_one_trackers_blocked: 0,
+    metrics_enabled: true,
   },
   onboarding: {
     api_token: "onboarding",
@@ -160,6 +162,7 @@ export const mockedProfiles: Record<(typeof mockIds)[number], ProfileData> = {
     emails_replied: 0,
     level_one_trackers_blocked: 0,
     store_phone_log: true,
+    metrics_enabled: true,
   },
   some: {
     api_token: "some",
@@ -182,6 +185,7 @@ export const mockedProfiles: Record<(typeof mockIds)[number], ProfileData> = {
     emails_replied: 40,
     level_one_trackers_blocked: 72,
     store_phone_log: true,
+    metrics_enabled: true,
   },
   full: {
     api_token: "full",
@@ -204,6 +208,7 @@ export const mockedProfiles: Record<(typeof mockIds)[number], ProfileData> = {
     emails_replied: 9631,
     level_one_trackers_blocked: 1409,
     store_phone_log: true,
+    metrics_enabled: true,
   },
 };
 export const mockedRelayaddresses: Record<

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -6,6 +6,7 @@ import { useLocalDismissal } from "../hooks/localDismissal";
 import { CloseIcon, WarningFilledIcon, InfoBulbIcon } from "./Icons";
 import { useGaViewPing } from "../hooks/gaViewPing";
 import { useL10n } from "../hooks/l10n";
+import { useMetrics } from "../hooks/metrics";
 
 export type BannerProps = {
   children: ReactNode;
@@ -135,6 +136,7 @@ type BannerCtaProps = {
 } & ({ target: string } | { onClick: () => void }); // At least one of `target` and `onClick` is required:
 export const BannerCta = (props: BannerCtaProps) => {
   const ctaRef = useGaViewPing(props.gaViewPing ?? null);
+  const metricsEnabled = useMetrics();
 
   // If no URL to link to is provided (via `target`), render a <button> rather than an <a>:
   if (typeof props.target !== "string") {
@@ -151,8 +153,8 @@ export const BannerCta = (props: BannerCtaProps) => {
     );
   }
 
-  // When given a relative URL to link to in `target`, render an <a> (via <Link>):
-  if (props.target.startsWith("/")) {
+  // When given a relative URL to link to in `target`, or metrics are disabled, render an <a> (via <Link>):
+  if (props.target.startsWith("/") || !metricsEnabled) {
     return (
       <div
         className={
@@ -166,7 +168,7 @@ export const BannerCta = (props: BannerCtaProps) => {
     );
   }
 
-  // When given a URL to link to in `target`, render an <a> (via <OutboundLink>):
+  // When given a URL to link to in `target`, and metrics are enabled, render an <a> (via <OutboundLink>):
   return (
     <div
       className={

--- a/frontend/src/components/dashboard/CornerNotification.tsx
+++ b/frontend/src/components/dashboard/CornerNotification.tsx
@@ -1,5 +1,4 @@
 import { useInView } from "react-intersection-observer";
-import { event as gaEvent } from "react-ga";
 import styles from "./CornerNotification.module.scss";
 import { CloseIcon } from "../Icons";
 import { ProfileData } from "../../hooks/api/profile";
@@ -10,6 +9,7 @@ import UpsellBannerUs from "../../pages/accounts/images/upsell-banner-us.svg";
 import { useGaViewPing } from "../../hooks/gaViewPing";
 import { RuntimeData } from "../../hooks/api/runtimeData";
 import { isFlagActive } from "../../functions/waffle";
+import { useGaEvent } from "../../hooks/gaEvent";
 import { useL10n } from "../../hooks/l10n";
 import { LinkButton } from "../Button";
 import { isPhonesAvailableInCountry } from "../../functions/getPlan";
@@ -35,6 +35,7 @@ export const CornerNotification = (props: Props) => {
     category: "Purchase Button",
     label: "4-mask-limit-upsell",
   });
+  const gaEvent = useGaEvent();
 
   const title = l10n.getString(
     `upsell-banner-4-masks-${isPhonesAvailable ? "us" : "non-us"}-heading`,

--- a/frontend/src/components/dashboard/EmailForwardingModal.tsx
+++ b/frontend/src/components/dashboard/EmailForwardingModal.tsx
@@ -23,7 +23,7 @@ import { Button } from "../Button";
 import { StaticImport } from "next/dist/shared/lib/get-img-props";
 import { CloseIcon } from "../Icons";
 import { aliasEmailTest } from "../../hooks/api/aliases";
-import { event as gaEvent } from "react-ga";
+import { useGaEvent } from "../../hooks/gaEvent";
 
 export type Props = {
   isOpen: boolean;
@@ -55,6 +55,7 @@ const ConfirmModal = (props: Props) => {
   const [inputValue, setInputValue] = useState("");
   const formRef = useRef<HTMLFormElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const gaEvent = useGaEvent();
 
   const onSubmit: FormEventHandler = async (event) => {
     event.preventDefault();

--- a/frontend/src/components/dashboard/FreeOnboarding.tsx
+++ b/frontend/src/components/dashboard/FreeOnboarding.tsx
@@ -15,8 +15,8 @@ import SmallArrow from "./images/free-onboarding-arrow.svg";
 import LargeArrow from "./images/free-onboarding-arrow-large.svg";
 import Image from "next/image";
 import { Button, LinkButton } from "../Button";
-import { event as gaEvent } from "react-ga";
 import { useGaViewPing } from "../../hooks/gaViewPing";
+import { useGaEvent } from "../../hooks/gaEvent";
 import { AliasData } from "../../hooks/api/aliases";
 import { UserData } from "../../hooks/api/user";
 import { RuntimeData } from "../../hooks/api/runtimeData";
@@ -45,6 +45,7 @@ export type Props = {
 export const FreeOnboarding = (props: Props) => {
   const l10n = useL10n();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const gaEvent = useGaEvent();
 
   let step = null;
   let button = null;

--- a/frontend/src/components/dashboard/PremiumOnboarding.tsx
+++ b/frontend/src/components/dashboard/PremiumOnboarding.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { event as gaEvent } from "react-ga";
 import { useOverlayTriggerState } from "react-stately";
 import Image from "next/image";
 import styles from "./PremiumOnboarding.module.scss";
@@ -15,6 +14,7 @@ import { getRuntimeConfig } from "../../config";
 import { useMinViewportWidth } from "../../hooks/mediaQuery";
 import { supportsChromeExtension } from "../../functions/userAgent";
 import { CheckBadgeIcon, CheckIcon } from "../Icons";
+import { useGaEvent } from "../../hooks/gaEvent";
 import { useL10n } from "../../hooks/l10n";
 import { VisuallyHidden } from "../VisuallyHidden";
 import { Localized } from "../Localized";
@@ -57,6 +57,7 @@ export const PremiumOnboarding = (props: Props) => {
     label: "onboarding-step-3-continue",
     value: 3,
   });
+  const gaEvent = useGaEvent();
 
   let step = null;
   let button = null;

--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from "react";
-import { event as gaEvent } from "react-ga";
 
 import Image from "next/image";
 import styles from "./ProfileBanners.module.scss";
@@ -24,6 +23,7 @@ import { renderDate } from "../../functions/renderDate";
 import { SubdomainPicker } from "./SubdomainPicker";
 import { useMinViewportWidth } from "../../hooks/mediaQuery";
 import { AliasData } from "../../hooks/api/aliases";
+import { useGaEvent } from "../../hooks/gaEvent";
 import { useL10n } from "../../hooks/l10n";
 
 export type Props = {
@@ -140,6 +140,7 @@ const BounceBanner = (props: BounceBannerProps) => {
 
 const NoFirefoxBanner = () => {
   const l10n = useL10n();
+  const gaEvent = useGaEvent();
 
   return (
     <Banner
@@ -177,6 +178,7 @@ type NoAddonBannerProps = {
 
 const NoAddonBanner = (props: NoAddonBannerProps) => {
   const l10n = useL10n();
+  const gaEvent = useGaEvent();
 
   return (
     <Banner
@@ -219,6 +221,7 @@ type NoChromeExtensionBannerProps = {
 // make dismissble
 const NoChromeExtensionBanner = (props: NoChromeExtensionBannerProps) => {
   const l10n = useL10n();
+  const gaEvent = useGaEvent();
 
   return (
     <Banner
@@ -263,6 +266,7 @@ type BundleBannerProps = {
 
 const BundlePromoBanner = (props: BundleBannerProps) => {
   const l10n = useL10n();
+  const gaEvent = useGaEvent();
 
   return (
     <Banner

--- a/frontend/src/components/dashboard/aliases/AliasGenerationButton.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasGenerationButton.tsx
@@ -11,7 +11,6 @@ import {
   AriaOverlayProps,
 } from "react-aria";
 import { AriaMenuItemProps } from "@react-aria/menu";
-import { event as gaEvent } from "react-ga";
 import {
   Item,
   MenuTriggerState,
@@ -39,6 +38,7 @@ import { RuntimeData } from "../../../hooks/api/runtimeData";
 import { isPeriodicalPremiumAvailableInCountry } from "../../../functions/getPlan";
 import { useGaViewPing } from "../../../hooks/gaViewPing";
 import { CustomAddressGenerationModal } from "./CustomAddressGenerationModal";
+import { useGaEvent } from "../../../hooks/gaEvent";
 import { useL10n } from "../../../hooks/l10n";
 import { isFlagActive } from "../../../functions/waffle";
 import { AddressPickerModal } from "./AddressPickerModal";
@@ -72,6 +72,7 @@ export const AliasGenerationButton = (props: Props) => {
     category: "Purchase Button",
     label: "profile-create-alias-upgrade-promo",
   });
+  const gaEvent = useGaEvent();
 
   const maxAliases = getRuntimeConfig().maxFreeAliases;
   if (!props.profile.has_premium && props.aliases.length >= maxAliases) {

--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.tsx
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.tsx
@@ -21,7 +21,6 @@ import {
   useOverlayTriggerState,
   useSliderState,
 } from "react-stately";
-import { event as gaEvent } from "react-ga";
 import styles from "./BlockLevelSlider.module.scss";
 import UmbrellaClosed from "./images/umbrella-closed.svg";
 import UmbrellaClosedMobile from "./images/umbrella-closed-mobile.svg";
@@ -31,6 +30,7 @@ import UmbrellaOpen from "./images/umbrella-open.svg";
 import UmbrellaOpenMobile from "./images/umbrella-open-mobile.svg";
 import { AliasData } from "../../../hooks/api/aliases";
 import { CloseIcon, LockIcon } from "../../Icons";
+import { useGaEvent } from "../../../hooks/gaEvent";
 import { useL10n } from "../../../hooks/l10n";
 import { VisuallyHidden } from "../../VisuallyHidden";
 
@@ -50,6 +50,7 @@ const onlyThumbIndex = 0;
 export const BlockLevelSlider = (props: Props) => {
   const l10n = useL10n();
   const trackRef = useRef<HTMLDivElement>(null);
+  const gaEvent = useGaEvent();
   const numberFormatter = new SliderValueFormatter(l10n);
   const sliderSettings: Parameters<typeof useSliderState>[0] = {
     minValue: 0,

--- a/frontend/src/components/dashboard/tips/Tips.tsx
+++ b/frontend/src/components/dashboard/tips/Tips.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import { useTabList, useTabPanel, useTab } from "react-aria";
 import { useTabListState, TabListState, Item } from "react-stately";
 import { useInView } from "react-intersection-observer";
-import { event as gaEvent } from "react-ga";
 import styles from "./Tips.module.scss";
 import MultiRepliesImage from "./images/multi-replies.svg";
 import { ArrowDownIcon, InfoIcon } from "../../Icons";
@@ -19,6 +18,7 @@ import { useRelayNumber } from "../../../hooks/api/relayNumber";
 import { RuntimeData } from "../../../hooks/api/runtimeData";
 import { isFlagActive } from "../../../functions/waffle";
 import { GenericTip } from "./GenericTip";
+import { useGaEvent } from "../../../hooks/gaEvent";
 import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
@@ -42,6 +42,7 @@ export const Tips = (props: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [wrapperRef, wrapperIsInView] = useInView({ threshold: 1 });
   const relayNumberData = useRelayNumber({ disable: !props.profile.has_phone });
+  const gaEvent = useGaEvent();
 
   const tips: TipEntry[] = [];
 

--- a/frontend/src/components/landing/BundleBanner.tsx
+++ b/frontend/src/components/landing/BundleBanner.tsx
@@ -16,6 +16,7 @@ import bundleFloatTwo from "./images/bundle-float-2.svg";
 import bundleFloatThree from "./images/bundle-float-3.svg";
 import { trackPlanPurchaseStart } from "../../functions/trackPurchase";
 import { useGaViewPing } from "../../hooks/gaViewPing";
+import { useGaEvent } from "../../hooks/gaEvent";
 import { useL10n } from "../../hooks/l10n";
 import { Localized } from "../Localized";
 
@@ -55,6 +56,7 @@ const FloatingFeatures = (props: FloatingFeaturesProps) => {
 
 export const BundleBanner = (props: Props) => {
   const l10n = useL10n();
+  const gaEvent = useGaEvent();
 
   const mainImage = (
     <img
@@ -135,6 +137,7 @@ export const BundleBanner = (props: Props) => {
                 href={getBundleSubscribeLink(props.runtimeData)}
                 onClick={() =>
                   trackPlanPurchaseStart(
+                    gaEvent,
                     { plan: "bundle" },
                     { label: "bundle-banner-upgrade-promo" },
                   )

--- a/frontend/src/components/landing/PlanMatrix.tsx
+++ b/frontend/src/components/landing/PlanMatrix.tsx
@@ -1,7 +1,6 @@
 import { useTab, useTabList, useTabPanel } from "react-aria";
 import { ReactNode, useRef } from "react";
 import Link from "next/link";
-import { event as gaEvent } from "react-ga";
 import {
   Item,
   TabListProps,
@@ -23,6 +22,7 @@ import {
 import { RuntimeData } from "../../hooks/api/runtimeData";
 import { CheckIcon, MozillaVpnWordmark } from "../Icons";
 import { getRuntimeConfig } from "../../config";
+import { useGaEvent } from "../../hooks/gaEvent";
 import { useGaViewPing } from "../../hooks/gaViewPing";
 import { Plan, trackPlanPurchaseStart } from "../../functions/trackPurchase";
 import { setCookie } from "../../functions/cookies";
@@ -93,6 +93,7 @@ export const PlanMatrix = (props: Props) => {
     category: "Purchase Bundle button",
     label: "plan-matrix-bundle-cta-mobile",
   });
+  const gaEvent = useGaEvent();
 
   const countSignIn = (label: string) => {
     gaEvent({
@@ -342,6 +343,7 @@ export const PlanMatrix = (props: Props) => {
                     href={getBundleSubscribeLink(props.runtimeData)}
                     onClick={() =>
                       trackPlanPurchaseStart(
+                        gaEvent,
                         { plan: "bundle" },
                         { label: "plan-matrix-bundle-cta-desktop" },
                       )
@@ -567,6 +569,7 @@ export const PlanMatrix = (props: Props) => {
                   href={getBundleSubscribeLink(props.runtimeData)}
                   onClick={() =>
                     trackPlanPurchaseStart(
+                      gaEvent,
                       { plan: "bundle" },
                       { label: "plan-matrix-bundle-cta-mobile" },
                     )
@@ -748,6 +751,7 @@ type PricingToggleProps = {
 };
 const PricingToggle = (props: PricingToggleProps) => {
   const l10n = useL10n();
+  const gaEvent = useGaEvent();
   const yearlyButtonRef = useGaViewPing(props.yearlyBilled.gaViewPing);
   const monthlyButtonRef = useGaViewPing(props.monthlyBilled.gaViewPing);
 
@@ -766,7 +770,7 @@ const PricingToggle = (props: PricingToggleProps) => {
           ref={yearlyButtonRef}
           href={props.yearlyBilled.subscribeLink}
           onClick={() =>
-            trackPlanPurchaseStart(props.yearlyBilled.plan, {
+            trackPlanPurchaseStart(gaEvent, props.yearlyBilled.plan, {
               label: props.yearlyBilled.gaViewPing?.label,
             })
           }
@@ -793,7 +797,7 @@ const PricingToggle = (props: PricingToggleProps) => {
           ref={monthlyButtonRef}
           href={props.monthlyBilled.subscribeLink}
           onClick={() =>
-            trackPlanPurchaseStart(props.monthlyBilled.plan, {
+            trackPlanPurchaseStart(gaEvent, props.monthlyBilled.plan, {
               label: props.monthlyBilled.gaViewPing?.label,
             })
           }

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -193,7 +193,7 @@ export const Layout = (props: Props) => {
                   theme={isDark ? "free" : "premium"}
                   handleToggle={handleToggle}
                   hasPremium={hasPremium}
-                  isLoggedIn={isLoggedIn}
+                  isLoggedIn={isLoggedIn === "logged-in"}
                   profile={profiles.data?.[0]}
                 />
               </div>
@@ -203,7 +203,7 @@ export const Layout = (props: Props) => {
             mobileMenuExpanded={mobileMenuExpanded}
             hasPremium={hasPremium}
             isPhonesAvailable={isPhonesAvailableInCountry(props.runtimeData)}
-            isLoggedIn={isLoggedIn}
+            isLoggedIn={isLoggedIn === "logged-in"}
             userEmail={usersData?.email}
             userAvatar={profiles.data?.[0].avatar}
           />

--- a/frontend/src/components/layout/navigation/AppPicker.tsx
+++ b/frontend/src/components/layout/navigation/AppPicker.tsx
@@ -28,7 +28,6 @@ import {
   RefObject,
 } from "react";
 import { AriaMenuItemProps } from "@react-aria/menu";
-import { event as gaEvent } from "react-ga";
 import Image from "next/image";
 import styles from "./AppPicker.module.scss";
 import FirefoxLogo from "../images/fx.png";
@@ -40,6 +39,7 @@ import FxMobileLogo from "../images/fx-mobile.png";
 import { Props as LayoutProps } from "../Layout";
 import { getRuntimeConfig } from "../../../config";
 import { BentoIcon } from "../../Icons";
+import { useGaEvent } from "../../../hooks/gaEvent";
 import { useL10n } from "../../../hooks/l10n";
 
 const getProducts = (referringSiteUrl: string) => ({
@@ -88,6 +88,7 @@ export type Props = {
  */
 export const AppPicker = (props: Props) => {
   const l10n = useL10n();
+  const gaEvent = useGaEvent();
 
   const products = getProducts(
     typeof document !== "undefined"
@@ -234,6 +235,7 @@ const AppPickerTrigger = ({
   const l10n = useL10n();
   const appPickerTriggerState = useMenuTriggerState(otherProps);
   const isFirstRenderDone = useRef(false);
+  const gaEvent = useGaEvent();
 
   const triggerButtonRef = useRef<HTMLButtonElement>(null);
   const { menuTriggerProps, menuProps } = useMenuTrigger(
@@ -270,7 +272,7 @@ const AppPickerTrigger = ({
       action: appPickerTriggerState.isOpen ? "bento-opened" : "bento-closed",
       label: getRuntimeConfig().frontendOrigin,
     });
-  }, [appPickerTriggerState.isOpen]);
+  }, [appPickerTriggerState.isOpen, gaEvent]);
 
   return (
     <div className={`${styles.wrapper} ${style}`}>

--- a/frontend/src/components/layout/navigation/SignInButton.tsx
+++ b/frontend/src/components/layout/navigation/SignInButton.tsx
@@ -1,7 +1,7 @@
-import { event as gaEvent } from "react-ga";
 import styles from "./SignInButton.module.scss";
 import { setCookie } from "../../../functions/cookies";
 import { getLoginUrl, useFxaFlowTracker } from "../../../hooks/fxaFlowTracker";
+import { useGaEvent } from "../../../hooks/gaEvent";
 import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
@@ -19,6 +19,7 @@ export const SignInButton = (props: Props): JSX.Element => {
     "relay-sign-in-header",
     signInFxaFlowTracker.flowData,
   );
+  const gaEvent = useGaEvent();
 
   return (
     <a

--- a/frontend/src/components/layout/navigation/SignUpButton.tsx
+++ b/frontend/src/components/layout/navigation/SignUpButton.tsx
@@ -1,6 +1,6 @@
-import { event as gaEvent } from "react-ga";
 import styles from "./SignUpButton.module.scss";
 import { setCookie } from "../../../functions/cookies";
+import { useGaEvent } from "../../../hooks/gaEvent";
 import { getLoginUrl, useFxaFlowTracker } from "../../../hooks/fxaFlowTracker";
 import { useL10n } from "../../../hooks/l10n";
 
@@ -18,6 +18,7 @@ export const SignUpButton = (props: Props): JSX.Element => {
     "relay-sign-up-header",
     signUpFxaFlowTracker.flowData,
   );
+  const gaEvent = useGaEvent();
 
   return (
     <a

--- a/frontend/src/components/layout/navigation/UpgradeButton.tsx
+++ b/frontend/src/components/layout/navigation/UpgradeButton.tsx
@@ -1,8 +1,7 @@
-import { event as gaEvent } from "react-ga";
-
 import styles from "./UpgradeButton.module.scss";
 import { useGaViewPing } from "../../../hooks/gaViewPing";
 import Link from "next/link";
+import { useGaEvent } from "../../../hooks/gaEvent";
 import { useL10n } from "../../../hooks/l10n";
 
 export const UpgradeButton = (): JSX.Element => {
@@ -11,6 +10,7 @@ export const UpgradeButton = (): JSX.Element => {
     category: "Purchase Button",
     label: "navbar-upgrade-button",
   });
+  const gaEvent = useGaEvent();
 
   return (
     <Link

--- a/frontend/src/components/layout/navigation/UserMenu.tsx
+++ b/frontend/src/components/layout/navigation/UserMenu.tsx
@@ -21,7 +21,6 @@ import {
 import { HTMLAttributes, Key, ReactNode, useRef, useState } from "react";
 import { AriaMenuItemProps } from "@react-aria/menu";
 import Link from "next/link";
-import { event as gaEvent } from "react-ga";
 import styles from "./UserMenu.module.scss";
 import {
   Cogwheel,
@@ -36,6 +35,7 @@ import { getRuntimeConfig } from "../../../config";
 import { getCsrfToken } from "../../../functions/cookies";
 import { useRuntimeData } from "../../../hooks/api/runtimeData";
 import { setCookie } from "../../../functions/cookies";
+import { useGaEvent } from "../../../hooks/gaEvent";
 import { useL10n } from "../../../hooks/l10n";
 
 export type Props = {
@@ -49,6 +49,7 @@ export const UserMenu = (props: Props) => {
   const profileData = useProfiles();
   const usersData = useUsers();
   const l10n = useL10n();
+  const gaEvent = useGaEvent();
 
   const itemKeys = {
     account: "account",

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.test.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mockGetLocaleModule } from "../../../../../__mocks__/functions/getLocale";
 import { mockUseL10nModule } from "../../../../../__mocks__/hooks/l10n";
-import { mockUseMetricsModule } from "../../../../../__mocks__/hooks/metrics";
+import { mockUseGoogleAnalyticsModule } from "../../../../../__mocks__/hooks/googleAnalytics";
 import { mockReactGa } from "../../../../../__mocks__/modules/react-ga";
 
 import { WhatsNewDashboard } from "./WhatsNewDashboard";
@@ -11,7 +11,10 @@ import { WhatsNewEntry } from "./WhatsNewMenu";
 jest.mock("react-ga", () => mockReactGa);
 jest.mock("../../../../functions/getLocale.ts", () => mockGetLocaleModule);
 jest.mock("../../../../hooks/gaViewPing.ts");
-jest.mock("../../../../hooks/metrics.ts", () => mockUseMetricsModule);
+jest.mock(
+  "../../../../hooks/googleAnalytics.ts",
+  () => mockUseGoogleAnalyticsModule,
+);
 jest.mock("../../../../hooks/l10n.ts", () => mockUseL10nModule);
 
 function getMockEntry(
@@ -41,192 +44,189 @@ function getMockEntry(
   };
 }
 
-describe.each(["enabled", "disabled"])(
-  "The 'What's new' dashboard, metrics %s",
-  (metricsState) => {
+describe("The 'What's new' dashboard", () => {
+  it("displays new entries by default", () => {
+    const allEntries: WhatsNewEntry[] = [
+      getMockEntry(1),
+      getMockEntry(2),
+      getMockEntry(3),
+    ];
+    const newEntries = [allEntries[0], allEntries[1]];
+
+    render(
+      <WhatsNewDashboard
+        new={newEntries}
+        archive={allEntries}
+        onClose={jest.fn()}
+      />,
+    );
+
+    const menuItems = screen.getAllByRole("menuitem");
+
+    expect(menuItems).toHaveLength(2);
+  });
+
+  it("allows viewing all entries", async () => {
+    const allEntries: WhatsNewEntry[] = [
+      getMockEntry(1),
+      getMockEntry(2),
+      getMockEntry(3),
+    ];
+    const newEntries = [allEntries[0], allEntries[1]];
+
+    render(
+      <WhatsNewDashboard
+        new={newEntries}
+        archive={allEntries}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(screen.getAllByRole("menuitem")).toHaveLength(2);
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(2);
+    expect(tabs[1]).toHaveTextContent(
+      "l10n string: [whatsnew-tab-archive-label], with vars: {}",
+    );
+
+    await userEvent.click(tabs[1]);
+
+    expect(screen.getAllByRole("menuitem")).toHaveLength(3);
+  });
+
+  it("dismisses an entry when it is viewed", async () => {
+    const allEntries: WhatsNewEntry[] = [
+      getMockEntry(1),
+      getMockEntry(2),
+      getMockEntry(3),
+    ];
+    const newEntries = [allEntries[0], allEntries[1]];
+
+    render(
+      <WhatsNewDashboard
+        new={newEntries}
+        archive={allEntries}
+        onClose={jest.fn()}
+      />,
+    );
+
+    const menuItems = screen.getAllByRole("menuitem");
+    await userEvent.click(menuItems[1]);
+
+    expect(allEntries[1].dismissal.dismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses all new entries when clicking 'Clear all'", async () => {
+    const allEntries: WhatsNewEntry[] = [
+      getMockEntry(1),
+      getMockEntry(2),
+      getMockEntry(3),
+    ];
+    const newEntries = [allEntries[0], allEntries[1]];
+
+    render(
+      <WhatsNewDashboard
+        new={newEntries}
+        archive={allEntries}
+        onClose={jest.fn()}
+      />,
+    );
+
+    const clearAllButton = screen.getByRole("button", {
+      name: "l10n string: [whatsnew-footer-clear-all-label], with vars: {}",
+    });
+    await userEvent.click(clearAllButton);
+
+    expect(allEntries[0].dismissal.dismiss).toHaveBeenCalledTimes(1);
+    expect(allEntries[1].dismissal.dismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an entry's content when clicking it", async () => {
+    const allEntries: WhatsNewEntry[] = [
+      getMockEntry(1),
+      getMockEntry(2),
+      getMockEntry(3),
+    ];
+    const newEntries = [allEntries[0], allEntries[1]];
+
+    render(
+      <WhatsNewDashboard
+        new={newEntries}
+        archive={allEntries}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(allEntries[1].content)).not.toBeInTheDocument();
+
+    const menuItems = screen.getAllByRole("menuitem");
+    await userEvent.click(menuItems[1]);
+
+    expect(screen.getByText(allEntries[1].content)).toBeInTheDocument();
+  });
+
+  it("can go back to overview of all new features after clicking one of them", async () => {
+    const allEntries: WhatsNewEntry[] = [
+      getMockEntry(1),
+      getMockEntry(2),
+      getMockEntry(3),
+    ];
+    const newEntries = [allEntries[0], allEntries[1]];
+
+    render(
+      <WhatsNewDashboard
+        new={newEntries}
+        archive={allEntries}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(allEntries[1]?.content)).not.toBeInTheDocument();
+
+    const menuItems = screen.getAllByRole("menuitem");
+    await userEvent.click(menuItems[1]);
+
+    expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
+
+    const goBackButton = screen.getByRole("button", {
+      name: "l10n string: [whatsnew-footer-back-label], with vars: {}",
+    });
+    await userEvent.click(goBackButton);
+
+    expect(screen.getAllByRole("menuitem")).toHaveLength(2);
+  });
+
+  it("shows an empty state view when there are no entries to show", () => {
+    const allEntries: WhatsNewEntry[] = [
+      getMockEntry(1),
+      getMockEntry(2),
+      getMockEntry(3),
+    ];
+    const newEntries: WhatsNewEntry[] = [];
+
+    render(
+      <WhatsNewDashboard
+        new={newEntries}
+        archive={allEntries}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("l10n string: [whatsnew-empty-message], with vars: {}"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe.each([true, false])(
+  "The 'What's new' dashboard metrics, with googleAnalytics=%s",
+  (googleAnalyticsAvailable) => {
     beforeEach(() => {
-      mockUseMetricsModule.useMetrics.mockReturnValue(
-        metricsState === "enabled",
+      mockUseGoogleAnalyticsModule.useGoogleAnalytics.mockReturnValue(
+        googleAnalyticsAvailable,
       );
     });
-
-    it("displays new entries by default", () => {
-      const allEntries: WhatsNewEntry[] = [
-        getMockEntry(1),
-        getMockEntry(2),
-        getMockEntry(3),
-      ];
-      const newEntries = [allEntries[0], allEntries[1]];
-
-      render(
-        <WhatsNewDashboard
-          new={newEntries}
-          archive={allEntries}
-          onClose={jest.fn()}
-        />,
-      );
-
-      const menuItems = screen.getAllByRole("menuitem");
-
-      expect(menuItems).toHaveLength(2);
-    });
-
-    it("allows viewing all entries", async () => {
-      const allEntries: WhatsNewEntry[] = [
-        getMockEntry(1),
-        getMockEntry(2),
-        getMockEntry(3),
-      ];
-      const newEntries = [allEntries[0], allEntries[1]];
-
-      render(
-        <WhatsNewDashboard
-          new={newEntries}
-          archive={allEntries}
-          onClose={jest.fn()}
-        />,
-      );
-
-      expect(screen.getAllByRole("menuitem")).toHaveLength(2);
-
-      const tabs = screen.getAllByRole("tab");
-      expect(tabs).toHaveLength(2);
-      expect(tabs[1]).toHaveTextContent(
-        "l10n string: [whatsnew-tab-archive-label], with vars: {}",
-      );
-
-      await userEvent.click(tabs[1]);
-
-      expect(screen.getAllByRole("menuitem")).toHaveLength(3);
-    });
-
-    it("dismisses an entry when it is viewed", async () => {
-      const allEntries: WhatsNewEntry[] = [
-        getMockEntry(1),
-        getMockEntry(2),
-        getMockEntry(3),
-      ];
-      const newEntries = [allEntries[0], allEntries[1]];
-
-      render(
-        <WhatsNewDashboard
-          new={newEntries}
-          archive={allEntries}
-          onClose={jest.fn()}
-        />,
-      );
-
-      const menuItems = screen.getAllByRole("menuitem");
-      await userEvent.click(menuItems[1]);
-
-      expect(allEntries[1].dismissal.dismiss).toHaveBeenCalledTimes(1);
-    });
-
-    it("dismisses all new entries when clicking 'Clear all'", async () => {
-      const allEntries: WhatsNewEntry[] = [
-        getMockEntry(1),
-        getMockEntry(2),
-        getMockEntry(3),
-      ];
-      const newEntries = [allEntries[0], allEntries[1]];
-
-      render(
-        <WhatsNewDashboard
-          new={newEntries}
-          archive={allEntries}
-          onClose={jest.fn()}
-        />,
-      );
-
-      const clearAllButton = screen.getByRole("button", {
-        name: "l10n string: [whatsnew-footer-clear-all-label], with vars: {}",
-      });
-      await userEvent.click(clearAllButton);
-
-      expect(allEntries[0].dismissal.dismiss).toHaveBeenCalledTimes(1);
-      expect(allEntries[1].dismissal.dismiss).toHaveBeenCalledTimes(1);
-    });
-
-    it("shows an entry's content when clicking it", async () => {
-      const allEntries: WhatsNewEntry[] = [
-        getMockEntry(1),
-        getMockEntry(2),
-        getMockEntry(3),
-      ];
-      const newEntries = [allEntries[0], allEntries[1]];
-
-      render(
-        <WhatsNewDashboard
-          new={newEntries}
-          archive={allEntries}
-          onClose={jest.fn()}
-        />,
-      );
-
-      expect(screen.queryByText(allEntries[1].content)).not.toBeInTheDocument();
-
-      const menuItems = screen.getAllByRole("menuitem");
-      await userEvent.click(menuItems[1]);
-
-      expect(screen.getByText(allEntries[1].content)).toBeInTheDocument();
-    });
-
-    it("can go back to overview of all new features after clicking one of them", async () => {
-      const allEntries: WhatsNewEntry[] = [
-        getMockEntry(1),
-        getMockEntry(2),
-        getMockEntry(3),
-      ];
-      const newEntries = [allEntries[0], allEntries[1]];
-
-      render(
-        <WhatsNewDashboard
-          new={newEntries}
-          archive={allEntries}
-          onClose={jest.fn()}
-        />,
-      );
-
-      expect(
-        screen.queryByText(allEntries[1]?.content),
-      ).not.toBeInTheDocument();
-
-      const menuItems = screen.getAllByRole("menuitem");
-      await userEvent.click(menuItems[1]);
-
-      expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
-
-      const goBackButton = screen.getByRole("button", {
-        name: "l10n string: [whatsnew-footer-back-label], with vars: {}",
-      });
-      await userEvent.click(goBackButton);
-
-      expect(screen.getAllByRole("menuitem")).toHaveLength(2);
-    });
-
-    it("shows an empty state view when there are no entries to show", () => {
-      const allEntries: WhatsNewEntry[] = [
-        getMockEntry(1),
-        getMockEntry(2),
-        getMockEntry(3),
-      ];
-      const newEntries: WhatsNewEntry[] = [];
-
-      render(
-        <WhatsNewDashboard
-          new={newEntries}
-          archive={allEntries}
-          onClose={jest.fn()}
-        />,
-      );
-
-      expect(
-        screen.getByText(
-          "l10n string: [whatsnew-empty-message], with vars: {}",
-        ),
-      ).toBeInTheDocument();
-    });
-
     it("measures how often people switch tabs", async () => {
       const allEntries: WhatsNewEntry[] = [
         getMockEntry(1),
@@ -247,7 +247,7 @@ describe.each(["enabled", "disabled"])(
       await userEvent.click(tabs[1]);
       await userEvent.click(tabs[0]);
 
-      if (metricsState === "enabled") {
+      if (googleAnalyticsAvailable) {
         expect(mockReactGa.event).toHaveBeenCalledTimes(2);
         expect(mockReactGa.event).toHaveBeenCalledWith({
           category: "News",
@@ -283,7 +283,7 @@ describe.each(["enabled", "disabled"])(
       const menuItems = screen.getAllByRole("menuitem");
       await userEvent.click(menuItems[1]);
 
-      if (metricsState === "enabled") {
+      if (googleAnalyticsAvailable) {
         expect(mockReactGa.event).toHaveBeenCalledTimes(1);
         expect(mockReactGa.event).toHaveBeenCalledWith({
           category: "News",
@@ -319,7 +319,7 @@ describe.each(["enabled", "disabled"])(
       });
       await userEvent.click(goBackButton);
 
-      if (metricsState === "enabled") {
+      if (googleAnalyticsAvailable) {
         expect(mockReactGa.event).toHaveBeenCalledTimes(2);
         expect(mockReactGa.event).toHaveBeenCalledWith({
           category: "News",
@@ -352,7 +352,7 @@ describe.each(["enabled", "disabled"])(
       });
       await userEvent.click(clearAllButton);
 
-      if (metricsState === "enabled") {
+      if (googleAnalyticsAvailable) {
         expect(mockReactGa.event).toHaveBeenCalledTimes(1);
         expect(mockReactGa.event).toHaveBeenCalledWith({
           category: "News",

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.test.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mockGetLocaleModule } from "../../../../../__mocks__/functions/getLocale";
 import { mockUseL10nModule } from "../../../../../__mocks__/hooks/l10n";
+import { mockUseMetricsModule } from "../../../../../__mocks__/hooks/metrics";
 import { mockReactGa } from "../../../../../__mocks__/modules/react-ga";
 
 import { WhatsNewDashboard } from "./WhatsNewDashboard";
@@ -10,6 +11,7 @@ import { WhatsNewEntry } from "./WhatsNewMenu";
 jest.mock("react-ga", () => mockReactGa);
 jest.mock("../../../../functions/getLocale.ts", () => mockGetLocaleModule);
 jest.mock("../../../../hooks/gaViewPing.ts");
+jest.mock("../../../../hooks/metrics.ts", () => mockUseMetricsModule);
 jest.mock("../../../../hooks/l10n.ts", () => mockUseL10nModule);
 
 function getMockEntry(
@@ -39,299 +41,328 @@ function getMockEntry(
   };
 }
 
-describe("The 'What's new' dashboard", () => {
-  it("displays new entries by default", () => {
-    const allEntries: WhatsNewEntry[] = [
-      getMockEntry(1),
-      getMockEntry(2),
-      getMockEntry(3),
-    ];
-    const newEntries = [allEntries[0], allEntries[1]];
-
-    render(
-      <WhatsNewDashboard
-        new={newEntries}
-        archive={allEntries}
-        onClose={jest.fn()}
-      />,
-    );
-
-    const menuItems = screen.getAllByRole("menuitem");
-
-    expect(menuItems).toHaveLength(2);
-  });
-
-  it("allows viewing all entries", async () => {
-    const allEntries: WhatsNewEntry[] = [
-      getMockEntry(1),
-      getMockEntry(2),
-      getMockEntry(3),
-    ];
-    const newEntries = [allEntries[0], allEntries[1]];
-
-    render(
-      <WhatsNewDashboard
-        new={newEntries}
-        archive={allEntries}
-        onClose={jest.fn()}
-      />,
-    );
-
-    expect(screen.getAllByRole("menuitem")).toHaveLength(2);
-
-    const tabs = screen.getAllByRole("tab");
-    expect(tabs).toHaveLength(2);
-    expect(tabs[1]).toHaveTextContent(
-      "l10n string: [whatsnew-tab-archive-label], with vars: {}",
-    );
-
-    await userEvent.click(tabs[1]);
-
-    expect(screen.getAllByRole("menuitem")).toHaveLength(3);
-  });
-
-  it("dismisses an entry when it is viewed", async () => {
-    const allEntries: WhatsNewEntry[] = [
-      getMockEntry(1),
-      getMockEntry(2),
-      getMockEntry(3),
-    ];
-    const newEntries = [allEntries[0], allEntries[1]];
-
-    render(
-      <WhatsNewDashboard
-        new={newEntries}
-        archive={allEntries}
-        onClose={jest.fn()}
-      />,
-    );
-
-    const menuItems = screen.getAllByRole("menuitem");
-    await userEvent.click(menuItems[1]);
-
-    expect(allEntries[1].dismissal.dismiss).toHaveBeenCalledTimes(1);
-  });
-
-  it("dismisses all new entries when clicking 'Clear all'", async () => {
-    const allEntries: WhatsNewEntry[] = [
-      getMockEntry(1),
-      getMockEntry(2),
-      getMockEntry(3),
-    ];
-    const newEntries = [allEntries[0], allEntries[1]];
-
-    render(
-      <WhatsNewDashboard
-        new={newEntries}
-        archive={allEntries}
-        onClose={jest.fn()}
-      />,
-    );
-
-    const clearAllButton = screen.getByRole("button", {
-      name: "l10n string: [whatsnew-footer-clear-all-label], with vars: {}",
+describe.each(["enabled", "disabled"])(
+  "The 'What's new' dashboard, metrics %s",
+  (metricsState) => {
+    beforeEach(() => {
+      mockUseMetricsModule.useMetrics.mockReturnValue(
+        metricsState === "enabled",
+      );
     });
-    await userEvent.click(clearAllButton);
 
-    expect(allEntries[0].dismissal.dismiss).toHaveBeenCalledTimes(1);
-    expect(allEntries[1].dismissal.dismiss).toHaveBeenCalledTimes(1);
-  });
+    it("displays new entries by default", () => {
+      const allEntries: WhatsNewEntry[] = [
+        getMockEntry(1),
+        getMockEntry(2),
+        getMockEntry(3),
+      ];
+      const newEntries = [allEntries[0], allEntries[1]];
 
-  it("shows an entry's content when clicking it", async () => {
-    const allEntries: WhatsNewEntry[] = [
-      getMockEntry(1),
-      getMockEntry(2),
-      getMockEntry(3),
-    ];
-    const newEntries = [allEntries[0], allEntries[1]];
+      render(
+        <WhatsNewDashboard
+          new={newEntries}
+          archive={allEntries}
+          onClose={jest.fn()}
+        />,
+      );
 
-    render(
-      <WhatsNewDashboard
-        new={newEntries}
-        archive={allEntries}
-        onClose={jest.fn()}
-      />,
-    );
+      const menuItems = screen.getAllByRole("menuitem");
 
-    expect(screen.queryByText(allEntries[1].content)).not.toBeInTheDocument();
-
-    const menuItems = screen.getAllByRole("menuitem");
-    await userEvent.click(menuItems[1]);
-
-    expect(screen.getByText(allEntries[1].content)).toBeInTheDocument();
-  });
-
-  it("can go back to overview of all new features after clicking one of them", async () => {
-    const allEntries: WhatsNewEntry[] = [
-      getMockEntry(1),
-      getMockEntry(2),
-      getMockEntry(3),
-    ];
-    const newEntries = [allEntries[0], allEntries[1]];
-
-    render(
-      <WhatsNewDashboard
-        new={newEntries}
-        archive={allEntries}
-        onClose={jest.fn()}
-      />,
-    );
-
-    expect(screen.queryByText(allEntries[1]?.content)).not.toBeInTheDocument();
-
-    const menuItems = screen.getAllByRole("menuitem");
-    await userEvent.click(menuItems[1]);
-
-    expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
-
-    const goBackButton = screen.getByRole("button", {
-      name: "l10n string: [whatsnew-footer-back-label], with vars: {}",
+      expect(menuItems).toHaveLength(2);
     });
-    await userEvent.click(goBackButton);
 
-    expect(screen.getAllByRole("menuitem")).toHaveLength(2);
-  });
+    it("allows viewing all entries", async () => {
+      const allEntries: WhatsNewEntry[] = [
+        getMockEntry(1),
+        getMockEntry(2),
+        getMockEntry(3),
+      ];
+      const newEntries = [allEntries[0], allEntries[1]];
 
-  it("shows an empty state view when there are no entries to show", () => {
-    const allEntries: WhatsNewEntry[] = [
-      getMockEntry(1),
-      getMockEntry(2),
-      getMockEntry(3),
-    ];
-    const newEntries: WhatsNewEntry[] = [];
+      render(
+        <WhatsNewDashboard
+          new={newEntries}
+          archive={allEntries}
+          onClose={jest.fn()}
+        />,
+      );
 
-    render(
-      <WhatsNewDashboard
-        new={newEntries}
-        archive={allEntries}
-        onClose={jest.fn()}
-      />,
-    );
+      expect(screen.getAllByRole("menuitem")).toHaveLength(2);
 
-    expect(
-      screen.getByText("l10n string: [whatsnew-empty-message], with vars: {}"),
-    ).toBeInTheDocument();
-  });
+      const tabs = screen.getAllByRole("tab");
+      expect(tabs).toHaveLength(2);
+      expect(tabs[1]).toHaveTextContent(
+        "l10n string: [whatsnew-tab-archive-label], with vars: {}",
+      );
 
-  it("measures how often people switch tabs", async () => {
-    const allEntries: WhatsNewEntry[] = [
-      getMockEntry(1),
-      getMockEntry(2),
-      getMockEntry(3),
-    ];
-    const newEntries = [allEntries[0], allEntries[1]];
+      await userEvent.click(tabs[1]);
 
-    render(
-      <WhatsNewDashboard
-        new={newEntries}
-        archive={allEntries}
-        onClose={jest.fn()}
-      />,
-    );
-
-    const tabs = screen.getAllByRole("tab");
-    await userEvent.click(tabs[1]);
-    await userEvent.click(tabs[0]);
-
-    expect(mockReactGa.event).toHaveBeenCalledTimes(2);
-    expect(mockReactGa.event).toHaveBeenCalledWith({
-      category: "News",
-      action: "Switch to 'History' tab",
-      label: "news-dashboard",
+      expect(screen.getAllByRole("menuitem")).toHaveLength(3);
     });
-    expect(mockReactGa.event).toHaveBeenCalledWith({
-      category: "News",
-      action: "Switch to 'News' tab",
-      label: "news-dashboard",
+
+    it("dismisses an entry when it is viewed", async () => {
+      const allEntries: WhatsNewEntry[] = [
+        getMockEntry(1),
+        getMockEntry(2),
+        getMockEntry(3),
+      ];
+      const newEntries = [allEntries[0], allEntries[1]];
+
+      render(
+        <WhatsNewDashboard
+          new={newEntries}
+          archive={allEntries}
+          onClose={jest.fn()}
+        />,
+      );
+
+      const menuItems = screen.getAllByRole("menuitem");
+      await userEvent.click(menuItems[1]);
+
+      expect(allEntries[1].dismissal.dismiss).toHaveBeenCalledTimes(1);
     });
-  });
 
-  it("measures how often entries are opened", async () => {
-    const allEntries: WhatsNewEntry[] = [
-      getMockEntry(1),
-      getMockEntry(2),
-      getMockEntry(3),
-    ];
-    const newEntries = [allEntries[0], allEntries[1]];
+    it("dismisses all new entries when clicking 'Clear all'", async () => {
+      const allEntries: WhatsNewEntry[] = [
+        getMockEntry(1),
+        getMockEntry(2),
+        getMockEntry(3),
+      ];
+      const newEntries = [allEntries[0], allEntries[1]];
 
-    render(
-      <WhatsNewDashboard
-        new={newEntries}
-        archive={allEntries}
-        onClose={jest.fn()}
-      />,
-    );
+      render(
+        <WhatsNewDashboard
+          new={newEntries}
+          archive={allEntries}
+          onClose={jest.fn()}
+        />,
+      );
 
-    const menuItems = screen.getAllByRole("menuitem");
-    await userEvent.click(menuItems[1]);
+      const clearAllButton = screen.getByRole("button", {
+        name: "l10n string: [whatsnew-footer-clear-all-label], with vars: {}",
+      });
+      await userEvent.click(clearAllButton);
 
-    expect(mockReactGa.event).toHaveBeenCalledTimes(1);
-    expect(mockReactGa.event).toHaveBeenCalledWith({
-      category: "News",
-      action: "Open entry",
-      label: allEntries[1].title,
+      expect(allEntries[0].dismissal.dismiss).toHaveBeenCalledTimes(1);
+      expect(allEntries[1].dismissal.dismiss).toHaveBeenCalledTimes(1);
     });
-  });
 
-  it("measures how often entries are closed", async () => {
-    const allEntries: WhatsNewEntry[] = [
-      getMockEntry(1),
-      getMockEntry(2),
-      getMockEntry(3),
-    ];
-    const newEntries = [allEntries[0], allEntries[1]];
+    it("shows an entry's content when clicking it", async () => {
+      const allEntries: WhatsNewEntry[] = [
+        getMockEntry(1),
+        getMockEntry(2),
+        getMockEntry(3),
+      ];
+      const newEntries = [allEntries[0], allEntries[1]];
 
-    render(
-      <WhatsNewDashboard
-        new={newEntries}
-        archive={allEntries}
-        onClose={jest.fn()}
-      />,
-    );
+      render(
+        <WhatsNewDashboard
+          new={newEntries}
+          archive={allEntries}
+          onClose={jest.fn()}
+        />,
+      );
 
-    const menuItems = screen.getAllByRole("menuitem");
-    await userEvent.click(menuItems[1]);
+      expect(screen.queryByText(allEntries[1].content)).not.toBeInTheDocument();
 
-    const goBackButton = screen.getByRole("button", {
-      name: "l10n string: [whatsnew-footer-back-label], with vars: {}",
+      const menuItems = screen.getAllByRole("menuitem");
+      await userEvent.click(menuItems[1]);
+
+      expect(screen.getByText(allEntries[1].content)).toBeInTheDocument();
     });
-    await userEvent.click(goBackButton);
 
-    expect(mockReactGa.event).toHaveBeenCalledTimes(2);
-    expect(mockReactGa.event).toHaveBeenCalledWith({
-      category: "News",
-      action: "Close entry",
-      label: allEntries[1].title,
+    it("can go back to overview of all new features after clicking one of them", async () => {
+      const allEntries: WhatsNewEntry[] = [
+        getMockEntry(1),
+        getMockEntry(2),
+        getMockEntry(3),
+      ];
+      const newEntries = [allEntries[0], allEntries[1]];
+
+      render(
+        <WhatsNewDashboard
+          new={newEntries}
+          archive={allEntries}
+          onClose={jest.fn()}
+        />,
+      );
+
+      expect(
+        screen.queryByText(allEntries[1]?.content),
+      ).not.toBeInTheDocument();
+
+      const menuItems = screen.getAllByRole("menuitem");
+      await userEvent.click(menuItems[1]);
+
+      expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
+
+      const goBackButton = screen.getByRole("button", {
+        name: "l10n string: [whatsnew-footer-back-label], with vars: {}",
+      });
+      await userEvent.click(goBackButton);
+
+      expect(screen.getAllByRole("menuitem")).toHaveLength(2);
     });
-  });
 
-  it("measures how often all new entries are moved to the 'History' tab at once", async () => {
-    const allEntries: WhatsNewEntry[] = [
-      getMockEntry(1),
-      getMockEntry(2),
-      getMockEntry(3),
-    ];
-    const newEntries = [allEntries[0], allEntries[1]];
+    it("shows an empty state view when there are no entries to show", () => {
+      const allEntries: WhatsNewEntry[] = [
+        getMockEntry(1),
+        getMockEntry(2),
+        getMockEntry(3),
+      ];
+      const newEntries: WhatsNewEntry[] = [];
 
-    render(
-      <WhatsNewDashboard
-        new={newEntries}
-        archive={allEntries}
-        onClose={jest.fn()}
-      />,
-    );
+      render(
+        <WhatsNewDashboard
+          new={newEntries}
+          archive={allEntries}
+          onClose={jest.fn()}
+        />,
+      );
 
-    const clearAllButton = screen.getByRole("button", {
-      name: "l10n string: [whatsnew-footer-clear-all-label], with vars: {}",
+      expect(
+        screen.getByText(
+          "l10n string: [whatsnew-empty-message], with vars: {}",
+        ),
+      ).toBeInTheDocument();
     });
-    await userEvent.click(clearAllButton);
 
-    expect(mockReactGa.event).toHaveBeenCalledTimes(1);
-    expect(mockReactGa.event).toHaveBeenCalledWith({
-      category: "News",
-      action: "Clear all",
-      label: "news-dashboard",
-      value: newEntries.length,
+    it("measures how often people switch tabs", async () => {
+      const allEntries: WhatsNewEntry[] = [
+        getMockEntry(1),
+        getMockEntry(2),
+        getMockEntry(3),
+      ];
+      const newEntries = [allEntries[0], allEntries[1]];
+
+      render(
+        <WhatsNewDashboard
+          new={newEntries}
+          archive={allEntries}
+          onClose={jest.fn()}
+        />,
+      );
+
+      const tabs = screen.getAllByRole("tab");
+      await userEvent.click(tabs[1]);
+      await userEvent.click(tabs[0]);
+
+      if (metricsState === "enabled") {
+        expect(mockReactGa.event).toHaveBeenCalledTimes(2);
+        expect(mockReactGa.event).toHaveBeenCalledWith({
+          category: "News",
+          action: "Switch to 'History' tab",
+          label: "news-dashboard",
+        });
+        expect(mockReactGa.event).toHaveBeenCalledWith({
+          category: "News",
+          action: "Switch to 'News' tab",
+          label: "news-dashboard",
+        });
+      } else {
+        expect(mockReactGa.event).not.toBeCalled();
+      }
     });
-  });
-});
+
+    it("measures how often entries are opened", async () => {
+      const allEntries: WhatsNewEntry[] = [
+        getMockEntry(1),
+        getMockEntry(2),
+        getMockEntry(3),
+      ];
+      const newEntries = [allEntries[0], allEntries[1]];
+
+      render(
+        <WhatsNewDashboard
+          new={newEntries}
+          archive={allEntries}
+          onClose={jest.fn()}
+        />,
+      );
+
+      const menuItems = screen.getAllByRole("menuitem");
+      await userEvent.click(menuItems[1]);
+
+      if (metricsState === "enabled") {
+        expect(mockReactGa.event).toHaveBeenCalledTimes(1);
+        expect(mockReactGa.event).toHaveBeenCalledWith({
+          category: "News",
+          action: "Open entry",
+          label: allEntries[1].title,
+        });
+      } else {
+        expect(mockReactGa.event).not.toBeCalled();
+      }
+    });
+
+    it("measures how often entries are closed", async () => {
+      const allEntries: WhatsNewEntry[] = [
+        getMockEntry(1),
+        getMockEntry(2),
+        getMockEntry(3),
+      ];
+      const newEntries = [allEntries[0], allEntries[1]];
+
+      render(
+        <WhatsNewDashboard
+          new={newEntries}
+          archive={allEntries}
+          onClose={jest.fn()}
+        />,
+      );
+
+      const menuItems = screen.getAllByRole("menuitem");
+      await userEvent.click(menuItems[1]);
+
+      const goBackButton = screen.getByRole("button", {
+        name: "l10n string: [whatsnew-footer-back-label], with vars: {}",
+      });
+      await userEvent.click(goBackButton);
+
+      if (metricsState === "enabled") {
+        expect(mockReactGa.event).toHaveBeenCalledTimes(2);
+        expect(mockReactGa.event).toHaveBeenCalledWith({
+          category: "News",
+          action: "Close entry",
+          label: allEntries[1].title,
+        });
+      } else {
+        expect(mockReactGa.event).not.toBeCalled();
+      }
+    });
+
+    it("measures how often all new entries are moved to the 'History' tab at once", async () => {
+      const allEntries: WhatsNewEntry[] = [
+        getMockEntry(1),
+        getMockEntry(2),
+        getMockEntry(3),
+      ];
+      const newEntries = [allEntries[0], allEntries[1]];
+
+      render(
+        <WhatsNewDashboard
+          new={newEntries}
+          archive={allEntries}
+          onClose={jest.fn()}
+        />,
+      );
+
+      const clearAllButton = screen.getByRole("button", {
+        name: "l10n string: [whatsnew-footer-clear-all-label], with vars: {}",
+      });
+      await userEvent.click(clearAllButton);
+
+      if (metricsState === "enabled") {
+        expect(mockReactGa.event).toHaveBeenCalledTimes(1);
+        expect(mockReactGa.event).toHaveBeenCalledWith({
+          category: "News",
+          action: "Clear all",
+          label: "news-dashboard",
+          value: newEntries.length,
+        });
+      } else {
+        expect(mockReactGa.event).not.toBeCalled();
+      }
+    });
+  },
+);

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.tsx
@@ -1,11 +1,11 @@
 import { ReactNode, useRef, useState } from "react";
 import { useTab, useTabList, useTabPanel } from "react-aria";
 import { Item, TabListState, useTabListState } from "react-stately";
-import { event as gaEvent } from "react-ga";
 import { CloseIcon } from "../../../Icons";
 import styles from "./WhatsNewDashboard.module.scss";
 import { WhatsNewList } from "./WhatsNewList";
 import { WhatsNewEntry } from "./WhatsNewMenu";
+import { useGaEvent } from "../../../../hooks/gaEvent";
 import { useL10n } from "../../../../hooks/l10n";
 
 export type Props = {
@@ -16,6 +16,7 @@ export type Props = {
 
 export const WhatsNewDashboard = (props: Props) => {
   const l10n = useL10n();
+  const gaEvent = useGaEvent();
   const [expandedEntry, setExpandedEntry] = useState<WhatsNewEntry>();
   // `onClearAll` is undefined when there are no entries,
   // which signals to <Tabs> that the "Clear all" button should not be shown.

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -18,7 +18,6 @@ import {
   useOverlayTrigger,
 } from "react-aria";
 import { useOverlayTriggerState } from "react-stately";
-import { event as gaEvent } from "react-ga";
 import { StaticImageData } from "next/image";
 import styles from "./WhatsNewMenu.module.scss";
 import SizeLimitHero from "./images/size-limit-hero-10mb.svg";
@@ -70,6 +69,7 @@ import {
 import { CountdownTimer } from "../../../CountdownTimer";
 import Link from "next/link";
 import { GiftIcon } from "../../../Icons";
+import { useGaEvent } from "../../../../hooks/gaEvent";
 import { useL10n } from "../../../../hooks/l10n";
 import { VisuallyHidden } from "../../../VisuallyHidden";
 import { useOverlayBugWorkaround } from "../../../../hooks/overlayBugWorkaround";
@@ -121,6 +121,7 @@ const CtaLinkButton = (props: CtaProps) => {
 
 export const WhatsNewMenu = (props: Props) => {
   const l10n = useL10n();
+  const gaEvent = useGaEvent();
 
   const triggerState = useOverlayTriggerState({
     onOpenChange(isOpen) {

--- a/frontend/src/components/layout/topmessage/CsatSurvey.tsx
+++ b/frontend/src/components/layout/topmessage/CsatSurvey.tsx
@@ -1,4 +1,3 @@
-import { event as gaEvent } from "react-ga";
 import styles from "./CsatSurvey.module.scss";
 import { useFirstSeen } from "../../../hooks/firstSeen";
 import {
@@ -10,6 +9,7 @@ import { CloseIcon } from "../../Icons";
 import { parseDate } from "../../../functions/parseDate";
 import { useState } from "react";
 import { getLocale } from "../../../functions/getLocale";
+import { useGaEvent } from "../../../hooks/gaEvent";
 import { useL10n } from "../../../hooks/l10n";
 
 type SurveyLinks = {
@@ -68,6 +68,7 @@ export const CsatSurvey = (props: Props) => {
   const firstSeen = useFirstSeen();
   const l10n = useL10n();
   const [answer, setAnswer] = useState<keyof SurveyLinks>();
+  const gaEvent = useGaEvent();
 
   let reasonToShow:
     | null

--- a/frontend/src/components/layout/topmessage/HolidayPromoBanner.tsx
+++ b/frontend/src/components/layout/topmessage/HolidayPromoBanner.tsx
@@ -9,7 +9,7 @@ import {
   isPeriodicalPremiumAvailableInCountry,
 } from "../../../functions/getPlan";
 import { ProfileData } from "../../../hooks/api/profile";
-import { event as gaEvent } from "react-ga";
+import { useGaEvent } from "../../../hooks/gaEvent";
 import { useGaViewPing } from "../../../hooks/gaViewPing";
 
 type Props = {
@@ -20,6 +20,7 @@ type Props = {
 
 export const HolidayPromoBanner = (props: Props) => {
   const l10n = useL10n();
+  const gaEvent = useGaEvent();
   const router = useRouter();
   const coupon = "HOLIDAY20";
   const subscribeLink = isPeriodicalPremiumAvailableInCountry(props.runtimeData)

--- a/frontend/src/components/layout/topmessage/InterviewRecruitment.tsx
+++ b/frontend/src/components/layout/topmessage/InterviewRecruitment.tsx
@@ -1,7 +1,7 @@
-import { event as gaEvent } from "react-ga";
 import styles from "./InterviewRecruitment.module.scss";
 import { CloseIcon } from "../../Icons";
 import { useLocalDismissal } from "../../../hooks/localDismissal";
+import { useGaEvent } from "../../../hooks/gaEvent";
 import { useGaViewPing } from "../../../hooks/gaViewPing";
 import { useL10n } from "../../../hooks/l10n";
 
@@ -21,6 +21,7 @@ export const InterviewRecruitment = () => {
     category: "Recruitment",
     label: recruitmentLabel,
   });
+  const gaEvent = useGaEvent();
 
   // Only show if the user hasn't closed the recruitment banner before:
   if (dismissal.isDismissed) {

--- a/frontend/src/components/layout/topmessage/NpsSurvey.tsx
+++ b/frontend/src/components/layout/topmessage/NpsSurvey.tsx
@@ -1,10 +1,10 @@
-import { event as gaEvent } from "react-ga";
 import styles from "./NpsSurvey.module.scss";
 import { useFirstSeen } from "../../../hooks/firstSeen";
 import { useLocalDismissal } from "../../../hooks/localDismissal";
 import { useIsLoggedIn } from "../../../hooks/session";
 import { useProfiles } from "../../../hooks/api/profile";
 import { CloseIcon } from "../../Icons";
+import { useGaEvent } from "../../../hooks/gaEvent";
 import { useL10n } from "../../../hooks/l10n";
 
 /**
@@ -21,6 +21,7 @@ export const NpsSurvey = () => {
   const firstSeen = useFirstSeen();
   const isLoggedIn = useIsLoggedIn();
   const l10n = useL10n();
+  const gaEvent = useGaEvent();
 
   const hasBeenUserForThreeDays =
     isLoggedIn &&

--- a/frontend/src/components/layout/topmessage/PhoneSurvey.tsx
+++ b/frontend/src/components/layout/topmessage/PhoneSurvey.tsx
@@ -1,9 +1,9 @@
-import { event as gaEvent } from "react-ga";
 import styles from "./PhoneSurvey.module.scss";
 import { CloseIcon } from "../../Icons";
 import { useLocalDismissal } from "../../../hooks/localDismissal";
 import { useGaViewPing } from "../../../hooks/gaViewPing";
 import { useRelayNumber } from "../../../hooks/api/relayNumber";
+import { useGaEvent } from "../../../hooks/gaEvent";
 import { useL10n } from "../../../hooks/l10n";
 
 /**
@@ -18,6 +18,7 @@ export const PhoneSurvey = () => {
     "Answer 4 questions about phone masking to help improve your experience.";
 
   const l10n = useL10n();
+  const gaEvent = useGaEvent();
   const dismissal = useLocalDismissal("phone-survey-2022-11");
   const linkRef = useGaViewPing({
     category: "Phone launch survey",

--- a/frontend/src/components/phones/dashboard/SendersPanelView.tsx
+++ b/frontend/src/components/phones/dashboard/SendersPanelView.tsx
@@ -10,10 +10,12 @@ import disabledSendersDataIllustration from "./images/sender-data-disabled-illus
 import emptySenderDataIllustration from "./images/sender-data-empty-illustration.svg";
 import { useInboundContact } from "../../../hooks/api/inboundContact";
 import { OutboundLink } from "react-ga";
+import Link from "next/link";
 import { formatPhone } from "../../../functions/formatPhone";
 import { parseDate } from "../../../functions/parseDate";
 import { getLocale } from "../../../functions/getLocale";
 import { useL10n } from "../../../hooks/l10n";
+import { useMetrics } from "../../../hooks/metrics";
 
 export type Props = {
   type: "primary" | "disabled" | "empty";
@@ -22,6 +24,7 @@ export type Props = {
 
 export const SendersPanelView = (props: Props) => {
   const l10n = useL10n();
+  const metricsEnabled = useMetrics();
   const inboundContactData = useInboundContact();
   const inboundArray = inboundContactData.data;
   const dateTimeFormatter = new Intl.DateTimeFormat(getLocale(l10n), {
@@ -42,6 +45,23 @@ export const SendersPanelView = (props: Props) => {
     </div>
   );
 
+  const updateSettingsWithMetrics = (
+    <OutboundLink
+      to="/accounts/settings/"
+      eventLabel="Update Settings"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {l10n.getString("phone-dashboard-sender-disabled-update-settings")}
+    </OutboundLink>
+  );
+
+  const updateSettingsWithoutMetrics = (
+    <Link href="/accounts/settings/" target="_blank" rel="noopener noreferrer">
+      {l10n.getString("phone-dashboard-sender-disabled-update-settings")}
+    </Link>
+  );
+
   const disabledCallerSMSSendersPanel = (
     <div className={styles["senders-panel"]}>
       <Image
@@ -59,14 +79,9 @@ export const SendersPanelView = (props: Props) => {
         {l10n.getString("phone-dashboard-sender-disabled-body")}
       </p>
       <div className={styles["update-settings-cta"]}>
-        <OutboundLink
-          to="/accounts/settings/"
-          eventLabel="Update Settings"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {l10n.getString("phone-dashboard-sender-disabled-update-settings")}
-        </OutboundLink>
+        {metricsEnabled
+          ? updateSettingsWithMetrics
+          : updateSettingsWithoutMetrics}
       </div>
     </div>
   );

--- a/frontend/src/components/phones/onboarding/PurchasePhonesPlan.tsx
+++ b/frontend/src/components/phones/onboarding/PurchasePhonesPlan.tsx
@@ -18,6 +18,7 @@ import {
 import { ReactNode, useRef } from "react";
 import { useTab, useTabList, useTabPanel } from "react-aria";
 import { useL10n } from "../../../hooks/l10n";
+import { useGaEvent } from "../../../hooks/gaEvent";
 
 export type Props = {
   runtimeData: RuntimeDataWithPhonesAvailable;
@@ -62,6 +63,7 @@ const PricingToggle = (props: PricingToggleProps) => {
     category: "Purchase monthly Premium+phones button",
     label: "phone-onboarding-purchase-monthly-cta",
   });
+  const gaEvent = useGaEvent();
 
   return (
     <PricingTabs>
@@ -83,6 +85,7 @@ const PricingToggle = (props: PricingToggleProps) => {
           href={getPhoneSubscribeLink(props.runtimeData, "yearly")}
           onClick={() =>
             trackPlanPurchaseStart(
+              gaEvent,
               { plan: "phones", billing_period: "yearly" },
               {
                 label: "phone-onboarding-purchase-yearly-cta",
@@ -110,6 +113,7 @@ const PricingToggle = (props: PricingToggleProps) => {
           href={getPhoneSubscribeLink(props.runtimeData, "monthly")}
           onClick={() =>
             trackPlanPurchaseStart(
+              gaEvent,
               { plan: "phones", billing_period: "monthly" },
               {
                 label: "phone-onboarding-purchase-monthly-cta",

--- a/frontend/src/functions/trackPurchase.ts
+++ b/frontend/src/functions/trackPurchase.ts
@@ -1,4 +1,4 @@
-import { event as gaEvent, EventArgs } from "react-ga";
+import { EventArgs } from "../hooks/gaEvent";
 import { setCookie } from "./cookies";
 
 type ArgsWithoutCategory = Omit<EventArgs, "category">;
@@ -11,7 +11,10 @@ export type PurchaseTrackingArgs = Partial<ArgsWithoutCategory> &
  *
  * @deprecated Used to track purchases when we just had a single Premium plan.
  */
-export const trackPurchaseStart = (args?: PurchaseTrackingArgs) => {
+export const trackPurchaseStart = (
+  gaEvent: (event: EventArgs) => void,
+  args?: PurchaseTrackingArgs,
+) => {
   gaEvent({
     ...args,
     category: "Purchase Button",
@@ -45,6 +48,7 @@ export const getCookieId = (plan: Plan): string => {
  * When the user initiates a plan-specific purchase flow, this allows us to see whether the purchase gets completed across our different websites.
  */
 export const trackPlanPurchaseStart = (
+  gaEvent: (event: EventArgs) => void,
   plan: Plan,
   args?: PurchaseTrackingArgs,
 ) => {

--- a/frontend/src/hooks/api/profile.ts
+++ b/frontend/src/hooks/api/profile.ts
@@ -23,6 +23,7 @@ export type ProfileData = {
   emails_replied: number;
   level_one_trackers_blocked: number;
   store_phone_log: boolean;
+  metrics_enabled: boolean;
 };
 
 export type ProfilesData = [ProfileData];

--- a/frontend/src/hooks/fxaFlowTracker.ts
+++ b/frontend/src/hooks/fxaFlowTracker.ts
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import { event as gaEvent, EventArgs } from "react-ga";
 import { IntersectionOptions, useInView } from "react-intersection-observer";
 import { getRuntimeConfig } from "../config";
 import { useRuntimeData } from "./api/runtimeData";
+import { useGaEvent, EventArgs } from "./gaEvent";
 
 export type FxaFlowTrackerArgs = Omit<
   EventArgs,
@@ -23,6 +23,7 @@ export function useFxaFlowTracker(
   options?: IntersectionOptions,
 ) {
   const runtimeData = useRuntimeData();
+  const gaEvent = useGaEvent();
   const { ref } = useInView({
     threshold: 1,
     ...options,

--- a/frontend/src/hooks/gaEvent.ts
+++ b/frontend/src/hooks/gaEvent.ts
@@ -1,0 +1,10 @@
+import { event, EventArgs } from "react-ga";
+
+export type { EventArgs };
+
+export function useGaEvent() {
+  function gaEvent(args: EventArgs) {
+    event({ ...args });
+  }
+  return gaEvent;
+}

--- a/frontend/src/hooks/gaEvent.ts
+++ b/frontend/src/hooks/gaEvent.ts
@@ -1,17 +1,14 @@
 import { event, EventArgs } from "react-ga";
-import { useMetrics } from "./metrics";
+import { useGoogleAnalytics } from "./googleAnalytics";
 
 export type { EventArgs };
+
+function dropGaEvent(_args: EventArgs) {}
 
 /**
  * Returns a function that sends a ping if there is no user or the user has enabled metrics.
  */
 export function useGaEvent() {
-  const metricsEnabled = useMetrics();
-  function gaEvent(args: EventArgs) {
-    if (metricsEnabled) {
-      event({ ...args });
-    }
-  }
-  return gaEvent;
+  const googleAnalytics = useGoogleAnalytics();
+  return googleAnalytics ? event : dropGaEvent;
 }

--- a/frontend/src/hooks/gaEvent.ts
+++ b/frontend/src/hooks/gaEvent.ts
@@ -1,10 +1,17 @@
 import { event, EventArgs } from "react-ga";
+import { useMetrics } from "./metrics";
 
 export type { EventArgs };
 
+/**
+ * Returns a function that sends a ping if there is no user or the user has enabled metrics.
+ */
 export function useGaEvent() {
+  const metricsEnabled = useMetrics();
   function gaEvent(args: EventArgs) {
-    event({ ...args });
+    if (metricsEnabled) {
+      event({ ...args });
+    }
   }
   return gaEvent;
 }

--- a/frontend/src/hooks/gaViewPing.ts
+++ b/frontend/src/hooks/gaViewPing.ts
@@ -1,5 +1,5 @@
-import { event as gaEvent, EventArgs } from "react-ga";
 import { IntersectionOptions, useInView } from "react-intersection-observer";
+import { useGaEvent, EventArgs } from "./gaEvent";
 
 export type GaViewPingArgs = Omit<EventArgs, "action" | "nonInteraction">;
 
@@ -14,6 +14,7 @@ export function useGaViewPing(
   args: GaViewPingArgs | null,
   options?: IntersectionOptions,
 ) {
+  const gaEvent = useGaEvent();
   const { ref } = useInView({
     threshold: 1,
     ...options,

--- a/frontend/src/hooks/googleAnalytics.ts
+++ b/frontend/src/hooks/googleAnalytics.ts
@@ -1,0 +1,41 @@
+import ReactGa from "react-ga";
+import { useState } from "react";
+import { singletonHook } from "react-singleton-hook";
+import { getRuntimeConfig } from "../config";
+
+const gaIsInitialized = false;
+let globalEnableGoogleAnalytics = (_: boolean): void | never => {
+  throw new Error("you must useGoogleAnalytics before initializing.");
+};
+
+export const useGoogleAnalytics = singletonHook(gaIsInitialized, () => {
+  const [isInitialized, setIsInitialized] = useState(gaIsInitialized);
+  globalEnableGoogleAnalytics = setIsInitialized;
+  return isInitialized;
+});
+
+export function initGoogleAnalytics() {
+  ReactGa.initialize(getRuntimeConfig().googleAnalyticsId, {
+    titleCase: false,
+    debug: process.env.NEXT_PUBLIC_DEBUG === "true",
+  });
+  ReactGa.set({
+    anonymizeIp: true,
+    transport: "beacon",
+  });
+  const cookies = document.cookie.split("; ");
+  const gaEventCookies = cookies.filter((item) =>
+    item.trim().startsWith("server_ga_event:"),
+  );
+  gaEventCookies.forEach((item) => {
+    const serverEventLabel = item.split("=")[1];
+    if (serverEventLabel) {
+      ReactGa.event({
+        category: "server event",
+        action: "fired",
+        label: serverEventLabel,
+      });
+    }
+  });
+  globalEnableGoogleAnalytics(true);
+}

--- a/frontend/src/hooks/metrics.ts
+++ b/frontend/src/hooks/metrics.ts
@@ -1,12 +1,20 @@
 import { useIsLoggedIn } from "./session";
 import { useProfiles } from "./api/profile";
 
+export type MetricsState = "enabled" | "disabled" | "unknown";
+
 /**
- * Returns True if metrics should be enabled
+ * Should metrics be emitted?
+ * @returns MetricsState, 'unknown' if loading profile, 'enabled' or 'disabled' after loading
  */
-export function useMetrics() {
-  const profileData = useProfiles();
+export function useMetrics(): MetricsState {
   const isLoggedIn = useIsLoggedIn();
-  const metricsEnabled = !isLoggedIn || profileData?.data?.[0].metrics_enabled;
-  return metricsEnabled;
+  const profileData = useProfiles();
+  if (isLoggedIn === "unknown") {
+    return "unknown";
+  }
+  const metricsEnabled =
+    isLoggedIn === "logged-out" ||
+    profileData?.data?.[0].metrics_enabled === true;
+  return metricsEnabled ? "enabled" : "disabled";
 }

--- a/frontend/src/hooks/metrics.ts
+++ b/frontend/src/hooks/metrics.ts
@@ -1,0 +1,12 @@
+import { useIsLoggedIn } from "./session";
+import { useProfiles } from "./api/profile";
+
+/**
+ * Returns True if metrics should be enabled
+ */
+export function useMetrics() {
+  const profileData = useProfiles();
+  const isLoggedIn = useIsLoggedIn();
+  const metricsEnabled = !isLoggedIn || profileData?.data?.[0].metrics_enabled;
+  return metricsEnabled;
+}

--- a/frontend/src/hooks/metrics.ts
+++ b/frontend/src/hooks/metrics.ts
@@ -1,5 +1,6 @@
 import { useIsLoggedIn } from "./session";
 import { useProfiles } from "./api/profile";
+import { hasDoNotTrackEnabled } from "../functions/userAgent";
 
 export type MetricsState = "enabled" | "disabled" | "unknown";
 
@@ -10,11 +11,15 @@ export type MetricsState = "enabled" | "disabled" | "unknown";
 export function useMetrics(): MetricsState {
   const isLoggedIn = useIsLoggedIn();
   const profileData = useProfiles();
+  const dnt = hasDoNotTrackEnabled();
+  if (dnt) {
+    return "disabled";
+  }
   if (isLoggedIn === "unknown") {
     return "unknown";
   }
-  const metricsEnabled =
-    isLoggedIn === "logged-out" ||
-    profileData?.data?.[0].metrics_enabled === true;
+  const anonVisitor = isLoggedIn === "logged-out";
+  const profileMetricsEnabled = profileData?.data?.[0].metrics_enabled === true;
+  const metricsEnabled = anonVisitor || profileMetricsEnabled;
   return metricsEnabled ? "enabled" : "disabled";
 }

--- a/frontend/src/hooks/purchaseTracker.ts
+++ b/frontend/src/hooks/purchaseTracker.ts
@@ -1,14 +1,15 @@
 import { useEffect } from "react";
-import { event as gaEvent } from "react-ga";
 import { clearCookie, getCookie } from "../functions/cookies";
 import { getCookieId, getGaCategory, Plan } from "../functions/trackPurchase";
 import { ProfileData } from "./api/profile";
+import { useGaEvent } from "./gaEvent";
 
 /**
  * Include this in pages that Subscription platform sends the user back to
  * to count how many people purchased which plan.
  */
 export const usePurchaseTracker = (profileData?: ProfileData) => {
+  const gaEvent = useGaEvent();
   useEffect(() => {
     // This cookie is set in `trackPurchaseStart()`
     const hasClickedPurchaseCookie = getCookie("clicked-purchase") === "true";
@@ -48,5 +49,5 @@ export const usePurchaseTracker = (profileData?: ProfileData) => {
         clearCookie(getCookieId(plan));
       }
     });
-  }, [profileData]);
+  }, [profileData, gaEvent]);
 };

--- a/frontend/src/hooks/session.ts
+++ b/frontend/src/hooks/session.ts
@@ -3,6 +3,7 @@ import { useProfiles } from "./api/profile";
 export function useIsLoggedIn(): boolean {
   const profileData = useProfiles();
   const isLoggedIn =
+    typeof profileData !== "undefined" &&
     typeof profileData.data !== "undefined" &&
     typeof profileData.error === "undefined";
 

--- a/frontend/src/hooks/session.ts
+++ b/frontend/src/hooks/session.ts
@@ -1,11 +1,23 @@
 import { useProfiles } from "./api/profile";
 
-export function useIsLoggedIn(): boolean {
-  const profileData = useProfiles();
-  const isLoggedIn =
-    typeof profileData !== "undefined" &&
-    typeof profileData.data !== "undefined" &&
-    typeof profileData.error === "undefined";
+export type LoggedInState = "logged-out" | "logged-in" | "unknown";
 
-  return isLoggedIn;
+/*
+ * Is the user logged in?
+ * @returns LoggedInState, 'unknown' if loading profiles, 'logged-in' or 'logged-out' once known
+ */
+export function useIsLoggedIn(): LoggedInState {
+  const profileData = useProfiles();
+  const checking =
+    typeof profileData === "undefined" ||
+    (typeof profileData.data === "undefined" &&
+      typeof profileData.error === "undefined");
+  if (checking) {
+    return "unknown";
+  }
+  return typeof profileData !== "undefined" &&
+    typeof profileData.data !== "undefined" &&
+    typeof profileData.error === "undefined"
+    ? "logged-in"
+    : "logged-out";
 }

--- a/frontend/src/pages/_app.page.tsx
+++ b/frontend/src/pages/_app.page.tsx
@@ -6,7 +6,6 @@ import { LocalizationProvider, ReactLocalization } from "@fluent/react";
 import { OverlayProvider } from "@react-aria/overlays";
 import ReactGa from "react-ga";
 import { getL10n } from "../functions/getL10n";
-import { hasDoNotTrackEnabled } from "../functions/userAgent";
 import { AddonDataContext, useAddonElementWatcher } from "../hooks/addon";
 import { ReactAriaI18nProvider } from "../components/ReactAriaI18nProvider";
 import { initialiseApiMocks } from "../apiMocks/initialise";
@@ -42,11 +41,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   }, []);
 
   useEffect(() => {
-    if (
-      !hasDoNotTrackEnabled() &&
-      metricsEnabled === "enabled" &&
-      !googleAnalytics
-    ) {
+    if (metricsEnabled === "enabled" && !googleAnalytics) {
       initGoogleAnalytics();
     }
   }, [metricsEnabled, googleAnalytics]);

--- a/frontend/src/pages/_app.page.tsx
+++ b/frontend/src/pages/_app.page.tsx
@@ -13,11 +13,13 @@ import { ReactAriaI18nProvider } from "../components/ReactAriaI18nProvider";
 import { initialiseApiMocks } from "../apiMocks/initialise";
 import { mockIds } from "../apiMocks/mockData";
 import { useIsLoggedIn } from "../hooks/session";
+import { useMetrics } from "../hooks/metrics";
 import "@stripe/stripe-js";
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const isLoggedIn = useIsLoggedIn();
+  const metricsEnabled = useMetrics();
   const addonDataElementRef = useRef<HTMLElement>(null);
 
   const addonData = useAddonElementWatcher(addonDataElementRef);
@@ -36,7 +38,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   }, []);
 
   useEffect(() => {
-    if (hasDoNotTrackEnabled()) {
+    if (hasDoNotTrackEnabled() || !metricsEnabled) {
       return;
     }
     ReactGa.initialize(getRuntimeConfig().googleAnalyticsId, {
@@ -61,14 +63,14 @@ function MyApp({ Component, pageProps }: AppProps) {
         });
       }
     });
-  }, []);
+  }, [metricsEnabled]);
 
   useEffect(() => {
-    if (hasDoNotTrackEnabled()) {
+    if (hasDoNotTrackEnabled() || !metricsEnabled) {
       return;
     }
     ReactGa.pageview(router.asPath);
-  }, [router.asPath]);
+  }, [router.asPath, metricsEnabled]);
 
   const [waitingForMsw, setIsWaitingForMsw] = useState(
     process.env.NEXT_PUBLIC_MOCK_API === "true",

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -18,7 +18,6 @@ import {
   useTooltip,
   useTooltipTrigger,
 } from "react-aria";
-import { event as gaEvent } from "react-ga";
 import { useMenuTriggerState, useTooltipTriggerState } from "react-stately";
 import { toast } from "react-toastify";
 import styles from "./profile.module.scss";
@@ -33,6 +32,7 @@ import {
   getFullAddress,
   useAliases,
 } from "../../hooks/api/aliases";
+import { useGaEvent } from "../../hooks/gaEvent";
 import { useUsers } from "../../hooks/api/user";
 import { AliasList } from "../../components/dashboard/aliases/AliasList";
 import { ProfileBanners } from "../../components/dashboard/ProfileBanners";
@@ -76,6 +76,7 @@ const Profile: NextPage = () => {
     category: "Purchase Button",
     label: "profile-set-custom-domain",
   });
+  const gaEvent = useGaEvent();
   const hash = getCookie("profile-location-hash");
   if (hash) {
     document.location.hash = hash;

--- a/frontend/src/pages/contains-tracker-warning.page.tsx
+++ b/frontend/src/pages/contains-tracker-warning.page.tsx
@@ -7,6 +7,8 @@ import { FaqAccordionItem } from "../components/landing/FaqAccordion";
 import { useEffect, useState } from "react";
 import { RoundedInfoTriangleIcon } from "../components/Icons";
 import { OutboundLink } from "react-ga";
+import Link from "next/link";
+import { useMetrics } from "../hooks/metrics";
 
 type TrackerWarningData = {
   sender: string;
@@ -18,6 +20,7 @@ const ContainsTracker: NextPage = () => {
   const runtimeData = useRuntimeData();
   const l10n = useL10n();
   const [trackerData, setTrackerData] = useState<TrackerWarningData | null>();
+  const metricsEnabled = useMetrics();
 
   useEffect(() => {
     function updateTrackerData() {
@@ -49,6 +52,27 @@ const ContainsTracker: NextPage = () => {
       },
     });
 
+  const TrackerLinkWithMetrics = trackerData && (
+    <OutboundLink
+      to={trackerData.original_link}
+      eventLabel={l10n.getString("contains-tracker-warning-view-link-cta")}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <span>{l10n.getString("contains-tracker-warning-view-link-cta")}</span>
+    </OutboundLink>
+  );
+
+  const TrackerLinkWithoutMetrics = trackerData && (
+    <Link
+      href={trackerData.original_link}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <span>{l10n.getString("contains-tracker-warning-view-link-cta")}</span>
+    </Link>
+  );
+
   const TrackerWarningBanner = trackerData && (
     <>
       <div className={styles["warning-banner-container"]}>
@@ -64,18 +88,7 @@ const ContainsTracker: NextPage = () => {
       </div>
       <div className={styles["warning-banner-button"]}>
         <div className={styles["cta-button"]}>
-          <OutboundLink
-            to={trackerData.original_link}
-            eventLabel={l10n.getString(
-              "contains-tracker-warning-view-link-cta",
-            )}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <span>
-              {l10n.getString("contains-tracker-warning-view-link-cta")}
-            </span>
-          </OutboundLink>
+          {metricsEnabled ? TrackerLinkWithMetrics : TrackerLinkWithoutMetrics}
         </div>
       </div>
     </>

--- a/frontend/src/pages/premium.page.tsx
+++ b/frontend/src/pages/premium.page.tsx
@@ -1,6 +1,5 @@
 import { NextPage } from "next";
 import Image from "next/image";
-import { event as gaEvent } from "react-ga";
 import styles from "./premium.module.scss";
 import { Layout } from "../components/layout/Layout";
 import { useGaViewPing } from "../hooks/gaViewPing";
@@ -14,6 +13,7 @@ import {
 import { PlanMatrix } from "../components/landing/PlanMatrix";
 import { BundleBanner } from "../components/landing/BundleBanner";
 import { useFlaggedAnchorLinks } from "../hooks/flaggedAnchorLinks";
+import { useGaEvent } from "../hooks/gaEvent";
 import { useL10n } from "../hooks/l10n";
 import { Localized } from "../components/Localized";
 import { HighlightedFeatures } from "../components/landing/HighlightedFeatures";
@@ -26,6 +26,7 @@ const PremiumPromo: NextPage = () => {
     category: "Purchase Button",
     label: "premium-promo-cta",
   });
+  const gaEvent = useGaEvent();
 
   const cta = isPeriodicalPremiumAvailableInCountry(runtimeData.data) ? (
     <LinkButton

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react-ga": "^3.3.1",
         "react-intersection-observer": "^9.6.0",
         "react-qr-code": "^2.0.12",
+        "react-singleton-hook": "^4.0.1",
         "react-stately": "^3.29.1",
         "react-toastify": "^10.0.4",
         "swr": "^2.2.4"
@@ -12823,6 +12824,22 @@
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-singleton-hook": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-singleton-hook/-/react-singleton-hook-4.0.1.tgz",
+      "integrity": "sha512-fWuk8VxcZPChrkQasDLM8pgd/7kyi+Cr/5FfCiD99FicjEru+JmtEZNnN4lJ8Z7KbqAST5CYPlpz6lmNsZFGNw==",
+      "peerDependencies": {
+        "react": "18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-stately": {
       "version": "3.29.1",
       "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.29.1.tgz",
@@ -20407,6 +20424,7 @@
         "react-ga": "^3.3.1",
         "react-intersection-observer": "^9.6.0",
         "react-qr-code": "^2.0.12",
+        "react-singleton-hook": "^4.0.1",
         "react-stately": "^3.29.1",
         "react-test-renderer": "^18.2.0",
         "react-toastify": "^10.0.4",
@@ -24064,6 +24082,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
       }
+    },
+    "react-singleton-hook": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-singleton-hook/-/react-singleton-hook-4.0.1.tgz",
+      "integrity": "sha512-fWuk8VxcZPChrkQasDLM8pgd/7kyi+Cr/5FfCiD99FicjEru+JmtEZNnN4lJ8Z7KbqAST5CYPlpz6lmNsZFGNw==",
+      "requires": {}
     },
     "react-stately": {
       "version": "3.29.1",


### PR DESCRIPTION
The [Metrics for Relying Parties - Opt-Opt section](https://mozilla.github.io/ecosystem-platform/relying-parties/reference/metrics-for-relying-parties#user-opt-out) says:

> Users may opt-out of metrics from the FxA settings page. If they do, FxA will not collect or store metrics and relying parties must not either.
>
> [User profiles](https://github.com/mozilla/fxa/blob/main/packages/fxa-profile-server/docs/API.md#get-v1profile) include the `metricsEnabled` boolean. When the value is `false` relying parties should not collect any metrics tied to the user. Relying parties should check this value every time the profile is requested.

For MPP-3644, this PR implements reading this value on the backend, and forwarding it via the API.

This also includes front-end changes to use this new signal to decide if we should load Google Analytics.

# Testing

1. Run `npm -w frontend install` to install the new `react-singleton-hook` dependency
2. Run `npm -w frontend run watch` to build the frontend with debugging on
3. Start up the server locally with `./manage.py runserver`,
4. Load http://127.0.0.1:8000/ , open developer tools, and reload
    - [x] You should see Logs in the dev tools Console about Google Analytics loading, sending events and pageviews
5. If not logged in, log in
    - [x] You should see Logs in the dev tools Console about Google Analytics loading, sending events and pageviews
6. Navigate to http://127.0.0.1:8000/api/v1/profiles/
    - [x] You should see `"metrics_enabled": true` in the JSON response.
7. Go to https://accounts.stage.mozaws.net, log in if needed, and deselect "Help improve ⁨Mozilla accounts⁩" under "Data Collection and Use".
8. Go to http://127.0.0.1:8000/accounts/logout/ to log out, ensure the dev tools are open, clear the Console output, and then log in again
   - [x] After log in, Google Analytics is not loaded.
9. Go to http://127.0.0.1:8000/api/v1/profiles/.
  - [x] You should see `"metrics_enabled": false`
