### PR TITLE
pin python-ipware==2.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ django-csp==3.8
 django-debug-toolbar==4.3.0
 django-filter==24.2
 django-ipware==6.0.5
-python-ipware!=2.0.4  # Breaks tests
+python-ipware==2.0.3  # 2.0.4, 2.0.5 break tests
 django-redis==5.4.0
 django-ftl==0.14
 django-referrer-policy==1.0


### PR DESCRIPTION
`python-ipware` 2.0.5 also breaks tests.