### PR TITLE
MPP-3799: Add schemas to API views for phones

### DIFF
--- a/api/serializers/phones.py
+++ b/api/serializers/phones.py
@@ -101,12 +101,22 @@ class InboundSmsSerializer(serializers.Serializer):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-
         # Change to reserved keyword "from"
-        assert "from_" in self.fields
         self.fields["from"] = self.fields.pop("from_")
 
 
 class InboundCallSerializer(serializers.Serializer):
     Caller = serializers.CharField()
     Called = serializers.CharField()
+
+
+class TwilioMessagesSerializer(serializers.Serializer):
+    from_ = serializers.CharField()
+    to = serializers.CharField()
+    date_sent = serializers.CharField()
+    body = serializers.CharField()
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Change to reserved keyword "from"
+        self.fields["from"] = self.fields.pop("from_")

--- a/api/serializers/phones.py
+++ b/api/serializers/phones.py
@@ -122,6 +122,11 @@ class TwilioMessagesSerializer(serializers.Serializer):
         self.fields["from"] = self.fields.pop("from_")
 
 
+class TwilioSmsStatusSerializer(serializers.Serializer):
+    SmsStatus = serializers.CharField()
+    MessageSid = serializers.CharField()
+
+
 class OutboundSmsSerializer(serializers.Serializer):
     body = serializers.CharField()
     destination = serializers.CharField()

--- a/api/serializers/phones.py
+++ b/api/serializers/phones.py
@@ -125,3 +125,7 @@ class TwilioMessagesSerializer(serializers.Serializer):
 class OutboundSmsSerializer(serializers.Serializer):
     body = serializers.CharField()
     destination = serializers.CharField()
+
+
+class OutboundCallSerializer(serializers.Serializer):
+    to = serializers.CharField()

--- a/api/serializers/phones.py
+++ b/api/serializers/phones.py
@@ -120,3 +120,8 @@ class TwilioMessagesSerializer(serializers.Serializer):
         super().__init__(*args, **kwargs)
         # Change to reserved keyword "from"
         self.fields["from"] = self.fields.pop("from_")
+
+
+class OutboundSmsSerializer(serializers.Serializer):
+    body = serializers.CharField()
+    destination = serializers.CharField()

--- a/api/serializers/phones.py
+++ b/api/serializers/phones.py
@@ -122,6 +122,15 @@ class TwilioMessagesSerializer(serializers.Serializer):
         self.fields["from"] = self.fields.pop("from_")
 
 
+class TwilioNumberSuggestion(serializers.Serializer):
+    friendly_name = serializers.CharField()
+    iso_country = serializers.CharField()
+    locality = serializers.CharField()
+    phone_number = serializers.CharField()
+    postal_code = serializers.CharField()
+    region = serializers.CharField()
+
+
 class TwilioSmsStatusSerializer(serializers.Serializer):
     SmsStatus = serializers.CharField()
     MessageSid = serializers.CharField()

--- a/api/serializers/phones.py
+++ b/api/serializers/phones.py
@@ -127,6 +127,13 @@ class TwilioSmsStatusSerializer(serializers.Serializer):
     MessageSid = serializers.CharField()
 
 
+class TwilioVoiceStatusSerializer(serializers.Serializer):
+    CallSid = serializers.CharField()
+    Called = serializers.CharField()
+    CallStatus = serializers.CharField()
+    CallDuration = serializers.IntegerField(required=False)
+
+
 class OutboundSmsSerializer(serializers.Serializer):
     body = serializers.CharField()
     destination = serializers.CharField()

--- a/api/serializers/phones.py
+++ b/api/serializers/phones.py
@@ -94,7 +94,12 @@ class InboundContactSerializer(serializers.ModelSerializer):
         ]
 
 
