### PR TITLE
MPP-3827: Move non-model code out of `emails/models.py`

### DIFF
--- a/emails/apps.py
+++ b/emails/apps.py
@@ -49,7 +49,8 @@ class EmailsConfig(AppConfig):
         self.badwords = self._load_terms("badwords.text")
         self.blocklist = self._load_terms("blocklist.text")
 
-    def _load_terms(self, filename):
+    def _load_terms(self, filename: str) -> list[str]:
+        """Load a list of terms from a file."""
         terms = []
         terms_file_path = os.path.join(settings.BASE_DIR, "emails", filename)
         with open(terms_file_path) as terms_file:

--- a/emails/exceptions.py
+++ b/emails/exceptions.py
@@ -1,0 +1,105 @@
+"""Exceptions raised by emails app"""
+
+from django.conf import settings
+from django.core.exceptions import BadRequest
+
+from api.exceptions import ErrorContextType, RelayAPIException
+
+
+class CannotMakeSubdomainException(BadRequest):
+    """Exception raised by Profile due to error on subdomain creation.
+
+    Attributes:
+        message -- optional explanation of the error
+    """
+
+    def __init__(self, message: str | None = None) -> None:
+        self.message = message
+
+
+class CannotMakeAddressException(RelayAPIException):
+    """Base exception for RelayAddress or DomainAddress creation failure."""
+
+
+class AccountIsPausedException(CannotMakeAddressException):
+    default_code = "account_is_paused"
+    default_detail = "Your account is on pause."
+    status_code = 403
+
+
+class AccountIsInactiveException(CannotMakeAddressException):
+    default_code = "account_is_inactive"
+    default_detail = "Your account is not active."
+    status_code = 403
+
+
+class RelayAddrFreeTierLimitException(CannotMakeAddressException):
+    default_code = "free_tier_limit"
+    default_detail_template = (
+        "You’ve used all {free_tier_limit} email masks included with your free account."
+        " You can reuse an existing mask, but using a unique mask for each account is"
+        " the most secure option."
+    )
+    status_code = 403
+
+    def __init__(self, free_tier_limit: int | None = None):
+        self.free_tier_limit = free_tier_limit or settings.MAX_NUM_FREE_ALIASES
+        super().__init__()
+
+    def error_context(self) -> ErrorContextType:
+        return {"free_tier_limit": self.free_tier_limit}
+
+
+class DomainAddrFreeTierException(CannotMakeAddressException):
+    default_code = "free_tier_no_subdomain_masks"
+    default_detail = (
+        "Your free account does not include custom subdomains for masks."
+        " To create custom masks, upgrade to Relay Premium."
+    )
+    status_code = 403
+
+
+class DomainAddrNeedSubdomainException(CannotMakeAddressException):
+    default_code = "need_subdomain"
+    default_detail = "Please select a subdomain before creating a custom email address."
+    status_code = 400
+
+
+class DomainAddrUpdateException(CannotMakeAddressException):
+    """Exception raised when attempting to edit an existing domain address field."""
+
+    default_code = "address_not_editable"
+    default_detail = "You cannot edit an existing domain address field."
+    status_code = 400
+
+
+class DomainAddrUnavailableException(CannotMakeAddressException):
+    default_code = "address_unavailable"
+    default_detail_template = (
+        "“{unavailable_address}” could not be created."
+        " Please try again with a different mask name."
+    )
+    status_code = 400
+
+    def __init__(self, unavailable_address: str):
+        self.unavailable_address = unavailable_address
+        super().__init__()
+
+    def error_context(self) -> ErrorContextType:
+        return {"unavailable_address": self.unavailable_address}
+
+
+class DomainAddrDuplicateException(CannotMakeAddressException):
+    default_code = "duplicate_address"
+    default_detail_template = (
+        "“{duplicate_address}” already exists."
+        " Please try again with a different mask name."
+    )
+    status_code = 409
+
+    def __init__(self, duplicate_address: str):
+        self.duplicate_address = duplicate_address
+        super().__init__()
+
+    def error_context(self) -> ErrorContextType:
+        return {"duplicate_address": self.duplicate_address}

--- a/emails/migrations/0024_increase_subdomain_length.py
+++ b/emails/migrations/0024_increase_subdomain_length.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations, models
 
