### PR TITLE
E2E FxA auth selector updates

### DIFF
--- a/e2e-tests/pages/authPage.ts
+++ b/e2e-tests/pages/authPage.ts
@@ -12,18 +12,33 @@ export class AuthPage {
   readonly verifyCodeInputField: Locator;
   readonly confirmCodeButton: Locator;
   readonly newPasswordInputFieldSignIn: Locator;
+  readonly passwordSignupInputField: Locator;
+  readonly passwordSignupConfirmInputField: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.emailInputField = page.locator('input[name="email"]');
     this.passwordInputField = page.locator("#password");
-    this.passwordConfirmInputField = page.locator("#vpassword");
-    this.ageInputField = page.locator("#age");
+    this.passwordSignupInputField =
+      process.env["E2E_TEST_ENV"] === "prod"
+        ? page.locator("#password")
+        : page.getByTestId("new-password-input-field");
+    this.passwordSignupConfirmInputField =
+      process.env["E2E_TEST_ENV"] === "prod"
+        ? page.locator("#vpassword")
+        : page.getByTestId("verify-password-input-field");
+    this.ageInputField =
+      process.env["E2E_TEST_ENV"] === "prod"
+        ? page.locator("#age")
+        : page.getByTestId("age-input-field");
     this.continueButton = page.locator("#submit-btn");
     this.createAccountButton = page.getByRole("button", {
       name: "Create account",
     });
-    this.verifyCodeInputField = page.locator("div.card input");
+    this.verifyCodeInputField =
+      process.env["E2E_TEST_ENV"] === "prod"
+        ? page.locator("div.card input")
+        : page.getByTestId("confirm-signup-code-input-field");
     this.confirmCodeButton = page.getByRole("button", { name: "Confirm" });
     this.newPasswordInputFieldSignIn = page.locator(
       "input[data-testid='input-field'][name='password'][type='password']",
@@ -79,10 +94,10 @@ export class AuthPage {
       .getByText("Set your password")
       .waitFor({ state: "attached", timeout: 3000 });
     await forceNonReactLink(this.page);
-    await this.passwordInputField.fill(
+    await this.passwordSignupInputField.fill(
       process.env.E2E_TEST_ACCOUNT_PASSWORD as string,
     );
-    await this.passwordConfirmInputField.fill(
+    await this.passwordSignupConfirmInputField.fill(
       process.env.E2E_TEST_ACCOUNT_PASSWORD as string,
     );
     await this.ageInputField.type("31");

--- a/e2e-tests/pages/dashboardPage.ts
+++ b/e2e-tests/pages/dashboardPage.ts
@@ -251,6 +251,9 @@ export class DashboardPage {
 
     // randomize between 1.5-2.5 secs between each generate to deal with issue of multiple quick clicks
     await this.page.waitForTimeout(Math.random() * 2500 + 1500);
+    if (await this.closeCornerUpsell.isVisible()) {
+      await this.closeCornerUpsell.click();
+    }
     await this.generateMask(numberOfMasks - 1, isPremium);
   }
 

--- a/e2e-tests/specs/relay-e2e.spec.ts
+++ b/e2e-tests/specs/relay-e2e.spec.ts
@@ -5,7 +5,7 @@ test.describe.configure({ mode: "parallel" });
 test.describe("FxA auth, random mask generation, and email forwarding @health_check", () => {
   test.skip(
     process.env.E2E_TEST_ENV === "prod",
-    "This test only works on stage/dev environments",
+    "This test only works on stage/dev environments because you cannot use masks to sign up for monitor, see 'Email forwarding and trackers removal' for a similar test",
   );
   // use stored authenticated state
   test.use({ storageState: "state.json" });


### PR DESCRIPTION
😞 Tests are failing because FxA updated their stage account creation page and verification page again and the selectors no longer work. 

How to test: 
* Run the tests in this branch on the Github Actions tab.
  * Passing: https://github.com/mozilla/fx-private-relay/actions/runs/8853574473


# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] Customer Experience team has seen or waived a demo of functionality.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
