### PR TITLE
MPP-3799: Add schemas for privaterelay APIs

### DIFF
--- a/api/views/privaterelay.py
+++ b/api/views/privaterelay.py
@@ -11,7 +11,7 @@ from allauth.socialaccount.adapter import get_adapter as get_social_adapter
 from allauth.socialaccount.helpers import complete_social_login
 from allauth.socialaccount.models import SocialAccount
 from django_filters.rest_framework import FilterSet
-from drf_spectacular.utils import OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema
 from rest_framework.authentication import get_authorization_header
 from rest_framework.decorators import (
     api_view,
@@ -106,7 +106,28 @@ class UserViewSet(ModelViewSet):
 
 
 @permission_classes([IsAuthenticated])
-@extend_schema(tags=["privaterelay"], request=WebcompatIssueSerializer)
+@extend_schema(
+    tags=["privaterelay"],
+    request=WebcompatIssueSerializer,
+    examples=[
+        OpenApiExample(
+            "mask not accepted",
+            {
+                "issue_on_domain": "https://accounts.firefox.com",
+                "user_agent": "Firefox",
+                "email_mask_not_accepted": True,
+                "add_on_visual_issue": False,
+                "email_not_received": False,
+                "other_issue": "",
+            },
+        )
+    ],
+    responses={
+        "201": OpenApiResponse(description="Report was submitted"),
+        "400": OpenApiResponse(description="Report was rejected due to errors."),
+        "401": OpenApiResponse(description="Authentication required."),
+    },
+)
 @api_view(["POST"])
 def report_webcompat_issue(request):
     """Report a Relay issue from an extension or integration."""

--- a/api/views/privaterelay.py
+++ b/api/views/privaterelay.py
@@ -63,7 +63,10 @@ class FlagFilter(FilterSet):
         ]
 
 
+@extend_schema(tags=["privaterelay"])
 class FlagViewSet(ModelViewSet):
+    """Feature flags."""
+
     serializer_class = FlagSerializer
     permission_classes = [IsAuthenticated, CanManageFlags]
     filterset_class = FlagFilter
@@ -74,7 +77,10 @@ class FlagViewSet(ModelViewSet):
         return flags
 
 
+@extend_schema(tags=["privaterelay"])
 class ProfileViewSet(ModelViewSet):
+    """Relay user extended profile data."""
+
     serializer_class = ProfileSerializer
     permission_classes = [IsAuthenticated, IsOwner]
     http_method_names = ["get", "post", "head", "put", "patch"]
@@ -85,7 +91,10 @@ class ProfileViewSet(ModelViewSet):
         return Profile.objects.none()
 
 
+@extend_schema(tags=["privaterelay"])
 class UserViewSet(ModelViewSet):
+    """Relay user data stored in Django user model."""
+
     serializer_class = UserSerializer
     permission_classes = [IsAuthenticated, IsOwner]
     http_method_names = ["get", "head"]
@@ -97,9 +106,11 @@ class UserViewSet(ModelViewSet):
 
 
 @permission_classes([IsAuthenticated])
-@extend_schema(methods=["POST"], request=WebcompatIssueSerializer)
+@extend_schema(tags=["privaterelay"], request=WebcompatIssueSerializer)
 @api_view(["POST"])
 def report_webcompat_issue(request):
+    """Report a Relay issue from an extension or integration."""
+
     serializer = WebcompatIssueSerializer(data=request.data)
     if serializer.is_valid():
         info_logger.info("webcompat_issue", extra=serializer.data)
@@ -111,9 +122,11 @@ def report_webcompat_issue(request):
     return Response(serializer.errors, status=HTTP_400_BAD_REQUEST)
 
 
+@extend_schema(tags=["privaterelay"])
 @api_view()
 @permission_classes([AllowAny])
 def runtime_data(request):
+    """Get data needed to present the Relay dashboard to a vistor or user."""
     flags = get_waffle_flag_model().get_all()
     flag_values = [(f.name, f.is_active(request)) for f in flags]
     switches = Switch.get_all()
@@ -148,6 +161,7 @@ def runtime_data(request):
 
 
 @extend_schema(
+    tags=["privaterelay"],
     responses={
         201: OpenApiResponse(description="Created; returned when user is created."),
         202: OpenApiResponse(


### PR DESCRIPTION
# How to test:

In the browsable API at http://127.0.0.1:8000/api/v1/docs/, views are grouped, and each view function has documentation and examples:

  - privaterelay
    - The CRUD views for `/api/v1/flags/`, `/api/v1/profiles/`, and `/api/v1/users/` are unchanged, except for a basic description.
    - `POST /api/v1/report_webcompat_issue/`
    - `GET /api/v1/runtime_data/`
    - `POST /api/v1/terms-accepted-user/` - Added documentation, but still can't test in the browsable API due to restrictions on `Authentication` field, [part of the spec](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#fixed-fields-10). We'd have to implement an authorization scheme instead, could be tricky.

When running `./manage.py check --deploy`, no views in `api/views/privaterelay.py` have a `drf_spectacular.W002` warning.
