### PR TITLE
Fix for e2e workflows actions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,6 +2,25 @@ name: Relay e2e tests
 on:
   schedule:
     - cron: 0 8 * * *
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        default: stage
+        type: string
+      health_check:
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      E2E_TEST_ACCOUNT_FREE: 
+        required: true
+      E2E_TEST_ACCOUNT_PASSWORD:
+        required: true
+      E2E_TEST_ACCOUNT_PREMIUM:
+        required: true
+      E2E_TEST_BASE_URL:
+        required: true 
   workflow_dispatch:
     inputs:
       environment:
@@ -40,7 +59,7 @@ jobs:
           commandenv="${{ inputs.environment != null && inputs.environment || 'stage'
           }}"
 
-          if ${{ inputs.health_check }}; then
+          if ${{ contains(inputs.health_check, 'true') }}; then
             E2E_TEST_ENV=$commandenv npx playwright test --grep "@health_check"
           else
             npm run test:$commandenv

--- a/.github/workflows/relay_e2e_health.yml
+++ b/.github/workflows/relay_e2e_health.yml
@@ -3,12 +3,10 @@ on:
   schedule:
     - cron: 0 9 * * *
 jobs:
-  relaye2e_health_check:
-    name: Relay e2e tests, health check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run Playwright health check tests
-        uses: ./.github/workflows/playwright.yml
-        with:
-          environment: stage
-          health_check: true
+  relay_health: 
+    uses: ./.github/workflows/playwright.yml
+    with:
+      environment: stage
+      health_check: true
+    secrets: inherit
+    

--- a/e2e-tests/pages/dashboardPage.ts
+++ b/e2e-tests/pages/dashboardPage.ts
@@ -44,6 +44,7 @@ export class DashboardPage {
   readonly generateNewMaskPremiumButton: Locator;
   readonly premiumRandomMask: Locator;
   readonly closeCornerUpsell: Locator;
+  readonly closeCornerTips: Locator;
   readonly blockPromotions: Locator;
   readonly blockAll: Locator;
   readonly blockLevelAllLabel: Locator;
@@ -111,6 +112,9 @@ export class DashboardPage {
     this.premiumDomainMask = page.locator('//li[@data-key="custom"]');
     this.closeCornerUpsell = page.locator(
       '//button[starts-with(@class, "CornerNotification_close-button")]',
+    );
+    this.closeCornerTips = page.locator(
+      '//button[starts-with(@class, "Tips_close-button")]',
     );
     this.bottomUgradeBanner = page.locator(
       '//div[starts-with(@class, "profile_bottom-banner-wrapper")]',
@@ -270,13 +274,17 @@ export class DashboardPage {
       numberOfMasks = 0;
     }
 
+    if (await this.closeCornerUpsell.isVisible()) {
+      await this.closeCornerUpsell.click();
+    }
+
+    if (await this.closeCornerTips.isVisible()) {
+      await this.closeCornerTips.click();
+    }
+
     // check number of masks available
     if (numberOfMasks === 0) {
       return;
-    }
-
-    if (await this.closeCornerUpsell.isVisible()) {
-      await this.closeCornerUpsell.click();
     }
 
     // if clear all, check if there's an expanded mask card


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes the health check workflow file. It ran into errors previously for improperly reusing the playwright.yml workflow, and because `inputs.health_check` is null when the cronjob runs, resulting in a syntax error here https://github.com/mozilla/fx-private-relay/blob/93980f3a7107dd6705970509bc135bc45ac2195a/.github/workflows/playwright.yml#L43.

Used the following for reusable workflows, https://docs.github.com/en/actions/using-workflows/reusing-workflows

Runs but premium tests fail due to our premium account being paused, https://github.com/mozilla/fx-private-relay/actions/runs/8835571804/job/24260047206



# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] Customer Experience team has seen or waived a demo of functionality.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
