### PR TITLE
MPP-4841: Handle trailing newline in headers

### DIFF
--- a/emails/tests/fixtures/encoded_trailing_newline_expected.email
+++ b/emails/tests/fixtures/encoded_trailing_newline_expected.email
@@ -1,0 +1,201 @@
+MIME-Version: 1.0
+Subject: An encoded newline
+From: "newline@trouble.example.com [via Relay]" <ebsbdsan7@test.com>
+To: user@example.com
+Reply-To: replies@default.com
+Resent-From: newline@trouble.example.com
+Content-Type: text/html; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/T=
+R/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns=3D"http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv=3D"Content-Type" content=3D"text/html; charset=3Dutf-8" =
+/>
+    <meta name=3D"viewport" content=3D"width=3Ddevice-width"/>
+    <style>
+    @font-face {
+      font-family: 'inter';
+      font-style: normal;
+      src: local('Inter Regular'), local('Inter-Regular'), url(https://relay.=
+firefox.com/fonts/Inter/Inter-Regular.4232a675a077.woff2?v=3D3.18) format('wo=
+ff');
+    }
+    @font-face {
+      font-family: 'inter medium';
+      font-style: bold;
+      src: local('Inter Medium'), local('Inter-Medium'), url(https://relay.fi=
+refox.com/fonts/Inter/Inter-Medium.woff2?v=3D3.18) format('woff');
+    }
+    * {
+      box-sizing: border-box;
+    }
+    #relay-email-header,
+    #relay-email-footer {
+      font-family: 'inter', Arial, sans-serif;
+      color: #FFFFFF;
+      font-size: 12px;
+      line-height: 140% !important;
+    }
+    a.container-link {
+      transition: all 0.2s ease;
+      text-underline-offset: 2px;
+      font-family: 'inter medium', Arial, sans-serif;
+    }
+    a.container-link:hover {
+      color: #20123ad5;
+      transition: all 0.2s ease;
+    }
+    a.container-link {
+      color: #FFFFFF;
+      font-size: 12px;
+    }
+    a.container-link:hover,
+    a.container-link:focus,
+    a.container-link:active {
+      transition: all 0.2s ease;
+    }
+    .email-trackers-removed-icon {
+      margin-right: 5px;
+      vertical-align: bottom;
+    }
+    /* this deals with long email addresses */
+    .forwarded-from-email {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 500px;
+    }
+    @media screen and (max-width: 1200px) {
+      .forwarded-from-email {
+        width: 300px;
+      }
+    }
+    @media screen and (max-width: 1024px) {
+        .relay-trackers-removed {
+          /* Avoid margin when header-block-right content overflows */
+          display: block !important;
+          margin-right: 0 !important;
+        }
+    }
+    @media screen and (max-width: 768px){
+      .footer-block {
+        display: block;
+        width: 100%;
+      }
+      .header-block-left,
+      .header-block-right {
+        display: block;
+        width: 100%;
+        text-align: left;
+      }
+      .header-block-right {
+        margin-top: 4px;
+      }
+      .relay-trackers-removed,
+      .relay-mask {
+        width: 100%;
+        display: block;
+      }
+      .forwarded-from-email {
+        width: 250px;
+      }
+      .footer-block {
+        display: block;
+        text-align: left !important;
+      }
+      .footer-block .container-link.dashboard {
+        margin-left: 5px !important;
+      }
+    }
+    @media screen and (max-width: 425px) {
+      .forwarded-from-email {
+        width: 200px;
+      }
+    }
+    </style>
+  </head>
+  <body id=3D"relay-email" style=3D"padding: 0; margin: 0;">
+    <!-- Header -->
+    <table id=3D"relay-email-header" width=3D"100%" bgcolor=3D"#3D3D3D" style=
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+      <tr>
+        <td class=3D"relay-logo-img" style=3D"width: 30px; vertical-align: to=
+p;" >
+          <img width=3D"30" src=3D"http://127.0.0.1:8000/static/images/email-=
+images/relay-icon.png" style=3D"margin-right: 5px; display: inline-block; ver=
+tical-align: top;" alt=3D"relay icon"/>
+        </td>
+        <td class=3D"header-block-left" style=3D"vertical-align: bottom;" wid=
+th=3D"50%" align=3D"left" style=3D"padding-top: 5px;">
+          <p style=3D"margin-top: 0; margin-bottom: 0; vertical-align: middle=
+; display: inline-block;">
+            <span class=3D"forwarded-from-email" style=3D"display: block; col=
+or: #FFFFFF; font-family: 'inter', Arial, sans-serif; font-size: 12px;">
+            Forwarded from <a href=3D"http://127.0.0.1:8000/accounts/profile/=
+#ebsbdsan7%40test.com" class=3D"container-link" style=3D"margin-right: 30px;c=
+olor: #FFFFFF;font-size: 12px;">ebsbdsan7@test.com</a>
+            </span>
+            <span style=3D"margin-top: 0; color: #FFFFFF; font-family: 'inter=
+', Arial, sans-serif; font-size: 12px;">
+                by <a href=3D"http://127.0.0.1:8000/accounts/profile/" class=
+=3D"container-link" style=3D"margin-right: 30px;color: #FFFFFF;font-size: 12p=
+x;">Firefox Relay</a>
+            </span>
+          </p>
+        </td>
+        <td class=3D"header-block-right" style=3D"vertical-align: bottom;" wi=
+dth=3D"50%" align=3D"right">
+          <p class=3D"relay-trackers-removed" style=3D"margin: 0 16px 0 0; ve=
+rtical-align: bottom; display: inline-block; color: #FFFFFF; font-family: 'in=
+ter', Arial, sans-serif; font-size: 12px;">
+              <span dir=3D"auto">0</span> email trackers removed
+          </p>
+          <p class=3D"relay-mask" style=3D"margin: 0; display: inline-block;">
+              <a class=3D"container-link" href=3D"http://127.0.0.1:8000/premi=
+um" style=3D"color: #FFFFFF;">
+                Upgrade for more protection
+              </a>
+          </p>
+        </td>
+      </tr>
+    </table>
+    <!-- Email Body -->
+    <table id=3D"relay-email-body" width=3D"100%" style=3D"padding: 0; max-wi=
+dth:850px;" align=3D"center">
+      <tr>
+        <td width=3D"100%" style=3D"padding-left: 15px; padding-right: 15px;">
+          <html>
+ <head>
+  <title>I put a newline in the Subject</title>
+ </head>
+ <body>
+  <p>Enjoy your newline! Enjoy <a href=3D"https://datatracker.ietf.org/doc/ht=
+ml/rfc2047">RFC 2047</a>!</p>
+ </body>
+</html>
+        </td>
+      </tr>
+    </table>
+    <!-- Footer -->
+    <table id=3D"relay-email-footer" width=3D"100%" bgcolor=3D"#3D3D3D" style=
+=3D"background: #3D3D3D; padding: 8px 16px; margin-top: 30px; margin-bottom: =
+30px; width: 96%; border-radius: 6px; max-width: 1200px;" align=3D"center">
+      <tr>
+        <td class=3D"footer-block" width=3D"50%" align=3D"left">
+          <a class=3D"container-link" href=3D"http://127.0.0.1:8000">
+            <img width=3D"130" src=3D"http://127.0.0.1:8000/static/images/ema=
+il-images/relay-logo-emails-dark-bg.png" style=3D"margin: 0;" alt=3D"relay lo=
+go"/>
+          </a>
+        </td>
+        <td class=3D"footer-block" width=3D"50%" align=3D"right">
+          <a class=3D"container-link dashboard" href=3D"http://127.0.0.1:8000=
+/accounts/profile" style=3D"color: #FFFFFF;">Your dashboard</a>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/emails/tests/fixtures/encoded_trailing_newline_incoming.email
+++ b/emails/tests/fixtures/encoded_trailing_newline_incoming.email
@@ -1,0 +1,17 @@
+Date: Tue, 09 Jul 2024 20:02:30 +0200
+Subject: An =?UTF-8?Q?encoded_newline=0A?=
+From: New Line Trouble <newline@trouble.example.com>
+To: ebsbdsan7@test.com
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+
+<html>
+ <head>
+  <title>I put a newline in the Subject</title>
+ </head>
+ <body>
+  <p>Enjoy your newline! Enjoy <a href=3D"https://datatracker.ietf.org/doc/ht=
+ml/rfc2047">RFC 2047</a>!</p>
+ </body>
+</html>

--- a/emails/views.py
+++ b/emails/views.py
@@ -1065,7 +1065,7 @@ def _replace_headers(
     for header, value in headers.items():
         del email[header]
         try:
-            email[header] = value
+            email[header] = value.rstrip("\r\n")
         except Exception as e:
             issues["outgoing"].append(
                 (header, {"exception_on_write": repr(e), "value": value})


### PR DESCRIPTION
The Python `email` library does not expect newlines in header values. It rejects newlines with a `ValueError`, except when the newline is at the end of the value. A newline can be present in the incoming email due to encoding. This newline is injected into the forwarded email. The mail client interprets this as the start of the email, and stops header processing.

This PR strips any trailing newlines from the header value, fixing issue #4841.

# How to test:

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).