### PR TITLE
MPP-3827: Switch from `RequestsClient` to `APIClient`, remove transaction tests

### DIFF
--- a/api/tests/emails_views_tests.py
+++ b/api/tests/emails_views_tests.py
@@ -144,7 +144,7 @@ def test_post_domainaddress_free_user_error(
     assert get_glean_event(caplog) is None
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_post_domainaddress_conflict_existing(
     prem_api_client: APIClient, premium_user: User, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -169,7 +169,7 @@ def test_post_domainaddress_conflict_existing(
     assert get_glean_event(caplog) is None
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 @override_flag("custom_domain_management_redesign", active=True)
 def test_post_domainaddress_conflict_deleted(
     prem_api_client: APIClient, premium_user: User, caplog: pytest.LogCaptureFixture

--- a/api/tests/iq_views_tests.py
+++ b/api/tests/iq_views_tests.py
@@ -25,7 +25,7 @@ INBOUND_SMS_PATH = "/api/v1/inbound_sms_iq/"
 
 @pytest.fixture()
 def phone_user(db):
-    yield make_phone_test_user()
+    return make_phone_test_user()
 
 
 @pytest.fixture(autouse=True)

--- a/api/tests/iq_views_tests.py
+++ b/api/tests/iq_views_tests.py
@@ -54,7 +54,7 @@ def _make_real_phone_with_mock_iq(phone_user, **kwargs):
     return real_phone
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_iq_endpoint_missing_verificationtoken_header():
     client = APIClient()
     response = client.post(INBOUND_SMS_PATH)
@@ -63,7 +63,7 @@ def test_iq_endpoint_missing_verificationtoken_header():
     assert "missing Verificationtoken header" in response_body["detail"]
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_iq_endpoint_missing_messageid_header():
     client = APIClient()
     response = client.post(INBOUND_SMS_PATH, headers={"Verificationtoken": "valid"})
@@ -73,7 +73,7 @@ def test_iq_endpoint_missing_messageid_header():
     assert "missing MessageId header" in response_body["detail"]
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_iq_endpoint_invalid_hash():
     message_id = "9a09df23-01f3-4e0f-adbc-2a783878a574"
     client = APIClient()
@@ -87,7 +87,7 @@ def test_iq_endpoint_invalid_hash():
     assert "verficiationToken != computed sha256" in response_body["detail"]
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_iq_endpoint_valid_hash_no_auth_failed_status():
     message_id = "9a09df23-01f3-4e0f-adbc-2a783878a574"
     token = compute_iq_mac(message_id)
@@ -108,10 +108,9 @@ def _prepare_valid_iq_request_client() -> APIClient:
     )
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_iq_endpoint_missing_required_params():
     client = _prepare_valid_iq_request_client()
-
     resp = client.post(INBOUND_SMS_PATH, {})
 
     assert resp.status_code == 400
@@ -121,7 +120,7 @@ def test_iq_endpoint_missing_required_params():
     assert "Request missing from, to, or text" in resp_body[0]
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_iq_endpoint_unknown_number():
     unknown_number = "234567890"
     client = _prepare_valid_iq_request_client()
@@ -140,7 +139,6 @@ def test_iq_endpoint_unknown_number():
     assert "Could not find relay number." in resp_body[0]
 
 
-@pytest.mark.django_db(transaction=True)
 def test_iq_endpoint_disabled_number(phone_user):
     # TODO: should we return empty 200 to iQ when number is disabled?
     _make_real_phone_with_mock_iq(phone_user, verified=True)
@@ -161,7 +159,6 @@ def test_iq_endpoint_disabled_number(phone_user):
     assert resp.status_code == 200
 
 
-@pytest.mark.django_db(transaction=True)
 @responses.activate
 def test_iq_endpoint_success(phone_user):
     _make_real_phone_with_mock_iq(phone_user, verified=True)
@@ -188,7 +185,6 @@ def test_iq_endpoint_success(phone_user):
     assert rsp.call_count == 1
 
 
-@pytest.mark.django_db(transaction=True)
 @responses.activate
 def test_reply_with_no_remaining_texts(phone_user):
     real_phone = _make_real_phone_with_mock_iq(phone_user, verified=True)
@@ -218,7 +214,6 @@ def test_reply_with_no_remaining_texts(phone_user):
     assert relay_number.remaining_texts == 0
 
 
-@pytest.mark.django_db(transaction=True)
 @responses.activate
 def test_reply_with_no_phone_capability(phone_user):
     real_phone = _make_real_phone_with_mock_iq(phone_user, verified=True)
@@ -247,7 +242,6 @@ def test_reply_with_no_phone_capability(phone_user):
     assert rsp.call_count == 0
 
 
-@pytest.mark.django_db(transaction=True)
 @responses.activate
 def test_reply_without_previous_sender_error(phone_user):
     real_phone = _make_real_phone_with_mock_iq(phone_user, verified=True)
@@ -288,7 +282,6 @@ def test_reply_without_previous_sender_error(phone_user):
     assert rsp.call_count == 1
 
 
-@pytest.mark.django_db(transaction=True)
 @responses.activate
 def test_reply_with_previous_sender_works(phone_user):
     real_phone = _make_real_phone_with_mock_iq(phone_user, verified=True)


### PR DESCRIPTION
The `RequestsClient` docs have [this detail](https://www.django-rest-framework.org/api-guide/testing/#requestsclient-and-working-with-the-database):

> The `RequestsClient` class is useful if you want to write tests that solely interact with the service interface. This is a little stricter than using the standard Django test client, as it means that all interactions should be via the API.
>
> If you're using `RequestsClient` you'll want to ensure that test setup, and results assertions are performed as regular API calls, rather than interacting with the database models directly. For example, rather than checking that `Customer.objects.count() == 3` you would list the customers endpoint, and ensure that it contains three records.

The existing IQ tests mixed API requests with direct database interactions, such as `test_iq_endpoint_disabled_number()`, which created a disabled phone using the Django ORM. I could not see a way to do the test setup with the API, so `RequestsClient` can't be used for all the tests.

Once the tests are converted to use `APIClient`, the transaction test case is no longer needed. This is good because `pytest-django` [uses TransactionalTestCase](https://github.com/pytest-dev/pytest-django/blob/5bf88bed30844fe58d9f1171704794fe76426e92/pytest_django/fixtures.py#L202-L205), but with `allow_cascade=False` ([Django code](https://github.com/django/django/blob/20c2d625d3d5062e43918d1d7b6f623202491dd4/django/test/testcases.py#L1234-L1242)). This means test cleanup in transaction tests will run `TRUNCATE TABLE emails_profile, emails_relayaddress...`, but without `CASCADE`. This makes it very hard to pass the CircleCI migration tests when adding new models with relations to existing models. @say-yawn saw this issue in PR #4688, but we didn't tackle it. Removing all the `transaction=true` puts it off for another day, and also speeds up tests.