### PR TITLE
MPP-3786: Settings additions for security and dockerflow configuration

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -731,6 +731,7 @@ if RELAY_CHANNEL == "local":
     # In local dev, next runs on localhost and makes requests to /accounts/
     CORS_ALLOWED_ORIGINS += [
         "http://localhost:3000",
+        "http://0.0.0.0:3000",
         "http://127.0.0.1:8000",
     ]
     CORS_URLS_REGEX = r"^/(api|accounts)/"
@@ -751,10 +752,6 @@ if RELAY_CHANNEL == "local":
     # origin and thus has access to the same cookies.
     CORS_ALLOW_CREDENTIALS = True
     SESSION_COOKIE_SAMESITE = None
-    CORS_ALLOWED_ORIGINS += [
-        "http://localhost:3000",
-        "http://0.0.0.0:3000",
-    ]
     CSRF_TRUSTED_ORIGINS += [
         "http://localhost:3000",
         "http://0.0.0.0:3000",

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -660,6 +660,11 @@ LOGGING = {
             "level": "DEBUG",
             "propagate": IN_PYTEST,
         },
+        "dockerflow": {
+            "handlers": ["console_err"],
+            "level": "WARNING",
+            "propagate": IN_PYTEST,
+        },
     },
 }
 

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -871,6 +871,7 @@ DOCKERFLOW_CHECKS = [
 ]
 if REDIS_URL:
     DOCKERFLOW_CHECKS.append("dockerflow.django.checks.check_redis_connected")
+DOCKERFLOW_REQUEST_ID_HEADER_NAME = config("DOCKERFLOW_REQUEST_ID_HEADER_NAME", None)
 SILENCED_SYSTEM_CHECKS = config("SILENCED_SYSTEM_CHECKS", "", cast=Csv())
 
 # django-ftl settings

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -599,6 +599,11 @@ FXA_SUPPORT_URL = config("FXA_SUPPORT_URL", f"{FXA_BASE_ORIGIN}/support/")
 
 LOGGING = {
     "version": 1,
+    "filters": {
+        "request_id": {
+            "()": "dockerflow.logging.RequestIdLogFilter",
+        },
+    },
     "formatters": {
         "json": {
             "()": "dockerflow.logging.JsonLogFormatter",
@@ -611,11 +616,13 @@ LOGGING = {
             "class": "logging.StreamHandler",
             "stream": sys.stdout,
             "formatter": "json",
+            "filters": ["request_id"],
         },
         "console_err": {
             "level": "DEBUG",
             "class": "logging.StreamHandler",
             "formatter": "json",
+            "filters": ["request_id"],
         },
     },
     "loggers": {

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -63,6 +63,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 # defaulting to blank to be production-broken by default
 SECRET_KEY = config("SECRET_KEY", None)
+SECRET_KEY_FALLBACKS = config("SECRET_KEY_FALLBACKS", "", cast=Csv())
 SITE_ORIGIN: str | None = config("SITE_ORIGIN", None)
 
 ORIGIN_CHANNEL_MAP: dict[str, RELAY_CHANNEL_NAME] = {
@@ -95,9 +96,14 @@ SECURE_REDIRECT_EXEMPT = [
     r"^__heartbeat__",
     r"^__lbheartbeat__",
 ]
+SECURE_HSTS_INCLUDE_SUBDOMAINS = config(
+    "DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS", False, cast=bool
+)
+SECURE_HSTS_PRELOAD = config("DJANGO_SECURE_HSTS_PRELOAD", False, cast=bool)
 SECURE_HSTS_SECONDS = config("DJANGO_SECURE_HSTS_SECONDS", None)
 SECURE_BROWSER_XSS_FILTER = config("DJANGO_SECURE_BROWSER_XSS_FILTER", True)
 SESSION_COOKIE_SECURE = config("DJANGO_SESSION_COOKIE_SECURE", False, cast=bool)
+CSRF_COOKIE_SECURE = config("DJANGO_CSRF_COOKIE_SECURE", False, cast=bool)
 BASKET_ORIGIN = config("BASKET_ORIGIN", "https://basket.mozilla.org")
 # maps fxa profile hosts to respective avatar hosts for CSP
 AVATAR_IMG_SRC_MAP = {
@@ -863,6 +869,7 @@ DOCKERFLOW_CHECKS = [
 ]
 if REDIS_URL:
     DOCKERFLOW_CHECKS.append("dockerflow.django.checks.check_redis_connected")
+SILENCED_SYSTEM_CHECKS = config("SILENCED_SYSTEM_CHECKS", "", cast=Csv())
 
 # django-ftl settings
 AUTO_RELOAD_BUNDLES = False  # Requires pyinotify

--- a/privaterelay/tests/utils.py
+++ b/privaterelay/tests/utils.py
@@ -31,6 +31,7 @@ def log_extra(log_record: LogRecord) -> dict[str, Any]:
         "process",
         "processName",
         "relativeCreated",
+        "rid",
         "stack_info",
         "thread",
         "threadName",


### PR DESCRIPTION
This PR adds environment overrides for some security settings and dockerflow configuration that we may want to enable in production:

* [SECRET_KEY_FALLBACKS](https://docs.djangoproject.com/en/4.2/ref/settings/#secret-key-fallbacks) - Allows rotating `SECRET_KEY` without instantly invalidating sessions.
* [SECURE_HSTS_INCLUDE_SUBDOMAINS](https://docs.djangoproject.com/en/4.2/ref/settings/#secure-hsts-include-subdomains) - Adds `includeSubDomains` to `Strict-Transport-Security` header. See [HTTP Strict Transport Security](https://docs.djangoproject.com/en/4.2/ref/middleware/#http-strict-transport-security) for more info.
* [SECURE_HSTS_PRELOAD](https://docs.djangoproject.com/en/4.2/ref/settings/#secure-hsts-preload) - Adds `preload` to `Strict-Transport-Security` header
* [CSRF_COOKIE_SECURE](https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-cookie-secure) - Adds 'secure' to the CSRF cookie.
* `DOCKERFLOW_REQUEST_ID_HEADER_NAME` - Sets the name for a header that dockerflow should use for an externally set request ID. Both Heroku and GCP set a request ID, but under different headers.
* [SILENCED_SYSTEM_CHECKS](https://docs.djangoproject.com/en/4.2/ref/settings/#silenced-system-checks) - A list of system check messages to ignore. Dockerflow consults this list for the healthcheck endpoint.

It also updates the logger config:

* Add `dockerflow` log to the stderr stream at `WARNING` level. This is where failed healthcheck messages go.
* Add dockerflow's `RequestIdLogFilter`. This will add a request ID to log messages, so we can correlate the logs for a single request.