### PR TITLE
MPP-3686: Fix iOS overflow breaking for mask text in delete modal

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.module.scss
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.module.scss
@@ -69,6 +69,8 @@
       padding: $spacing-lg $spacing-lg $spacing-sm;
       color: $color-grey-50;
       margin-bottom: $spacing-sm;
+      user-select: auto;
+      -webkit-user-select: auto; // Fixes overflow breaking in iOS devices (MPP-3686)
     }
 
     .permanence-warning {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3686.

<!-- When adding a new feature: -->

# Bug description

When opening the delete modal on iOS devices, or holding the cancel button in the modal, the text for the users mask can go off of the modal and does not correctly wrap around.

# Screenshot (if applicable)

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/7acf3433-cb4c-4bc2-b3af-a61f74798e6c)

# How to test

1. Navigate to the Relay email mask dashboard;

2. Open any mask and tap on the “Delete” button;

3. Observe the layout of the long Stage mask;

4. Tap and hold tap on the “Cancel” button of the delete mask modal;

5. Observe the behaviour;

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] Customer Experience team has seen or waived a demo of functionality.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
