### PR TITLE
Group boto and boto types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,13 @@ updates:
           # Requires django-stubs 4.2.7
           - "3.14.5"
     groups:
+      boto:
+        patterns:
+          - "boto3"
+          - "boto3-stubs"
+          - "botocore"
+          - "botocore-stubs"
+          - "mypy-boto3-ses"
       testing-libraries:
         patterns:
           - "coverage"
@@ -52,11 +59,8 @@ updates:
           - "responses"
       typing-stubs:
         patterns:
-          - "boto3-stubs"
-          - "botocore-stubs"
           - "django-stubs"
           - "djangorestframework-stubs"
-          - "mypy-boto3-ses"
           - "types-pyOpenSSL"
           - "types-requests"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
boto dependencies are generated from API specifications and change weekly. The typing modules are often modified on the same schedule. Grouping them will avoid mismatches and help the typing group update less often.

This was suggested by @groovecoder on February 12.