### PR TITLE
CircleCI Fix: Remove merged strings from pending.ftl

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ If you're not yet ready to submit some strings for translation, you can
 tentatively add them to `frontend/pendingTranslations.ftl`. Strings in that file
 will show up until strings with the same ID are added to the l10n repository.
 
+Similarly, there is a `pending_locales/pending.ftl` where temporary backend locales strings can be stored. Once the strings from the pull request in [the l10n repo](https://github.com/mozilla-l10n/fx-private-relay-l10n) has been merged into the Relay repo, these respective strings need to be removed from `pending_locales/pending.ftl` to avoid failing CircleCI tests.
+
 #### Commit translations for release
 
 To commit updates to the app's translations (e.g., before a release), we need

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -3,8 +3,3 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # This is the Django equivalent of frontend/pendingTranslations.ftl
-
-# Variables:
-#   $duplicate_address (string) - User-set email address that already exists
-api-error-duplicate-address = “{ $duplicate_address }” already exists. Please try again with a different mask name.
-api-error-address-not-editable = You cannot edit an existing domain address field.


### PR DESCRIPTION
This fixes failing CircleCI tests by removing pending.ftl strings that were merged in https://github.com/mozilla/fx-private-relay/commit/c61dbeda5ddc5ee62413a5ce41d91ca6a491343f, which caused the tests to break.