### PR TITLE
Switch to default docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,14 +190,6 @@ jobs:
           at: /tmp/workspace
       - checkout_with_submodules
       - setup_remote_docker:
-          # Use a version of Docker that works with Node, see
-          # https://support.circleci.com/hc/en-us/articles/360050934711-Docker-build-fails-with-EPERM-operation-not-permitted-copyfile-when-using-node-14-9-0-or-later-
-          # (apparently version 17.09.0-ce is lower than 1.9.1, but 19.03.13 is not?)
-          # and
-          # https://github.com/nodejs/docker-node#supported-docker-versions
-          # and
-          # https://circleci.com/docs/2.0/building-docker-images/#docker-version
-          version: 20.10.11
           docker_layer_caching: True
       - restore_cache:
           key: v1-frontend-build-{{ .Branch }}-{{ .Revision }}


### PR DESCRIPTION
CircleCI is deprecating older Docker versions, and has a schedule that will fail jobs using the old versions. Use the default tag, which is currently Docker 24, and will be Docker 25 when that is released.

References:
* https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176 
* https://circleci.com/docs/remote-docker-images-support-policy/