### PR TITLE
MPP-3731, MPP-3702: Fix alias copy button overflow into block-level label

### DIFF
--- a/frontend/src/components/dashboard/aliases/LabelEditor.module.scss
+++ b/frontend/src/components/dashboard/aliases/LabelEditor.module.scss
@@ -47,6 +47,7 @@
   // leading it to overlap this confirmation message.
   // Thus, this z-index makes this message overlap that.
   z-index: 2;
+  pointer-events: none; // Stop the label from blocking the copy button
 
   &.is-shown {
     opacity: 1;

--- a/frontend/src/components/dashboard/aliases/MaskCard.module.scss
+++ b/frontend/src/components/dashboard/aliases/MaskCard.module.scss
@@ -16,129 +16,110 @@
   }
 }
 
-.bar {
+.summary {
   display: flex;
   align-items: center;
-  gap: $spacing-sm;
+  position: relative;
   padding: $spacing-sm;
+  gap: $spacing-sm;
+  flex-wrap: wrap;
 
-  .summary {
-    flex: 1 1 auto;
-    // Override flex children's default `min-width: auto` to allow the summary
-    // to shrink instead of pushing out the collapse button:
-    min-width: 0;
+  @media screen and #{$mq-md} {
+    gap: $spacing-sm;
+    flex-wrap: nowrap;
+  }
+
+  .label-editor-wrapper {
+    overflow: visible;
+
+    @media screen and #{$mq-md} {
+      // Same as .summary's gap:
+      padding-inline-end: $spacing-sm;
+      border-right: 1px solid $color-grey-10;
+    }
+  }
+
+  .copy-button-wrapper {
     display: flex;
     align-items: center;
-    flex-wrap: wrap;
     position: relative;
+    overflow: hidden;
+    width: 90%;
+
+    @media screen and #{$mq-md} {
+      width: 100%;
+    }
 
     @media screen and #{$mq-md} {
       gap: $spacing-sm;
-      flex-wrap: nowrap;
+    }
+    @media screen and (max-width: $screen-xs) {
+      overflow: hidden;
+    }
+  }
+
+  .copy-button {
+    display: flex;
+    align-items: center;
+    gap: $spacing-xs;
+    background-color: transparent;
+    color: $color-blue-50;
+    border-style: none;
+    font-family: $font-stack-firefox;
+    font-weight: 500;
+    border-radius: $border-radius-sm;
+    cursor: pointer;
+    overflow: inherit;
+
+    &:hover {
+      color: $color-green-70;
     }
 
-    .label-editor-wrapper {
-      @media screen and #{$mq-md} {
-        // Same as .summary's gap:
-        padding-inline-end: $spacing-sm;
-        border-right: 1px solid $color-grey-10;
-      }
+    samp {
+      font-family: inherit;
+      align-self: start;
+      white-space: nowrap;
+      overflow: inherit;
+      text-overflow: ellipsis;
     }
 
-    .copy-button-wrapper {
-      display: flex;
-      align-items: center;
+    .copy-icon {
+      width: 15px; // Fixed size for the copy icon
+      flex: 1 0 auto; // Avoid copied icon shrinking
+    }
+  }
 
-      @media screen and #{$mq-md} {
-        gap: $spacing-sm;
-      }
-      @media screen and (max-width: $screen-xs) {
-        overflow: hidden;
-      }
+  .copied-confirmation {
+    background-color: $color-green-50;
+    padding: $spacing-xs $spacing-sm;
+    border-radius: $border-radius-md;
+    font-weight: 600;
+    opacity: 1;
+    pointer-events: none;
+
+    @media screen and (max-width: $screen-md) {
+      @include text-body-sm;
+    }
+    @media screen and (max-width: $content-sm) {
+      position: absolute;
+      right: 0;
     }
 
-    .copy-button {
-      display: flex;
-      align-items: center;
-      gap: $spacing-xs;
-      background-color: transparent;
-      color: $color-blue-50;
-      border-style: none;
-      font-family: $font-stack-firefox;
-      font-weight: 500;
-      border-radius: $border-radius-sm;
-      cursor: pointer;
-
-      &:hover {
-        color: $color-green-70;
-      }
-
-      samp {
-        font-family: inherit;
-        max-width: 250px; // Setting a fixed width to truncate string
-        align-self: start;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-
-        // Magic numbers: Stops long mask domains from overflowing, and enforces an ellipsis.
-        @media screen and #{$mq-sm} {
-          max-width: 350px; // Flex items wrap on smaller screens, hence there is more space
-        }
-        @media screen and #{$mq-md} {
-          max-width: 320px;
-        }
-        @media screen and (min-width: $content-lg) {
-          max-width: 400px;
-        }
-        // Note: Since the mask card is being used in a container (.main-wrapper) with a max-width of $content-xl,
-        // this will work. But if we use a mask card where the max-width of the parent container is < $content-xl,
-        // this formatting will break and could cause overflow (ex. MPP-3594). It could be worthwhile to do a re-design of the mask card CSS as whole.
-        @media screen and (min-width: $content-xl) {
-          max-width: calc($content-md - 140px);
-        }
-      }
-
-      .copy-icon {
-        width: 15px; // Fixed size for the copy icon
-      }
+    &[aria-hidden="true"] {
+      opacity: 0;
+      // Only fade out when disappearing:
+      transition: opacity 2s;
     }
