### PR TITLE
MPP-3730: Fix login redirects in dev/stage/prod

### DIFF
--- a/privaterelay/allauth.py
+++ b/privaterelay/allauth.py
@@ -47,7 +47,11 @@ class AccountAdapter(DefaultAccountAdapter):
             # Staticfiles are not available
             pass
         else:
-            found = middleware.find_file(path)
+            found = middleware.find_file(path) or middleware.find_file_at_path(
+                "staticfiles/" + path, path
+            )
+
+            # Is this a frontend URL?
             if found:
                 return True
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->
Closing this PR. find_file_at_path does not return None.

This PR fixes MPP-3730.

# Bug description

These URLs works, redirects to the API profile page after login:

https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/accounts/fxa/login/?next=/api/v1/profiles/

https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net/accounts/fxa/login/?next=/api/v1/profiles/

https://relay.firefox.com/accounts/fxa/login/?next=/api/v1/profiles/

Locally, accounts/fxa/login/?next=/faq/ works.
It does not work in stage/dev/prod because we use staticfiles, redirects to the dashboard instead of the FAQ and emits a Sentry error:

https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/accounts/fxa/login/?next=/faq/

https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net/accounts/fxa/login/?next=/faq/

https://relay.firefox.com/accounts/fxa/login/?next=/faq/

Sentry Issue: [RELAY-JH](https://mozilla.sentry.io/issues/4928696585/?referrer=jira_integration)

# Screenshot (if applicable)

# How to test

1. push to dev server and go to https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/accounts/fxa/login/?next=/faq/

2. Verify you are redirected to the faq page.

# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] Customer Experience team has seen or waived a demo of functionality.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
