### PR TITLE
call useMetrics hook to check FxA profile metricsEnabled

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -32,6 +32,7 @@ import { isPhonesAvailableInCountry } from "../../functions/getPlan";
 import { useL10n } from "../../hooks/l10n";
 import { HolidayPromoBanner } from "./topmessage/HolidayPromoBanner";
 import { isFlagActive } from "../../functions/waffle";
+import { useMetrics } from "../../hooks/metrics";
 import { GoogleAnalyticsWorkaround } from "../GoogleAnalyticsWorkaround";
 
 export type Props = {
@@ -53,6 +54,7 @@ export const Layout = (props: Props) => {
   const hasPremium: boolean = profiles.data?.[0].has_premium ?? false;
   const usersData = useUsers().data?.[0];
   const [mobileMenuExpanded, setMobileMenuExpanded] = useState<boolean>(false);
+  const metricsEnabled = useMetrics();
 
   useEffect(() => {
     makeToast(l10n, usersData);
@@ -286,7 +288,9 @@ export const Layout = (props: Props) => {
           </footer>
         </div>
       </div>
-      {props.runtimeData !== undefined && navigator.doNotTrack !== "1" ? (
+      {props.runtimeData !== undefined &&
+      navigator.doNotTrack !== "1" &&
+      metricsEnabled === "enabled" ? (
         <GoogleAnalyticsWorkaround
           gaId={props.runtimeData.GA4_MEASUREMENT_ID}
           debugMode={


### PR DESCRIPTION
How to test:
1. Since our local apps cannot receive webhook events from FXA, use [the admin UI to update the `SocialAccount` for a user](http://127.0.0.1:8000/admin/socialaccount/socialaccount/): In their "Extra data" field, edit the JSON to set `"metricsEnabled": false`
2. Open the Network developer tool in a browser window
3. Sign the user out and back into the app to make sure the front-end code has "fresh" profile data
   * [ ] On the resulting page, check the Network developer tool: there should be 0 requests to google-analytics or googletagmanager
4. Repeat step 1 but edit the JSON to set `"metricsEnabled": true`
5. Refresh the page
   * [ ] On the resulting page, check the Network developer tool: there should be 1+ requests to google-analytics or googletagmanager

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] ~Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).~
