### PR TITLE
MPP-3753: Disable DomainAddress address field updates

### DIFF
--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -560,6 +560,49 @@ def test_patch_domainaddress_read_only_mask_type(
     assert get_glean_event(caplog) is None
 
 
+def test_patch_domainaddress_address_fails(
+    prem_api_client: APIClient, premium_user: User, caplog: pytest.LogCaptureFixture
+) -> None:
+    """PATCH should not succeed when attempting to update the address field."""
+    existing = DomainAddress.objects.create(user=premium_user, address="my-new-alias")
+    url = reverse("domainaddress-detail", args=[existing.id])
+    get_json = prem_api_client.get(url).json()
+    assert get_json["address"] == "my-new-alias"
+    response = prem_api_client.patch(url, data={"address": "my-new-edited-alias"})
+    ret_data = response.json()
+
+    assert response.status_code == 400
+    assert ret_data["detail"] == "You cannot edit an existing domain address field."
+    assert ret_data["error_code"] == "address_exists"
+    assert get_glean_event(caplog) is None
+
+
+def test_patch_domainaddress_addr_with_id_fails(
+    prem_api_client: APIClient, premium_user: User, caplog: pytest.LogCaptureFixture
+) -> None:
+    """
+    PATCH should not succeed when updating the address field and an 'id' field should have no effect on
+    the request because it is a read-only field
+    """
+
+    existing_alias = DomainAddress.objects.create(
+        user=premium_user, address="my-new-alias"
+    )
+
+    url = reverse("domainaddress-detail", args=[existing_alias.id])
+    get_json = prem_api_client.get(url).json()
+    assert get_json["address"] == "my-new-alias"
+    response = prem_api_client.patch(
+        url, data={"id": 100, "address": "my-new-edited-alias"}
+    )
+    ret_data = response.json()
+
+    assert response.status_code == 400
+    assert ret_data["detail"] == "You cannot edit an existing domain address field."
+    assert ret_data["error_code"] == "address_exists"
+    assert get_glean_event(caplog) is None
+
+
 def test_delete_domainaddress(
     prem_api_client: APIClient, premium_user: User, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -573,7 +573,7 @@ def test_patch_domainaddress_address_fails(
 
     assert response.status_code == 400
     assert ret_data["detail"] == "You cannot edit an existing domain address field."
-    assert ret_data["error_code"] == "address_exists"
+    assert ret_data["error_code"] == "address_not_editable"
     assert get_glean_event(caplog) is None
 
 
@@ -599,7 +599,7 @@ def test_patch_domainaddress_addr_with_id_fails(
 
     assert response.status_code == 400
     assert ret_data["detail"] == "You cannot edit an existing domain address field."
-    assert ret_data["error_code"] == "address_exists"
+    assert ret_data["error_code"] == "address_not_editable"
     assert get_glean_event(caplog) is None
 
 

--- a/emails/models.py
+++ b/emails/models.py
@@ -689,7 +689,7 @@ class DomainAddrNeedSubdomainException(CannotMakeAddressException):
 class DomainAddrUpdateException(CannotMakeAddressException):
     """Exception raised when attempting to edit an existing domain address field."""
 
-    default_code = "address_exists"
+    default_code = "address_not_editable"
     default_detail = "You cannot edit an existing domain address field."
     status_code = 400
 

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -7,4 +7,4 @@
 # Variables:
 #   $duplicate_address (string) - User-set email address that already exists
 api-error-duplicate-address = “{ $duplicate_address }” already exists. Please try again with a different mask name.
-api-error-address-exists = You cannot edit an existing domain address field.
+api-error-address-not-editable = You cannot edit an existing domain address field.

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -7,3 +7,4 @@
 # Variables:
 #   $duplicate_address (string) - User-set email address that already exists
 api-error-duplicate-address = “{ $duplicate_address }” already exists. Please try again with a different mask name.
+api-error-address-exists = You cannot edit an existing domain address field.


### PR DESCRIPTION
This PR fixes MPP-3753.

<!-- When adding a new feature: -->

# New feature description

Disables updates to the address field for DomainAddress'.

# Screenshot (if applicable)

Not applicable.

# How to test

1. Log in or create account with premium emails and a domain locally

2. Create a new domain mask

3. Go to api/v1/docs/#/domainaddresses/domainaddresses_list, select GET /api/v1/domainaddresses/, click “Try it out”, scroll down and then click “Execute”, to get the list of domain addresses. Get the ID for the new domain mask.

4. Still on  api/v1/docs/#/domainaddresses/domainaddresses_list, select PATCH /api/v1/domainaddresses/{id}/. Click “Try it out”, enter the ID for the new domain mask, and enter JSON that changes the address, such as {"address": "Huh-You-Can-Change-This"}.


# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] Customer Experience team has seen or waived a demo of functionality.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