+  }
 
-    .copied-confirmation {
-      background-color: $color-green-50;
-      padding: $spacing-xs $spacing-sm;
-      border-radius: $border-radius-md;
-      font-weight: 600;
-      opacity: 1;
-      pointer-events: none;
-      z-index: 2; // Places copied label above promotions label
+  .block-level-label {
+    text-align: end;
+    color: $color-grey-50;
+    display: none;
+    flex-shrink: 0;
 
-      @media screen and (max-width: $screen-md) {
-        @include text-body-sm;
-      }
-      @media screen and (max-width: $content-sm) {
-        position: absolute;
-        right: 0;
-      }
-
-      &[aria-hidden="true"] {
-        opacity: 0;
-        // Only fade out when disappearing:
-        transition: opacity 2s;
-      }
-    }
-
-    .block-level-label {
-      flex: 1 0 auto;
-      text-align: end;
-      color: $color-grey-50;
-      display: none;
-
-      @media screen and #{$mq-lg} {
-        display: initial;
-        position: absolute;
-        right: 0;
-      }
+    @media screen and #{$mq-lg} {
+      display: initial;
     }
   }
 
@@ -153,7 +134,14 @@
     color: $color-grey-40;
     border-radius: $border-radius-sm;
     width: $layout-sm;
-    z-index: 3; // Ensures that the button gets placed above the copied label (needed for long custom domains at viewport width ~ 780px)
+    position: absolute;
+    right: 0;
+    margin: 0 $spacing-sm;
+
+    @media screen and #{$mq-md} {
+      position: relative;
+      margin-left: auto;
+    }
 
     @media (any-pointer: coarse) {
       width: $layout-md;

--- a/frontend/src/components/dashboard/aliases/MaskCard.module.scss
+++ b/frontend/src/components/dashboard/aliases/MaskCard.module.scss
@@ -49,7 +49,6 @@
     @media screen and #{$mq-md} {
       width: 100%;
     }
-
     @media screen and #{$mq-md} {
       gap: $spacing-sm;
     }
@@ -142,7 +141,6 @@
       position: relative;
       margin-left: auto;
     }
-
     @media (any-pointer: coarse) {
       width: $layout-md;
     }

