### PR TITLE
Move Python configuration to `pyproject.toml`

### DIFF
--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -846,9 +846,10 @@ class SNSNotificationRepliesTest(SNSNotificationTestBase):
             operation_name="S3.something",
             error_response={"Error": {"Code": "NoSuchKey", "Message": "the message"}},
         )
-        with self.assertLogs(INFO_LOG) as info_caplog, self.assertLogs(
-            ERROR_LOG, "ERROR"
-        ) as events_caplog:
+        with (
+            self.assertLogs(INFO_LOG) as info_caplog,
+            self.assertLogs(ERROR_LOG, "ERROR") as events_caplog,
+        ):
             response = _sns_notification(EMAIL_SNS_BODIES["s3_stored_replies"])
         self.mock_send_raw_email.assert_not_called()
         assert response.status_code == 404
@@ -866,9 +867,10 @@ class SNSNotificationRepliesTest(SNSNotificationTestBase):
             operation_name="S3.something",
             error_response={"Error": {"Code": "IsNapping", "Message": "snooze"}},
         )
-        with self.assertLogs(INFO_LOG) as info_caplog, self.assertLogs(
-            ERROR_LOG, "ERROR"
-        ) as error_caplog:
+        with (
+            self.assertLogs(INFO_LOG) as info_caplog,
+            self.assertLogs(ERROR_LOG, "ERROR") as error_caplog,
+        ):
             response = _sns_notification(EMAIL_SNS_BODIES["s3_stored_replies"])
         self.mock_send_raw_email.assert_not_called()
         assert response.status_code == 503
@@ -888,9 +890,10 @@ class SNSNotificationRepliesTest(SNSNotificationTestBase):
             EMAIL_SNS_BODIES["s3_stored_replies"], text="text content"
         )
         self.mock_send_raw_email.side_effect = SEND_RAW_EMAIL_FAILED
-        with self.assertLogs(INFO_LOG) as info_caplog, self.assertLogs(
-            ERROR_LOG, "ERROR"
-        ) as error_caplog:
+        with (
+            self.assertLogs(INFO_LOG) as info_caplog,
+            self.assertLogs(ERROR_LOG, "ERROR") as error_caplog,
+        ):
             response = _sns_notification(EMAIL_SNS_BODIES["s3_stored_replies"])
         assert response.status_code == 400
         assert response.content == b"SES client error"
@@ -1412,9 +1415,10 @@ class SNSNotificationValidUserEmailsInS3Test(TestCase):
             {"Error": {"Code": "SomeErrorCode", "Message": "Details"}}, ""
         )
 
-        with self.assertLogs(INFO_LOG) as info_caplog, self.assertLogs(
-            ERROR_LOG, "ERROR"
-        ) as error_caplog:
+        with (
+            self.assertLogs(INFO_LOG) as info_caplog,
+            self.assertLogs(ERROR_LOG, "ERROR") as error_caplog,
+        ):
             response = _sns_notification(EMAIL_SNS_BODIES["s3_stored"])
         self.mock_remove_message_from_s3.assert_not_called()
         assert response.status_code == 503
@@ -1519,9 +1523,10 @@ class SnsMessageTest(TestCase):
             operation_name="S3.something",
             error_response={"Error": {"Code": "NoSuchKey", "Message": "the message"}},
         )
-        with self.assertLogs(INFO_LOG) as info_caplog, self.assertLogs(
-            ERROR_LOG, "ERROR"
-        ) as error_caplog:
+        with (
+            self.assertLogs(INFO_LOG) as info_caplog,
+            self.assertLogs(ERROR_LOG, "ERROR") as error_caplog,
+        ):
             response = _sns_message(self.message_json)
         self.mock_ses_client.send_raw_email.assert_not_called()
         assert response.status_code == 404
@@ -1535,9 +1540,10 @@ class SnsMessageTest(TestCase):
 
     def test_ses_send_raw_email_has_client_error_early_exits(self) -> None:
         self.mock_ses_client.send_raw_email.side_effect = SEND_RAW_EMAIL_FAILED
-        with self.assertLogs(INFO_LOG) as info_caplog, self.assertLogs(
-            ERROR_LOG, "ERROR"
-        ) as error_caplog:
+        with (
+            self.assertLogs(INFO_LOG) as info_caplog,
+            self.assertLogs(ERROR_LOG, "ERROR") as error_caplog,
+        ):
             response = _sns_message(self.message_json)
         self.mock_ses_client.send_raw_email.assert_called_once()
         assert response.status_code == 503
@@ -1624,17 +1630,21 @@ class GetAddressTest(TestCase):
             assert _get_address("domain@subdomain.Test.Com") == self.domain_address
 
     def test_subdomain_for_wrong_domain_raises(self) -> None:
