### PR TITLE
MPP-3731, MPP-3702: Fix alias copy button's overflow into block-level label and unclickable area in mobile width's

### DIFF
--- a/frontend/src/components/dashboard/aliases/LabelEditor.module.scss
+++ b/frontend/src/components/dashboard/aliases/LabelEditor.module.scss
@@ -47,6 +47,7 @@
   // leading it to overlap this confirmation message.
   // Thus, this z-index makes this message overlap that.
   z-index: 2;
+  pointer-events: none; // Stop the label from blocking the alias copy button in mobile width's
 
   &.is-shown {
     opacity: 1;

--- a/frontend/src/components/dashboard/aliases/MaskCard.module.scss
+++ b/frontend/src/components/dashboard/aliases/MaskCard.module.scss
@@ -48,6 +48,7 @@
     .copy-button-wrapper {
       display: flex;
       align-items: center;
+      overflow: hidden;
 
       @media screen and #{$mq-md} {
         gap: $spacing-sm;
@@ -68,6 +69,7 @@
       font-weight: 500;
       border-radius: $border-radius-sm;
       cursor: pointer;
+      overflow: inherit;
 
       &:hover {
         color: $color-green-70;
@@ -75,32 +77,15 @@
 
       samp {
         font-family: inherit;
-        max-width: 250px; // Setting a fixed width to truncate string
         align-self: start;
         white-space: nowrap;
-        overflow: hidden;
+        overflow: inherit;
         text-overflow: ellipsis;
-
-        // Magic numbers: Stops long mask domains from overflowing, and enforces an ellipsis.
-        @media screen and #{$mq-sm} {
-          max-width: 350px; // Flex items wrap on smaller screens, hence there is more space
-        }
-        @media screen and #{$mq-md} {
-          max-width: 320px;
-        }
-        @media screen and (min-width: $content-lg) {
-          max-width: 400px;
-        }
-        // Note: Since the mask card is being used in a container (.main-wrapper) with a max-width of $content-xl,
-        // this will work. But if we use a mask card where the max-width of the parent container is < $content-xl,
-        // this formatting will break and could cause overflow (ex. MPP-3594). It could be worthwhile to do a re-design of the mask card CSS as whole.
-        @media screen and (min-width: $content-xl) {
-          max-width: calc($content-md - 140px);
-        }
       }
 
       .copy-icon {
         width: 15px; // Fixed size for the copy icon
+        flex: 1 0 auto; // Avoid copied icon shrinking
       }
     }
 
@@ -136,8 +121,6 @@
 
       @media screen and #{$mq-lg} {
         display: initial;
-        position: absolute;
-        right: 0;
       }
     }
   }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes two issues,

MPP-3702: On mobile devices, the leftmost side of the alias copy button is not clickable because it is blocked by the "label confirmation" label.

MPP-3731: Depending on the users country, localized strings can be long and overlap with the alias text within the mask card (see screenshot in ticket). 

# Screenshot (if applicable)

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/218a87a8-1cd8-4011-a2c6-822a8320b0cd)
* Long labels will truncate the alias correctly now. 

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/24a289d1-e618-49c9-86d2-b53b2a06697b)
* The circled area is clickable now.

# How to test

MPP-3731:
* Go to settings in your browser and change your language to Spanish
* Go to the relay website
* Create a long mask (50-62 chars)
* Observe the mask card

MPP-3702:
* Navigate to the Relay email mask dashboard;
* Make the viewport width ~500 px (so that the label editor and mask are in two seperate rows)
* Try copying the mask by clicking the left most side of it (the first few letters).
* Observe the behaviour; 

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] Customer Experience team has seen or waived a demo of functionality.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