-class InboundSmsSerializer(serializers.Serializer):
+class TwilioInboundCallSerializer(serializers.Serializer):
+    Caller = serializers.CharField()
+    Called = serializers.CharField()
+
+
+class TwilioInboundSmsSerializer(serializers.Serializer):
     text = serializers.CharField()
     from_ = serializers.CharField()
     to = serializers.CharField()
@@ -103,11 +108,6 @@ class InboundSmsSerializer(serializers.Serializer):
         super().__init__(*args, **kwargs)
         # Change to reserved keyword "from"
         self.fields["from"] = self.fields.pop("from_")
-
-
-class InboundCallSerializer(serializers.Serializer):
-    Caller = serializers.CharField()
-    Called = serializers.CharField()
 
 
 class TwilioMessagesSerializer(serializers.Serializer):

--- a/api/serializers/phones.py
+++ b/api/serializers/phones.py
@@ -92,3 +92,16 @@ class InboundContactSerializer(serializers.ModelSerializer):
             "num_texts_blocked",
             "last_text_date",
         ]
+
+
+class InboundSmsSerializer(serializers.Serializer):
+    text = serializers.CharField()
+    from_ = serializers.CharField()
+    to = serializers.CharField()
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        # Change to reserved keyword "from"
+        assert "from_" in self.fields
+        self.fields["from"] = self.fields.pop("from_")

--- a/api/serializers/phones.py
+++ b/api/serializers/phones.py
@@ -131,6 +131,14 @@ class TwilioNumberSuggestion(serializers.Serializer):
     region = serializers.CharField()
 
 
+class TwilioNumberSuggestionGroups(serializers.Serializer):
+    real_num = serializers.CharField()
+    same_prefix_options = TwilioNumberSuggestion(many=True)
+    other_areas_options = TwilioNumberSuggestion(many=True)
+    same_area_options = TwilioNumberSuggestion(many=True)
+    random_options = TwilioNumberSuggestion(many=True)
+
+
 class TwilioSmsStatusSerializer(serializers.Serializer):
     SmsStatus = serializers.CharField()
     MessageSid = serializers.CharField()

--- a/api/serializers/phones.py
+++ b/api/serializers/phones.py
@@ -134,6 +134,17 @@ class TwilioVoiceStatusSerializer(serializers.Serializer):
     CallDuration = serializers.IntegerField(required=False)
 
 
+class IqInboundSmsSerializer(serializers.Serializer):
+    text = serializers.CharField()
+    from_ = serializers.CharField()
+    to = serializers.CharField()
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Change to reserved keyword "from"
+        self.fields["from"] = self.fields.pop("from_")
+
+
 class OutboundSmsSerializer(serializers.Serializer):
     body = serializers.CharField()
     destination = serializers.CharField()

--- a/api/serializers/phones.py
+++ b/api/serializers/phones.py
@@ -105,3 +105,8 @@ class InboundSmsSerializer(serializers.Serializer):
         # Change to reserved keyword "from"
         assert "from_" in self.fields
         self.fields["from"] = self.fields.pop("from_")
+
+
+class InboundCallSerializer(serializers.Serializer):
+    Caller = serializers.CharField()
+    Called = serializers.CharField()

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -475,6 +475,18 @@ def vCard(request: Request, lookup_key: str) -> response.Response:
     return resp
 
 
