### PR TITLE
MPP-4763 - Prefer `user.profile` to `Profile.objects.get(user=user)`

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,8 +1,6 @@
 from rest_framework import permissions
 from waffle import flag_is_active
 
-from emails.models import Profile
-
 READ_METHODS = ["GET", "HEAD"]
 
 
@@ -15,16 +13,14 @@ class HasPremium(permissions.BasePermission):
     def has_permission(self, request, view):
         if request.method in READ_METHODS:
             return True
-        profile = Profile.objects.get(request.user)
-        return profile.has_premium
+        return request.user.profile.has_premium
 
 
 class HasPhoneService(permissions.BasePermission):
     def has_permission(self, request, view):
         if request.method in READ_METHODS:
             return True
-        profile = Profile.objects.get(user=request.user)
-        return profile.has_phone
+        return request.user.profile.has_phone
 
 
 class CanManageFlags(permissions.BasePermission):

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,4 +1,8 @@
+from django.contrib.auth.models import AnonymousUser
+
 from rest_framework import permissions
+from rest_framework.request import Request
+from rest_framework.views import APIView
 from waffle import flag_is_active
 
 READ_METHODS = ["GET", "HEAD"]
@@ -10,14 +14,18 @@ class IsOwner(permissions.BasePermission):
 
 
 class HasPremium(permissions.BasePermission):
-    def has_permission(self, request, view):
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        if isinstance(request.user, AnonymousUser):
+            return False
         if request.method in READ_METHODS:
             return True
         return request.user.profile.has_premium
 
 
 class HasPhoneService(permissions.BasePermission):
-    def has_permission(self, request, view):
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        if isinstance(request.user, AnonymousUser):
+            return False
         if request.method in READ_METHODS:
             return True
         return request.user.profile.has_phone

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -17,8 +17,6 @@ from twilio.request_validator import RequestValidator
 from twilio.rest import Client
 from waffle.testutils import override_flag
 
-from emails.models import Profile
-
 if settings.PHONES_ENABLED:
     from api.views.phones import MatchByPrefix, _match_by_prefix
     from phones.models import InboundContact, RealPhone, RelayNumber
