### PR TITLE
MPP-3784: Add FxA ID to logs for bounces and complaints

### DIFF
--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -907,6 +907,9 @@ class SNSNotificationRepliesTest(SNSNotificationTestBase):
 class BounceHandlingTest(TestCase):
     def setUp(self):
         self.user = baker.make(User, email="relayuser@test.com")
+        self.sa: SocialAccount = baker.make(
+            SocialAccount, user=self.user, provider="fxa", uid=str(uuid4())
+        )
 
     def test_sns_message_with_hard_bounce(self) -> None:
         pre_request_datetime = datetime.now(timezone.utc)
@@ -930,6 +933,7 @@ class BounceHandlingTest(TestCase):
             "domain": "test.com",
             "relay_action": "hard_bounce",
             "user_match": "found",
+            "fxa_id": self.sa.uid,
         }
 
         mm.assert_incr_once(
@@ -964,6 +968,7 @@ class BounceHandlingTest(TestCase):
             "domain": "test.com",
             "relay_action": "soft_bounce",
             "user_match": "found",
+            "fxa_id": self.sa.uid,
         }
 
         mm.assert_incr_once(
@@ -994,6 +999,7 @@ class BounceHandlingTest(TestCase):
             "domain": "test.com",
             "relay_action": "auto_block_spam",
             "user_match": "found",
+            "fxa_id": self.sa.uid,
         }
 
         mm.assert_incr_once(

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -1021,7 +1021,7 @@ class BounceHandlingTest(TestCase):
 
         log_data = log_extra(logs.records[0])
         assert log_data["user_match"] == "found"
-        assert "fxa_id" not in log_data
+        assert not log_data["fxa_id"]
 
 
 @override_settings(STATSD_ENABLED=True)
@@ -1097,7 +1097,7 @@ class ComplaintHandlingTest(TestCase):
 
         log_data = log_extra(logs.records[0])
         assert log_data["user_match"] == "found"
-        assert "fxa_id" not in log_data
+        assert not log_data["fxa_id"]
 
 
 class SNSNotificationRemoveEmailsInS3Test(TestCase):

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -1019,6 +1019,9 @@ class ComplaintHandlingTest(TestCase):
 
     def setUp(self):
         self.user = baker.make(User, email="relayuser@test.com")
+        self.sa: SocialAccount = baker.make(
+            SocialAccount, user=self.user, provider="fxa", uid=str(uuid4())
+        )
 
     def test_notification_type_complaint(self):
         """
@@ -1071,6 +1074,7 @@ class ComplaintHandlingTest(TestCase):
             "domain": "test.com",
             "relay_action": "auto_block_spam",
             "user_match": "found",
+            "fxa_id": self.sa.uid,
         }
 
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -1474,7 +1474,7 @@ def _handle_bounce(message_json: AWS_SNSMessageJSON) -> HttpResponse:
             user = User.objects.get(email=recipient_address)
             profile = user.profile
             data["user_match"] = "found"
-            if fxa := profile.fxa:
+            if (fxa := profile.fxa) and profile.metrics_enabled:
                 data["fxa_id"] = fxa.uid
         except User.DoesNotExist:
             # TODO: handle bounce for a user who no longer exists
@@ -1577,7 +1577,7 @@ def _handle_complaint(message_json: AWS_SNSMessageJSON) -> HttpResponse:
             user = User.objects.get(email=recipient_address)
             profile = user.profile
             data["user_match"] = "found"
-            if fxa := profile.fxa:
+            if (fxa := profile.fxa) and profile.metrics_enabled:
                 data["fxa_id"] = fxa.uid
         except User.DoesNotExist:
             data["user_match"] = "missing"

--- a/emails/views.py
+++ b/emails/views.py
@@ -1544,11 +1544,6 @@ def _handle_complaint(message_json: AWS_SNSMessageJSON) -> HttpResponse:
     * complaint_user_agent - identifies the client used to file the complaint
     * complaint_extra - Extra data from complainedRecipients data, if any
     * domain - User's domain, if an address was given
-
-    Emits a legacy log "complaint_received", with data:
-    * recipient_domains: list of extracted user domains
-    * subtype: 'onaccounsuppressionlist', or 'none'
-    * feedback: feedback from ISP or 'none'
     """
     complaint = deepcopy(message_json.get("complaint", {}))
     complained_recipients = complaint.pop("complainedRecipients", [])
@@ -1606,17 +1601,6 @@ def _handle_complaint(message_json: AWS_SNSMessageJSON) -> HttpResponse:
             tags=[generate_tag(key, val) for key, val in tags.items()],
         )
         info_logger.info("complaint_notification", extra=data)
-
-    # Legacy log, can be removed Q4 2023
-    domains = [data["domain"] for data in complaint_data if "domain" in data]
-    info_logger.info(
-        "complaint_received",
-        extra={
-            "recipient_domains": sorted(domains),
-            "subtype": subtype,
-            "feedback": feedback,
-        },
-    )
 
     if any(data["user_match"] == "missing" for data in complaint_data):
         return HttpResponse("Address does not exist", status=404)

--- a/emails/views.py
+++ b/emails/views.py
@@ -1439,9 +1439,6 @@ def _handle_bounce(message_json: AWS_SNSMessageJSON) -> HttpResponse:
     * bounce_diagnostic: 'diagnosticCode' from bounced recipient data, or None
     * bounce_extra: Extra data from bounce_recipient data, if any
     * domain: User's real email address domain, if an address was given
