### PR TITLE
MPP-3834: Allow inline script, but keep API docs from requiring them

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -4,7 +4,7 @@ from django.urls import URLPattern, URLResolver, include, path, register_convert
 from drf_spectacular.views import (
     SpectacularAPIView,
     SpectacularRedocView,
-    SpectacularSwaggerView,
+    SpectacularSwaggerSplitView,
 )
 from rest_framework import routers
 
@@ -76,7 +76,7 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path(
         "v1/docs/",
         enable_if_setting("API_DOCS_ENABLED")(
-            SpectacularSwaggerView.as_view(url_name="schema")
+            SpectacularSwaggerSplitView.as_view(url_name="schema")
         ),
         name="schema-swagger-ui",
     ),

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -140,7 +140,7 @@ else:
     ]
 
 API_DOCS_ENABLED = config("API_DOCS_ENABLED", False, cast=bool) or DEBUG
-_CSP_SCRIPT_INLINE = API_DOCS_ENABLED or USE_SILK
+_CSP_SCRIPT_INLINE = USE_SILK
 
 # When running locally, styles might get refreshed while the server is running, so their
 # hashes would get oudated. Hence, we just allow all of them.


### PR DESCRIPTION
*Update - PR #4838 included some of this work, so I've rebased to a single commit.*

The [FAQ](https://drf-spectacular.readthedocs.io/en/latest/faq.html#my-swagger-ui-and-or-redoc-page-is-blank) notes that `SpectacularSwaggerSplitView` can be used to avoid the inline script, but also notes that URL re-writing may break it. This PR switches to `SpectacularSwaggerSplitView`, so only [silk](https://pypi.org/project/django-silk/) is needed for inline scripts (as well as GA4, which we hope to fix soon).

# How to test:

* Load the website, change to different pages. The site continues to load.
* Go to http://127.0.0.1:8000/docs. The page loads, and you can run an API call like `GET /api/v1/profiles/`.