### PR TITLE
MPP-3807 Remove extension related queries on Glean mentrics

### DIFF
--- a/api/tests/emails_views_tests.py
+++ b/api/tests/emails_views_tests.py
@@ -450,15 +450,14 @@ def test_post_relayaddress_with_generated_for_success(
     assert response.status_code == 201
 
     assert (event := get_glean_event(caplog)) is not None
-    address = free_user.relayaddress_set.get()
     expected_event = create_expected_glean_event(
         category="email_mask",
         name="created",
         user=free_user,
         extra_items={
             "n_random_masks": "1",
-            "has_extension": "true",
-            "date_got_extension": str(int(address.created_at.timestamp())),
+            "has_extension": "false",
+            "date_got_extension": "-2",
             "is_random_mask": "true",
             "created_by_api": "true",
             "has_website": "true",

--- a/privaterelay/tests/glean_tests.py
+++ b/privaterelay/tests/glean_tests.py
@@ -106,20 +106,20 @@ def test_user_data_free_user() -> None:
     assert user_data.date_joined_premium is None
     assert user_data.premium_status == "free"
     assert user_data.has_extension is False
-    assert user_data.date_got_extension is None
+    assert user_data.date_got_extension == datetime.min
 
 
 @pytest.mark.django_db
 def test_user_data_addon_user() -> None:
     """Data is extracted for a free user of the add-on."""
     user = make_free_test_user()
-    ra = user.relayaddress_set.create(generated_for="example.com")
+    user.relayaddress_set.create(generated_for="example.com")
 
     user_data = UserData.from_user(user)
 
     assert user_data.n_random_masks == 1
-    assert user_data.has_extension is True
-    assert user_data.date_got_extension == ra.created_at
+    assert user_data.has_extension is False
+    assert user_data.date_got_extension == datetime.min
 
 
 @pytest.mark.django_db

--- a/privaterelay/tests/utils.py
+++ b/privaterelay/tests/utils.py
@@ -188,7 +188,7 @@ def create_expected_glean_event(
             "premium_status": "free",
             "date_joined_premium": "-1",
             "has_extension": "false",
-            "date_got_extension": "-1",
+            "date_got_extension": "-2",
         }
         | user_extra_items
         | extra_items


### PR DESCRIPTION
The DB utilization randomly spikes of 100% DB usage that can result into service interruption or outage. During the spikes the slowest queries are caused while querying if the user has extension and deriving when the extension was installed for the Glean metric pings. For now default `has_extension` and `date_got_extension` to `False` and `-2`

How to test:

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).