-
-    Emits a legacy log "bounced recipient domain: {domain}", with data from
-    bounced recipient data, without the email address.
     """
     bounce = message_json.get("bounce", {})
     bounce_type = bounce.get("bounceType", "none")
@@ -1517,19 +1514,6 @@ def _handle_bounce(message_json: AWS_SNSMessageJSON) -> HttpResponse:
             tags=[generate_tag(key, val) for key, val in tags.items()],
         )
         info_logger.info("bounce_notification", extra=data)
-
-        # Legacy log, can be removed Q4 2023
-        recipient_domain = data.get("domain")
-        if recipient_domain:
-            legacy_extra = {
-                "action": data.get("bounce_action"),
-                "status": data.get("bounce_status"),
-                "diagnosticCode": data.get("bounce_diagnostic"),
-            }
-            legacy_extra.update(data.get("bounce_extra", {}))
-            info_logger.info(
-                f"bounced recipient domain: {recipient_domain}", extra=legacy_extra
-            )
 
     if any(data["user_match"] == "missing" for data in bounce_data):
         return HttpResponse("Address does not exist", status=404)

--- a/emails/views.py
+++ b/emails/views.py
@@ -1476,6 +1476,8 @@ def _handle_bounce(message_json: AWS_SNSMessageJSON) -> HttpResponse:
             data["user_match"] = "found"
             if (fxa := profile.fxa) and profile.metrics_enabled:
                 data["fxa_id"] = fxa.uid
+            else:
+                data["fxa_id"] = ""
         except User.DoesNotExist:
             # TODO: handle bounce for a user who no longer exists
             # add to SES account-wide suppression list?
@@ -1579,6 +1581,8 @@ def _handle_complaint(message_json: AWS_SNSMessageJSON) -> HttpResponse:
             data["user_match"] = "found"
             if (fxa := profile.fxa) and profile.metrics_enabled:
                 data["fxa_id"] = fxa.uid
+            else:
+                data["fxa_id"] = ""
         except User.DoesNotExist:
             data["user_match"] = "missing"
             continue

--- a/emails/views.py
+++ b/emails/views.py
@@ -1544,6 +1544,7 @@ def _handle_complaint(message_json: AWS_SNSMessageJSON) -> HttpResponse:
     * complaint_user_agent - identifies the client used to file the complaint
     * complaint_extra - Extra data from complainedRecipients data, if any
     * domain - User's domain, if an address was given
+    * fxa_id - The Mozilla account ID of the user
     """
     complaint = deepcopy(message_json.get("complaint", {}))
     complained_recipients = complaint.pop("complainedRecipients", [])
@@ -1576,6 +1577,8 @@ def _handle_complaint(message_json: AWS_SNSMessageJSON) -> HttpResponse:
             user = User.objects.get(email=recipient_address)
             profile = user.profile
             data["user_match"] = "found"
+            if fxa := profile.fxa:
+                data["fxa_id"] = fxa.uid
         except User.DoesNotExist:
             data["user_match"] = "missing"
             continue

--- a/emails/views.py
+++ b/emails/views.py
@@ -1439,7 +1439,7 @@ def _handle_bounce(message_json: AWS_SNSMessageJSON) -> HttpResponse:
     * bounce_diagnostic: 'diagnosticCode' from bounced recipient data, or None
     * bounce_extra: Extra data from bounce_recipient data, if any
     * domain: User's real email address domain, if an address was given
-    * fxa_id - The Mozilla account ID of the user
+    * fxa_id - The Mozilla account (previously known as Firefox Account) ID of the user
     """
     bounce = message_json.get("bounce", {})
     bounce_type = bounce.get("bounceType", "none")
@@ -1546,7 +1546,7 @@ def _handle_complaint(message_json: AWS_SNSMessageJSON) -> HttpResponse:
     * complaint_user_agent - identifies the client used to file the complaint
     * complaint_extra - Extra data from complainedRecipients data, if any
     * domain - User's domain, if an address was given
-    * fxa_id - The Mozilla account ID of the user
+    * fxa_id - The Mozilla account (previously known as Firefox Account) ID of the user
     """
     complaint = deepcopy(message_json.get("complaint", {}))
     complained_recipients = complaint.pop("complainedRecipients", [])

--- a/emails/views.py
+++ b/emails/views.py
@@ -1439,6 +1439,7 @@ def _handle_bounce(message_json: AWS_SNSMessageJSON) -> HttpResponse:
     * bounce_diagnostic: 'diagnosticCode' from bounced recipient data, or None
     * bounce_extra: Extra data from bounce_recipient data, if any
     * domain: User's real email address domain, if an address was given
+    * fxa_id - The Mozilla account ID of the user
     """
     bounce = message_json.get("bounce", {})
     bounce_type = bounce.get("bounceType", "none")
@@ -1473,6 +1474,8 @@ def _handle_bounce(message_json: AWS_SNSMessageJSON) -> HttpResponse:
             user = User.objects.get(email=recipient_address)
             profile = user.profile
             data["user_match"] = "found"
+            if fxa := profile.fxa:
+                data["fxa_id"] = fxa.uid
         except User.DoesNotExist:
             # TODO: handle bounce for a user who no longer exists
             # add to SES account-wide suppression list?


### PR DESCRIPTION
This adds the user's FxA ID to the log when we receive a bounce or complaint. This is an aid in debugging an increase in either metric, allowing us to see if a particular user is responsible for the increase. It can also aid in customer support, to diagnose if a user's email is bouncing. If the user opts-out of Mozilla account metrics, their FxA ID will not be included in the data.

This also removes some legacy logs marked for deletion last year.

# How to Test

- [x] I've added a unit test to test for potential regressions of this bug.
