### PR TITLE
Avoid python-ipware 2.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ django-csp==3.8
 django-debug-toolbar==4.3.0
 django-filter==24.2
 django-ipware==6.0.5
+python-ipware!=2.0.4  # Breaks tests
 django-redis==5.4.0
 django-ftl==0.14
 django-referrer-policy==1.0


### PR DESCRIPTION
 python-ipware 2.0.4 breaks the test [test_request_data_routable_ip_is_extracted](https://github.com/mozilla/fx-private-relay/blob/380a13732c56b323f0c7e9407bab4307f9c0f43f/privaterelay/tests/glean_tests.py#L66-L75). It works with 2.0.3.
 
 Filed upstream as https://github.com/un33k/django-ipware/issues/117.
 
 