### PR TITLE
MPP-4763: Move user creation methods to `privaterelay.tests.utils`

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -8,7 +8,7 @@ from allauth.socialaccount.models import SocialApp
 from model_bakery import baker
 from rest_framework.test import APIClient
 
-from emails.tests.models_tests import make_free_test_user, make_premium_test_user
+from privaterelay.tests.utils import make_free_test_user, make_premium_test_user
 
 
 @pytest.fixture

--- a/api/tests/serializers_tests.py
+++ b/api/tests/serializers_tests.py
@@ -8,7 +8,7 @@ from waffle.models import Flag
 
 from api.serializers.privaterelay import FlagSerializer
 from emails.models import RelayAddress
-from emails.tests.models_tests import make_free_test_user, make_premium_test_user
+from privaterelay.tests.utils import make_free_test_user, make_premium_test_user
 
 
 class PremiumValidatorsTest(APITestCase):

--- a/emails/tests/cleaners_tests.py
+++ b/emails/tests/cleaners_tests.py
@@ -9,8 +9,7 @@ from model_bakery import baker
 
 from emails.cleaners import MissingProfileCleaner, ServerStorageCleaner
 from emails.models import DomainAddress, RelayAddress
-
-from .models_tests import make_premium_test_user, make_storageless_test_user
+from privaterelay.tests.utils import make_premium_test_user, make_storageless_test_user
 
 
 def setup_server_storage_test_data(

--- a/emails/tests/mgmt_send_welcome_emails_tests.py
+++ b/emails/tests/mgmt_send_welcome_emails_tests.py
@@ -12,8 +12,8 @@ from allauth.socialaccount.models import SocialAccount
 from botocore.exceptions import ClientError
 
 from emails.models import Profile
-from emails.tests.models_tests import make_free_test_user
 from privaterelay.ftl_bundles import main as ftl_bundle
+from privaterelay.tests.utils import make_free_test_user
 
 COMMAND_NAME = "send_welcome_emails"
 

--- a/emails/tests/signals_tests.py
+++ b/emails/tests/signals_tests.py
@@ -3,8 +3,9 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
+from privaterelay.tests.utils import make_free_test_user
+
 from ..models import Profile
-from .models_tests import make_free_test_user
 
 
 class MeasureFeatureUsageSignalTest(TestCase):

--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -17,8 +17,6 @@ from emails.utils import (
     remove_trackers,
 )
 
-from .models_tests import make_free_test_user, make_premium_test_user  # noqa: F401
-
 
 class GetEmailDomainFromSettingsTest(TestCase):
     @override_settings(RELAY_CHANNEL="dev", SITE_ORIGIN="https://test.com")

--- a/emails/tests/validator_tests.py
+++ b/emails/tests/validator_tests.py
@@ -7,6 +7,8 @@ from django.test import TestCase
 
 from waffle.testutils import override_flag
 
+from privaterelay.tests.utils import make_free_test_user, make_premium_test_user
+
 from ..exceptions import CannotMakeSubdomainException
 from ..models import (
     DomainAddress,
@@ -22,7 +24,6 @@ from ..validators import (
     valid_address_pattern,
     valid_available_subdomain,
 )
-from .models_tests import make_free_test_user, make_premium_test_user
 
 
 class HasBadWordsTest(TestCase):

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -65,9 +65,6 @@ from privaterelay.tests.utils import (
     create_expected_glean_event,
     get_glean_event,
     log_extra,
-)
-
-from .models_tests import (
     make_free_test_user,
     make_premium_test_user,
     upgrade_test_user_to_premium,

--- a/privaterelay/tests/glean_tests.py
+++ b/privaterelay/tests/glean_tests.py
@@ -15,12 +15,6 @@ from pytest_django.fixtures import SettingsWrapper
 
 from api.serializers.emails import RelayAddressSerializer
 from emails.models import RelayAddress
-from emails.tests.models_tests import (
-    make_free_test_user,
-    make_premium_test_user,
-    phone_subscription,
-    vpn_subscription,
-)
 from privaterelay.glean_interface import (
     EmailBlockedReason,
     EmailMaskData,
@@ -28,7 +22,13 @@ from privaterelay.glean_interface import (
     RequestData,
     UserData,
 )
-from privaterelay.tests.utils import create_expected_glean_event
+from privaterelay.tests.utils import (
+    create_expected_glean_event,
+    make_free_test_user,
+    make_premium_test_user,
+    phone_subscription,
+    vpn_subscription,
+)
 from privaterelay.types import RELAY_CHANNEL_NAME
 from privaterelay.utils import glean_logger as utils_glean_logger
 

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -34,7 +34,7 @@ from emails.models import (
     RelayAddress,
     address_hash,
 )
-from emails.tests.models_tests import premium_subscription
+from privaterelay.tests.utils import premium_subscription
 
 from ..apps import PrivateRelayConfig
 from ..fxa_utils import NoSocialToken


### PR DESCRIPTION
Helper functions like `make_free_test_user` are used all over the code. This moves them from `emails.tests.model_tests` to `privaterelay.tests.utils`, which will make even more sense when `Profile` moves to `privaterelay.models`.