### PR TITLE
for MPP-3755: use Thread to send event data to GA async

### DIFF
--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -1,11 +1,11 @@
 import json
 import logging
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Literal
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 from uuid import uuid4
 
 from django.contrib.auth.models import User
@@ -35,7 +35,7 @@ from emails.tests.models_tests import premium_subscription
 
 from ..apps import PrivateRelayConfig
 from ..fxa_utils import NoSocialToken
-from ..views import _update_all_data, fxa_verifying_keys
+from ..views import _update_all_data, fxa_verifying_keys, send_ga_ping
 
 
 def test_no_social_token():
@@ -564,25 +564,75 @@ def test_lbheartbeat_view(client) -> None:
     assert response.content == b""
 
 
-def test_metrics_event_GET(client) -> None:
+@pytest.fixture
+def mock_metrics_thread_and_report() -> (
+    Iterator[dict[Literal["thread", "report"], Mock]]
+):
+    """
+    Setup mocks for metrics event.
+
+    Replace google_measurement_protocol.report with a Mock
+    Replace Thread with a mock version that calls immediately.
+    """
+
+    with (
+        patch("privaterelay.views.threading.Thread", spec=True) as mock_thread_cls,
+        patch("privaterelay.views.report") as mock_report,
+    ):
+
+        mock_thread = Mock(spec_set=["start"])
+
+        def create_thread(
+            target: Callable[[str, str, Any], None],
+            args: tuple[str, str, Any],
+            daemon: bool,
+        ) -> Mock:
+            assert target == send_ga_ping
+            assert daemon
+
+            def call_send_ga_ping() -> None:
+                target(*args)
+
+            mock_thread.start.side_effect = call_send_ga_ping
+            return mock_thread
+
+        mock_thread_cls.side_effect = create_thread
+        yield {"thread": mock_thread, "report": mock_report}
+
+
+def test_metrics_event_GET(client, mock_metrics_thread_and_report) -> None:
     response = client.get("/metrics-event")
     assert response.status_code == 405
+    mock_metrics_thread_and_report["thread"].start.assert_not_called()
+    mock_metrics_thread_and_report["report"].assert_not_called()
 
 
-def test_metrics_event_POST_non_json(client) -> None:
+def test_metrics_event_POST_non_json(client, mock_metrics_thread_and_report) -> None:
     response = client.post("/metrics-event")
     assert response.status_code == 415
+    mock_metrics_thread_and_report["thread"].start.assert_not_called()
+    mock_metrics_thread_and_report["report"].assert_not_called()
 
 
-def test_metrics_event_POST_json_no_ga_uuid(client) -> None:
+def test_metrics_event_POST_json_no_ga_uuid(
+    client, mock_metrics_thread_and_report
+) -> None:
     response = client.post(
         "/metrics-event", {"category": "addon"}, content_type="application/json"
     )
     assert response.status_code == 404
+    mock_metrics_thread_and_report["thread"].start.assert_not_called()
+    mock_metrics_thread_and_report["report"].assert_not_called()
 
 
-def test_metrics_event_POST_json_ga_uuid_ok(client) -> None:
+def test_metrics_event_POST_json_ga_uuid_ok(
+    client, mock_metrics_thread_and_report, settings
+) -> None:
     response = client.post(
         "/metrics-event", {"ga_uuid": "anything-is-ok"}, content_type="application/json"
     )
     assert response.status_code == 200
+    mock_metrics_thread_and_report["thread"].start.assert_called_once_with()
+    mock_metrics_thread_and_report["report"].assert_called_once_with(
+        settings.GOOGLE_ANALYTICS_ID, "anything-is-ok", ANY
+    )

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -562,3 +562,27 @@ def test_lbheartbeat_view(client) -> None:
     response = client.get("/__lbheartbeat__")
     assert response.status_code == 200
     assert response.content == b""
+
+
+def test_metrics_event_GET(client) -> None:
+    response = client.get("/metrics-event")
+    assert response.status_code == 405
+
+
+def test_metrics_event_POST_non_json(client) -> None:
+    response = client.post("/metrics-event")
+    assert response.status_code == 415
+
+
+def test_metrics_event_POST_json_no_ga_uuid(client) -> None:
+    response = client.post(
+        "/metrics-event", {"category": "addon"}, content_type="application/json"
+    )
+    assert response.status_code == 404
+
+
+def test_metrics_event_POST_json_ga_uuid_ok(client) -> None:
+    response = client.post(
+        "/metrics-event", {"ga_uuid": "anything-is-ok"}, content_type="application/json"
+    )
+    assert response.status_code == 200

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -95,7 +95,7 @@ def profile_subdomain(request):
         return JsonResponse({"message": e.message, "subdomain": subdomain}, status=400)
 
 
-def send_ga_ping(ga_id, ga_uuid, data):
+def send_ga_ping(ga_id: str, ga_uuid: str, data: Any) -> None:
     try:
         report(ga_id, ga_uuid, data)
     except Exception as e:
@@ -104,7 +104,7 @@ def send_ga_ping(ga_id, ga_uuid, data):
 
 @csrf_exempt
 @require_http_methods(["POST"])
-def metrics_event(request):
+def metrics_event(request: HttpRequest) -> JsonResponse:
     try:
         request_data = json.loads(request.body)
     except json.JSONDecodeError:

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import threading
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from functools import cache
@@ -94,6 +95,13 @@ def profile_subdomain(request):
         return JsonResponse({"message": e.message, "subdomain": subdomain}, status=400)
 
 
+def send_ga_ping(ga_id, ga_uuid, data):
+    try:
+        report(ga_id, ga_uuid, data)
+    except Exception as e:
+        logger.error("metrics_event", extra={"error": e})
+
+
 @csrf_exempt
 @require_http_methods(["POST"])
 def metrics_event(request):
@@ -115,11 +123,12 @@ def metrics_event(request):
         dimension5=request_data.get("dimension5", None),
         dimension7=request_data.get("dimension7", "website"),
     )
-    try:
-        report(settings.GOOGLE_ANALYTICS_ID, request_data.get("ga_uuid"), event_data)
-    except Exception as e:
-        logger.error("metrics_event", extra={"error": e})
-        return JsonResponse({"msg": "Unable to report metrics event."}, status=500)
+    t = threading.Thread(
+        target=send_ga_ping,
+        args=[settings.GOOGLE_ANALYTICS_ID, request_data.get("ga_uuid"), event_data],
+        daemon=True,
+    )
+    t.start()
     return JsonResponse({"msg": "OK"}, status=200)
 
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR is for #MPP-3755.

How to test:
1. Run `pytest`
2. Inspect the Relay extension to capture a network request to `/metrics-event` endpoint
3. Use the "Copy as cURL" command to copy it
4. Paste the `curl` command to your command-line
5. Change the `https://relay.firefox.com` to `http://127.0.0.1:8000`
   * [x] It should work!

Checklist:
- ~[x] l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- ~[x] I've added or updated relevant docs in the docs/ directory.~
- ~[x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).