-        with pytest.raises(
-            ObjectDoesNotExist
-        ) as exc_info, MetricsMock() as mm, self.assertNoLogs(GLEAN_LOG, "INFO"):
+        with (
+            pytest.raises(ObjectDoesNotExist) as exc_info,
+            MetricsMock() as mm,
+            self.assertNoLogs(GLEAN_LOG, "INFO"),
+        ):
             _get_address("unknown@subdomain.example.com")
         assert str(exc_info.value) == "Address does not exist"
         mm.assert_incr_once("fx.private.relay.email_for_not_supported_domain")
 
     def test_unknown_subdomain_raises(self) -> None:
-        with pytest.raises(
-            Profile.DoesNotExist
-        ), MetricsMock() as mm, self.assertNoLogs(GLEAN_LOG, "INFO"):
+        with (
+            pytest.raises(Profile.DoesNotExist),
+            MetricsMock() as mm,
+            self.assertNoLogs(GLEAN_LOG, "INFO"),
+        ):
             _get_address("domain@unknown.test.com")
         mm.assert_incr_once("fx.private.relay.email_for_dne_subdomain")
 

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -298,9 +298,12 @@ def setup_fxa_rp_events(
             json.dumps(profile_response.data),
         )
 
-    with responses.RequestsMock() as mock_responses, patch(
-        "privaterelay.views.fxa_verifying_keys", return_value=[fxa_verifying_key]
-    ) as mock_fxa_verifying_keys:
+    with (
+        responses.RequestsMock() as mock_responses,
+        patch(
+            "privaterelay.views.fxa_verifying_keys", return_value=[fxa_verifying_key]
+        ) as mock_fxa_verifying_keys,
+    ):
         mock_responses.add_callback(
             responses.GET,
             f"{settings.SOCIALACCOUNT_PROVIDERS['fxa']['PROFILE_ENDPOINT']}/profile",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[project]
+requires-python = ">= 3.11"
+
 [tool.mypy]
 plugins = ["mypy_django_plugin.main"]
 mypy_path = "$MYPY_CONFIG_FILE_DIR/mypy_stubs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,13 @@
 [project]
 requires-python = ">= 3.11"
 
+[tool.django-stubs]
+django_settings_module = "privaterelay.settings"
+
 [tool.mypy]
-plugins = ["mypy_django_plugin.main"]
-mypy_path = "$MYPY_CONFIG_FILE_DIR/mypy_stubs"
 exclude = "env"
+mypy_path = "$MYPY_CONFIG_FILE_DIR/mypy_stubs"
+plugins = ["mypy_django_plugin.main"]
 python_version = "3.11"
 show_error_codes = true
 strict = true
@@ -17,9 +20,6 @@ disallow_any_generics = false
 disallow_untyped_calls = false
 disallow_incomplete_defs = false
 disallow_untyped_defs = false
-
-[tool.django-stubs]
-django_settings_module = "privaterelay.settings"
 
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
@@ -49,10 +49,10 @@ module = [
     "oauthlib.oauth2.rfc6749.errors",
     "requests_oauthlib",
     "silk",
-    "twilio.base.instance_resource",
     "twilio.base.exceptions",
-    "twilio.rest",
+    "twilio.base.instance_resource",
     "twilio.request_validator",
+    "twilio.rest",
     "vobject",
     "waffle",
     "waffle.models",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,10 @@ module = [
     "whitenoise.middleware",
     "whitenoise.storage",
 ]
+
+[tool.paul-mclendahand]
+# Creates a PR that combines several dependabot PRs
+# https://github.com/willkg/paul-mclendahand
+github_project="fx-private-relay"
+github_user="mozilla"
+main_branch="main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,14 @@ module = [
 github_project="fx-private-relay"
 github_user="mozilla"
 main_branch="main"
+
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "privaterelay.settings"
+python_files = "tests.py test_*.py *_tests.py"
+norecursedirs = ".git .local extension frontend node_modules"
+testpaths = [
+    "api",
+    "emails",
+    "phones",
+    "privaterelay",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-DJANGO_SETTINGS_MODULE = privaterelay.settings
-python_files = tests.py test_*.py *_tests.py
-norecursedirs = .git .local extension frontend node_modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,0 @@
-[tool:paul-mclendahand]
-github_user=mozilla
-github_project=fx-private-relay
-main_branch=main


### PR DESCRIPTION
Make several changes to centralize Python configuration in `pyproject.toml`:

* Set the minimum Python version to 3.11, which allows `black` to use [parenthesized context managers](https://docs.python.org/3.10/whatsnew/3.10.html#parenthesized-context-managers) from Python 3.10.
* Move config for [paul-mclendahand](https://github.com/willkg/paul-mclendahand) from `setup.cfg` to `pyproject.toml`
* Move config for `pytest` from `pytest.ini` to `pyproject.toml`
* Alphabetize `pyproject.toml` where appropriate