+@extend_schema(
+    request=OpenApiRequest(),
+    responses={
+        "200": OpenApiResponse(
+            {"type": "object"},
+            description="Welcome message sent.",
+            examples=[OpenApiExample("success", {"msg": "sent"})],
+        ),
+        "401": OpenApiResponse(description="Not allowed"),
+        "404": OpenApiResponse(description="User does not have a Relay number."),
+    },
+)
 @decorators.api_view(["POST"])
 @decorators.permission_classes([permissions.IsAuthenticated, HasPhoneService])
 def resend_welcome_sms(request):

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -14,7 +14,12 @@ from django.forms import model_to_dict
 
 import django_ftl
 import phonenumbers
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+)
 from rest_framework import (
     decorators,
     exceptions,
@@ -424,6 +429,25 @@ def _get_number_details(e164_number):
         return None
 
 
+@extend_schema(
+    responses={
+        "200": OpenApiResponse(
+            bytes,
+            description="A Virtual Contact File (VCF) for the user's Relay number.",
+            examples=[
+                OpenApiExample(
+                    name="partial VCF",
+                    media_type="text/x-vcard",
+                    value=(
+                        "BEGIN:VCARD\nVERSION:3.0\nFN:Firefox Relay\n"
+                        "TEL:+14045555555\nEND:VCARD\n"
+                    ),
+                )
+            ],
+        ),
+        "404": OpenApiResponse(description="No or unknown lookup key"),
+    }
+)
 @decorators.api_view()
 @decorators.permission_classes([permissions.AllowAny])
 @decorators.renderer_classes([vCardRenderer])

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -63,6 +63,7 @@ from ..serializers.phones import (
     InboundSmsSerializer,
     RealPhoneSerializer,
     RelayNumberSerializer,
+    TwilioMessagesSerializer,
 )
 
 logger = logging.getLogger("events")
@@ -994,18 +995,35 @@ def outbound_sms(request):
     parameters=[
         OpenApiParameter(
             name="with",
-            type=str,
-            required=False,
             description="filter to messages with the given E.164 number",
         ),
         OpenApiParameter(
             name="direction",
-            type=str,
-            required=False,
+            enum=["inbound", "outbound"],
             description="filter to inbound or outbound messages",
         ),
     ],
-    methods=["GET"],
+    responses={
+        "200": OpenApiResponse(
+            TwilioMessagesSerializer(many=True),
+            description="A list of the user's SMS messages.",
+            examples=[
+                OpenApiExample(
+                    "success",
+                    {
+                        "to": "+13035556789",
+                        "date_sent": datetime.now(UTC).isoformat(),
+                        "body": "Hello!",
+                        "from": "+14045556789",
+                    },
+                )
+            ],
+        ),
+        "400": OpenApiResponse(description="Unable to complete request."),
+        "403": OpenApiResponse(
+            description="Caller does not have 'outbound_phone' waffle flag."
+        ),
+    },
 )
 @decorators.api_view(["GET"])
 def list_messages(request):

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -61,6 +61,7 @@ from ..serializers.phones import (
     InboundCallSerializer,
     InboundContactSerializer,
     InboundSmsSerializer,
+    OutboundSmsSerializer,
     RealPhoneSerializer,
     RelayNumberSerializer,
     TwilioMessagesSerializer,
@@ -943,12 +944,23 @@ def outbound_call(request):
 
 @decorators.permission_classes([permissions.IsAuthenticated, HasPhoneService])
 @extend_schema(
-    parameters=[
-        OpenApiParameter(name="body", required=True, type=str),
-        OpenApiParameter(name="destination", required=True, type=str),
-    ],
-    methods=["POST"],
-    responses={200: None},
+    request=OpenApiRequest(
+        OutboundSmsSerializer,
+        examples=[
+            OpenApiExample("request", {"body": "Hello!", "destination": "+13045554567"})
+        ],
+    ),
+    responses={
+        200: OpenApiResponse(description="Message sent."),
+        400: OpenApiResponse(
+            description="Input error, or user does not have a Relay phone."
+        ),
+        401: OpenApiResponse(description="Authentication required."),
+        403: OpenApiResponse(
+            description="User does not have 'outbound_phone' waffle flag."
+        ),
+        405: OpenApiResponse(description="Method not allowed"),
+    },
 )
 @decorators.api_view(["POST"])
 def outbound_sms(request):

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -58,13 +58,13 @@ from ..exceptions import ConflictError, ErrorContextType
 from ..permissions import HasPhoneService
 from ..renderers import TemplateTwiMLRenderer, vCardRenderer
 from ..serializers.phones import (
-    InboundCallSerializer,
     InboundContactSerializer,
-    InboundSmsSerializer,
     OutboundCallSerializer,
     OutboundSmsSerializer,
     RealPhoneSerializer,
     RelayNumberSerializer,
+    TwilioInboundCallSerializer,
+    TwilioInboundSmsSerializer,
     TwilioMessagesSerializer,
     TwilioSmsStatusSerializer,
     TwilioVoiceStatusSerializer,
@@ -542,7 +542,7 @@ def _get_user_error_message(real_phone: RealPhone, sms_exception) -> Any:
         OpenApiParameter(name="X-Twilio-Signature", required=True, location="header"),
     ],
     request=OpenApiRequest(
-        InboundSmsSerializer,
+        TwilioInboundSmsSerializer,
         examples=[
             OpenApiExample(
                 "request",
@@ -737,7 +737,7 @@ def inbound_sms_iq(request: Request) -> response.Response:
         OpenApiParameter(name="X-Twilio-Signature", required=True, location="header"),
     ],
     request=OpenApiRequest(
-        InboundCallSerializer,
+        TwilioInboundCallSerializer,
         examples=[
             OpenApiExample(
                 "request",

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -68,6 +68,7 @@ from ..serializers.phones import (
     TwilioInboundSmsSerializer,
     TwilioMessagesSerializer,
     TwilioNumberSuggestion,
+    TwilioNumberSuggestionGroups,
     TwilioSmsStatusSerializer,
     TwilioVoiceStatusSerializer,
 )
@@ -317,6 +318,41 @@ class RelayNumberViewSet(SaveToRequestUser, viewsets.ModelViewSet):
         incr_if_enabled("phones_RelayNumberViewSet.partial_update")
         return super().partial_update(request, *args, **kwargs)
 
+    @extend_schema(
+        responses={
+            "200": OpenApiResponse(
+                TwilioNumberSuggestionGroups(),
+                description="Suggested numbers based on the user's real number",
+                examples=[
+                    OpenApiExample(
+                        "suggestions",
+                        {
+                            "real_num": "4045556789",
+                            "same_prefix_options": [],
+                            "other_areas_options": [],
+                            "same_area_options": [],
+                            "random_options": [
+                                {
+                                    "friendly_name": "(256) 555-3456",
+                                    "iso_country": "US",
+                                    "locality": "Gadsden",
+                                    "phone_number": "+12565553456",
+                                    "postal_code": "35903",
+                                    "region": "AL",
+                                }
+                            ],
+                        },
+                    )
+                ],
+            ),
+            "400": OpenApiResponse(
+                description=(
+                    "User has not verified their real number,"
+                    " or already has a Relay number."
+                )
+            ),
+        },
+    )
     @decorators.action(detail=False)
     def suggestions(self, request):
         """

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -61,6 +61,7 @@ from ..serializers.phones import (
     InboundCallSerializer,
     InboundContactSerializer,
     InboundSmsSerializer,
+    OutboundCallSerializer,
     OutboundSmsSerializer,
     RealPhoneSerializer,
     RelayNumberSerializer,
@@ -903,9 +904,21 @@ def sms_status(request):
 
 @decorators.permission_classes([permissions.IsAuthenticated, HasPhoneService])
 @extend_schema(
-    parameters=[OpenApiParameter(name="to", required=True, type=str)],
-    methods=["POST"],
-    responses={200: None},
+    request=OpenApiRequest(
+        OutboundCallSerializer,
+        examples=[OpenApiExample("request", {"to": "+13035556789"})],
+    ),
+    responses={
+        200: OpenApiResponse(description="Call initiated."),
+        400: OpenApiResponse(
+            description="Input error, or user does not have a Relay phone."
+        ),
+        401: OpenApiResponse(description="Authentication required."),
+        403: OpenApiResponse(
+            description="User does not have 'outbound_phone' waffle flag."
+        ),
+        405: OpenApiResponse(description="Method not allowed"),
+    },
 )
 @decorators.api_view(["POST"])
 def outbound_call(request):

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -67,6 +67,7 @@ from ..serializers.phones import (
     TwilioInboundCallSerializer,
     TwilioInboundSmsSerializer,
     TwilioMessagesSerializer,
+    TwilioNumberSuggestion,
     TwilioSmsStatusSerializer,
     TwilioVoiceStatusSerializer,
 )
@@ -333,6 +334,44 @@ class RelayNumberViewSet(SaveToRequestUser, viewsets.ModelViewSet):
         numbers = suggested_numbers(request.user)
         return response.Response(numbers)
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "location",
+                required=False,
+                location="query",
+                examples=[OpenApiExample("Miami FL USA", "Miami")],
+            ),
+            OpenApiParameter(
+                "area_code",
+                required=False,
+                location="query",
+                examples=[OpenApiExample("Tulsa OK USA", "918")],
+            ),
+        ],
+        responses={
+            "200": OpenApiResponse(
+                TwilioNumberSuggestion(many=True),
+                description="List of available numbers",
+                examples=[
+                    OpenApiExample(
+                        "Tulsa, OK",
+                        {
+                            "friendly_name": "(918) 555-6789",
+                            "iso_country": "US",
+                            "locality": "Tulsa",
+                            "phone_number": "+19185556789",
+                            "postal_code": "74120",
+                            "region": "OK",
+                        },
+                    )
+                ],
+            ),
+            "404": OpenApiResponse(
+                description="Neither location or area_code was speciifed"
+            ),
+        },
+    )
     @decorators.action(detail=False)
     def search(self, request):
         """

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -86,6 +86,7 @@ class RealPhoneRateThrottle(throttling.UserRateThrottle):
     rate = settings.PHONE_RATE_LIMIT
 
 
+@extend_schema(tags=["phones"])
 class RealPhoneViewSet(SaveToRequestUser, viewsets.ModelViewSet):
     """
     Get real phone number records for the authenticated user.
@@ -262,6 +263,7 @@ class RealPhoneViewSet(SaveToRequestUser, viewsets.ModelViewSet):
         return super().destroy(request, *args, **kwargs)
 
 
+@extend_schema(tags=["phones"])
 class RelayNumberViewSet(SaveToRequestUser, viewsets.ModelViewSet):
     http_method_names = ["get", "post", "patch"]
     permission_classes = [permissions.IsAuthenticated, HasPhoneService]
@@ -364,6 +366,7 @@ class RelayNumberViewSet(SaveToRequestUser, viewsets.ModelViewSet):
         return response.Response({}, 404)
 
 
+@extend_schema(tags=["phones"])
 class InboundContactViewSet(viewsets.ModelViewSet):
     http_method_names = ["get", "patch"]
     permission_classes = [permissions.IsAuthenticated, HasPhoneService]
@@ -438,6 +441,7 @@ def _get_number_details(e164_number):
 
 
 @extend_schema(
+    tags=["phones"],
     responses={
         "200": OpenApiResponse(
             bytes,
@@ -454,7 +458,7 @@ def _get_number_details(e164_number):
             ],
         ),
         "404": OpenApiResponse(description="No or unknown lookup key"),
-    }
+    },
 )
 @decorators.api_view()
 @decorators.permission_classes([permissions.AllowAny])
@@ -482,6 +486,7 @@ def vCard(request: Request, lookup_key: str) -> response.Response:
 
 
 @extend_schema(
+    tags=["phones"],
     request=OpenApiRequest(),
     responses={
         "200": OpenApiResponse(
@@ -538,6 +543,7 @@ def _get_user_error_message(real_phone: RealPhone, sms_exception) -> Any:
 
 
 @extend_schema(
+    tags=["phones: Twilio"],
     parameters=[
         OpenApiParameter(name="X-Twilio-Signature", required=True, location="header"),
     ],
@@ -667,6 +673,7 @@ def inbound_sms(request):
     )
 
 
+@extend_schema(tags=["phones: Inteliquent"])
 @decorators.api_view(["POST"])
 @decorators.permission_classes([permissions.AllowAny])
 def inbound_sms_iq(request: Request) -> response.Response:
@@ -733,6 +740,7 @@ def inbound_sms_iq(request: Request) -> response.Response:
 
 
 @extend_schema(
+    tags=["phones: Twilio"],
     parameters=[
         OpenApiParameter(name="X-Twilio-Signature", required=True, location="header"),
     ],
@@ -853,6 +861,7 @@ def inbound_call(request):
 
 
 @extend_schema(
+    tags=["phones: Twilio"],
     request=OpenApiRequest(
         TwilioVoiceStatusSerializer,
         examples=[
@@ -918,6 +927,7 @@ def voice_status(request):
 
 
 @extend_schema(
+    tags=["phones: Twilio"],
     request=OpenApiRequest(
         TwilioSmsStatusSerializer,
         examples=[
@@ -962,6 +972,7 @@ def sms_status(request):
 
 @decorators.permission_classes([permissions.IsAuthenticated, HasPhoneService])
 @extend_schema(
+    tags=["phones: Outbound"],
     request=OpenApiRequest(
         OutboundCallSerializer,
         examples=[OpenApiExample("request", {"to": "+13035556789"})],
@@ -1015,6 +1026,7 @@ def outbound_call(request):
 
 @decorators.permission_classes([permissions.IsAuthenticated, HasPhoneService])
 @extend_schema(
+    tags=["phones: Outbound"],
     request=OpenApiRequest(
         OutboundSmsSerializer,
         examples=[
@@ -1075,6 +1087,7 @@ def outbound_sms(request):
 
 @decorators.permission_classes([permissions.IsAuthenticated, HasPhoneService])
 @extend_schema(
+    tags=["phones: Outbound"],
     parameters=[
         OpenApiParameter(
             name="with",

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -1012,7 +1012,6 @@ def sms_status(request):
         403: OpenApiResponse(
             description="User does not have 'outbound_phone' waffle flag."
         ),
-        405: OpenApiResponse(description="Method not allowed"),
     },
 )
 @decorators.api_view(["POST"])
@@ -1068,7 +1067,6 @@ def outbound_call(request):
         403: OpenApiResponse(
             description="User does not have 'outbound_phone' waffle flag."
         ),
-        405: OpenApiResponse(description="Method not allowed"),
     },
 )
 @decorators.api_view(["POST"])


### PR DESCRIPTION
Add the schema details for the phones views. No changes have been made to the API code. In the future, they can be updated to use the new serializers created for documentation purposes.

# How to test
With `PHONES_ENABLED=True`:

* In the browsable API at http://127.0.0.1:8000/api/v1/docs/, views are grouped, and each view function has documentation and examples
  - phones: Outbound
    - `POST /api/v1/call/`
    - `POST /api/v1/message/`
    - `POST /api/v1/messages/`
  - phones: Twilio
    - `POST /api/v1/inbound_call/`
    - `POST /api/v1/inbound_sms/`
    - `POST /api/v1/sms_status/`
    - `POST /api/v1/voice_status/`
  - phones
    - The CRUD views for `/api/v1/inboundcontact/`, `/api/v1/realphone/`, and `/api/v1/relaynumber` are unchanged. The changed views:
    - `POST /api/v1/realphone/resend_welcome_sms`
    - `GET /api/v1/relaynumber/search/`
    - `GET /api/v1/relaynumber/suggestions/`
    - `GET /api/v1/vCard/{lookup_key}/`
 
 With `IQ_ENABLED=True`, an additional group is available, between "phones: Twilio" and "phones":
 
 * phones: Inteliquent
   - `POST /api/v1/inbound_sms_iq`
 
When running `./manage.py check --deploy`, no views in `api/views/phones.py` have a `drf_spectacular.W002` warning.