@@ -957,9 +955,8 @@ def test_inbound_sms_reply_with_no_remaining_texts(phone_user, mocked_twilio_cli
 def test_inbound_sms_valid_twilio_signature_no_phone_log(
     phone_user, mocked_twilio_client
 ):
-    profile = Profile.objects.get(user=phone_user)
-    profile.store_phone_log = False
-    profile.save()
+    phone_user.profile.store_phone_log = False
+    phone_user.profile.save()
     _make_real_phone(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user, enabled=True)
     inbound_number = "+15556660000"
@@ -981,9 +978,8 @@ def test_inbound_sms_valid_twilio_signature_no_phone_log(
 def test_inbound_sms_valid_twilio_signature_blocked_contact(
     phone_user, mocked_twilio_client
 ):
-    profile = Profile.objects.get(user=phone_user)
-    profile.store_phone_log = True
-    profile.save()
+    phone_user.profile.store_phone_log = True
+    phone_user.profile.save()
     _make_real_phone(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user, enabled=True)
     inbound_number = "+15556660000"
@@ -1033,9 +1029,8 @@ def test_inbound_sms_reply_not_storing_phone_log(phone_user, mocked_twilio_clien
     real_phone = _make_real_phone(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user, enabled=True)
     mocked_twilio_client.reset_mock()
-    profile = Profile.objects.get(user=phone_user)
-    profile.store_phone_log = False
-    profile.save()
+    phone_user.profile.store_phone_log = False
+    phone_user.profile.save()
 
     client = APIClient()
     path = "/api/v1/inbound_sms"

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -953,8 +953,8 @@ def test_inbound_sms_reply_with_no_remaining_texts(phone_user, mocked_twilio_cli
 
 
 def test_inbound_sms_valid_twilio_signature_no_phone_log(
-    phone_user, mocked_twilio_client
-):
+    phone_user: User, mocked_twilio_client: Mock
+) -> None:
     phone_user.profile.store_phone_log = False
     phone_user.profile.save()
     _make_real_phone(phone_user, verified=True)
@@ -976,8 +976,8 @@ def test_inbound_sms_valid_twilio_signature_no_phone_log(
 
 
 def test_inbound_sms_valid_twilio_signature_blocked_contact(
-    phone_user, mocked_twilio_client
-):
+    phone_user: User, mocked_twilio_client: Mock
+) -> None:
     phone_user.profile.store_phone_log = True
     phone_user.profile.save()
     _make_real_phone(phone_user, verified=True)
@@ -1025,7 +1025,9 @@ def test_inbound_sms_valid_twilio_signature_blocked_contact(
     assert inbound_contact.last_inbound_date == pre_block_contact_date
 
 
-def test_inbound_sms_reply_not_storing_phone_log(phone_user, mocked_twilio_client):
+def test_inbound_sms_reply_not_storing_phone_log(
+    phone_user: User, mocked_twilio_client: Mock
+) -> None:
     real_phone = _make_real_phone(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user, enabled=True)
     mocked_twilio_client.reset_mock()

--- a/emails/models.py
+++ b/emails/models.py
@@ -656,7 +656,6 @@ class RelayAddress(models.Model):
         )
         deleted_address.save()
         profile = self.user.profile
-        profile.refresh_from_db()
         profile.address_last_deleted = datetime.now(UTC)
         profile.num_address_deleted += 1
         profile.num_email_forwarded_in_deleted_address += self.num_forwarded

--- a/emails/models.py
+++ b/emails/models.py
@@ -822,10 +822,6 @@ class DomainAddress(models.Model):
             update_fields=update_fields,
         )
 
-    @property
-    def user_profile(self):
-        return Profile.objects.get(user=self.user)
-
     @staticmethod
     def make_domain_address(
         user: User, address: str | None = None, made_via_email: bool = False
@@ -852,7 +848,7 @@ class DomainAddress(models.Model):
         # TODO: create hard bounce receipt rule in AWS for the address
         deleted_address = DeletedAddress.objects.create(
             address_hash=address_hash(
-                self.address, self.user_profile.subdomain, self.domain_value
+                self.address, self.user.profile.subdomain, self.domain_value
             ),
             num_forwarded=self.num_forwarded,
             num_blocked=self.num_blocked,

--- a/emails/models.py
+++ b/emails/models.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from collections.abc import Iterable
 from datetime import UTC, datetime, timedelta
 from hashlib import sha256
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -645,7 +645,7 @@ class RelayAddress(models.Model):
     def __str__(self):
         return self.address
 
-    def delete(self, *args, **kwargs):
+    def delete(self, *args: Any, **kwargs: Any) -> tuple[int, dict[str, int]]:
         # TODO: create hard bounce receipt rule in AWS for the address
         deleted_address = DeletedAddress.objects.create(
             address_hash=address_hash(self.address, domain=self.domain_value),

--- a/emails/models.py
+++ b/emails/models.py
@@ -655,7 +655,8 @@ class RelayAddress(models.Model):
             num_spam=self.num_spam,
         )
         deleted_address.save()
-        profile = Profile.objects.get(user=self.user)
+        profile = self.user.profile
+        profile.refresh_from_db()
         profile.address_last_deleted = datetime.now(UTC)
         profile.num_address_deleted += 1
         profile.num_email_forwarded_in_deleted_address += self.num_forwarded
@@ -859,9 +860,7 @@ class DomainAddress(models.Model):
             num_spam=self.num_spam,
         )
         deleted_address.save()
-        # self.user_profile is a property and should not be used to
-        # update values on the user's profile
-        profile = Profile.objects.get(user=self.user)
+        profile = self.user.profile
         profile.address_last_deleted = datetime.now(UTC)
         profile.num_address_deleted += 1
         profile.num_email_forwarded_in_deleted_address += self.num_forwarded
@@ -885,7 +884,7 @@ class DomainAddress(models.Model):
 
     @property
     def full_address(self) -> str:
-        return f"{self.address}@{self.user_profile.subdomain}.{self.domain_value}"
+        return f"{self.address}@{self.user.profile.subdomain}.{self.domain_value}"
 
     @property
     def metrics_id(self) -> str:

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -1290,7 +1290,7 @@ class DomainAddressTest(TestCase):
         assert exc_info.value.get_codes() == "duplicate_address"
 
     @override_flag("custom_domain_management_redesign", active=False)
-    def test_make_domain_address_can_make_dupe_of_deleted(self):
+    def test_make_domain_address_can_make_dupe_of_deleted(self) -> None:
         address = "same-address"
         domain_address = DomainAddress.make_domain_address(self.user, address=address)
         domain_address_hash = address_hash(
@@ -1308,7 +1308,7 @@ class DomainAddressTest(TestCase):
         assert dupe_domain_address.full_address == domain_address.full_address
 
     @override_flag("custom_domain_management_redesign", active=True)
-    def test_make_domain_address_cannot_make_dupe_of_deleted(self):
+    def test_make_domain_address_cannot_make_dupe_of_deleted(self) -> None:
         address = "same-address"
         domain_address = DomainAddress.make_domain_address(self.user, address=address)
         domain_address_hash = address_hash(

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -1295,7 +1295,7 @@ class DomainAddressTest(TestCase):
         domain_address = DomainAddress.make_domain_address(self.user, address=address)
         domain_address_hash = address_hash(
             domain_address.address,
-            domain_address.user_profile.subdomain,
+            domain_address.user.profile.subdomain,
             domain_address.domain_value,
         )
         domain_address.delete()
@@ -1313,7 +1313,7 @@ class DomainAddressTest(TestCase):
         domain_address = DomainAddress.make_domain_address(self.user, address=address)
         domain_address_hash = address_hash(
             domain_address.address,
-            domain_address.user_profile.subdomain,
+            domain_address.user.profile.subdomain,
             domain_address.domain_value,
         )
         domain_address.delete()

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -395,10 +395,9 @@ class SNSNotificationIncomingTest(SNSNotificationTestBase):
             RelayAddress, user=self.user, address="ebsbdsan7", domain=2
         )
         self.premium_user = make_premium_test_user()
-        self.premium_profile = Profile.objects.get(user=self.premium_user)
-        self.premium_profile.subdomain = "subdomain"
-        self.premium_profile.last_engagement = datetime.now(UTC)
-        self.premium_profile.save()
+        self.premium_user.profile.subdomain = "subdomain"
+        self.premium_user.profile.last_engagement = datetime.now(UTC)
+        self.premium_user.profile.save()
 
     def test_single_recipient_sns_notification(self) -> None:
         pre_sns_notification_last_engagement = self.ra.user.profile.last_engagement

--- a/phones/tests/models_tests.py
+++ b/phones/tests/models_tests.py
@@ -715,7 +715,7 @@ def test_area_code_numbers(mock_twilio_client):
     assert mock_list.call_args_list == [call(area_code="918", limit=10)]
 
 
-def test_save_store_phone_log_no_relay_number_does_nothing():
+def test_save_store_phone_log_no_relay_number_does_nothing() -> None:
     user = make_phone_test_user()
     user.profile.store_phone_log = True
     user.profile.save()
@@ -728,7 +728,7 @@ def test_save_store_phone_log_no_relay_number_does_nothing():
     assert not user.profile.store_phone_log
 
 
-def test_save_store_phone_log_true_doesnt_delete_data():
+def test_save_store_phone_log_true_doesnt_delete_data() -> None:
     user = make_phone_test_user()
     baker.make(RealPhone, user=user, verified=True)
     relay_number = baker.make(RelayNumber, user=user)
@@ -740,7 +740,7 @@ def test_save_store_phone_log_true_doesnt_delete_data():
     assert inbound_contact
 
 
-def test_save_store_phone_log_false_deletes_data():
+def test_save_store_phone_log_false_deletes_data() -> None:
     user = make_phone_test_user()
     baker.make(RealPhone, user=user, verified=True)
     relay_number = baker.make(RelayNumber, user=user)

--- a/privaterelay/tests/glean_tests.py
+++ b/privaterelay/tests/glean_tests.py
@@ -423,6 +423,7 @@ def test_log_email_mask_deleted(
         extra_items={
             "n_random_masks": "0",
             "is_random_mask": "true",
+            "n_deleted_random_masks": "1",
         },
         user=user,
         event_time=parts.event_timestamp_ms,

--- a/privaterelay/tests/mgmt_sync_phone_related_dates_on_profile_tests.py
+++ b/privaterelay/tests/mgmt_sync_phone_related_dates_on_profile_tests.py
@@ -102,8 +102,8 @@ def create_free_phones_flag_for_user(user: User) -> None:
 
 @patch(f"{MOCK_BASE}.get_phone_subscription_dates")
 def test_free_phone_user_gets_only_date_phone_subscription_reset_field_updated(
-    mocked_dates, patch_datetime_now, db
-):
+    mocked_dates: Mock, patch_datetime_now: Mock, db: None
+) -> None:
     expected_now = patch_datetime_now
     mocked_dates.return_value = (None, None, None)
     account: SocialAccount = baker.make(SocialAccount, provider="fxa")
@@ -122,8 +122,8 @@ def test_free_phone_user_gets_only_date_phone_subscription_reset_field_updated(
 
 @patch(f"{MOCK_BASE}.get_phone_subscription_dates")
 def test_free_phone_user_with_existing_date_phone_subscription_reset_field_does_not_update(  # noqa: E501
-    mocked_dates, patch_datetime_now, db
-):
+    mocked_dates: Mock, patch_datetime_now: datetime, db: None
+) -> None:
     expected_now = patch_datetime_now
     mocked_dates.return_value = (None, None, None)
     account: SocialAccount = baker.make(SocialAccount, provider="fxa")
@@ -144,8 +144,8 @@ def test_free_phone_user_with_existing_date_phone_subscription_reset_field_does_
 
 @patch(f"{MOCK_BASE}.get_phone_subscription_dates")
 def test_monthly_phone_subscriber_profile_date_fields_all_updated(
-    mocked_dates, patch_datetime_now, phone_user
-):
+    mocked_dates: Mock, patch_datetime_now: datetime, phone_user: User
+) -> None:
     date_subscribed_phone = datetime.now(UTC) - timedelta(3)
     phone_user.profile.date_subscribed_phone = date_subscribed_phone
     phone_user.profile.save()
@@ -168,8 +168,8 @@ def test_monthly_phone_subscriber_profile_date_fields_all_updated(
 
 @patch(f"{MOCK_BASE}.get_phone_subscription_dates")
 def test_monthly_phone_subscriber_renewed_subscription_profile_date_phone_subscription_start_and_end_updated(  # noqa: E501
-    mocked_dates, patch_datetime_now, phone_user
-):
+    mocked_dates: Mock, patch_datetime_now: datetime, phone_user: User
+) -> None:
     profile = phone_user.profile
     first_day_of_current_month = datetime.now(UTC).replace(day=1)
     # get first of the last month
@@ -204,8 +204,8 @@ def test_monthly_phone_subscriber_renewed_subscription_profile_date_phone_subscr
 
 @patch(f"{MOCK_BASE}.get_phone_subscription_dates")
 def test_yearly_phone_subscriber_profile_date_fields_all_updated(
-    mocked_dates, patch_datetime_now, phone_user
-):
+    mocked_dates: Mock, patch_datetime_now: datetime, phone_user: User
+) -> None:
     date_subscribed_phone = datetime.now(UTC) - timedelta(3)
     mocked_dates.return_value = (
         date_subscribed_phone,
@@ -226,8 +226,8 @@ def test_yearly_phone_subscriber_profile_date_fields_all_updated(
 
 @patch(f"{MOCK_BASE}.get_phone_subscription_dates")
 def test_yearly_phone_subscriber_with_subscription_date_older_than_31_days_profile_date_fields_all_updated(  # noqa: E501
-    mocked_dates, patch_datetime_now, phone_user
-):
+    mocked_dates: Mock, patch_datetime_now: datetime, phone_user: User
+) -> None:
     date_subscribed_phone = datetime.now(UTC) - timedelta(90)
     phone_user.profile.date_subscribed_phone = date_subscribed_phone
     phone_user.profile.save()
@@ -251,11 +251,11 @@ def test_yearly_phone_subscriber_with_subscription_date_older_than_31_days_profi
 @pytest.mark.django_db
 @patch(f"{MOCK_BASE}.get_phone_subscription_dates")
 def test_command_with_one_update(
-    mocked_dates,
-    patch_datetime_now,
-    phone_user,
-    capsys,
-):
+    mocked_dates: Mock,
+    patch_datetime_now: datetime,
+    phone_user: User,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     date_subscribed_phone = datetime.now(UTC)
     phone_user.profile.date_subscribed_phone = date_subscribed_phone
     phone_user.profile.save()

--- a/privaterelay/tests/mgmt_sync_phone_related_dates_on_profile_tests.py
+++ b/privaterelay/tests/mgmt_sync_phone_related_dates_on_profile_tests.py
@@ -15,7 +15,6 @@ from allauth.socialaccount.models import SocialAccount
 from model_bakery import baker
 from waffle.models import Flag
 
-from emails.models import Profile
 from privaterelay.management.commands.sync_phone_related_dates_on_profile import (
     sync_phone_related_dates_on_profile,
 )
@@ -69,10 +68,10 @@ def test_phone_subscription_user_with_no_phone_subscription_data_does_not_get_up
     phone_user: User,
 ) -> None:
     mocked_dates.return_value = (None, None, None)
-    profile = Profile.objects.get(user=phone_user)
 
     num_profiles_updated = sync_phone_related_dates_on_profile("subscription")
 
+    profile = phone_user.profile
     profile.refresh_from_db()
     assert profile.date_phone_subscription_reset is None
     assert profile.date_subscribed_phone is None
@@ -108,11 +107,11 @@ def test_free_phone_user_gets_only_date_phone_subscription_reset_field_updated(
     expected_now = patch_datetime_now
     mocked_dates.return_value = (None, None, None)
     account: SocialAccount = baker.make(SocialAccount, provider="fxa")
-    profile = Profile.objects.get(user=account.user)
-    create_free_phones_flag_for_user(profile.user)
+    create_free_phones_flag_for_user(account.user)
 
     num_profiles_updated = sync_phone_related_dates_on_profile("free")
 
+    profile = account.user.profile
     profile.refresh_from_db()
     assert profile.date_phone_subscription_reset == expected_now.replace(day=1)
     assert profile.date_subscribed_phone is None
@@ -128,13 +127,13 @@ def test_free_phone_user_with_existing_date_phone_subscription_reset_field_does_
     expected_now = patch_datetime_now
     mocked_dates.return_value = (None, None, None)
     account: SocialAccount = baker.make(SocialAccount, provider="fxa")
-    profile = Profile.objects.get(user=account.user)
-    profile.date_phone_subscription_reset = expected_now
-    profile.save()
-    create_free_phones_flag_for_user(profile.user)
+    account.user.profile.date_phone_subscription_reset = expected_now
+    account.user.profile.save()
+    create_free_phones_flag_for_user(account.user)
 
     num_profiles_updated = sync_phone_related_dates_on_profile("free")
 
+    profile = account.user.profile
     profile.refresh_from_db()
     assert profile.date_phone_subscription_reset == expected_now
     assert profile.date_subscribed_phone is None
@@ -147,10 +146,9 @@ def test_free_phone_user_with_existing_date_phone_subscription_reset_field_does_
 def test_monthly_phone_subscriber_profile_date_fields_all_updated(
     mocked_dates, patch_datetime_now, phone_user
 ):
-    profile = Profile.objects.get(user=phone_user)
     date_subscribed_phone = datetime.now(UTC) - timedelta(3)
-    profile.date_subscribed_phone = date_subscribed_phone
-    profile.save()
+    phone_user.profile.date_subscribed_phone = date_subscribed_phone
+    phone_user.profile.save()
     mocked_dates.return_value = (
         date_subscribed_phone,
         date_subscribed_phone,
@@ -159,6 +157,7 @@ def test_monthly_phone_subscriber_profile_date_fields_all_updated(
 
     num_profiles_updated = sync_phone_related_dates_on_profile("subscription")
 
+    profile = phone_user.profile
     profile.refresh_from_db()
     assert profile.date_phone_subscription_reset == date_subscribed_phone
     assert profile.date_subscribed_phone == date_subscribed_phone
@@ -171,7 +170,7 @@ def test_monthly_phone_subscriber_profile_date_fields_all_updated(
 def test_monthly_phone_subscriber_renewed_subscription_profile_date_phone_subscription_start_and_end_updated(  # noqa: E501
     mocked_dates, patch_datetime_now, phone_user
 ):
-    profile = Profile.objects.get(user=phone_user)
+    profile = phone_user.profile
     first_day_of_current_month = datetime.now(UTC).replace(day=1)
     # get first of the last month
     first_day_of_last_month = (first_day_of_current_month - timedelta(1)).replace(day=1)
@@ -207,7 +206,6 @@ def test_monthly_phone_subscriber_renewed_subscription_profile_date_phone_subscr
 def test_yearly_phone_subscriber_profile_date_fields_all_updated(
     mocked_dates, patch_datetime_now, phone_user
 ):
-    profile = Profile.objects.get(user=phone_user)
     date_subscribed_phone = datetime.now(UTC) - timedelta(3)
     mocked_dates.return_value = (
         date_subscribed_phone,
@@ -217,6 +215,7 @@ def test_yearly_phone_subscriber_profile_date_fields_all_updated(
 
     num_profiles_updated = sync_phone_related_dates_on_profile("subscription")
 
+    profile = phone_user.profile
     profile.refresh_from_db()
     assert profile.date_phone_subscription_reset == date_subscribed_phone
     assert profile.date_subscribed_phone == date_subscribed_phone
@@ -229,10 +228,9 @@ def test_yearly_phone_subscriber_profile_date_fields_all_updated(
 def test_yearly_phone_subscriber_with_subscription_date_older_than_31_days_profile_date_fields_all_updated(  # noqa: E501
     mocked_dates, patch_datetime_now, phone_user
 ):
-    profile = Profile.objects.get(user=phone_user)
     date_subscribed_phone = datetime.now(UTC) - timedelta(90)
-    profile.date_subscribed_phone = date_subscribed_phone
-    profile.save()
+    phone_user.profile.date_subscribed_phone = date_subscribed_phone
+    phone_user.profile.save()
     mocked_dates.return_value = (
         date_subscribed_phone,
         date_subscribed_phone,
@@ -240,6 +238,7 @@ def test_yearly_phone_subscriber_with_subscription_date_older_than_31_days_profi
     )
     num_profiles_updated = sync_phone_related_dates_on_profile("subscription")
 
+    profile = phone_user.profile
     profile.refresh_from_db()
     sixty_two_days_from_subsciprion_date = date_subscribed_phone + timedelta(62)
     assert profile.date_phone_subscription_reset == sixty_two_days_from_subsciprion_date
@@ -257,10 +256,9 @@ def test_command_with_one_update(
     phone_user,
     capsys,
 ):
-    profile = Profile.objects.get(user=phone_user)
     date_subscribed_phone = datetime.now(UTC)
-    profile.date_subscribed_phone = date_subscribed_phone
-    profile.save()
+    phone_user.profile.date_subscribed_phone = date_subscribed_phone
+    phone_user.profile.save()
     mocked_dates.return_value = (
         date_subscribed_phone,
         date_subscribed_phone,
@@ -270,6 +268,7 @@ def test_command_with_one_update(
     out, err = capsys.readouterr()
     num_profiles_updated = int(out.split(" ")[0])
 
+    profile = phone_user.profile
     profile.refresh_from_db()
     assert profile.date_phone_subscription_reset == date_subscribed_phone
     assert profile.date_subscribed_phone == date_subscribed_phone


### PR DESCRIPTION
The pattern `profile = Profile.objects.get(user=user)` was useful when `user` had a `ForiegnKey` relationship. Since #2749, it has been unnecessary. Switching these to `user.profile` has some benefits:

* In most cases, it reduces the lines of code
* It removes a possible mismatch between `user.profile` and the stand-alone `Profile` object, which could introduce bugs
* In some cases, importing `Profile` is no longer needed, which will reduce the code changes when moving `Profile` to `privaterelay`.