### PR TITLE
Remove react-qr-code and mobile_app flag

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,6 @@
     "react-dom": "18.3.1",
     "react-ga": "^3.3.1",
     "react-intersection-observer": "^9.10.2",
-    "react-qr-code": "^2.0.12",
     "react-singleton-hook": "^4.0.1",
     "react-stately": "^3.31.0",
     "react-toastify": "^10.0.5",

--- a/frontend/src/hooks/api/runtimeData.ts
+++ b/frontend/src/hooks/api/runtimeData.ts
@@ -16,8 +16,7 @@ export type FlagNames =
   | "premium_promo_banners"
   | "mask_redesign"
   | "holiday_promo_2023"
-  | "four_mask_limit_upsell"
-  | "mobile_app";
+  | "four_mask_limit_upsell";
 
 type WaffleFlag = [FlagNames, boolean];
 

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -30,7 +30,6 @@ import { useAddonData } from "../../hooks/addon";
 import { isFlagActive } from "../../functions/waffle";
 import { isPhonesAvailableInCountry } from "../../functions/getPlan";
 import { useL10n } from "../../hooks/l10n";
-import QRCode from "react-qr-code";
 
 const Settings: NextPage = () => {
   const runtimeData = useRuntimeData();
@@ -232,14 +231,6 @@ const Settings: NextPage = () => {
             </span>
           </span>
         </div>
-        {isFlagActive(runtimeData.data, "mobile_app") ? (
-          <div className={styles["settings-api-qr-code-wrapper"]}>
-            <div className={styles["settings-api-qr-code"]}>
-              <QRCode value={"Token " + profile.api_token} />
-            </div>
-            <p>Scan the code with your Relay mobile app.</p>
-          </div>
-        ) : null}
         <div className={styles["settings-api-key-copy"]}>
           {l10n.getString("settings-api-key-description")}{" "}
           <b>{l10n.getString("settings-api-key-description-bolded")}</b>

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "react-dom": "18.3.1",
         "react-ga": "^3.3.1",
         "react-intersection-observer": "^9.10.2",
-        "react-qr-code": "^2.0.12",
         "react-singleton-hook": "^4.0.1",
         "react-stately": "^3.31.0",
         "react-toastify": "^10.0.5",
@@ -12616,11 +12615,6 @@
         }
       ]
     },
-    "node_modules/qr.js": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
-      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "dev": true,
@@ -12756,24 +12750,6 @@
       "version": "17.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/react-qr-code": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.12.tgz",
-      "integrity": "sha512-k+pzP5CKLEGBRwZsDPp98/CAJeXlsYRHM2iZn1Sd5Th/HnKhIZCSg27PXO58zk8z02RaEryg+60xa4vyywMJwg==",
-      "dependencies": {
-        "prop-types": "^15.8.1",
-        "qr.js": "0.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.x || ^17.x || ^18.x",
-        "react-native-svg": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-svg": {
-          "optional": true
-        }
-      }
     },
     "node_modules/react-shallow-renderer": {
       "version": "16.15.0",
@@ -20572,7 +20548,6 @@
         "react-dom": "18.3.1",
         "react-ga": "^3.3.1",
         "react-intersection-observer": "^9.10.2",
-        "react-qr-code": "^2.0.12",
         "react-singleton-hook": "^4.0.1",
         "react-stately": "^3.31.0",
         "react-test-renderer": "^18.3.1",
@@ -23939,11 +23914,6 @@
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
       "dev": true
     },
-    "qr.js": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
-      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
-    },
     "querystringify": {
       "version": "2.2.0",
       "dev": true
@@ -24034,15 +24004,6 @@
     "react-is": {
       "version": "17.0.2",
       "dev": true
-    },
-    "react-qr-code": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.12.tgz",
-      "integrity": "sha512-k+pzP5CKLEGBRwZsDPp98/CAJeXlsYRHM2iZn1Sd5Th/HnKhIZCSg27PXO58zk8z02RaEryg+60xa4vyywMJwg==",
-      "requires": {
-        "prop-types": "^15.8.1",
-        "qr.js": "0.0.0"
-      }
     },
     "react-shallow-renderer": {
       "version": "16.15.0",


### PR DESCRIPTION
We're not going to be using it AFAIK, so that saves us a dependency. Created to make https://github.com/mozilla/fx-private-relay/pull/4704 redundant.

I did see references to `mobile_app` in `/api/tests/phones_views_tests.py` as well, but in actual code, so...? In any case, I don't think the UI needs to do anything in response to the flag, so the changes in this PR at least should be safe.