### PR TITLE
MPP-3106: Fix "Learn more" tooltip going off screen on mobile devices

### DIFF
--- a/frontend/src/pages/accounts/profile.module.scss
+++ b/frontend/src/pages/accounts/profile.module.scss
@@ -131,7 +131,6 @@
         background-color: $color-white;
         border: 1px solid $color-light-gray-20;
         border-radius: $border-radius-md;
-        position: relative;
 
         @media screen and #{$mq-lg} {
           // On small screens, stats have a border and all that, but since


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3106.

# Bug description

The "Learn more" tooltip for trackers removal can go off the screen in iOS and android devices.

# Screenshot of fix

<img src="https://github.com/mozilla/fx-private-relay/assets/59676643/61a0e78b-a6db-45dd-b76e-d56b87e082a3" height="500px"/>

# How to test

1. Login to premium relay account on a mobile device in Safari or Chrome
2. Select "Learn more" under the trackers removed stats box
3. Verify that the tooltip does not go out of bounds.


# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] Customer Experience team has seen or waived a demo of functionality.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
