### PR TITLE
MPP-3839: Update email header logging

### DIFF
--- a/emails/policy.py
+++ b/emails/policy.py
@@ -73,6 +73,7 @@ class RelayHeaderRegistry(PythonHeaderRegistry):
         as_unstructured = as_unstructured_cls(name, value)
         # Avoid mypy attr-defined error for setting a dynamic attribute
         setattr(header_instance, "as_unstructured", as_unstructured)
+        setattr(header_instance, "as_raw", value)
         return header_instance
 
 

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -641,7 +641,7 @@ class SNSNotificationIncomingTest(SNSNotificationTestBase):
         assert self.ra.num_forwarded == 1
         assert self.ra.last_used_at
         assert (datetime.now(tz=UTC) - self.ra.last_used_at).seconds < 2.0
-        mock_logger.warning.assert_not_called()
+        mock_logger.info.assert_not_called()
 
     @patch("emails.views.info_logger")
     def test_from_with_unquoted_commas_is_parsed(self, mock_logger: Mock) -> None:
@@ -675,7 +675,7 @@ class SNSNotificationIncomingTest(SNSNotificationTestBase):
             }
         ]
 
-        mock_logger.warning.assert_called_once_with(
+        mock_logger.info.assert_called_once_with(
             "_handle_received: forwarding issues",
             extra={"issues": {"headers": expected_header_errors}},
         )
@@ -696,7 +696,7 @@ class SNSNotificationIncomingTest(SNSNotificationTestBase):
                 ],
             },
         )
-        mock_logger.warning.assert_not_called()
+        mock_logger.info.assert_not_called()
 
     @patch("emails.views.info_logger")
     def test_invalid_message_id_is_forwarded(self, mock_logger: Mock) -> None:
@@ -717,7 +717,7 @@ class SNSNotificationIncomingTest(SNSNotificationTestBase):
                 "raw_value": "<[d7c5838b5ab944f89e3f0c1b85674aef====@example.com]>",
             }
         ]
-        mock_logger.warning.assert_called_once_with(
+        mock_logger.info.assert_called_once_with(
             "_handle_received: forwarding issues",
             extra={"issues": {"headers": expected_header_errors}},
         )
@@ -748,7 +748,7 @@ class SNSNotificationIncomingTest(SNSNotificationTestBase):
                 "raw_value": "An =?UTF-8?Q?encoded_newline=0A?=",
             }
         ]
