### PR TITLE
MPP-2530 - Modernize code with `pyupgrade --py311-plus`

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -130,16 +130,16 @@ class StrictReadOnlyFieldsMixin:
             return attrs
 
         # Getting the declared read only fields and read only fields from Meta
-        read_only_fields = set(
+        read_only_fields = {
             field_name for field_name, field in self.fields.items() if field.read_only
-        ).union(set(getattr(self.Meta, "read_only_fields", set())))
+        }.union(set(getattr(self.Meta, "read_only_fields", set())))
 
         # Getting implicit read only fields that are in the Profile model, but were not
         # defined in the serializer.  By default, they won't update if put in the body
         # of a request, but they still give a 200 response (which we don't want).
-        implicit_read_only_fields = set(
+        implicit_read_only_fields = {
             field for field in vars(self.Meta.model) if field not in self.fields
-        )
+        }
 
         received_read_only_fields = set(self.initial_data).intersection(
             read_only_fields.union(implicit_read_only_fields)

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -1512,14 +1512,12 @@ def test_inbound_sms_reply_no_prefix_last_sender(
     assert relay_number.texts_forwarded == multi_reply.old_texts_forwarded + 1
 
 
-_match_by_prefix_candidates = set(
-    (
-        "+13015550000",
-        "+13025550001",
-        "+13035550001",  # Same last 4 digits as above
-        "+13045551301",  # Last 4 match first 4 of oldest
-    )
-)
+_match_by_prefix_candidates = {
+    "+13015550000",
+    "+13025550001",
+    "+13035550001",  # Same last 4 digits as above
+    "+13045551301",  # Last 4 match first 4 of oldest
+}
 
 
 MatchByPrefixParams = tuple[

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Iterator, Literal
+from typing import Literal
+from collections.abc import Iterator
 from unittest.mock import Mock, patch, call
 import re
 

--- a/emails/apps.py
+++ b/emails/apps.py
@@ -53,7 +53,7 @@ class EmailsConfig(AppConfig):
     def _load_terms(self, filename):
         terms = []
         terms_file_path = os.path.join(settings.BASE_DIR, "emails", filename)
-        with open(terms_file_path, "r") as terms_file:
+        with open(terms_file_path) as terms_file:
             for word in terms_file:
                 if len(word.strip()) > 0 and word.strip()[0] == "#":
                     continue

--- a/emails/apps.py
+++ b/emails/apps.py
@@ -41,7 +41,7 @@ class EmailsConfig(AppConfig):
             logger.exception("exception during S3 connect")
 
     def __init__(self, app_name, app_module):
-        super(EmailsConfig, self).__init__(app_name, app_module)
+        super().__init__(app_name, app_module)
 
         # badwords file from:
         # https://www.cs.cmu.edu/~biglou/resources/bad-words.txt

--- a/emails/management/commands/check_health.py
+++ b/emails/management/commands/check_health.py
@@ -57,7 +57,7 @@ class Command(CommandFromDjangoSettings):
     def handle(self, verbosity, *args, **kwargs):
         """Handle call from command line (called by BaseCommand)"""
         self.init_from_settings(verbosity)
-        with open(self.healthcheck_path, mode="r", encoding="utf8") as healthcheck_file:
+        with open(self.healthcheck_path, encoding="utf8") as healthcheck_file:
             context = self.check_healthcheck(healthcheck_file, self.max_age)
         if context["success"]:
             if self.verbosity > 1:

--- a/emails/models.py
+++ b/emails/models.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 from collections import namedtuple
 from datetime import datetime, timedelta, timezone
 from hashlib import sha256
-from typing import Iterable, Literal
+from typing import Literal
+from collections.abc import Iterable
 import logging
 import random
 import re

--- a/emails/models.py
+++ b/emails/models.py
@@ -772,7 +772,7 @@ class RelayAddress(models.Model):
         profile.num_deleted_relay_addresses += 1
         profile.last_engagement = datetime.now(timezone.utc)
         profile.save()
-        return super(RelayAddress, self).delete(*args, **kwargs)
+        return super().delete(*args, **kwargs)
 
     def save(
         self,
@@ -1018,7 +1018,7 @@ class DomainAddress(models.Model):
         profile.num_deleted_domain_addresses += 1
         profile.last_engagement = datetime.now(timezone.utc)
         profile.save()
-        return super(DomainAddress, self).delete(*args, **kwargs)
+        return super().delete(*args, **kwargs)
 
     @property
     def domain_value(self):

--- a/emails/models.py
+++ b/emails/models.py
@@ -821,7 +821,7 @@ class RelayAddress(models.Model):
 
     @property
     def full_address(self):
-        return "%s@%s" % (self.address, self.domain_value)
+        return f"{self.address}@{self.domain_value}"
 
     @property
     def metrics_id(self) -> str:
@@ -1026,7 +1026,7 @@ class DomainAddress(models.Model):
 
     @property
     def full_address(self):
-        return "%s@%s.%s" % (
+        return "{}@{}.{}".format(
             self.address,
             self.user_profile.subdomain,
             self.domain_value,

--- a/emails/models.py
+++ b/emails/models.py
@@ -973,7 +973,7 @@ class DomainAddress(models.Model):
     @staticmethod
     def make_domain_address(
         user_profile: Profile, address: str | None = None, made_via_email: bool = False
-    ) -> "DomainAddress":
+    ) -> DomainAddress:
         check_user_can_make_domain_address(user_profile)
 
         if not address:

--- a/emails/models.py
+++ b/emails/models.py
@@ -584,10 +584,10 @@ def address_hash(address, subdomain=None, domain=None):
     if not domain:
         domain = get_domains_from_settings()["MOZMAIL_DOMAIN"]
     if subdomain:
-        return sha256(f"{address}@{subdomain}.{domain}".encode("utf-8")).hexdigest()
+        return sha256(f"{address}@{subdomain}.{domain}".encode()).hexdigest()
     if domain == settings.RELAY_FIREFOX_DOMAIN:
-        return sha256(f"{address}".encode("utf-8")).hexdigest()
-    return sha256(f"{address}@{domain}".encode("utf-8")).hexdigest()
+        return sha256(f"{address}".encode()).hexdigest()
+    return sha256(f"{address}@{domain}".encode()).hexdigest()
 
 
 def address_default():
@@ -622,7 +622,7 @@ def get_domain_numerical(domain_address):
 
 
 def hash_subdomain(subdomain, domain=settings.MOZMAIL_DOMAIN):
-    return sha256(f"{subdomain}.{domain}".encode("utf-8")).hexdigest()
+    return sha256(f"{subdomain}.{domain}".encode()).hexdigest()
 
 
 class RegisteredSubdomain(models.Model):

--- a/emails/tests/mgmt_process_emails_from_sqs_tests.py
+++ b/emails/tests/mgmt_process_emails_from_sqs_tests.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
-from typing import Any, Generator, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
+from collections.abc import Generator
 from unittest.mock import patch, Mock
 from uuid import uuid4
 import json

--- a/emails/tests/mgmt_process_emails_from_sqs_tests.py
+++ b/emails/tests/mgmt_process_emails_from_sqs_tests.py
@@ -375,7 +375,7 @@ def test_writes_healthcheck_file(test_settings):
     """Running the command writes to the healthcheck file."""
     call_command("process_emails_from_sqs")
     healthcheck_path = test_settings.PROCESS_EMAIL_HEALTHCHECK_PATH
-    with open(healthcheck_path, "r", encoding="utf-8") as healthcheck_file:
+    with open(healthcheck_path, encoding="utf-8") as healthcheck_file:
         content = json.load(healthcheck_file)
     assert content == {
         "timestamp": content["timestamp"],

--- a/emails/tests/mgmt_send_welcome_emails_tests.py
+++ b/emails/tests/mgmt_send_welcome_emails_tests.py
@@ -1,5 +1,4 @@
 import pytest
-from typing import Tuple
 from unittest.mock import MagicMock, patch
 
 from botocore.exceptions import ClientError
@@ -144,7 +143,7 @@ def _assert_caplog_for_1_email_to_user(
     assert "Exiting" in rec4.getMessage()
 
 
-def _get_send_email_args(mock_ses_client: MagicMock) -> Tuple:
+def _get_send_email_args(mock_ses_client: MagicMock) -> tuple:
     call_args = mock_ses_client.send_email.call_args[1]
     to_addresses = call_args["Destination"]["ToAddresses"]
     source = call_args["Source"]

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -167,29 +167,27 @@ class MiscEmailModelsTest(TestCase):
     @override_settings(RELAY_FIREFOX_DOMAIN="firefox.com")
     def test_address_hash_without_subdomain_domain_firefox(self):
         address = "aaaaaaaaa"
-        expected_hash = sha256(f"{address}".encode("utf-8")).hexdigest()
+        expected_hash = sha256(f"{address}".encode()).hexdigest()
         assert address_hash(address, domain="firefox.com") == expected_hash
 
     @override_settings(RELAY_FIREFOX_DOMAIN="firefox.com")
     def test_address_hash_without_subdomain_domain_not_firefoxz(self):
         non_default = "test.com"
         address = "aaaaaaaaa"
-        expected_hash = sha256(f"{address}@{non_default}".encode("utf-8")).hexdigest()
+        expected_hash = sha256(f"{address}@{non_default}".encode()).hexdigest()
         assert address_hash(address, domain=non_default) == expected_hash
 
     def test_address_hash_with_subdomain(self):
         address = "aaaaaaaaa"
         subdomain = "test"
         domain = get_domains_from_settings().get("MOZMAIL_DOMAIN")
-        expected_hash = sha256(
-            f"{address}@{subdomain}.{domain}".encode("utf-8")
-        ).hexdigest()
+        expected_hash = sha256(f"{address}@{subdomain}.{domain}".encode()).hexdigest()
         assert address_hash(address, subdomain, domain) == expected_hash
 
     def test_address_hash_with_additional_domain(self):
         address = "aaaaaaaaa"
         test_domain = "test.com"
-        expected_hash = sha256(f"{address}@{test_domain}".encode("utf-8")).hexdigest()
+        expected_hash = sha256(f"{address}@{test_domain}".encode()).hexdigest()
         assert address_hash(address, domain=test_domain) == expected_hash
 
     def test_get_domain_numerical(self):
@@ -320,7 +318,7 @@ class RelayAddressTest(TestCase):
     def test_delete_mozmail_deleted_address_object(self):
         relay_address = baker.make(RelayAddress, domain=2, user=self.user)
         address_hash = sha256(
-            f"{relay_address.address}@{relay_address.domain_value}".encode("utf-8")
+            f"{relay_address.address}@{relay_address.domain_value}".encode()
         ).hexdigest()
         relay_address.delete()
         deleted_count = DeletedAddress.objects.filter(address_hash=address_hash).count()

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -95,7 +95,7 @@ def load_fixtures(file_suffix: str) -> dict[str, AWS_SNSMessageJSON | str]:
         file_name = os.path.basename(fixture_file)
         key = file_name[: -len(file_suffix)]
         assert key not in fixtures
-        with open(fixture_file, "r") as f:
+        with open(fixture_file) as f:
             if ext == ".json":
                 fixtures[key] = json.load(f)
             else:

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -72,7 +72,7 @@ def get_trackers(level):
     trackers = []
     file_name = f"{tracker_list_name}.json"
     try:
-        with open(TRACKER_FOLDER_PATH / file_name, "r") as f:
+        with open(TRACKER_FOLDER_PATH / file_name) as f:
             trackers = json.load(f)
     except FileNotFoundError:
         trackers = download_trackers(shavar_prod_lists_url, category)

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -6,7 +6,8 @@ from email.headerregistry import Address, AddressHeader
 from email.message import EmailMessage
 from email.utils import formataddr, parseaddr
 from functools import cache
-from typing import cast, Any, Callable, TypeVar
+from typing import cast, Any, TypeVar
+from collections.abc import Callable
 import json
 import pathlib
 import re

--- a/emails/views.py
+++ b/emails/views.py
@@ -1007,7 +1007,7 @@ def _replace_headers(
     """
     # Look for headers to drop
     to_drop: list[str] = []
-    replacements: set[str] = set(_k.lower() for _k in headers.keys())
+    replacements: set[str] = {_k.lower() for _k in headers.keys()}
     issues: EmailHeaderIssues = defaultdict(list)
 
     # Detect non-compliant headers in incoming emails

--- a/phones/models.py
+++ b/phones/models.py
@@ -453,7 +453,7 @@ def suggested_numbers(user):
     same_prefix_options.extend(convert_twilio_numbers_to_dict(twilio_nums))
 
     # look for numbers with same area code, 2-number prefix and suffix
-    contains = "{}***{}".format(real_num[:7], real_num[10:]) if real_num else ""
+    contains = f"{real_num[:7]}***{real_num[10:]}" if real_num else ""
     twilio_nums = avail_nums.local.list(contains=contains, limit=10)
     same_prefix_options.extend(convert_twilio_numbers_to_dict(twilio_nums))
 

--- a/phones/models.py
+++ b/phones/models.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from math import floor
-from typing import Iterator, Optional
+from typing import Optional
+from collections.abc import Iterator
 import logging
 import phonenumbers
 import secrets

--- a/phones/models.py
+++ b/phones/models.py
@@ -452,7 +452,7 @@ def suggested_numbers(user):
     same_prefix_options.extend(convert_twilio_numbers_to_dict(twilio_nums))
 
     # look for numbers with same area code, 2-number prefix and suffix
-    contains = "%s***%s" % (real_num[:7], real_num[10:]) if real_num else ""
+    contains = "{}***{}".format(real_num[:7], real_num[10:]) if real_num else ""
     twilio_nums = avail_nums.local.list(contains=contains, limit=10)
     same_prefix_options.extend(convert_twilio_numbers_to_dict(twilio_nums))
 

--- a/phones/models.py
+++ b/phones/models.py
@@ -85,7 +85,7 @@ def get_valid_realphone_verification_record(user, number, verification_code):
     ).first()
 
 
-def get_last_text_sender(relay_number: "RelayNumber") -> Optional["InboundContact"]:
+def get_last_text_sender(relay_number: RelayNumber) -> InboundContact | None:
     """
     Get the last text sender.
 

--- a/privaterelay/cleaners.py
+++ b/privaterelay/cleaners.py
@@ -16,8 +16,8 @@ class DataIssueTask:
     check_description: str  # A sentence describing what this cleaner is checking.
     can_clean: bool  # True if the issue can be automatically cleaned
 
-    _counts: Optional[Counts]
-    _cleanup_data: Optional[CleanupData]
+    _counts: Counts | None
+    _cleanup_data: CleanupData | None
     _cleaned: bool
 
     def __init__(self):

--- a/privaterelay/management/commands/cleanup_data.py
+++ b/privaterelay/management/commands/cleanup_data.py
@@ -143,7 +143,7 @@ class Command(BaseCommand):
         verbosity: int,
         tasks: dict[str, DataIssueTask],
         issue_timers: dict[str, float],
-        clean_timers: Optional[dict[str, float]],
+        clean_timers: dict[str, float] | None,
     ) -> tuple[dict, dict]:
         """Gather full data and log data from tasks and timers."""
 

--- a/privaterelay/plans.py
+++ b/privaterelay/plans.py
@@ -140,16 +140,15 @@ relay_countries = set(get_args(CountryStr))
 # Periodic subscription categories
 PeriodStr = Literal["monthly", "yearly"]
 
+
 # A Stripe Price, along with key details for Relay website
 # https://stripe.com/docs/api/prices/object
-StripePriceDef = TypedDict(
-    "StripePriceDef",
-    {
-        "id": str,  # Must start with "price_"
-        "price": float,
-        "currency": CurrencyStr,
-    },
-)
+class StripePriceDef(TypedDict):
+    id: str  # Must start with "price_"
+    price: float
+    currency: CurrencyStr
+
+
 PricesForPeriodDict = dict[PeriodStr, StripePriceDef]
 LanguageOrAny = LanguageStr | Literal["*"]
 PricePeriodsForLanguageDict = dict[LanguageOrAny, PricesForPeriodDict]
@@ -196,52 +195,46 @@ _RegionalLanguageStr = Literal[
 # Stripe plans are associated with a country or country-language pair
 _CountryOrRegion = CountryStr | _RegionalLanguageStr
 
+
 # Types for _STRIPE_PLAN_DATA
-_StripeMonthlyPriceDetails = TypedDict(
-    "_StripeMonthlyPriceDetails", {"monthly": float, "monthly_when_yearly": float}
-)
-_StripeMonthlyCountryDetails = TypedDict(
-    "_StripeMonthlyCountryDetails",
-    {
-        "currency": CurrencyStr,
-        "monthly_id": str,
-        "yearly_id": str,
-    },
-)
-_StripeMonthlyPlanDetails = TypedDict(
-    "_StripeMonthlyPlanDetails",
-    {
-        "periods": Literal["monthly_and_yearly"],
-        "prices": dict[CurrencyStr, _StripeMonthlyPriceDetails],
-        "countries_and_regions": dict[_CountryOrRegion, _StripeMonthlyCountryDetails],
-    },
-)
-_StripeYearlyPriceDetails = TypedDict(
-    "_StripeYearlyPriceDetails", {"monthly_when_yearly": float}
-)
-_StripeYearlyCountryDetails = TypedDict(
-    "_StripeYearlyCountryDetails",
-    {
-        "currency": CurrencyStr,
-        "yearly_id": str,
-    },
-)
-_StripeYearlyPlanDetails = TypedDict(
-    "_StripeYearlyPlanDetails",
-    {
-        "periods": Literal["yearly"],
-        "prices": dict[CurrencyStr, _StripeYearlyPriceDetails],
-        "countries_and_regions": dict[_CountryOrRegion, _StripeYearlyCountryDetails],
-    },
-)
-_StripePlanData = TypedDict(
-    "_StripePlanData",
-    {
-        "premium": _StripeMonthlyPlanDetails,
-        "phones": _StripeMonthlyPlanDetails,
-        "bundle": _StripeYearlyPlanDetails,
-    },
-)
+class _StripeMonthlyPriceDetails(TypedDict):
+    monthly: float
+    monthly_when_yearly: float
+
+
+class _StripeMonthlyCountryDetails(TypedDict):
+    currency: CurrencyStr
+    monthly_id: str
+    yearly_id: str
+
+
+class _StripeMonthlyPlanDetails(TypedDict):
+    periods: Literal["monthly_and_yearly"]
+    prices: dict[CurrencyStr, _StripeMonthlyPriceDetails]
+    countries_and_regions: dict[_CountryOrRegion, _StripeMonthlyCountryDetails]
+
+
+class _StripeYearlyPriceDetails(TypedDict):
+    monthly_when_yearly: float
+
+
+class _StripeYearlyCountryDetails(TypedDict):
+    currency: CurrencyStr
+    yearly_id: str
+
+
+class _StripeYearlyPlanDetails(TypedDict):
+    periods: Literal["yearly"]
+    prices: dict[CurrencyStr, _StripeYearlyPriceDetails]
+    countries_and_regions: dict[_CountryOrRegion, _StripeYearlyCountryDetails]
+
+
+class _StripePlanData(TypedDict):
+    premium: _StripeMonthlyPlanDetails
+    phones: _StripeMonthlyPlanDetails
+    bundle: _StripeYearlyPlanDetails
+
+
 _StripePlanDetails = _StripeMonthlyPlanDetails | _StripeYearlyPlanDetails
 
 # Selected Stripe data
@@ -441,15 +434,14 @@ _STRIPE_PLAN_DATA: _StripePlanData = {
 
 # Private types for _RELAY_PLANS
 _RelayPlanCategory = Literal["premium", "phones", "bundle"]
-_RelayPlansByType = TypedDict(
-    "_RelayPlansByType",
-    {
-        "by_country_and_lang": dict[CountryStr, dict[LanguageStr, _CountryOrRegion]],
-        "by_country_override": dict[CountryStr, CountryStr],
-        "by_country": list[CountryStr],
-    },
-    total=False,
-)
+
+
+class _RelayPlansByType(TypedDict, total=False):
+    by_country_and_lang: dict[CountryStr, dict[LanguageStr, _CountryOrRegion]]
+    by_country_override: dict[CountryStr, CountryStr]
+    by_country: list[CountryStr]
+
+
 _RelayPlans = dict[_RelayPlanCategory, _RelayPlansByType]
 
 

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -218,9 +218,9 @@ TWILIO_MESSAGING_SERVICE_SID: list[str] = config(
 )
 TWILIO_TEST_ACCOUNT_SID: str | None = config("TWILIO_TEST_ACCOUNT_SID", None)
 TWILIO_TEST_AUTH_TOKEN: str | None = config("TWILIO_TEST_AUTH_TOKEN", None)
-TWILIO_ALLOWED_COUNTRY_CODES = set(
+TWILIO_ALLOWED_COUNTRY_CODES = {
     code.upper() for code in config("TWILIO_ALLOWED_COUNTRY_CODES", "US,CA", cast=Csv())
-)
+}
 MAX_MINUTES_TO_VERIFY_REAL_PHONE: int = config(
     "MAX_MINUTES_TO_VERIFY_REAL_PHONE", 5, cast=int
 )

--- a/privaterelay/tests/allauth_tests.py
+++ b/privaterelay/tests/allauth_tests.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from collections.abc import Iterator
 from unittest.mock import patch, Mock
 import pytest
 

--- a/privaterelay/tests/conftest.py
+++ b/privaterelay/tests/conftest.py
@@ -1,7 +1,7 @@
 """Shared fixtures for privaterelay tests"""
 
 from pathlib import Path
-from typing import Iterator
+from collections.abc import Iterator
 import json
 
 from pytest_django.fixtures import SettingsWrapper

--- a/privaterelay/tests/utils.py
+++ b/privaterelay/tests/utils.py
@@ -12,31 +12,29 @@ import pytest
 
 def log_extra(log_record: LogRecord) -> dict[str, Any]:
     """Reconstruct the "extra" argument to the log call"""
-    omit_log_record_keys = set(
-        (
-            "args",
-            "created",
-            "exc_info",
-            "exc_text",
-            "filename",
-            "funcName",
-            "levelname",
-            "levelno",
-            "lineno",
-            "message",
-            "module",
-            "msecs",
-            "msg",
-            "name",
-            "pathname",
-            "process",
-            "processName",
-            "relativeCreated",
-            "stack_info",
-            "thread",
-            "threadName",
-        )
-    )
+    omit_log_record_keys = {
+        "args",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "thread",
+        "threadName",
+    }
     return {
         key: val
         for key, val in log_record.__dict__.items()

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from collections.abc import Iterator
 from unittest.mock import patch
 import logging
 

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -3,7 +3,8 @@ import logging
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Iterator, Literal
+from typing import Any, Literal
+from collections.abc import Iterator
 from uuid import uuid4
 from unittest.mock import Mock, patch
 

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -3,7 +3,8 @@ from decimal import Decimal
 from functools import cache, wraps
 from pathlib import Path
 from string import ascii_uppercase
-from typing import Callable, TypedDict, cast, TYPE_CHECKING
+from typing import TypedDict, cast, TYPE_CHECKING
+from collections.abc import Callable
 import json
 import logging
 import random

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timezone
 from functools import lru_cache
 from hashlib import sha256
-from typing import Any, Iterable, Optional, TypedDict
+from typing import Any, Optional, TypedDict
+from collections.abc import Iterable
 import json
 import logging
 
@@ -199,7 +200,7 @@ def _authenticate_fxa_jwt(req_jwt: str) -> FxAEvent:
 
 def _verify_jwt_with_fxa_key(
     req_jwt: str, verifying_keys: list[dict[str, Any]]
-) -> Optional[FxAEvent]:
+) -> FxAEvent | None:
     if not verifying_keys:
         raise Exception("FXA verifying keys are not available.")
     social_app = SocialApp.objects.get(provider="fxa")
@@ -253,8 +254,8 @@ def _get_event_keys_from_jwt(authentic_jwt: FxAEvent) -> Iterable[str]:
 
 def update_fxa(
     social_account: SocialAccount,
-    authentic_jwt: Optional[FxAEvent] = None,
-    event_key: Optional[str] = None,
+    authentic_jwt: FxAEvent | None = None,
+    event_key: str | None = None,
 ) -> HttpResponse:
     try:
         client = _get_oauth2_session(social_account)


### PR DESCRIPTION
[pyupgrade](https://pypi.org/project/pyupgrade/) can reformat code to use update-to-date syntax and library usage. `--py311-plus` will use features in 3.11 and later. We'll be able to enforce this style with [ruff](https://github.com/astral-sh/ruff).

# How to test:
- CircleCI continues to pass