### PR TITLE
MPP-3846: Allow percent greater than 100%, and run in transaction

### DIFF
--- a/privaterelay/cleaner_task.py
+++ b/privaterelay/cleaner_task.py
@@ -827,8 +827,6 @@ class DataIssueTask:
             raise ValueError(f"whole ({whole}) can not be less than 0")
         if part < 0:
             raise ValueError(f"part ({part}) can not be negative")
-        if part > whole:
-            raise ValueError(f"part ({part}) can not be greater than whole ({whole})")
         len_whole = len(str(whole))
         return f"{part:{len_whole}d} ({part / whole:6.1%})"
 

--- a/privaterelay/management/commands/cleanup_data.py
+++ b/privaterelay/management/commands/cleanup_data.py
@@ -119,10 +119,16 @@ class Command(BaseCommand):
         total = 0
         timers: dict[str, float] = {}
         for slug, task in tasks.items():
-            with Timer(logger=None) as issue_timer:
-                total += task.issues()
-            timers[slug] = round(issue_timer.last, 3)
+            task_issues, task_time = self.find_issues_in_task(task)
+            total += task_issues
+            timers[slug] = task_time
         return total, timers
+
+    def find_issues_in_task(self, task: DataIssueTask) -> tuple[int, float]:
+        """Run a task, returning the number of issues and execution time."""
+        with Timer(logger=None) as issue_timer:
+            total = task.issues()
+        return total, round(issue_timer.last, 3)
 
     def clean_issues(
         self, tasks: dict[str, DataIssueTask]

--- a/privaterelay/management/commands/cleanup_data.py
+++ b/privaterelay/management/commands/cleanup_data.py
@@ -137,11 +137,21 @@ class Command(BaseCommand):
         total = 0
         timers: dict[str, float] = {}
         for slug, task in tasks.items():
-            if hasattr(task, "clean"):
-                with Timer(logger=None) as clean_timer:
-                    total += task.clean()
-            timers[slug] = round(clean_timer.last, 3)
+            task_cleaned, clean_time = self.clean_issues_in_task(task)
+            if task_cleaned is not None and clean_time is not None:
+                total += task_cleaned
+                timers[slug] = clean_time
         return total, timers
+
+    def clean_issues_in_task(
+        self, task: DataIssueTask
+    ) -> tuple[int, float] | tuple[None, None]:
+        """Run the task cleaner, returning issues cleaned and execution time."""
+        if not hasattr(task, "clean"):
+            return (None, None)
+        with Timer(logger=None) as clean_timer:
+            cleaned = task.clean()
+        return cleaned, round(clean_timer.last, 3)
 
     def prepare_data(
         self,

--- a/privaterelay/tests/cleaner_task_tests.py
+++ b/privaterelay/tests/cleaner_task_tests.py
@@ -695,6 +695,7 @@ class DeactivateOddUsersTask(CleanerTask):
         ( 1999,  2000,  "1999 (100.0%)"),
         (    1, 20000, "    1 (  0.0%)"),
         (19999, 20000, "19999 (100.0%)"),
+        (20000, 20000, "20000 (100.0%)"),
     ),
 )
 # fmt: on
@@ -702,11 +703,20 @@ def test_data_issue_task_as_percent(part: int, whole: int, expected: str) -> Non
     assert DataIssueTask._as_percent(part, whole) == expected
 
 
+def test_data_issue_task_as_percent_part_greater_than_whole() -> None:
+    """
+    Allow the part to be greater than the whole.
+
+    This can happen if the task is not run inside a transaction, so that user
+    actions can change the state of the database.
+    """
+    assert DataIssueTask._as_percent(201, 200) == "201 (100.5%)"
+
+
 @pytest.mark.parametrize(
     "part,whole,error",
     (
         (1, 0, r"^whole \(0\) can not be less than 0$"),
-        (2, 1, r"^part \(2\) can not be greater than whole \(1\)$"),
         (-1, 2, r"^part \(-1\) can not be negative$"),
     ),
 )


### PR DESCRIPTION
For one of the cleaners (most likely `emails.cleaner.ServerStorageCleaner`, one of the "parts" was greater than the "whole". One way this could happen is if something on the live API server updated the database in the middle of a cleaning command. For example, if the number of `RelayAddress` with `server_storage=False` was 100,000, and then someone created a new one, the number of `RelayAddress` with `server_storage=False` and no stored data would be 100,001.

This removes the check that the whole is greater than or equal to the part, allowing a percentage that is above 100%. I've added tests, along with a comment why.

I also refactored the `./manage.py cleanup_data` command to run each task in a transaction. This should ensure that the data is consistent through the run. This was a pure refactor, no test changes.

# How to test

Run both, see that they are successful:

```sh
./manage.py cleanup_data -v 2
./manage.py cleanup_data -v 2 --clean
```

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).