### PR TITLE
MPP-3487 - Fix tests, handle missing sqlcommenter in Python 3.12, 

### DIFF
--- a/emails/tests/sns_tests.py
+++ b/emails/tests/sns_tests.py
@@ -9,12 +9,7 @@ from ..sns import _grab_keyfile
 class GrabKeyfileTest(TestCase):
     @patch("emails.sns.urlopen")
     def test_grab_keyfile_checks_cert_url_origin(self, mock_urlopen):
-        cert_url = (
-            "https://sns.us-east-1.amazonaws.com/"
-            "SimpleNotificationService-7ff5318490ec183fbaddaa2a969abfda.pem"
-        )
-        assert mock_urlopen.called_once_with(cert_url)
-
+        cert_url = "https://attacker.com/cert.pem"
         with self.assertRaises(SuspiciousOperation):
-            cert_url = "https://attacker.com/cert.pem"
             _grab_keyfile(cert_url)
+        mock_urlopen.assert_not_called()

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -45,6 +45,13 @@ except ImportError:
     HAS_SILK = False
 
 try:
+    import google.cloud.sqlcommenter  # noqa: F401
+
+    HAS_SQLCOMMENTER = True
+except ImportError:
+    HAS_SQLCOMMENTER = False
+
+try:
     from privaterelay.glean.server_events import GLEAN_EVENT_MOZLOG_TYPE
 except ImportError:
     # File may not be generated yet. Will be checked at initialization
@@ -378,8 +385,10 @@ MIDDLEWARE += [
     "waffle.middleware.WaffleMiddleware",
     "privaterelay.middleware.AddDetectedCountryToRequestAndResponseHeaders",
     "privaterelay.middleware.StoreFirstVisit",
-    "google.cloud.sqlcommenter.django.middleware.SqlCommenter",
 ]
+
+if HAS_SQLCOMMENTER:
+    MIDDLEWARE.append("google.cloud.sqlcommenter.django.middleware.SqlCommenter")
 
 ROOT_URLCONF = "privaterelay.urls"
 

--- a/privaterelay/tests/utils.py
+++ b/privaterelay/tests/utils.py
@@ -33,6 +33,7 @@ def log_extra(log_record: LogRecord) -> dict[str, Any]:
         "relativeCreated",
         "rid",
         "stack_info",
+        "taskName",
         "thread",
         "threadName",
     }

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -3,7 +3,7 @@ import logging
 from collections.abc import Callable, Iterator
 from copy import deepcopy
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal
 from unittest.mock import ANY, Mock, patch
@@ -350,7 +350,7 @@ def get_fxa_event_jwt(
         "iss": "https://accounts.firefox.com/",
         "sub": fxa_id,
         "aud": client_id,
-        "iat": int(datetime.utcnow().timestamp()) + iat_skew,
+        "iat": int(datetime.now(UTC).timestamp()) + iat_skew,
         "jti": str(uuid4()),
         "events": {event_key: event_data},
     }
@@ -369,7 +369,7 @@ def test_fxa_rp_events_password_change(
         fxa_id=setup_fxa_rp_events.fxa_acct.uid,
         client_id=setup_fxa_rp_events.app.client_id,
         signing_key=setup_fxa_rp_events.key,
-        event_data={"changeTime": int(datetime.utcnow().timestamp()) - 100},
+        event_data={"changeTime": int(datetime.now(UTC).timestamp()) - 100},
     )
     auth_header = f"Bearer {event_jwt}"
 
@@ -395,7 +395,7 @@ def test_fxa_rp_events_password_change_slight_future_iat(
         fxa_id=setup_fxa_rp_events.fxa_acct.uid,
         client_id=setup_fxa_rp_events.app.client_id,
         signing_key=setup_fxa_rp_events.key,
-        event_data={"changeTime": int(datetime.utcnow().timestamp()) - 100},
+        event_data={"changeTime": int(datetime.now(UTC).timestamp()) - 100},
         iat_skew=3,
     )
     auth_header = f"Bearer {event_jwt}"
