### PR TITLE
Use `align-items: flex-start` to avoid warning

### DIFF
--- a/frontend/src/components/landing/Reviews.module.scss
+++ b/frontend/src/components/landing/Reviews.module.scss
@@ -159,7 +159,7 @@
   .review {
     display: flex;
     flex-direction: column;
-    align-items: start;
+    align-items: flex-start;
     position: relative; // allows us to animate - scroll
     width: 100%; // allows us to animate - scroll
     padding: $spacing-sm;


### PR DESCRIPTION
When running `npm run build`, I get this warning output:

```
> frontend@0.1.0 build
> next build

   ▲ Next.js 14.1.0

 ✓ Linting and checking validity of types    
   Creating an optimized production build ...
<w> [webpack.cache.PackFileCacheStrategy] Skipped not serializable cache item 'Compilation/modules|/Users/john/src/fx-private-relay/node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[6].oneOf[9].use[0]!/Users/john/src/fx-private-relay/node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[6].oneOf[9].use[1]!/Users/john/src/fx-private-relay/node_modules/next/dist/build/webpack/loaders/resolve-url-loader/index.js??ruleSet[1].rules[6].oneOf[9].use[2]!/Users/john/src/fx-private-relay/node_modules/next/dist/compiled/sass-loader/cjs.js??ruleSet[1].rules[6].oneOf[9].use[3]!/Users/john/src/fx-private-relay/frontend/src/components/landing/Reviews.module.scss': No serializer registered for Warning
<w> while serializing webpack/lib/cache/PackFileCacheStrategy.PackContentItems -> webpack/lib/NormalModule -> Array { 1 items } -> webpack/lib/ModuleWarning -> Warning
 ⚠ Compiled with warnings

./src/components/landing/Reviews.module.scss
Warning

(1:3214) autoprefixer: start value has mixed support, consider using flex-start instead

Import trace for requested module:
./src/components/landing/Reviews.module.scss
./src/components/landing/Reviews.tsx
./src/pages/index.page.tsx

 ✓ Collecting page data    
 ✓ Generating static pages (17/17) 
 ✓ Collecting build traces    
 ✓ Finalizing page optimization   
 ```
 
 After this change, the warning goes away:
 
 ```
 > frontend@0.1.0 build
> next build

   ▲ Next.js 14.1.0

 ✓ Linting and checking validity of types    
   Creating an optimized production build ...
 ✓ Compiled successfully
 ✓ Collecting page data    
 ✓ Generating static pages (17/17) 
 ✓ Collecting build traces    
 ✓ Finalizing page optimization
 ```
