### PR TITLE
MPP-3753: More test changes for write-once DomainAddress address

### DIFF
--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -506,8 +506,6 @@ def test_patch_domainaddress_same_value_used_on(
     "key,value",
     [
         ("id", -1),
-        # TODO MPP-3753: Make address a write-once field
-        pytest.param("address", "a-different-alias", marks=pytest.mark.xfail),
         ("domain", 1),
         ("full_address", "a-different-alias@premium.test.com"),
         ("created_at", "2024-02-15"),

--- a/api/tests/views_tests.py
+++ b/api/tests/views_tests.py
@@ -579,8 +579,8 @@ def test_patch_domainaddress_addr_with_id_fails(
     prem_api_client: APIClient, premium_user: User, caplog: pytest.LogCaptureFixture
 ) -> None:
     """
-    PATCH should not succeed when updating the address field and an 'id' field should have no effect on
-    the request because it is a read-only field
+    PATCH should not succeed when updating the address field and an 'id' field should
+    have no effect on the request because it is a read-only field
     """
 
     existing_alias = DomainAddress.objects.create(


### PR DESCRIPTION
This is follow-on work for PR #4519:

* Remove the TODO and the `address` test case for `test_patch_domainaddress_read_only`. If a caller tries to change the `address`, it is a 400 error, not a 200, as tested in `test_patch_domainaddress_address_fails`
* Wrap a comment to under 88 lines. This will be enforced soon with `ruff`.