-        mock_logger.warning.assert_called_once_with(
+        mock_logger.info.assert_called_once_with(
             "_handle_received: forwarding issues",
             extra={"issues": {"headers": expected_header_errors}},
         )

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -658,24 +658,23 @@ class SNSNotificationIncomingTest(SNSNotificationTestBase):
         self.check_sent_email_matches_fixture(
             "emperor_norton", replace_mime_boundaries=True
         )
-        expected_header_errors = {
-            "incoming": [
-                (
-                    "From",
-                    {
-                        "defect_count": 4,
-                        "parsed_value": (
-                            '"Norton I.", Emperor of the United States'
-                            " <norton@sf.us.example.com>"
-                        ),
-                        "raw_value": (
-                            "Norton I., Emperor of the United States"
-                            " <norton@sf.us.example.com>"
-                        ),
-                    },
-                )
-            ]
-        }
+
+        expected_header_errors = [
+            {
+                "header": "From",
+                "direction": "in",
+                "defect_count": 4,
+                "parsed_value": (
+                    '"Norton I.",'
+                    " Emperor of the United States <norton@sf.us.example.com>"
+                ),
+                "raw_value": (
+                    "Norton I.,"
+                    " Emperor of the United States <norton@sf.us.example.com>"
+                ),
+            }
+        ]
+
         mock_logger.warning.assert_called_once_with(
             "_handle_received: forwarding issues",
             extra={"issues": {"headers": expected_header_errors}},
@@ -709,22 +708,15 @@ class SNSNotificationIncomingTest(SNSNotificationTestBase):
         self.check_sent_email_matches_fixture(
             "message_id_in_brackets", replace_mime_boundaries=True
         )
-        expected_header_errors = {
-            "incoming": [
-                (
-                    "Message-ID",
-                    {
-                        "defect_count": 1,
-                        "parsed_value": (
-                            "<[d7c5838b5ab944f89e3f0c1b85674aef====@example.com]>"
-                        ),
-                        "raw_value": (
-                            "<[d7c5838b5ab944f89e3f0c1b85674aef====@example.com]>"
-                        ),
-                    },
-                )
-            ]
-        }
+        expected_header_errors = [
+            {
+                "header": "Message-ID",
+                "direction": "in",
+                "defect_count": 1,
+                "parsed_value": "<[d7c5838b5ab944f89e3f0c1b85674aef====@example.com]>",
+                "raw_value": "<[d7c5838b5ab944f89e3f0c1b85674aef====@example.com]>",
+            }
+        ]
         mock_logger.warning.assert_called_once_with(
             "_handle_received: forwarding issues",
             extra={"issues": {"headers": expected_header_errors}},
@@ -747,18 +739,15 @@ class SNSNotificationIncomingTest(SNSNotificationTestBase):
         assert self.ra.num_forwarded == 1
         assert self.ra.last_used_at
         assert (datetime.now(tz=UTC) - self.ra.last_used_at).seconds < 2.0
-        expected_header_errors = {
-            "incoming": [
-                (
-                    "Subject",
-                    {
-                        "defect_count": 1,
-                        "parsed_value": "An encoded newline\n",
-                        "raw_value": "An =?UTF-8?Q?encoded_newline=0A?=",
-                    },
-                )
-            ]
-        }
+        expected_header_errors = [
+            {
+                "header": "Subject",
+                "direction": "in",
+                "defect_count": 1,
+                "parsed_value": "An encoded newline\n",
+                "raw_value": "An =?UTF-8?Q?encoded_newline=0A?=",
+            }
+        ]
         mock_logger.warning.assert_called_once_with(
             "_handle_received: forwarding issues",
             extra={"issues": {"headers": expected_header_errors}},
@@ -2372,9 +2361,13 @@ def test_replace_headers_read_error_is_handled() -> None:
         issues = _replace_headers(email, new_headers)
 
     # The mocked exception was handled and logged
-    assert issues == {
-        "incoming": [("X-Fail", {"exception_on_read": "RuntimeError('I failed.')"})]
-    }
+    assert issues == [
+        {
+            "header": "X-Fail",
+            "direction": "in",
+            "exception_on_read": "RuntimeError('I failed.')",
+        }
+    ]
 
     # _replace_headers continued working with the remaining data, the headers are now
     # set to the desired new values.

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -668,7 +668,7 @@ class SNSNotificationIncomingTest(SNSNotificationTestBase):
                             '"Norton I.", Emperor of the United States'
                             " <norton@sf.us.example.com>"
                         ),
-                        "unstructured_value": (
+                        "raw_value": (
                             "Norton I., Emperor of the United States"
                             " <norton@sf.us.example.com>"
                         ),
@@ -718,7 +718,7 @@ class SNSNotificationIncomingTest(SNSNotificationTestBase):
                         "parsed_value": (
                             "<[d7c5838b5ab944f89e3f0c1b85674aef====@example.com]>"
                         ),
-                        "unstructured_value": (
+                        "raw_value": (
                             "<[d7c5838b5ab944f89e3f0c1b85674aef====@example.com]>"
                         ),
                     },
@@ -747,7 +747,22 @@ class SNSNotificationIncomingTest(SNSNotificationTestBase):
         assert self.ra.num_forwarded == 1
         assert self.ra.last_used_at
         assert (datetime.now(tz=UTC) - self.ra.last_used_at).seconds < 2.0
-        mock_logger.warning.assert_not_called()
+        expected_header_errors = {
+            "incoming": [
+                (
+                    "Subject",
+                    {
+                        "defect_count": 1,
+                        "parsed_value": "An encoded newline\n",
+                        "raw_value": "An =?UTF-8?Q?encoded_newline=0A?=",
+                    },
+                )
+            ]
+        }
+        mock_logger.warning.assert_called_once_with(
+            "_handle_received: forwarding issues",
+            extra={"issues": {"headers": expected_header_errors}},
+        )
 
 
 class SNSNotificationRepliesTest(SNSNotificationTestBase):

--- a/emails/types.py
+++ b/emails/types.py
@@ -34,7 +34,7 @@ class EmailHeaderExceptionOnWriteIssue(TypedDict):
 class EmailHeaderDefectIssue(TypedDict):
     defect_count: int
     parsed_value: str
-    unstructured_value: str
+    raw_value: str
 
 
 EmailHeaderIssue = (

--- a/emails/types.py
+++ b/emails/types.py
@@ -23,15 +23,21 @@ AWS_MailJSON = dict[str, Any]
 
 
 class EmailHeaderExceptionOnReadIssue(TypedDict):
+    header: str
+    direction: Literal["in"]
     exception_on_read: str
 
 
 class EmailHeaderExceptionOnWriteIssue(TypedDict):
+    header: str
+    direction: Literal["out"]
     exception_on_write: str
     value: str
 
 
 class EmailHeaderDefectIssue(TypedDict):
+    header: str
+    direction: Literal["in", "out"]
     defect_count: int
     parsed_value: str
     raw_value: str
@@ -43,8 +49,6 @@ EmailHeaderIssue = (
     | EmailHeaderDefectIssue
 )
 
-EmailHeaderIssues = dict[
-    Literal["incoming", "outgoing"], list[tuple[str, EmailHeaderIssue]]
-]
+EmailHeaderIssues = list[EmailHeaderIssue]
 
 EmailForwardingIssues = dict[Literal["headers"], EmailHeaderIssues]

--- a/emails/views.py
+++ b/emails/views.py
@@ -783,7 +783,7 @@ def _handle_received(message_json: AWS_SNSMessageJSON) -> HttpResponse:
     if has_text:
         incr_if_enabled("email_with_text_content", 1)
     if issues:
-        info_logger.warning(
+        info_logger.info(
             "_handle_received: forwarding issues", extra={"issues": issues}
         )
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -1042,7 +1042,18 @@ def _replace_headers(
                     {
                         "defect_count": len(value.defects),
                         "parsed_value": str(value),
-                        "unstructured_value": str(value.as_unstructured),
+                        "raw_value": str(value.as_raw),
+                    },
+                )
+            )
+        elif getattr(getattr(value, "_parse_tree", None), "all_defects", []):
+            issues["incoming"].append(
+                (
+                    header,
+                    {
+                        "defect_count": len(value._parse_tree.all_defects),
+                        "parsed_value": str(value),
+                        "raw_value": str(value.as_raw),
                     },
                 )
             )
@@ -1083,7 +1094,7 @@ def _replace_headers(
                     {
                         "defect_count": len(parsed_value.defects),
                         "parsed_value": str(parsed_value),
-                        "unstructured_value": str(parsed_value.as_unstructured),
+                        "raw_value": str(parsed_value.as_raw),
                     },
                 )
             )


### PR DESCRIPTION
This is a reporting follow-on for PR #4879 / issue #4841. There were a few issues with the header logging when diagnosing this issue:

* Some parsed headers (from the Python [headerregistry](https://docs.python.org/3.11/library/email.headerregistry.html) set `defects` as documented. Some, like the `Subject` header, do not. However, they are parsed as a `TokenList` with an [all_defects](https://github.com/python/cpython/blob/263c7e611bb24715e513d457a3477a61fff15162/Lib/email/_header_value_parser.py#L136-L138) property that returns any issues. The encoded newline was reported this way, and this may be a root cause of other header errors.
* The previous log entry used the "unstructured" value, which bypassed any special header processing. This was useful for the `Message-ID` bug back in PR #4035, but is less useful than the original raw value for other headers. This switches the log to the raw value. The unstructured value can be derived locally from this.
* The log entries `_handle_received: forwarding issues` are being discarded when routing log entries to BigQuery datasets. I don't know the exact cause, so I'm guessing and changing the log to match others that are getting through. I've used log exports to get a sample of the issues, but I can't determine long-term trends this way. I've changed the log level from `WARNING` to `INFO`, and used a list of dictionaries / objects instead of deeply nested objects with the header name as a key. I hope this will allow me to use BQ to further analyze header issues. 

# How to test:
The unit tests should be sufficient to show this is implemented without errors.

- [x] I've added a unit test to test for potential regressions of this bug.
standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
