### PR TITLE
fix MPP-3805: get FxA SocialApp from DB at startup

### DIFF
--- a/privaterelay/apps.py
+++ b/privaterelay/apps.py
@@ -81,6 +81,7 @@ class PrivateRelayConfig(AppConfig):
 
         try:
             del self.fxa_verifying_keys  # Clear cache
+            del self.fxa_social_app  # Clear cache
         except AttributeError:
             pass
 
@@ -93,3 +94,9 @@ class PrivateRelayConfig(AppConfig):
             keys: list[dict[str, Any]] = resp.json()["keys"]
             return keys
         return []
+
+    @cached_property
+    def fxa_social_app(self) -> Any:
+        from allauth.socialaccount.models import SocialApp
+
+        return SocialApp.objects.get(provider="fxa")

--- a/privaterelay/apps.py
+++ b/privaterelay/apps.py
@@ -2,7 +2,7 @@ import base64
 import json
 import os
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from django.apps import AppConfig
 from django.conf import settings
@@ -11,6 +11,10 @@ from django.utils.functional import cached_property
 import requests
 
 ROOT_DIR = os.path.abspath(os.curdir)
+
+
+if TYPE_CHECKING:
+    from allauth.socialaccount.models import SocialApp
 
 
 def get_profiler_startup_data() -> tuple[str | None, str | None]:
@@ -96,7 +100,7 @@ class PrivateRelayConfig(AppConfig):
         return []
 
     @cached_property
-    def fxa_social_app(self) -> Any:
+    def fxa_social_app(self) -> "SocialApp":
         from allauth.socialaccount.models import SocialApp
 
         return SocialApp.objects.get(provider="fxa")

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -237,7 +237,7 @@ def setup_fxa_rp_events(
     profile.save()
 
     # Create FxA app, account, token, etc.
-    fxa_app: SocialApp = baker.make(SocialApp, provider="fxa")
+    fxa_app: SocialApp = baker.make(SocialApp, provider="fxa", client_id="test-fxa")
     fxa_profile_data = {
         "email": user.email,
         "locale": "en-US,en;q=0.5",


### PR DESCRIPTION
This PR fixes #MPP-3805.

How to test:
1. Run `pytest`
   * [ ] It should pass

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).