### PR TITLE
E2E fixes for FxA auth page changes (2024-03-19)

### DIFF
--- a/e2e-tests/pages/authPage.ts
+++ b/e2e-tests/pages/authPage.ts
@@ -14,12 +14,12 @@ export class AuthPage {
     constructor(page: Page){
         this.page = page;
         this.emailInputField = page.locator('input[name="email"]');
-        this.passwordInputField = page.getByTestId('new-password-input-field');
-        this.passwordConfirmInputField = page.getByTestId('verify-password-input-field');
-        this.ageInputField = page.getByTestId('age-input-field');
+        this.passwordInputField = process.env["E2E_TEST_ENV"] === "prod" ? page.locator('#password') : page.getByTestId('new-password-input-field');
+        this.passwordConfirmInputField = process.env["E2E_TEST_ENV"] === "prod" ? page.locator('#vpassword') : page.getByTestId('verify-password-input-field');
+        this.ageInputField = process.env["E2E_TEST_ENV"] === "prod" ? page.locator('#age') : page.getByTestId('age-input-field');
         this.continueButton = page.locator('#submit-btn');
         this.createAccountButton = page.getByRole('button', { name: 'Create account' });
-        this.verifyCodeInputField = page.getByTestId('confirm-signup-code-input-field');
+        this.verifyCodeInputField = process.env["E2E_TEST_ENV"] === "prod" ? page.locator('div.card input') : page.getByTestId('confirm-signup-code-input-field');
         this.confirmCodeButton = page.getByRole('button', { name: 'Confirm' });
     }
 


### PR DESCRIPTION
In the FxA production environment, changes for account creation changes handled in https://github.com/mozilla/fx-private-relay/pull/4346 were reverted, causing failing tests for Relay prod. The changes were not reverted for the stage FxA auth page as of today, so no updates are needed there.


# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] Customer Experience team has seen or waived a demo of functionality.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
