### PR TITLE
For `ResponseMetrics` middleware, improve `view` tag and add tests

### DIFF
--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -1,3 +1,4 @@
+import re
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -54,6 +55,9 @@ class AddDetectedCountryToRequestAndResponseHeaders:
 
 
 class ResponseMetrics:
+
+    re_dockerflow = re.compile(r"/__(version|heartbeat|lbheartbeat)__/?$")
+
     def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
         self.get_response = get_response
 
@@ -80,6 +84,8 @@ class ResponseMetrics:
         if request.resolver_match:
             view = request.resolver_match.func
             return f"{view.__module__}.{view.__name__}"
+        if match := self.re_dockerflow.match(request.path_info):
+            return f"dockerflow.django.views.{match[1]}"
         return "<unknown_view>"
 
 

--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -83,6 +83,9 @@ class ResponseMetrics:
     def _get_metric_view_name(self, request: HttpRequest) -> str:
         if request.resolver_match:
             view = request.resolver_match.func
+            if hasattr(view, "view_class"):
+                # Wrapped with rest_framework.decorators.api_view
+                return f"{view.__module__}.{view.view_class.__name__}"
             return f"{view.__module__}.{view.__name__}"
         if match := self.re_dockerflow.match(request.path_info):
             return f"dockerflow.django.views.{match[1]}"

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -349,16 +349,7 @@ if PHONES_ENABLED:
     ]
 
 
-# statsd middleware has to be first to catch errors in everything else
-def _get_initial_middleware() -> list[str]:
-    if STATSD_ENABLED:
-        return [
-            "privaterelay.middleware.ResponseMetrics",
-        ]
-    return []
-
-
-MIDDLEWARE = _get_initial_middleware()
+MIDDLEWARE = ["privaterelay.middleware.ResponseMetrics"]
 
 if USE_SILK:
     MIDDLEWARE.append("silk.middleware.SilkyMiddleware")

