### PR TITLE
fix Hungary monthly stripe price plan ID

### DIFF
--- a/privaterelay/plans.py
+++ b/privaterelay/plans.py
@@ -329,7 +329,7 @@ _STRIPE_PLAN_DATA: _StripePlanData = {
             },
             "HU": {  # Hungary
                 "currency": "EUR",
-                "monthly_id": "price_1NOOJAJNcmPzuWtRV7Kmwmdm",
+                "monthly_id": "price_1PYB6XJNcmPzuWtR5Ff9cW3D",
                 "yearly_id": "price_1NOOKvJNcmPzuWtR2DEWIRE4",
             },
             "IE": {  # Ireland

--- a/privaterelay/tests/plans_tests.py
+++ b/privaterelay/tests/plans_tests.py
@@ -42,7 +42,7 @@ _PREMIUM_PRICE_DATA = {
     "FI": ("EUR", "_1LYBn9JNcmPzuWtRI3nvHgMi", "_1LYBq1JNcmPzuWtRmyEa08Wv"),
     "FR": ("EUR", "_1LYBuLJNcmPzuWtRn58XQcky", "_1LYBwcJNcmPzuWtRpgoWcb03"),
     "HR": ("EUR", "_1NOSznJNcmPzuWtRH7CEeAwA", "_1NOT0WJNcmPzuWtRpeNDEjvC"),
-    "HU": ("EUR", "_1NOOJAJNcmPzuWtRV7Kmwmdm", "_1NOOKvJNcmPzuWtR2DEWIRE4"),
+    "HU": ("EUR", "_1PYB6XJNcmPzuWtR5Ff9cW3D", "_1NOOKvJNcmPzuWtR2DEWIRE4"),
     "IT": ("EUR", "_1LYCMrJNcmPzuWtRTP9vD8wY", "_1LYCN2JNcmPzuWtRtWz7yMno"),
     "LT": ("EUR", "_1NHACcJNcmPzuWtR5ZJeVtJA", "_1NHADOJNcmPzuWtR2PSMBMLr"),
     "LV": ("EUR", "_1NHAASJNcmPzuWtRpcliwx0R", "_1NHA9lJNcmPzuWtRLf7DV6GA"),


### PR DESCRIPTION
See Slack thread here: https://mozilla.slack.com/archives/CG0AJ6E77/p1719934325736679

How to test:
1. Check out this branch
2. Add `hu` Hungarian language to your browser
3. Go to http://127.0.0.1:8000/premium/#pricing
4. Change the "E-mail-védelem" from "Évente" to "Havi" for Hungarian Monthly email purchase
   * [ ] Verify the link uses the new price ID: `price_1PYB6XJNcmPzuWtR5Ff9cW3D`

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).