-import emails.models
+import emails.validators
 
 
 class Migration(migrations.Migration):
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
                 max_length=63,
                 null=True,
                 unique=True,
-                validators=[emails.models.valid_available_subdomain],
+                validators=[emails.validators.valid_available_subdomain],
             ),
         ),
     ]

--- a/emails/models.py
+++ b/emails/models.py
@@ -17,14 +17,12 @@ from django.core.validators import MinLengthValidator
 from django.db import models, transaction
 from django.db.models.base import ModelBase
 from django.db.models.query import QuerySet
-from django.dispatch import receiver
 from django.utils.translation.trans_real import (
     get_supported_language_variant,
     parse_accept_lang_header,
 )
 
 from allauth.socialaccount.models import SocialAccount
-from rest_framework.authtoken.models import Token
 
 from privaterelay.plans import get_premium_countries
 from privaterelay.utils import (
@@ -559,18 +557,6 @@ class Profile(models.Model):
         if plan == "free":
             return "free"
         return f"{plan}_{self.plan_term}"
-
-
-@receiver(models.signals.post_save, sender=Profile)
-def copy_auth_token(sender, instance=None, created=False, **kwargs):
-    if created:
-        # baker triggers created during tests
-        # so first check the user doesn't already have a Token
-        try:
-            Token.objects.get(user=instance.user)
-            return
-        except Token.DoesNotExist:
-            Token.objects.create(user=instance.user, key=instance.api_token)
 
 
 def address_hash(address, subdomain=None, domain=None):

--- a/emails/models.py
+++ b/emails/models.py
@@ -13,7 +13,6 @@ from typing import Literal, cast
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.exceptions import BadRequest
 from django.core.validators import MinLengthValidator
 from django.db import models, transaction
 from django.db.models.base import ModelBase
@@ -27,7 +26,6 @@ from django.utils.translation.trans_real import (
 from allauth.socialaccount.models import SocialAccount
 from rest_framework.authtoken.models import Token
 
-from api.exceptions import ErrorContextType, RelayAPIException
 from privaterelay.plans import get_premium_countries
 from privaterelay.utils import (
     AcceptLanguageError,
@@ -36,6 +34,17 @@ from privaterelay.utils import (
 )
 
 from .apps import emails_config
+from .exceptions import (
+    AccountIsInactiveException,
+    AccountIsPausedException,
+    CannotMakeSubdomainException,
+    DomainAddrDuplicateException,
+    DomainAddrFreeTierException,
+    DomainAddrNeedSubdomainException,
+    DomainAddrUnavailableException,
+    DomainAddrUpdateException,
+    RelayAddrFreeTierLimitException,
+)
 from .utils import get_domains_from_settings, incr_if_enabled
 
 if settings.PHONES_ENABLED:
@@ -644,105 +653,6 @@ class RegisteredSubdomain(models.Model):
 
     def __str__(self):
         return self.subdomain_hash
-
-
-class CannotMakeSubdomainException(BadRequest):
-    """Exception raised by Profile due to error on subdomain creation.
-
-    Attributes:
-        message -- optional explanation of the error
-    """
-
-    def __init__(self, message=None):
-        self.message = message
-
-
-class CannotMakeAddressException(RelayAPIException):
-    """Base exception for RelayAddress or DomainAddress creation failure."""
-
-
-class AccountIsPausedException(CannotMakeAddressException):
-    default_code = "account_is_paused"
-    default_detail = "Your account is on pause."
-    status_code = 403
-
-
-class AccountIsInactiveException(CannotMakeAddressException):
-    default_code = "account_is_inactive"
-    default_detail = "Your account is not active."
-    status_code = 403
-
-
-class RelayAddrFreeTierLimitException(CannotMakeAddressException):
-    default_code = "free_tier_limit"
-    default_detail_template = (
-        "You’ve used all {free_tier_limit} email masks included with your free account."
-        " You can reuse an existing mask, but using a unique mask for each account is"
-        " the most secure option."
-    )
-    status_code = 403
-
-    def __init__(self, free_tier_limit: int | None = None):
-        self.free_tier_limit = free_tier_limit or settings.MAX_NUM_FREE_ALIASES
-        super().__init__()
-
-    def error_context(self) -> ErrorContextType:
-        return {"free_tier_limit": self.free_tier_limit}
-
-
-class DomainAddrFreeTierException(CannotMakeAddressException):
-    default_code = "free_tier_no_subdomain_masks"
-    default_detail = (
-        "Your free account does not include custom subdomains for masks."
-        " To create custom masks, upgrade to Relay Premium."
-    )
-    status_code = 403
-
-
-class DomainAddrNeedSubdomainException(CannotMakeAddressException):
-    default_code = "need_subdomain"
-    default_detail = "Please select a subdomain before creating a custom email address."
-    status_code = 400
-
-
-class DomainAddrUpdateException(CannotMakeAddressException):
-    """Exception raised when attempting to edit an existing domain address field."""
-
-    default_code = "address_not_editable"
-    default_detail = "You cannot edit an existing domain address field."
-    status_code = 400
-
-
-class DomainAddrUnavailableException(CannotMakeAddressException):
-    default_code = "address_unavailable"
-    default_detail_template = (
-        "“{unavailable_address}” could not be created."
-        " Please try again with a different mask name."
-    )
-    status_code = 400
-
-    def __init__(self, unavailable_address: str):
-        self.unavailable_address = unavailable_address
-        super().__init__()
-
-    def error_context(self) -> ErrorContextType:
-        return {"unavailable_address": self.unavailable_address}
-
-
-class DomainAddrDuplicateException(CannotMakeAddressException):
-    default_code = "duplicate_address"
-    default_detail_template = (
-        "“{duplicate_address}” already exists."
-        " Please try again with a different mask name."
-    )
-    status_code = 409
-
-    def __init__(self, duplicate_address: str):
-        self.duplicate_address = duplicate_address
-        super().__init__()
-
-    def error_context(self) -> ErrorContextType:
-        return {"duplicate_address": self.duplicate_address}
 
 
 class RelayAddress(models.Model):

--- a/emails/signals.py
+++ b/emails/signals.py
@@ -1,9 +1,12 @@
 import logging
 from hashlib import sha256
+from typing import Any
 
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
+
+from rest_framework.authtoken.models import Token
 
 from emails.models import Profile
 from emails.utils import incr_if_enabled, set_user_group
@@ -12,14 +15,18 @@ info_logger = logging.getLogger("eventsinfo")
 
 
 @receiver(post_save, sender=User)
-def create_user_profile(sender, instance, created, **kwargs):
+def create_user_profile(
+    sender: type[User], instance: User, created: bool, **kwargs: Any
+) -> None:
     if created:
         set_user_group(instance)
         Profile.objects.create(user=instance)
 
 
 @receiver(pre_save, sender=Profile)
-def measure_feature_usage(sender, instance, **kwargs):
+def measure_feature_usage(
+    sender: type[Profile], instance: Profile, **kwargs: Any
+) -> None:
     if instance._state.adding:
         # if newly created Profile ignore the signal
         return
@@ -35,11 +42,32 @@ def measure_feature_usage(sender, instance, **kwargs):
             incr_if_enabled("tracker_removal_enabled")
         if not instance.remove_level_one_email_trackers:
             incr_if_enabled("tracker_removal_disabled")
+        if instance.fxa:
+            # TODO create a utility function or property for hashed fxa uid
+            hashed_uid = sha256(instance.fxa.uid.encode("utf-8")).hexdigest()
+        else:
+            hashed_uid = "_no_fxa_"
         info_logger.info(
             "tracker_removal_feature",
             extra={
                 "enabled": instance.remove_level_one_email_trackers,
-                # TODO create a utility function or property for hashed fxa uid
-                "hashed_uid": sha256(instance.fxa.uid.encode("utf-8")).hexdigest(),
+                "hashed_uid": hashed_uid,
             },
         )
+
+
+@receiver(post_save, sender=Profile)
+def copy_auth_token(
+    sender: type[Profile],
+    instance: Profile | None = None,
+    created: bool = False,
+    **kwargs: Any,
+) -> None:
+    if created and instance is not None:
+        # baker triggers created during tests
+        # so first check the user doesn't already have a Token
+        try:
+            Token.objects.get(user=instance.user)
+            return
+        except Token.DoesNotExist:
+            Token.objects.create(user=instance.user, key=instance.api_token)

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -28,8 +28,6 @@ from ..models import (
     RelayAddress,
     address_hash,
     get_domain_numerical,
-    valid_address,
-    valid_address_pattern,
 )
 from ..utils import get_domains_from_settings
 
@@ -154,25 +152,6 @@ class GetDomainNumericalTest(TestCase):
     def test_get_domain_numerical(self):
         assert get_domain_numerical("default.com") == 1
         assert get_domain_numerical("test.com") == 2
-
-
-class ValidAddressPatternTest(TestCase):
-    def test_valid_address_pattern_is_valid(self):
-        assert valid_address_pattern("foo")
-        assert valid_address_pattern("foo-bar")
-        assert valid_address_pattern("foo.bar")
-        assert valid_address_pattern("f00bar")
-        assert valid_address_pattern("123foo")
-        assert valid_address_pattern("123")
-
-    def test_valid_address_pattern_is_not_valid(self):
-        assert not valid_address_pattern("-")
-        assert not valid_address_pattern("-foo")
-        assert not valid_address_pattern("foo-")
-        assert not valid_address_pattern(".foo")
-        assert not valid_address_pattern("foo.")
-        assert not valid_address_pattern("foo bar")
-        assert not valid_address_pattern("Foo")
 
 
 class RelayAddressTest(TestCase):
@@ -333,11 +312,6 @@ class RelayAddressTest(TestCase):
             user=user, address=address
         )
         assert not repeat_deleted_relay_address.address == address
-
-    def test_valid_address_dupe_of_deleted_invalid(self):
-        relay_address = RelayAddress.objects.create(user=baker.make(User))
-        relay_address.delete()
-        assert not valid_address(relay_address.address, relay_address.domain_value)
 
     @patch("emails.validators.badwords", return_value=[])
     @patch("emails.validators.blocklist", return_value=["blocked-word"])
@@ -1344,17 +1318,6 @@ class DomainAddressTest(TestCase):
             DeletedAddress.objects.filter(address_hash=domain_address_hash).count() == 1
         )
         assert dupe_domain_address.full_address == domain_address.full_address
-
-    @override_flag("custom_domain_management_redesign", active=True)
-    def test_valid_address_dupe_domain_address_of_deleted_is_not_valid(self):
-        address = "same-address"
-        domain_address = DomainAddress.make_domain_address(
-            self.user_profile, address=address
-        )
-        domain_address.delete()
-        assert not valid_address(
-            address, domain_address.domain_value, self.user_profile.subdomain
-        )
 
     @override_flag("custom_domain_management_redesign", active=True)
     def test_make_domain_address_cannot_make_dupe_of_deleted(self):

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -14,14 +14,16 @@ from allauth.socialaccount.models import SocialAccount
 from model_bakery import baker
 from waffle.testutils import override_flag
 
-from ..models import (
-    AbuseMetrics,
+from ..exceptions import (
     CannotMakeAddressException,
     CannotMakeSubdomainException,
-    DeletedAddress,
     DomainAddrDuplicateException,
-    DomainAddress,
     DomainAddrUnavailableException,
+)
+from ..models import (
+    AbuseMetrics,
+    DeletedAddress,
+    DomainAddress,
     Profile,
     RegisteredSubdomain,
     RelayAddress,

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -25,16 +25,11 @@ from ..models import (
     DeletedAddress,
     DomainAddress,
     Profile,
-    RegisteredSubdomain,
     RelayAddress,
     address_hash,
     get_domain_numerical,
-    has_bad_words,
-    hash_subdomain,
-    is_blocklisted,
     valid_address,
     valid_address_pattern,
-    valid_available_subdomain,
 )
 from ..utils import get_domains_from_settings
 
@@ -127,44 +122,7 @@ def vpn_subscription() -> str:
     return random.choice(vpn_only_plans)
 
 
-class MiscEmailModelsTest(TestCase):
-    def test_has_bad_words_with_bad_words(self):
-        assert has_bad_words("angry")
-
-    def test_has_bad_words_without_bad_words(self):
-        assert not has_bad_words("happy")
-
-    def test_has_bad_words_exact_match_on_small_words(self):
-        assert has_bad_words("ho")
-        assert not has_bad_words("horse")
-        assert has_bad_words("ass")
-        assert not has_bad_words("cassandra")
-        assert has_bad_words("hell")
-        assert not has_bad_words("shell")
-        assert has_bad_words("bra")
-        assert not has_bad_words("brain")
-        assert has_bad_words("fart")
-        assert not has_bad_words("farther")
-        assert has_bad_words("fu")
-        assert not has_bad_words("funny")
-        assert has_bad_words("poo")
-        assert not has_bad_words("pools")
-
-    def test_is_blocklisted_with_blocked_word(self):
-        assert is_blocklisted("mozilla")
-
-    def test_is_blocklisted_with_custom_blocked_word(self):
-        # custom blocked word
-        # see MPP-2077 for more details
-        assert is_blocklisted("customdomain")
-
-    def test_is_blocklisted_without_blocked_words(self):
-        assert not is_blocklisted("non-blocked-word")
-
-    @patch("emails.models.emails_config", return_value=Mock(blocklist=["blocked-word"]))
-    def test_is_blocklisted_with_mocked_blocked_words(self, mock_config: Mock) -> None:
-        assert is_blocklisted("blocked-word")
-
+class AddressHashTest(TestCase):
     @override_settings(RELAY_FIREFOX_DOMAIN="firefox.com")
     def test_address_hash_without_subdomain_domain_firefox(self):
         address = "aaaaaaaaa"
@@ -191,10 +149,14 @@ class MiscEmailModelsTest(TestCase):
         expected_hash = sha256(f"{address}@{test_domain}".encode()).hexdigest()
         assert address_hash(address, domain=test_domain) == expected_hash
 
+
+class GetDomainNumericalTest(TestCase):
     def test_get_domain_numerical(self):
         assert get_domain_numerical("default.com") == 1
         assert get_domain_numerical("test.com") == 2
 
+
+class ValidAddressPatternTest(TestCase):
     def test_valid_address_pattern_is_valid(self):
         assert valid_address_pattern("foo")
         assert valid_address_pattern("foo-bar")
@@ -377,11 +339,11 @@ class RelayAddressTest(TestCase):
         relay_address.delete()
         assert not valid_address(relay_address.address, relay_address.domain_value)
 
-    @patch(
-        "emails.models.emails_config",
-        return_value=Mock(badwords=[], blocklist=["blocked-word"]),
-    )
-    def test_address_contains_blocklist_invalid(self, mock_config: Mock) -> None:
+    @patch("emails.validators.badwords", return_value=[])
+    @patch("emails.validators.blocklist", return_value=["blocked-word"])
+    def test_address_contains_blocklist_invalid(
+        self, mock_blocklist: Mock, mock_badwords: Mock
+    ) -> None:
         blocked_word = "blocked-word"
         relay_address = RelayAddress.objects.create(
             user=baker.make(User), address=blocked_word
@@ -975,82 +937,6 @@ class ProfileSaveTest(ProfileTestCase):
             assert relay_address.description == self.TEST_DESCRIPTION
             assert relay_address.generated_for == self.TEST_GENERATED_FOR
             assert relay_address.used_on == self.TEST_USED_ON
-
-
-class ValidAvailableSubdomainTest(TestCase):
-    """Tests for valid_available_subdomain()"""
-
-    ERR_NOT_AVAIL = "error-subdomain-not-available"
-    ERR_EMPTY_OR_NULL = "error-subdomain-cannot-be-empty-or-null"
-
-    def reserve_subdomain_for_new_user(self, subdomain: str) -> User:
-        user = make_premium_test_user()
-        user.profile.add_subdomain(subdomain)
-        return user
-
-    def test_bad_word_raises(self) -> None:
-        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
-            valid_available_subdomain("angry")
-
-    def test_blocked_word_raises(self) -> None:
-        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
-            valid_available_subdomain("mozilla")
-
-    def test_taken_subdomain_raises(self) -> None:
-        subdomain = "thisisfine"
-        self.reserve_subdomain_for_new_user(subdomain)
-        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
-            valid_available_subdomain(subdomain)
-
-    def test_taken_subdomain_different_case_raises(self) -> None:
-        self.reserve_subdomain_for_new_user("thIsIsfInE")
-        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
-            valid_available_subdomain("THiSiSFiNe")
-
-    def test_inactive_subdomain_raises(self) -> None:
-        """subdomains registered by now deleted profiles are not available."""
-        subdomain = "thisisfine"
-        user = self.reserve_subdomain_for_new_user(subdomain)
-        user.delete()
-
-        registered_subdomain_count = RegisteredSubdomain.objects.filter(
-            subdomain_hash=hash_subdomain(subdomain)
-        ).count()
-        assert Profile.objects.filter(subdomain=subdomain).count() == 0
-        assert registered_subdomain_count == 1
-        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
-            valid_available_subdomain(subdomain)
-
-    def test_subdomain_with_space_raises(self) -> None:
-        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
-            valid_available_subdomain("my domain")
-
-    def test_subdomain_with_special_char_raises(self) -> None:
-        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
-            valid_available_subdomain("my@domain")
-
-    def test_subdomain_with_dash_returns_True(self) -> None:
-        assert valid_available_subdomain("my-domain") is True
-
-    def test_subdomain_with_dash_at_front_raises(self) -> None:
-        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
-            valid_available_subdomain("-mydomain")
-
-    def test_empty_subdomain_raises(self) -> None:
-        with self.assertRaisesMessage(
-            CannotMakeSubdomainException, self.ERR_EMPTY_OR_NULL
-        ):
-            valid_available_subdomain("")
-
-    def test_null_subdomain_raises(self) -> None:
-        with self.assertRaisesMessage(
-            CannotMakeSubdomainException, self.ERR_EMPTY_OR_NULL
-        ):
-            valid_available_subdomain(None)
-
-    def test_subdomain_with_space_at_end_raises(self) -> None:
-        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
-            valid_available_subdomain("mydomain ")
 
 
 class ProfileDisplayNameTest(ProfileTestCase):

--- a/emails/tests/validator_tests.py
+++ b/emails/tests/validator_tests.py
@@ -1,0 +1,128 @@
+"""Tests for field validators."""
+
+from unittest.mock import Mock, patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from ..exceptions import CannotMakeSubdomainException
+from ..models import Profile, RegisteredSubdomain, hash_subdomain
+from ..validators import has_bad_words, is_blocklisted, valid_available_subdomain
+from .models_tests import make_premium_test_user
+
+
+class HasBadWordsTest(TestCase):
+    def test_has_bad_words_with_bad_words(self) -> None:
+        assert has_bad_words("angry")
+
+    def test_has_bad_words_without_bad_words(self) -> None:
+        assert not has_bad_words("happy")
+
+    def test_has_bad_words_exact_match_on_small_words(self) -> None:
+        assert has_bad_words("ho")
+        assert not has_bad_words("horse")
+        assert has_bad_words("ass")
+        assert not has_bad_words("cassandra")
+        assert has_bad_words("hell")
+        assert not has_bad_words("shell")
+        assert has_bad_words("bra")
+        assert not has_bad_words("brain")
+        assert has_bad_words("fart")
+        assert not has_bad_words("farther")
+        assert has_bad_words("fu")
+        assert not has_bad_words("funny")
+        assert has_bad_words("poo")
+        assert not has_bad_words("pools")
+
+
+class IsBlocklistedTest(TestCase):
+    def test_is_blocklisted_with_blocked_word(self) -> None:
+        assert is_blocklisted("mozilla")
+
+    def test_is_blocklisted_with_custom_blocked_word(self) -> None:
+        # custom blocked word
+        # see MPP-2077 for more details
+        assert is_blocklisted("customdomain")
+
+    def test_is_blocklisted_without_blocked_words(self) -> None:
+        assert not is_blocklisted("non-blocked-word")
+
+    @patch("emails.validators.blocklist", return_value=["blocked-word"])
+    def test_is_blocklisted_with_mocked_blocked_words(self, mock_config: Mock) -> None:
+        assert is_blocklisted("blocked-word")
+
+
+class ValidAvailableSubdomainTest(TestCase):
+    """Tests for valid_available_subdomain()"""
+
+    ERR_NOT_AVAIL = "error-subdomain-not-available"
+    ERR_EMPTY_OR_NULL = "error-subdomain-cannot-be-empty-or-null"
+
+    def reserve_subdomain_for_new_user(self, subdomain: str) -> User:
+        user = make_premium_test_user()
+        user.profile.add_subdomain(subdomain)
+        return user
+
+    def test_bad_word_raises(self) -> None:
+        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
+            valid_available_subdomain("angry")
+
+    def test_blocked_word_raises(self) -> None:
+        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
+            valid_available_subdomain("mozilla")
+
+    def test_taken_subdomain_raises(self) -> None:
+        subdomain = "thisisfine"
+        self.reserve_subdomain_for_new_user(subdomain)
+        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
+            valid_available_subdomain(subdomain)
+
+    def test_taken_subdomain_different_case_raises(self) -> None:
+        self.reserve_subdomain_for_new_user("thIsIsfInE")
+        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
+            valid_available_subdomain("THiSiSFiNe")
+
+    def test_inactive_subdomain_raises(self) -> None:
+        """subdomains registered by now deleted profiles are not available."""
+        subdomain = "thisisfine"
+        user = self.reserve_subdomain_for_new_user(subdomain)
+        user.delete()
+
+        registered_subdomain_count = RegisteredSubdomain.objects.filter(
+            subdomain_hash=hash_subdomain(subdomain)
+        ).count()
+        assert Profile.objects.filter(subdomain=subdomain).count() == 0
+        assert registered_subdomain_count == 1
+        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
+            valid_available_subdomain(subdomain)
+
+    def test_subdomain_with_space_raises(self) -> None:
+        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
+            valid_available_subdomain("my domain")
+
+    def test_subdomain_with_special_char_raises(self) -> None:
+        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
+            valid_available_subdomain("my@domain")
+
+    def test_subdomain_with_dash_succeeds(self) -> None:
+        valid_available_subdomain("my-domain")
+
+    def test_subdomain_with_dash_at_front_raises(self) -> None:
+        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
+            valid_available_subdomain("-mydomain")
+
+    def test_empty_subdomain_raises(self) -> None:
+        with self.assertRaisesMessage(
+            CannotMakeSubdomainException, self.ERR_EMPTY_OR_NULL
+        ):
+            valid_available_subdomain("")
+
+    def test_null_subdomain_raises(self) -> None:
+        with self.assertRaisesMessage(
+            CannotMakeSubdomainException, self.ERR_EMPTY_OR_NULL
+        ):
+            valid_available_subdomain(None)
+
+    def test_subdomain_with_space_at_end_raises(self) -> None:
+        with self.assertRaisesMessage(CannotMakeSubdomainException, self.ERR_NOT_AVAIL):
+            valid_available_subdomain("mydomain ")

--- a/emails/tests/validator_tests.py
+++ b/emails/tests/validator_tests.py
@@ -174,9 +174,7 @@ class ValidAddressTest(TestCase):
         user.profile.subdomain = "mysubdomain"
         user.profile.save()
         address = "same-address"
-        domain_address = DomainAddress.make_domain_address(
-            user.profile, address=address
-        )
+        domain_address = DomainAddress.make_domain_address(user, address=address)
         domain_address.delete()
         assert not valid_address(
             address, domain_address.domain_value, user.profile.subdomain

--- a/emails/validators.py
+++ b/emails/validators.py
@@ -1,0 +1,64 @@
+"""Field validators for emails models."""
+
+import re
+from typing import Any
+
+from .apps import emails_config
+from .exceptions import CannotMakeSubdomainException
+
+# A valid subdomain:
+#   can't start or end with a hyphen
+#   must be 1-63 alphanumeric characters and/or hyphens
+_re_valid_subdomain = re.compile("^(?!-)[a-z0-9-]{1,63}(?<!-)$")
+
+
+def badwords() -> list[str]:
+    """Allow mocking of badwords in tests."""
+    return emails_config().badwords
+
+
+def has_bad_words(value: str) -> bool:
+    """Return True if the value is a short bad word or contains a long bad word."""
+    for badword in badwords():
+        badword = badword.strip()
+        if len(badword) <= 4 and badword == value:
+            return True
+        if len(badword) > 4 and badword in value:
+            return True
+    return False
+
+
+def blocklist() -> list[str]:
+    """Allow mocking of blocklist in tests."""
+    return emails_config().blocklist
+
+
+def is_blocklisted(value: str) -> bool:
+    """Return True if the value is a blocked word."""
+    return any(blockedword == value for blockedword in blocklist())
+
+
+def valid_available_subdomain(subdomain: Any) -> None:
+    """Raise CannotMakeSubdomainException if the subdomain fails a validation test."""
+    from .models import RegisteredSubdomain, hash_subdomain
+
+    if not subdomain:
+        raise CannotMakeSubdomainException("error-subdomain-cannot-be-empty-or-null")
+    subdomain = str(subdomain).lower()
+
+    # valid subdomains:
+    #   have to meet the rules for length and characters
+    valid = _re_valid_subdomain.match(subdomain) is not None
+    #   can't have "bad" words in them
+    bad_word = has_bad_words(subdomain)
+    #   can't have "blocked" words in them
+    blocked_word = is_blocklisted(subdomain)
+    #   can't be taken by someone else
+    taken = (
+        RegisteredSubdomain.objects.filter(
+            subdomain_hash=hash_subdomain(subdomain)
+        ).count()
+        > 0
+    )
+    if not valid or bad_word or blocked_word or taken:
+        raise CannotMakeSubdomainException("error-subdomain-not-available")

--- a/emails/views.py
+++ b/emails/views.py
@@ -41,8 +41,8 @@ from privaterelay.utils import (
     glean_logger,
 )
 
+from .exceptions import CannotMakeAddressException
 from .models import (
-    CannotMakeAddressException,
     DeletedAddress,
     DomainAddress,
     Profile,

--- a/emails/views.py
+++ b/emails/views.py
@@ -1379,7 +1379,7 @@ def _get_domain_address(local_portion: str, domain_portion: str) -> DomainAddres
                 # was unable to receive an email due to user no longer being a
                 # premium user as seen in exception thrown on make_domain_address
                 domain_address = DomainAddress.make_domain_address(
-                    locked_profile, local_portion, True
+                    locked_profile.user, local_portion, True
                 )
                 glean_logger().log_email_mask_created(
                     mask=domain_address,

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -26,12 +26,8 @@ from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
 from rest_framework.decorators import api_view, schema
 
 # from silk.profiling.profiler import silk_profile
-from emails.models import (
-    CannotMakeSubdomainException,
-    DomainAddress,
-    RelayAddress,
-    valid_available_subdomain,
-)
+from emails.exceptions import CannotMakeSubdomainException
+from emails.models import DomainAddress, RelayAddress, valid_available_subdomain
 from emails.utils import incr_if_enabled
 
 from .apps import PrivateRelayConfig

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -27,8 +27,9 @@ from rest_framework.decorators import api_view, schema
 
 # from silk.profiling.profiler import silk_profile
 from emails.exceptions import CannotMakeSubdomainException
-from emails.models import DomainAddress, RelayAddress, valid_available_subdomain
+from emails.models import DomainAddress, RelayAddress
 from emails.utils import incr_if_enabled
+from emails.validators import valid_available_subdomain
 
 from .apps import PrivateRelayConfig
 from .fxa_utils import NoSocialToken, _get_oauth2_session
@@ -78,8 +79,8 @@ def profile_subdomain(request):
     try:
         if request.method == "GET":
             subdomain = request.GET.get("subdomain", None)
-            available = valid_available_subdomain(subdomain)
-            return JsonResponse({"available": available})
+            valid_available_subdomain(subdomain)
+            return JsonResponse({"available": True})
         else:
             subdomain = request.POST.get("subdomain", None)
             profile.add_subdomain(subdomain)


### PR DESCRIPTION
This PR moves code around, in preparation for moving `Profile` (and other models) from the `emails` app to the `privaterelay` app.

* `emails/exceptions.py` - Defines the exceptions raised in the `emails` app
* `emails/validators.py` - Defines the validator functions used in the `emails` app.
* `emails/models.py`
   - The remaining functions have moved to the top of the file, and have type hints.
   - `DomainAddress.make_domain_address` used to take a `Profile`, and now takes a `User`.

This also involved moving tests around, and some test changes for the new interfaces.