@@ -426,7 +426,7 @@ def test_fxa_rp_events_password_change_far_future_iat(
         fxa_id=setup_fxa_rp_events.fxa_acct.uid,
         client_id=setup_fxa_rp_events.app.client_id,
         signing_key=setup_fxa_rp_events.key,
-        event_data={"changeTime": int(datetime.utcnow().timestamp()) - 100},
+        event_data={"changeTime": int(datetime.now(UTC).timestamp()) - 100},
         iat_skew=10,
     )
     auth_header = f"Bearer {event_jwt}"
@@ -493,7 +493,7 @@ def test_fxa_rp_events_subscription_change(
         event_data={
             "capabilities": ["new_capability"],
             "isActive": True,
-            "changeTime": int(datetime.utcnow().timestamp()) - 100,
+            "changeTime": int(datetime.now(UTC).timestamp()) - 100,
         },
     )
     auth_header = f"Bearer {event_jwt}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ module = [
     "django_filters.*",
     "django_ftl",
     "django_ftl.bundles",
+    "google.*",
     "google_measurement_protocol",
     "googlecloudprofiler",
     "ipware",

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ drf-spectacular-sidecar==2024.5.1
 glean_parser==14.1.2
 google-measurement-protocol==1.1.0
 google-cloud-profiler==4.1.0
-google-cloud-sqlcommenter==2.0.0
+google-cloud-sqlcommenter==2.0.0; python_version < '3.12'
 gunicorn==22.0.0
 jwcrypto==1.5.6
 markus[datadog]==4.2.0


### PR DESCRIPTION
This makes changes needed for tests to run under Python 3.12, with no deprecation warnings.

## Mock that doesn't do what was intended
For `test_grab_keyfile_checks_cert_url_origin`, the line 

```python
assert mock_urlopen.called_once_with(cert_url)
```
raises an exception:

```
AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_with'?
```

This is a new check for mock functions which are similar to the mock assertion functions. The developer probably intended:

```python
mock_urlopen.assert_called_once_with(cert_url)
```
However, this also fails. It would be a bit of work to make this pass, requiring mocking the return of a valid PEM. After a bit of reading, I re-wrote as:

```python
mock_urlopen.assert_not_called()
```
and called it after the `SuspiciousOperation` was raised. 

## LogRecord has new attribute `taskName`

This attribute was added to log the asyncio task name, https://github.com/python/cpython/issues/91513 . The `log_extra` helper needs to ignore it.

## `utcnow()` is finally going away

[datetime.utcnow()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) is one of the gotcha methods. It returns a `datetime` in UTC time, but _without_ timezone information. Django will catch this if you try to store in a model, but some of our test code still uses it. It now raises a `DeprecationWarning`. I've replaced this code with `datetime.now(UTC)`, which returns a timezone-aware datetime.

## google-cloud-sqlcommenter doesn't like Python 3.12

This module prints a bunch of `DeprecationWarning`s: in Python 3.11

```
/private/tmp/workspace/.py311/lib/python3.11/site-packages/google/__init__.py:17: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  __import__('pkg_resources').declare_namespace(__name__)
/private/tmp/workspace/.py311/lib/python3.11/site-packages/google/__init__.py:17: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google')`.
Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
  __import__('pkg_resources').declare_namespace(__name__)
```

In Python 3.12, `pkg_resources` is no longer installed automatically in virtualenvs, and these become an error:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/private/tmp/workspace/.py312/lib/python3.12/site-packages/google/__init__.py", line 17, in <module>
    __import__('pkg_resources').declare_namespace(__name__)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'pkg_resources'
```

You can install it via `setuptools`, but installing this unconditionally will cause issues when you are _not_ in a virtualenv, like our Docker image. I went with skipping it for Python 3.12, and not installing the middleware if the import fails (either not installed, or installed in virtualenv without `setuptools`). I opened https://github.com/google/sqlcommenter/issues/275 to track the issue.