### PR TITLE
MPP-2758: Fix email wrapper to display tracker report link correctly

### DIFF
--- a/emails/templates/emails/wrapped_email.html
+++ b/emails/templates/emails/wrapped_email.html
@@ -158,13 +158,13 @@
             {% comment %}
               Create this as a link if we have a report link to show
             {% endcomment %}
-            {% ftlmsg 'relay-email-trackers-removed' number=num_level_one_email_trackers_removed as num_level_one_email_trackers_removed %}
+            {% ftlmsg 'relay-email-trackers-removed' number=num_level_one_email_trackers_removed as num_level_one_email_trackers_removed_text %}
             {% if num_level_one_email_trackers_removed > 0 and tracker_report_link %}
             <a class="container-link" href="{{ tracker_report_link  }}" style="color: #FFFFFF;">
-              {{ num_level_one_email_trackers_removed | convert_fsi_to_span }}
+              {{ num_level_one_email_trackers_removed_text | convert_fsi_to_span }}
             </a>
             {% else %}
-              {{ num_level_one_email_trackers_removed | convert_fsi_to_span }}
+              {{ num_level_one_email_trackers_removed_text | convert_fsi_to_span }}
             {% endif %}
           </p>
 

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -1735,6 +1735,10 @@ def test_wrapped_email_test(
         "<li><strong>num_level_one_email_trackers_removed</strong>:"
         f"{num_level_one_email_trackers_removed}"
     ) in no_space_html
+    if has_tracker_report_link == "Yes" and num_level_one_email_trackers_removed != "0":
+        assert "/tracker-report/#" in no_space_html
+    else:
+        assert "/tracker-report/#" not in no_space_html
 
 
 @pytest.mark.parametrize("forwarded", ("False", "True"))


### PR DESCRIPTION
<!-- When fixing a bug: -->

This PR fixes MPP-2758.



<!-- When adding a new feature: -->

# Bug description

The tracker report link in forwarded emails were not showing up as a hyperlink. 

This is because of an incorrect condition comparing the tracker removal string, instead of the integer value of the number of trackers removed.

# Screenshot of fix

Now it is displayed as a hyperlink.

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/51601fb9-c121-4ced-960b-01dda6f9fe29)


# How to test

* Go to /emails/wrapped_email_test?language=en&has_premium=Yes&has_tracker_report_link=Yes&num_level_one_email_trackers_removed=1 in your local env
* Verify that the "X email tracker removed" is clickable and a hyperlink for X > 0.
* For X = 0, verify that it is not clickable.

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] Customer Experience team has seen or waived a demo of functionality.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