--- a/privaterelay/tests/middleware_tests.py
+++ b/privaterelay/tests/middleware_tests.py
@@ -88,7 +88,7 @@ def test_response_metrics_frontend_path(
     assert response.status_code == 200
     mm.assert_timing_once(
         "fx.private.relay.response",
-        tags=["status:200", "view:<unknown_view>", "method:GET"],
+        tags=["status:200", "view:<static_file>", "method:GET"],
     )
 
 
@@ -101,7 +101,7 @@ def test_response_metrics_frontend_file(
     assert response.status_code == 200
     mm.assert_timing_once(
         "fx.private.relay.response",
-        tags=["status:200", "view:<unknown_view>", "method:GET"],
+        tags=["status:200", "view:<static_file>", "method:GET"],
     )
 
 

--- a/privaterelay/tests/middleware_tests.py
+++ b/privaterelay/tests/middleware_tests.py
@@ -107,11 +107,15 @@ def test_response_metrics_frontend_path(
     """Frontend views emit the expected metrics."""
     with MetricsMock() as mm:
         response = client.get("/faq/")
-    assert response.status_code == 200
-    mm.assert_timing_once(
-        "fx.private.relay.response",
-        tags=["status:200", "view:<static_file>", "method:GET"],
-    )
+    # The file is found if the frontend build was done, the DEBUG setting,
+    #  if files were collected, etc.
+    assert response.status_code in [200, 404]
+    # Metrics are only emitted if found.
+    if response.status_code == 200:
+        mm.assert_timing_once(
+            "fx.private.relay.response",
+            tags=["status:200", "view:<static_file>", "method:GET"],
+        )
 
 
 @pytest.mark.django_db
@@ -121,11 +125,15 @@ def test_response_metrics_frontend_file(
     """Frontend files emit the expected metrics."""
     with MetricsMock() as mm:
         response = client.get("/favicon.svg")
-    assert response.status_code == 200
-    mm.assert_timing_once(
-        "fx.private.relay.response",
-        tags=["status:200", "view:<static_file>", "method:GET"],
-    )
+    # The file is found if the frontend build was done, the DEBUG setting,
+    #  if files were collected, etc.
+    assert response.status_code in [200, 404]
+    # Metrics are only emitted if found.
+    if response.status_code == 200:
+        mm.assert_timing_once(
+            "fx.private.relay.response",
+            tags=["status:200", "view:<static_file>", "method:GET"],
+        )
 
 
 def test_response_metrics_disabled(

--- a/privaterelay/tests/middleware_tests.py
+++ b/privaterelay/tests/middleware_tests.py
@@ -1,0 +1,81 @@
+"""Tests for Relay middlewares used in API and other server requests."""
+
+from django.test import Client
+from markus.testing import MetricsMock
+from pytest_django.fixtures import SettingsWrapper
+import pytest
+
+
+@pytest.fixture
+def response_metrics_settings(settings: SettingsWrapper) -> SettingsWrapper:
+    # Use some middleware in the declared order
+    settings.MIDDLEWARE = [
+        "privaterelay.middleware.ResponseMetrics",
+        "privaterelay.middleware.RelayStaticFilesMiddleware",
+        "dockerflow.django.middleware.DockerflowMiddleware",
+    ]
+    settings.STATSD_ENABLED = True
+    return settings
+
+
+def test_response_metrics_django_view(
+    client: Client, response_metrics_settings: SettingsWrapper
+) -> None:
+    with MetricsMock() as mm:
+        response = client.get("/metrics-event")
+    assert response.status_code == 405
+    mm.assert_timing_once(
+        "fx.private.relay.response",
+        tags=["status:405", "view:privaterelay.views.metrics_event", "method:GET"],
+    )
+
+
+def test_response_metrics_dockerflow_view(
+    client: Client, response_metrics_settings: SettingsWrapper
+) -> None:
+    with MetricsMock() as mm:
+        response = client.get("/__lbheartbeat__")
+    assert response.status_code == 200
+    mm.assert_timing_once(
+        "fx.private.relay.response",
+        tags=["status:200", "view:<unknown_view>", "method:GET"],
+    )
+
+
+@pytest.mark.django_db
+def test_response_metrics_api_view(
+    client: Client, response_metrics_settings: SettingsWrapper
+) -> None:
+    with MetricsMock() as mm:
+        response = client.get("/api/v1/runtime_data")
+    assert response.status_code == 200
+    mm.assert_timing_once(
+        "fx.private.relay.response",
+        tags=["status:200", "view:api.views.privaterelay.view", "method:GET"],
+    )
+
+
+@pytest.mark.django_db
+def test_response_metrics_frontend_view(
+    client: Client, response_metrics_settings: SettingsWrapper
+) -> None:
+    with MetricsMock() as mm:
+        response = client.get("/faq/")
+    assert response.status_code == 200
+    mm.assert_timing_once(
+        "fx.private.relay.response",
+        tags=["status:200", "view:<unknown_view>", "method:GET"],
+    )
+
+
+@pytest.mark.django_db
+def test_response_metrics_frontend_file(
+    client: Client, response_metrics_settings: SettingsWrapper
+) -> None:
+    with MetricsMock() as mm:
+        response = client.get("/favicon.svg")
+    assert response.status_code == 200
+    mm.assert_timing_once(
+        "fx.private.relay.response",
+        tags=["status:200", "view:<unknown_view>", "method:GET"],
+    )

--- a/privaterelay/tests/middleware_tests.py
+++ b/privaterelay/tests/middleware_tests.py
@@ -54,6 +54,19 @@ def test_response_metrics_dockerflow_view(
 
 
 @pytest.mark.django_db
+def test_response_metrics_api_viewset(
+    client: Client, response_metrics_settings: SettingsWrapper
+) -> None:
+    with MetricsMock() as mm:
+        response = client.get("/api/v1/users/")
+    assert response.status_code == 401
+    mm.assert_timing_once(
+        "fx.private.relay.response",
+        tags=["status:401", "view:api.views.privaterelay.UserViewSet", "method:GET"],
+    )
+
+
+@pytest.mark.django_db
 def test_response_metrics_api_view(
     client: Client, response_metrics_settings: SettingsWrapper
 ) -> None:
@@ -62,7 +75,7 @@ def test_response_metrics_api_view(
     assert response.status_code == 200
     mm.assert_timing_once(
         "fx.private.relay.response",
-        tags=["status:200", "view:api.views.privaterelay.view", "method:GET"],
+        tags=["status:200", "view:api.views.privaterelay.runtime_data", "method:GET"],
     )
 
 

--- a/privaterelay/tests/middleware_tests.py
+++ b/privaterelay/tests/middleware_tests.py
@@ -9,6 +9,7 @@ from pytest_django.fixtures import SettingsWrapper
 
 @pytest.fixture
 def response_metrics_settings(settings: SettingsWrapper) -> SettingsWrapper:
+    """Setup settings for ResponseMetrics tests."""
     # Use some middleware in the declared order
     use_middleware = {
         "privaterelay.middleware.ResponseMetrics",
@@ -23,7 +24,7 @@ def response_metrics_settings(settings: SettingsWrapper) -> SettingsWrapper:
 def test_response_metrics_django_view(
     client: Client, response_metrics_settings: SettingsWrapper
 ) -> None:
-    """Django views emit the expected metrics."""
+    """Django views emit the expected metric."""
     with MetricsMock() as mm:
         response = client.get("/metrics-event")
     assert response.status_code == 405
@@ -37,7 +38,7 @@ def test_response_metrics_django_view(
 def test_response_metrics_dockerflow_heartbeat(
     client: Client, response_metrics_settings: SettingsWrapper
 ) -> None:
-    """Dockerflow views are handled by the DockerflowMiddleware."""
+    """The Dockerflow __heartbeat__ endpoint emits the expected metric."""
     with MetricsMock() as mm:
         response = client.get("/__heartbeat__")
     # __heartbeat__ runs some security and connection tests
@@ -58,7 +59,7 @@ def test_response_metrics_dockerflow_heartbeat(
 def test_response_metrics_other_dockerflow_view(
     client: Client, response_metrics_settings: SettingsWrapper, viewname: str
 ) -> None:
-    """Dockerflow views are handled by the DockerflowMiddleware."""
+    """The other Dockerflow views emit the expected metrics."""
     with MetricsMock() as mm:
         response = client.get(f"/__{viewname}__")
     assert response.status_code == 200
@@ -76,6 +77,7 @@ def test_response_metrics_other_dockerflow_view(
 def test_response_metrics_api_viewset(
     client: Client, response_metrics_settings: SettingsWrapper
 ) -> None:
+    """API viewsets emit the expected metrics."""
     with MetricsMock() as mm:
         response = client.get("/api/v1/users/")
     assert response.status_code == 401
@@ -89,6 +91,7 @@ def test_response_metrics_api_viewset(
 def test_response_metrics_api_view(
     client: Client, response_metrics_settings: SettingsWrapper
 ) -> None:
+    """API functions wrapped in @api_view emit the expected metrics."""
     with MetricsMock() as mm:
         response = client.get("/api/v1/runtime_data")
     assert response.status_code == 200
@@ -101,7 +104,7 @@ def test_response_metrics_api_view(
 def test_response_metrics_frontend_path(
     client: Client, response_metrics_settings: SettingsWrapper
 ) -> None:
-    """Frontend views do not return through the ResponseMetrics middleware."""
+    """Frontend views emit the expected metrics."""
     with MetricsMock() as mm:
         response = client.get("/faq/")
     assert response.status_code == 200
@@ -115,6 +118,7 @@ def test_response_metrics_frontend_path(
 def test_response_metrics_frontend_file(
     client: Client, response_metrics_settings: SettingsWrapper
 ) -> None:
+    """Frontend files emit the expected metrics."""
     with MetricsMock() as mm:
         response = client.get("/favicon.svg")
     assert response.status_code == 200

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -376,7 +376,10 @@ def test_fxa_rp_events_password_change(
     with MetricsMock() as mm:
         response = client.get("/fxa-rp-events", HTTP_AUTHORIZATION=auth_header)
 
-    assert mm.get_records() == []
+    mm.assert_timing_once(
+        "fx.private.relay.response",
+        tags=["status:200", "view:privaterelay.views.fxa_rp_events", "method:GET"],
+    )
     assert caplog.record_tuples == [
         ("request.summary", logging.INFO, ""),
     ]
@@ -403,7 +406,10 @@ def test_fxa_rp_events_password_change_slight_future_iat(
     with MetricsMock() as mm:
         response = client.get("/fxa-rp-events", HTTP_AUTHORIZATION=auth_header)
 
-    assert mm.get_records() == []
+    mm.assert_timing_once(
+        "fx.private.relay.response",
+        tags=["status:200", "view:privaterelay.views.fxa_rp_events", "method:GET"],
+    )
     assert caplog.record_tuples == [
         ("request.summary", logging.INFO, ""),
     ]
@@ -434,7 +440,10 @@ def test_fxa_rp_events_password_change_far_future_iat(
     with MetricsMock() as mm, pytest.raises(jwt.ImmatureSignatureError):
         client.get("/fxa-rp-events", HTTP_AUTHORIZATION=auth_header)
 
-    assert mm.get_records() == []
+    mm.assert_timing_once(
+        "fx.private.relay.response",
+        tags=["status:500", "view:privaterelay.views.fxa_rp_events", "method:GET"],
+    )
     assert caplog.record_tuples == [
         ("eventsinfo", logging.WARNING, "fxa_rp_event.future_iat"),
         ("request.summary", logging.ERROR, "The token is not yet valid (iat)"),
@@ -462,7 +471,10 @@ def test_fxa_rp_events_profile_change(
     with MetricsMock() as mm:
         response = client.get("/fxa-rp-events", HTTP_AUTHORIZATION=auth_header)
 
-    assert mm.get_records() == []
+    mm.assert_timing_once(
+        "fx.private.relay.response",
+        tags=["status:200", "view:privaterelay.views.fxa_rp_events", "method:GET"],
+    )
     assert caplog.record_tuples == [
         ("eventsinfo", logging.INFO, "fxa_rp_event"),
         ("request.summary", logging.INFO, ""),
@@ -500,7 +512,10 @@ def test_fxa_rp_events_subscription_change(
 
     with MetricsMock() as mm:
         response = client.get("/fxa-rp-events", HTTP_AUTHORIZATION=auth_header)
-    assert mm.get_records() == []
+    mm.assert_timing_once(
+        "fx.private.relay.response",
+        tags=["status:200", "view:privaterelay.views.fxa_rp_events", "method:GET"],
+    )
     assert caplog.record_tuples == [
         ("eventsinfo", logging.INFO, "fxa_rp_event"),
         ("request.summary", logging.INFO, ""),
@@ -538,7 +553,10 @@ def test_fxa_rp_events_delete_user(
 
     with MetricsMock() as mm:
         response = client.get("/fxa-rp-events", HTTP_AUTHORIZATION=auth_header)
-    assert mm.get_records() == []
+    mm.assert_timing_once(
+        "fx.private.relay.response",
+        tags=["status:200", "view:privaterelay.views.fxa_rp_events", "method:GET"],
+    )
     assert caplog.record_tuples == [
         ("eventsinfo", logging.INFO, "fxa_rp_event"),
         ("request.summary", logging.INFO, ""),


### PR DESCRIPTION
The `ResponseMetrics` middleware emits the timing metric `fx.private.relay.response`. This gives us the application's view of the response time, bucketed by the hour. We use the `view` tag to segment by views, to determine trends over time and slow periods.

This PR improve the tag `view` in a few cases:

* `/api/v1/runtime_data`, other API view functions. - The tag was `api.views.privaterelay.view`. This is now `api.views.privaterelay.runtime_data`. Other API view functions also had '.view' for the last component, and now use their function name.
* `/__heartbeat__`, other Dockerflow views - The tag was `<unknown_view>`, and is now `dockerflow.django.views.heartbeat`. Similar changes are made for `/__version__` and `/__lbheartbeat__`.
* Frontend files - The tag was `<unknown_view>`, and is now `<static_file>`. 

This PR also includes tests for `ResponseMetrics`.

## How to test

- [x] I've added a unit test to test for potential regressions of this bug.