### PR TITLE
Remove Sentry logger for SocialAccount does not exist

### DIFF
--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -140,15 +140,6 @@ def fxa_rp_events(request: HttpRequest) -> HttpResponse:
     try:
         social_account = _get_account_from_jwt(authentic_jwt)
     except SocialAccount.DoesNotExist:
-        if settings.DEBUG:
-            info_logger.info(
-                "fxa_profile_update",
-                extra={
-                    "success": False,
-                    "reason": "SocialAccount does not exist.",
-                    "jwt": authentic_jwt,
-                },
-            )
         # Don't error, or FXA will retry
         return HttpResponse("202 Accepted", status=202)
 


### PR DESCRIPTION
Fix MPP-3767 and add debugging log instead.

How to test:
No more events sent to [RELAY-GB](https://mozilla.sentry.io/issues/4716503385/?referrer=jira_integration).

- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).