### PR TITLE
MPP-3827: Optimize badwords and blocklist checks

### DIFF
--- a/emails/apps.py
+++ b/emails/apps.py
@@ -54,10 +54,11 @@ class EmailsConfig(AppConfig):
         terms = []
         terms_file_path = os.path.join(settings.BASE_DIR, "emails", filename)
         with open(terms_file_path) as terms_file:
-            for word in terms_file:
-                if len(word.strip()) > 0 and word.strip()[0] == "#":
+            for raw_word in terms_file:
+                word = raw_word.strip()
+                if not word or (len(word) > 0 and word[0] == "#"):
                     continue
-                terms.append(word.strip())
+                terms.append(word)
         return terms
 
     def ready(self):

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -23,6 +23,7 @@ from privaterelay.tests.utils import (
     vpn_subscription,
 )
 
+from ..apps import BadWords
 from ..exceptions import (
     CannotMakeAddressException,
     CannotMakeSubdomainException,
@@ -237,8 +238,8 @@ class RelayAddressTest(TestCase):
         )
         assert not repeat_deleted_relay_address.address == address
 
-    @patch("emails.validators.badwords", return_value=[])
-    @patch("emails.validators.blocklist", return_value=["blocked-word"])
+    @patch("emails.validators.badwords", return_value=BadWords(short=set(), long=[]))
+    @patch("emails.validators.blocklist", return_value=set(["blocked-word"]))
     def test_address_contains_blocklist_invalid(
         self, mock_blocklist: Mock, mock_badwords: Mock
     ) -> None:

--- a/emails/tests/validator_tests.py
+++ b/emails/tests/validator_tests.py
@@ -62,7 +62,7 @@ class IsBlocklistedTest(TestCase):
     def test_is_blocklisted_without_blocked_words(self) -> None:
         assert not is_blocklisted("non-blocked-word")
 
-    @patch("emails.validators.blocklist", return_value=["blocked-word"])
+    @patch("emails.validators.blocklist", return_value=set(["blocked-word"]))
     def test_is_blocklisted_with_mocked_blocked_words(self, mock_config: Mock) -> None:
         assert is_blocklisted("blocked-word")
 


### PR DESCRIPTION
There are a few ways to reject a term provided by the user:

1. A short term, 4 characters or less, is in the bad words list.
2. A long term, 5 characters or more, contains a bad word that is 5 characters or more.
3. A word is in the blocklist

This PR uses a Python `set()` for the first and third checks, which should be faster than iterating over the whole list. It makes other changes to word list loading an related tests.

I used this file to time the differences:

https://gist.github.com/jwhitlock/b470221e18b61a6647dd5684f26a427d

I placed this at `emails/timeit.py`, and ran `./manage.py shell`:

```
>>> from emails.timeit import timer_test
>>> timer_test()
Checking that tests pass...
Old code took: 0.013196
New code took: 0.009787
Speedup is 1.3
```

This is faster, but the old version runs 1,000,000 times in 13ms, versus 10ms for the new version. This should have no noticable impact in production, so a valid review can reject it because it makes the code harder to understand.
