### PR TITLE
MPP-3352: Expand, refactor tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,8 @@ omit =
     manage.py,
     env/*,
     node_modules/*,
+exclude_also =
+    if TYPE_CHECKING
 
 [run]
 relative_files = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,7 +9,8 @@ omit =
     env/*,
     node_modules/*,
 exclude_also =
-    if TYPE_CHECKING
+    # Skip code that is only evaluated by static type checkers like pyright and mypy
+    if TYPE_CHECKING:
 
 [run]
 relative_files = True

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -501,6 +501,18 @@ def test_post_relayaddress_success(free_api_client, free_user) -> None:
     assert ret_data["enabled"]
 
 
+def test_post_relayaddress_with_generated_for_success(
+    free_api_client: APIClient, free_user: User
+) -> None:
+    """A mask generated on a website sets has_generated_for"""
+    response = free_api_client.post(
+        reverse("relayaddress-list"),
+        data={"generated_for": "example.com"},
+        format="json",
+    )
+    assert response.status_code == 201
+
+
 def test_post_relayaddress_free_mask_email_limit_error(
     settings, free_user, free_api_client
 ) -> None:

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -78,8 +78,15 @@ def make_storageless_test_user() -> User:
     return storageless_user
 
 
-def unlimited_subscription() -> str:
-    return random.choice(settings.SUBSCRIPTIONS_WITH_UNLIMITED)
+def premium_subscription() -> str:
+    assert settings.SUBSCRIPTIONS_WITH_UNLIMITED
+    premium_only_plans = list(
+        set(settings.SUBSCRIPTIONS_WITH_UNLIMITED)
+        - set(settings.SUBSCRIPTIONS_WITH_PHONE)
+        - set(settings.SUBSCRIPTIONS_WITH_VPN)
+    )
+    assert premium_only_plans
+    return random.choice(premium_only_plans)
 
 
 def phone_subscription() -> str:
@@ -87,7 +94,7 @@ def phone_subscription() -> str:
 
 
 def upgrade_test_user_to_premium(user):
-    random_sub = unlimited_subscription()
+    random_sub = premium_subscription()
     baker.make(
         SocialAccount,
         user=user,
@@ -1360,7 +1367,7 @@ class DomainAddressTest(TestCase):
             SocialAccount,
             user=user,
             provider="fxa",
-            extra_data={"subscriptions": [unlimited_subscription()]},
+            extra_data={"subscriptions": [premium_subscription()]},
         )
         user_profile = Profile.objects.get(user=user)
         with pytest.raises(CannotMakeAddressException) as exc_info:

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -486,20 +486,10 @@ class ProfileTestCase(TestCase):
         )
         return social_account
 
-    def premium_subscription(self) -> str:
-        assert settings.SUBSCRIPTIONS_WITH_UNLIMITED
-        premium_only_plans = list(
-            set(settings.SUBSCRIPTIONS_WITH_UNLIMITED)
-            - set(settings.SUBSCRIPTIONS_WITH_PHONE)
-            - set(settings.SUBSCRIPTIONS_WITH_VPN)
-        )
-        assert premium_only_plans
-        return random.choice(premium_only_plans)
-
     def upgrade_to_premium(self) -> None:
         """Add an unlimited emails subscription to the user."""
         social_account = self.get_or_create_social_account()
-        social_account.extra_data["subscriptions"].append(self.premium_subscription())
+        social_account.extra_data["subscriptions"].append(premium_subscription())
         social_account.save()
 
     def phone_subscription(self) -> str:
@@ -517,9 +507,7 @@ class ProfileTestCase(TestCase):
         social_account = self.get_or_create_social_account()
         social_account.extra_data["subscriptions"].append(self.phone_subscription())
         if not self.profile.has_premium:
-            social_account.extra_data["subscriptions"].append(
-                self.premium_subscription()
-            )
+            social_account.extra_data["subscriptions"].append(premium_subscription())
         social_account.save()
 
     def vpn_subscription(self) -> str:
@@ -537,9 +525,7 @@ class ProfileTestCase(TestCase):
         social_account = self.get_or_create_social_account()
         social_account.extra_data["subscriptions"].append(self.vpn_subscription())
         if not self.profile.has_premium:
-            social_account.extra_data["subscriptions"].append(
-                self.premium_subscription()
-            )
+            social_account.extra_data["subscriptions"].append(premium_subscription())
         if not self.profile.has_phone:
             social_account.extra_data["subscriptions"].append(self.phone_subscription())
         social_account.save()

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -919,15 +919,11 @@ class SNSNotificationRepliesTest(SNSNotificationTestBase):
         assert response.status_code == 400
         assert response.content == b"SES client error"
 
-        assert len(events_caplog.records) == 2
+        assert len(events_caplog.records) == 1
         events_log = events_caplog.records[0]
         assert events_log.message == "ses_client_error_raw_email"
         assert getattr(events_log, "Code") == "the code"
         assert getattr(events_log, "Message") == "the message"
-        events_log2 = events_caplog.records[1]
-        assert events_log2.message == "ses_client_error"
-        assert getattr(events_log2, "Code") == "the code"
-        assert getattr(events_log2, "Message") == "the message"
 
 
 class BounceHandlingTest(TestCase):

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -549,22 +549,22 @@ class SNSNotificationIncomingTest(SNSNotificationTestBase):
         assert self.ra.last_used_at is None
 
     @patch("emails.views.generate_from_header", side_effect=InvalidFromHeader())
-    @patch("emails.views.info_logger")
-    def test_invalid_from_header(self, mock_logger, mock_generate_from_header) -> None:
+    def test_invalid_from_header(self, mock_generate_from_header: Mock) -> None:
         """For MPP-3407, show logging for failed from address"""
-        response = _sns_notification(EMAIL_SNS_BODIES["single_recipient"])
+        with self.assertLogs("eventsinfo", "ERROR") as event_caplog:
+            response = _sns_notification(EMAIL_SNS_BODIES["single_recipient"])
         assert response.status_code == 503
-        mock_logger.error.assert_called_once_with(
-            "generate_from_header",
-            extra={
-                "from_address": "fxastage@protonmail.com",
-                "source": "fxastage@protonmail.com",
-                "common_headers_from": ["fxastage <fxastage@protonmail.com>"],
-                "headers_from": [
-                    {"name": "From", "value": "fxastage <fxastage@protonmail.com>"}
-                ],
-            },
-        )
+
+        assert len(event_caplog.records) == 1
+        event_log = event_caplog.records[0]
+        assert getattr(event_log, "from_address") == "fxastage@protonmail.com"
+        assert getattr(event_log, "source") == "fxastage@protonmail.com"
+        assert getattr(event_log, "common_headers_from") == [
+            "fxastage <fxastage@protonmail.com>"
+        ]
+        assert getattr(event_log, "headers_from") == [
+            {"name": "From", "value": "fxastage <fxastage@protonmail.com>"}
+        ]
 
         self.mock_send_raw_email.assert_not_called()
         self.mock_remove_message_from_s3.assert_not_called()

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -875,7 +875,7 @@ class SNSNotificationRepliesTest(SNSNotificationTestBase):
         assert response.status_code == 403
         assert response.content == b"Relay replies require a premium account"
 
-    def test_get_message_content_from_s3_not_found(self):
+    def test_get_message_content_from_s3_not_found(self) -> None:
         self.mock_get_content.side_effect = ClientError(
             operation_name="S3.something",
             error_response={"Error": {"Code": "NoSuchKey", "Message": "the message"}},
@@ -892,7 +892,7 @@ class SNSNotificationRepliesTest(SNSNotificationTestBase):
         assert getattr(events_log, "Code") == "NoSuchKey"
         assert getattr(events_log, "Message") == "the message"
 
-    def test_get_message_content_from_s3_other_error(self):
+    def test_get_message_content_from_s3_other_error(self) -> None:
         self.mock_get_content.side_effect = ClientError(
             operation_name="S3.something",
             error_response={"Error": {"Code": "IsNapping", "Message": "snooze"}},
@@ -909,7 +909,7 @@ class SNSNotificationRepliesTest(SNSNotificationTestBase):
         assert getattr(events_log, "Code") == "IsNapping"
         assert getattr(events_log, "Message") == "snooze"
 
-    def test_ses_client_error(self):
+    def test_ses_client_error(self) -> None:
         self.mock_get_content.return_value = create_email_from_notification(
             EMAIL_SNS_BODIES["s3_stored_replies"], text="text content"
         )
@@ -1480,7 +1480,7 @@ class SnsMessageTest(TestCase):
         self.mock_ses_client = ses_client_patcher.start()
         self.addCleanup(ses_client_patcher.stop)
 
-    def test_get_message_content_from_s3_not_found(self):
+    def test_get_message_content_from_s3_not_found(self) -> None:
         self.mock_get_content.side_effect = ClientError(
             operation_name="S3.something",
             error_response={"Error": {"Code": "NoSuchKey", "Message": "the message"}},
@@ -1497,7 +1497,7 @@ class SnsMessageTest(TestCase):
         assert getattr(events_log, "Code") == "NoSuchKey"
         assert getattr(events_log, "Message") == "the message"
 
-    def test_ses_send_raw_email_has_client_error_early_exits(self):
+    def test_ses_send_raw_email_has_client_error_early_exits(self) -> None:
         self.mock_ses_client.send_raw_email.side_effect = SEND_RAW_EMAIL_FAILED
         with self.assertLogs("events", "ERROR") as events_caplog:
             response = _sns_message(self.message_json)

--- a/emails/views.py
+++ b/emails/views.py
@@ -1251,8 +1251,7 @@ def _handle_reply(
             destination_address=to_address,
             message=email,
         )
-    except ClientError as e:
-        logger.error("ses_client_error", extra=e.response["Error"])
+    except ClientError:
         return HttpResponse("SES client error", status=400)
 
     reply_record.increment_num_replied()

--- a/privaterelay/tests/conftest.py
+++ b/privaterelay/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from typing import Iterator
+import json
 
 from pytest_django.fixtures import SettingsWrapper
 import pytest
@@ -15,5 +16,12 @@ def version_json_path(tmp_path: Path, settings: SettingsWrapper) -> Iterator[Pat
     get_version_info.cache_clear()
     settings.BASE_DIR = tmp_path
     path = settings.BASE_DIR / "version.json"
+    default_build_info = {
+        "commit": "the_commit_hash",
+        "version": "2024.01.17",
+        "source": "https://github.com/mozilla/fx-private-relay",
+        "build": "https://circleci.com/gh/mozilla/fx-private-relay/100",
+    }
+    path.write_text(json.dumps(default_build_info))
     yield path
     get_version_info.cache_clear()

--- a/privaterelay/tests/utils.py
+++ b/privaterelay/tests/utils.py
@@ -1,4 +1,10 @@
-def log_extra(log_record):
+"""Helper functions for tests"""
+
+from logging import LogRecord
+from typing import Any
+
+
+def log_extra(log_record: LogRecord) -> dict[str, Any]:
     """Reconstruct the "extra" argument to the log call"""
     omit_log_record_keys = set(
         (

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -1,6 +1,5 @@
 from typing import Iterator
 from unittest.mock import patch
-import json
 import logging
 
 from django.contrib.auth.models import AbstractBaseUser, Group, User
@@ -589,7 +588,9 @@ def test_flag_is_active_for_task_override_existing_to_inactive(
     ids=("missing", "empty", "list", "other object"),
 )
 def test_get_version_info_bad_contents(version_json_path, content: str | None) -> None:
-    if content is not None:
+    if content is None:
+        version_json_path.unlink()
+    else:
         version_json_path.write_text(content)
     info = get_version_info()
     assert info == {
@@ -600,13 +601,12 @@ def test_get_version_info_bad_contents(version_json_path, content: str | None) -
     }
 
 
-def test_get_version_info(version_json_path) -> None:
-    build_info = {
+@pytest.mark.usefixtures("version_json_path")
+def test_get_version_info() -> None:
+    version_info = get_version_info()
+    assert version_info == {
         "commit": "the_commit_hash",
         "version": "2024.01.17",
         "source": "https://github.com/mozilla/fx-private-relay",
         "build": "https://circleci.com/gh/mozilla/fx-private-relay/100",
     }
-    version_json_path.write_text(json.dumps(build_info))
-    version_info = get_version_info()
-    assert version_info == build_info

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -30,7 +30,7 @@ from emails.models import (
     RelayAddress,
     address_hash,
 )
-from emails.tests.models_tests import unlimited_subscription
+from emails.tests.models_tests import premium_subscription
 
 from ..apps import PrivateRelayConfig
 from ..fxa_utils import NoSocialToken
@@ -246,7 +246,7 @@ def setup_fxa_rp_events(
         "uid": str(uuid4()),
         "avatar": "https://profile.stage.mozaws.net/v1/avatar/t",
         "avatarDefault": False,
-        "subscriptions": [unlimited_subscription(), "test-phone"],
+        "subscriptions": [premium_subscription(), "test-phone"],
     }
     fxa_acct: SocialAccount = baker.make(
         SocialAccount,


### PR DESCRIPTION
In preparation for adding Glean metrics in MPP-3352, this PR expands and refactors the tests. This will reduce the size and complexity of the near-future Glean PR.

There is one code change, to remove a redundant error log. The rest are test changes, so running the tests should be sufficient to validate the PR.

Each commit is roughly one refactor:

* Add default data to `version_json_path` fixture
* Add `PATCH` and `DELETE` tests for address APIs. This exposes an issue that the `DomainAddress.address` (the local part of a custom mask) is allowed to change with a `PATCH`. This field should be writable at creation and read-only later. Tracked in MPP-3753.
* Add test for `RandomAddress` with `generated_for`. This pattern is used as the signal that the address was generated on a website, and will be a distinct interaction event in the future.
* Add type annotations to `log_record` test utility
* Ignore `TYPE_CHECKING` lines in coverage. This code is only evaluated by static type checkers, so it is impossible to get code coverage for them.
* Refactor plan setting in Profile tests. Previously, the shared `ProfileTestCase.upgrade_to_premium(`) could randomly select a VPN bundle plan. It now only selects a unlimited email protection plan. Addition helpers `.upgrade_to_phone` and `.upgrade_to_vpn_bundle` can upgrade the test user to those plan levels. This exposed some issues with the Django model cache around `User` and `Profile`. The `make_free_test_user` and `make_premium_test_user` functions now update the profile through `user.profile`, making the cache consistent.
* Rename `unlimited_subscription` to `premium_subscription`, and only return unlimited email plans. Use in `upgrade_test_user_to_premium`, so that these users are only ones with the unlimited email plans, not the VPN bundle.
* Move replies tests to new test case. Split `SNSNotificationTest` into three parts:
    - `SNSNotificationTestBase` - shared setup and helper functions
    -` SNSNotificationIncomingTest` - tests for emails to Relay users
    - `SNSNotificationRepliesTest` - test for email replies from Relay users
* Convert test to `assertLogs` instead of mock logger
* Add and expand email failure tests. Test more failure modes for incoming emails and Relay user replies. Check log messages and emitted metrics.

- ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- ~I've added or updated relevant docs in the docs/ directory.~
- ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).