### PR TITLE
Update tests for `STATSD_DEBUG=True`

### DIFF
--- a/privaterelay/tests/utils.py
+++ b/privaterelay/tests/utils.py
@@ -10,6 +10,15 @@ from django.contrib.auth.models import User
 import pytest
 
 
+def omit_markus_logs(caplog: pytest.LogCaptureFixture) -> list[LogRecord]:
+    """
+    Return log records that are not markus debug logs.
+
+    Markus debug logs are enabled at Django setup with STATSD_DEBUG=True
+    """
+    return [rec for rec in caplog.records if rec.name != "markus"]
+
+
 def log_extra(log_record: LogRecord) -> dict[str, Any]:
     """Reconstruct the "extra" argument to the log call"""
     omit_log_record_keys = {


### PR DESCRIPTION
When `DJANGO_STATSD_ENABLED=True` and `STATSD_DEBUG=True`, log messages like these are emitted:

```
{"Timestamp": 1717537908384410880, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 66599, "Fields": {"rid": null, "msg": "METRICS|2024-06-04 21:51:48|timing|fx.private.relay.response|55.711984634399414|#status:200,view:<static_file>,method:GET"}}
{"Timestamp": 1717537908517943040, "Type": "markus", "Logger": "fx-private-relay", "Hostname": "jwhitlock-MB-M2.lan", "EnvVersion": "2.0", "Severity": 6, "Pid": 66599, "Fields": {"rid": null, "msg": "METRICS|2024-06-04 21:51:48|timing|fx.private.relay.response|82.79109001159668|#status:200,view:<static_file>,method:GET"}}
```
The second message has details about the `response` timing metric:

```
METRICS|2024-06-04 21:51:48|timing|fx.private.relay.response|82.79109001159668|#status:200,view:<static_file>,method:GET
```

This can be useful for local debugging or understanding metrics. It can also be very noisy, and break tests that do not expect them. This PR updates the some tests to filter out the metrics logs.