--- a/frontend/src/components/dashboard/aliases/MaskCard.tsx
+++ b/frontend/src/components/dashboard/aliases/MaskCard.tsx
@@ -122,53 +122,49 @@ export const MaskCard = (props: Props) => {
   return (
     <>
       <div className={classNames}>
-        <div className={styles.bar}>
-          <div className={styles.summary}>
-            {props.showLabelEditor && (
-              <div className={styles["label-editor-wrapper"]}>
-                <LabelEditor
-                  label={props.mask.description}
-                  placeholder={props.placeholder}
-                  onSubmit={(newLabel) =>
-                    props.onUpdate({ description: newLabel })
-                  }
-                />
-              </div>
-            )}
-            <div className={styles["copy-button-wrapper"]}>
-              <button
-                className={styles["copy-button"]}
-                title={l10n.getString("profile-label-click-to-copy")}
-                aria-label={l10n.getString("profile-label-click-to-copy-alt", {
-                  address: props.mask.full_address,
-                })}
-                onClick={copyAddressToClipboard}
-              >
-                <samp className={styles.address}>
-                  {props.mask.full_address}
-                </samp>
-                <span className={styles["copy-icon"]}>
-                  <CopyIcon alt="" />
-                </span>
-              </button>
-              <span
-                aria-hidden={!justCopied}
-                className={styles["copied-confirmation"]}
-              >
-                {l10n.getString("profile-label-copied")}
+        <div className={styles.summary}>
+          {props.showLabelEditor && (
+            <div className={styles["label-editor-wrapper"]}>
+              <LabelEditor
+                label={props.mask.description}
+                placeholder={props.placeholder}
+                onSubmit={(newLabel) =>
+                  props.onUpdate({ description: newLabel })
+                }
+              />
+            </div>
+          )}
+          <div className={styles["copy-button-wrapper"]}>
+            <button
+              className={styles["copy-button"]}
+              title={l10n.getString("profile-label-click-to-copy")}
+              aria-label={l10n.getString("profile-label-click-to-copy-alt", {
+                address: props.mask.full_address,
+              })}
+              onClick={copyAddressToClipboard}
+            >
+              <samp className={styles.address}>{props.mask.full_address}</samp>
+              <span className={styles["copy-icon"]}>
+                <CopyIcon alt="" />
               </span>
-            </div>
-            <div className={styles["block-level-label"]}>
-              {props.mask.enabled === false
-                ? l10n.getString("profile-promo-email-blocking-label-none-2")
-                : props.mask.block_list_emails === true
-                  ? l10n.getString(
-                      "profile-promo-email-blocking-label-promotionals-2",
-                    )
-                  : l10n.getString(
-                      "profile-promo-email-blocking-label-forwarding-2",
-                    )}
-            </div>
+            </button>
+            <span
+              aria-hidden={!justCopied}
+              className={styles["copied-confirmation"]}
+            >
+              {l10n.getString("profile-label-copied")}
+            </span>
+          </div>
+          <div className={styles["block-level-label"]}>
+            {props.mask.enabled === false
+              ? l10n.getString("profile-promo-email-blocking-label-none-2")
+              : props.mask.block_list_emails === true
+                ? l10n.getString(
+                    "profile-promo-email-blocking-label-promotionals-2",
+                  )
+                : l10n.getString(
+                    "profile-promo-email-blocking-label-forwarding-2",
+                  )}
           </div>
           <button
             {...expandButtonProps}
@@ -188,6 +184,7 @@ export const MaskCard = (props: Props) => {
             />
           </button>
         </div>
+
         <div
           id={detailsElementId}
           className={styles["details-wrapper"]}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes two issues,

MPP-3702: On mobile devices, the leftmost side of the alias copy button is not clickable because it is blocked by the "label confirmation" label.

MPP-3731: Depending on the users country, localized strings can be long and overlap with the alias text within the mask card (see screenshot in ticket). 

# Screenshot (if applicable)

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/ee9d07f6-e99d-476c-9a40-52517bf98bf3)
* Long labels will truncate the alias correctly now. 

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/24a289d1-e618-49c9-86d2-b53b2a06697b)
* The circled area is clickable now.

# How to test

MPP-3731:
* Go to settings in your browser and change your language to Spanish
* Go to the relay website
* Create a long mask (50-62 chars)
* Observe the mask card

MPP-3702:
* Navigate to the Relay email mask dashboard;
* Make the viewport width ~500 px (so that the label editor and mask are in two seperate rows)
* Try copying the mask by clicking the left most side of it (the first few letters).
* Observe the behaviour; 

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] Customer Experience team has seen or waived a demo of functionality.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
