### PR TITLE
add google-cloud-sqlcommenter

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -377,6 +377,7 @@ MIDDLEWARE += [
     "waffle.middleware.WaffleMiddleware",
     "privaterelay.middleware.AddDetectedCountryToRequestAndResponseHeaders",
     "privaterelay.middleware.StoreFirstVisit",
+    "google.cloud.sqlcommenter.django.middleware.SqlCommenter",
 ]
 
 ROOT_URLCONF = "privaterelay.urls"

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ drf-spectacular-sidecar==2024.4.1
 glean_parser==14.0.1
 google-measurement-protocol==1.1.0
 google-cloud-profiler==4.1.0
+google-cloud-sqlcommenter==2.0.0
 gunicorn==22.0.0
 jwcrypto==1.5.6
 markus[datadog]==4.2.0


### PR DESCRIPTION
This PR is for #MPP-3746.

## How to test:
1. `pip install -r requirements.txt`
2. Be sure that your postgresql is logging to a directory and log file you can see (I made the changes in https://stackoverflow.com/q/722221 and restarted my postgresql server)
3. `python manage.py runserver`
4. Sign in at http://127.0.0.1:8000/
5. Go to `http://127.0.0.1:8000/api/v1/relayaddresses/?format=json`
6. Open your postgresql log file from step 2
   * [x] You should see strings like this appended to the SQL `SELECT` statement logs: `/*controller='relayaddress-list',framework='django%3A4.2.11',route='api/v1/relayaddresses/%24'*/`

## Checklist
- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
