### PR TITLE
remove CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-frontend/src/pages/faq* @stephaniehobson @bcolsson
-frontend/src/pages/premium* @stephaniehobson @bcolsson
-frontend/src/pages/index* @stephaniehobson @bcolsson


### PR DESCRIPTION
When we planned to move Relay pages to www.mozilla.org, we used the `CODEOWNERS` file to notify ENGRs on the @mozilla/webdev-bedrock team when we changed our pages. We're not planning to move Relay pages to www.mozilla.org anymore, so we can remove this file.