### PR TITLE
MPP-3809: Add slack integration for e2e failure alerts

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -77,3 +77,53 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 5
+      - name: Send GitHub Action trigger data to Slack workflow
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        if: failure()
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Link to job:* *<https://github.com/mozilla/fx-private-relay/actions/runs/${{ github.run_id }}|Relay e2e tests>*"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:* \n ${{ github.workflow }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Status:*\n ${{ job.status }}  "
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Ref:*\n ${{ github.ref }}  "
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Triggered by:*\n ${{ github.triggering_actor }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GHA_FAILURES_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/e2e-tests/pages/mozillaMonitorPage.ts
+++ b/e2e-tests/pages/mozillaMonitorPage.ts
@@ -32,5 +32,8 @@ export class MozillaMonitorPage {
     await this.page.waitForURL("**/oauth/signup**");
     const authPage = new AuthPage(this.page);
     await authPage.signUp(randomMask, true);
+    await this.page
+      .getByText("Enter confirmation code")
+      .waitFor({ state: "attached", timeout: 3000 });
   }
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3809

# New feature description

Sends an alert to #relay-alerts in slack when e2e tests fail.

# Screenshot (if applicable)

![image](https://github.com/mozilla/fx-private-relay/assets/59676643/26b69689-72d1-46fd-9e96-344ff4b98c8e)

# How to test

# Checklist (Definition of Done)
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] Customer Experience team has seen or waived a demo of functionality.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] l10n changes have been submitted to the l10n repository, if any.
