### PR TITLE
Fix GitHub action dependabot-glean-parser

### DIFF
--- a/.github/workflows/dependabot-glean-parser.yml
+++ b/.github/workflows/dependabot-glean-parser.yml
@@ -81,13 +81,16 @@ jobs:
       - name: Commit changed file
         run: |
           set -x
-          exit_code=0
-          git diff-index HEAD
-          git diff-index --quiet --exit-code --ignore-submodules HEAD || exit_code=$?
-          if (( exit_code == 0 )); then echo "no changes, exit_code=$exit_code"; else echo "changes, exit_code=$exit_code"; fi
           git config user.email "<>"
           git config user.name "GitHub Actions - Run new glean-parser"
           git diff
           git add privaterelay/glean/server_events.py
-          git commit --message="Re-generate code with glean-parser $GLEAN_VERSION" || echo "No changes to commit"
+          has_changes=1
+          git commit --message="Re-generate code with glean-parser $GLEAN_VERSION" || has_changes=0
+          if (( has_changes == 0 ))
+          then
+            echo "no changes, has_changes=$has_changes"
+          else
+            echo "has changes, has_changes=$has_changes"
+          fi
           git push origin HEAD:pull/${{ github.ref_name }}

--- a/.github/workflows/dependabot-glean-parser.yml
+++ b/.github/workflows/dependabot-glean-parser.yml
@@ -89,8 +89,7 @@ jobs:
           git commit --message="Re-generate code with glean-parser $GLEAN_VERSION" || has_changes=0
           if (( has_changes == 0 ))
           then
-            echo "no changes, has_changes=$has_changes"
-          else
-            echo "has changes, has_changes=$has_changes"
+            echo "no changes to push"
+            exit 0
           fi
           git push origin HEAD:pull/${{ github.ref_name }}

--- a/.github/workflows/dependabot-glean-parser.yml
+++ b/.github/workflows/dependabot-glean-parser.yml
@@ -80,8 +80,9 @@ jobs:
         run: .circleci/python_job.bash run build_glean
       - name: Commit changed file
         run: |
-          git diff-index --quiet HEAD
-          if $? -eq 0; then echo "no changes"; fi
+          exit_code=0
+          git diff-index --quiet HEAD || exit_code=$?
+          if (( exit_code == 0 )); then echo "no changes"; fi
           git config user.email "<>"
           git config user.name "GitHub Actions - Run new glean-parser"
           git diff

--- a/.github/workflows/dependabot-glean-parser.yml
+++ b/.github/workflows/dependabot-glean-parser.yml
@@ -80,7 +80,9 @@ jobs:
         run: .circleci/python_job.bash run build_glean
       - name: Commit changed file
         run: |
+          set -x
           exit_code=0
+          git diff-index HEAD
           git diff-index --quiet --exit-code --ignore-submodules HEAD || exit_code=$?
           if (( exit_code == 0 )); then echo "no changes, exit_code=$exit_code"; else echo "changes, exit_code=$exit_code"; fi
           git config user.email "<>"

--- a/.github/workflows/dependabot-glean-parser.yml
+++ b/.github/workflows/dependabot-glean-parser.yml
@@ -6,63 +6,9 @@ permissions:
   pull-requests: write
 
 jobs:
-  debug-variables:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print some variables
-        run: |
-          echo "GITHUB_ACTOR=$GITHUB_ACTOR"
-          echo "GITHUB_ACTOR_ID=$GITHUB_ACTOR_ID"
-          echo "GITHUB_BASE_REF=$GITHUB_BASE_REF"
-          echo "GITHUB_HEAD_REF=$GITHUB_HEAD_REF"
-          echo "GITHUB_REF=$GITHUB_REF"
-          echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"
-          echo "github.actor=${{github.actor}}"
-          echo "github.actor_id=${{github.actor_id}}"
-          echo "github.base_ref=${{ github.base_ref }}"
-          echo "github.head_ref=${{ github.head_ref }}"
-          echo "github.ref=${{ github.ref }}"
-          echo "github.ref_name=${{ github.ref_name }}"
-  has-glean-parser:
-    runs-on: ubuntu-latest
-    if: ${{ contains( github.head_ref, 'glean-parser' ) }}
-    steps:
-      - name: Success
-        run: echo "${{ github.head_ref }} contains 'glean-parser'"
-  starts-with-glean-parser:
-    runs-on: ubuntu-latest
-    if: ${{ startsWith( github.head_ref, 'dependabot/pip/glean-parser' ) }}
-    steps:
-      - name: Success
-        run: echo "${{ github.head_ref }} contains 'glean-parser'"
-  is-dependabot-name:
-    runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    steps:
-      - name: success
-        run: echo "${{ github.actor }} is 'dependabot[bot]'"
-  is-dependabot-id:
-    runs-on: ubuntu-latest
-    if: ${{ github.actor_id == 49699333 }}
-    steps:
-      - name: success
-        run: echo "${{ github.actor_d }} is 4969933 (dependabot[bot])"
-  is-jwhitlock-name:
-    runs-on: ubuntu-latest
-    if: ${{ github.actor == 'jwhitlock' }}
-    steps:
-      - name: success
-        run: echo "${{ github.actor }} is 'jwhitlock'"
-  is-jwhitlock-id:
-    runs-on: ubuntu-latest
-    if: ${{ github.actor_id == 286017 }}
-    steps:
-      - name: success
-        run: echo "${{ github.actor_d }} is 286017 (jwhitlock)"
-
   regen-with-new-glean-parser:
     runs-on: ubuntu-latest
-    if: ${{ true || github.actor == 'dependabot[bot]' && startsWith( github.head_ref, 'dependabot/pip/glean-parser' ) }}
+    if: ${{ github.actor == 'dependabot[bot]' && startsWith( github.head_ref, 'dependabot/pip/glean-parser' ) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -80,7 +26,6 @@ jobs:
         run: .circleci/python_job.bash run build_glean
       - name: Commit changed file
         run: |
-          set -x
           git config user.email "<>"
           git config user.name "GitHub Actions - Run new glean-parser"
           git diff

--- a/.github/workflows/dependabot-glean-parser.yml
+++ b/.github/workflows/dependabot-glean-parser.yml
@@ -25,10 +25,16 @@ jobs:
           echo "github.ref_name=${{ github.ref_name }}"
   has-glean-parser:
     runs-on: ubuntu-latest
-    if: ${{ contains( github.ref, 'glean-parser' ) }}
+    if: ${{ contains( github.head_ref, 'glean-parser' ) }}
     steps:
       - name: Success
-        run: echo "${{ github.ref }} contains 'glean-parser'"
+        run: echo "${{ github.head_ref }} contains 'glean-parser'"
+  starts-with-glean-parser:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith( github.head_ref, 'dependabot/pip/glean-parser' ) }}
+    steps:
+      - name: Success
+        run: echo "${{ github.head_ref }} contains 'glean-parser'"
   is-dependabot-name:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
@@ -56,7 +62,7 @@ jobs:
 
   regen-with-new-glean-parser:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' && contains( github.ref, 'glean-parser' ) }}
+    if: ${{ github.actor == 'dependabot[bot]' && startsWith( github.head_ref, 'dependabot/pip/glean-parser' ) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/dependabot-glean-parser.yml
+++ b/.github/workflows/dependabot-glean-parser.yml
@@ -81,8 +81,8 @@ jobs:
       - name: Commit changed file
         run: |
           exit_code=0
-          git diff-index --quiet HEAD || exit_code=$?
-          if (( exit_code == 0 )); then echo "no changes, exit_code=$exit_code"; else echo "change, exit_code=$exit_code"; fi
+          git diff-index --quiet --exit-code --ignore-submodules HEAD || exit_code=$?
+          if (( exit_code == 0 )); then echo "no changes, exit_code=$exit_code"; else echo "changes, exit_code=$exit_code"; fi
           git config user.email "<>"
           git config user.name "GitHub Actions - Run new glean-parser"
           git diff

--- a/.github/workflows/dependabot-glean-parser.yml
+++ b/.github/workflows/dependabot-glean-parser.yml
@@ -62,7 +62,7 @@ jobs:
 
   regen-with-new-glean-parser:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' && startsWith( github.head_ref, 'dependabot/pip/glean-parser' ) }}
+    if: ${{ true || github.actor == 'dependabot[bot]' && startsWith( github.head_ref, 'dependabot/pip/glean-parser' ) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -76,20 +76,13 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r requirements.txt
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Run glean-parser to regenerate code
         run: .circleci/python_job.bash run build_glean
       - name: Commit changed file
         run: |
           git config user.email "<>"
           git config user.name "GitHub Actions - Run new glean-parser"
+          git diff
           git add privaterelay/glean/server_events.py
           git commit --message="Re-generate code with glean-parser $GLEAN_VERSION" || echo "No changes to commit"
           git push
-        env:
-          GLEAN_VERSION: ${{steps.dependabot-metadata.outputs.new-version}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-glean-parser.yml
+++ b/.github/workflows/dependabot-glean-parser.yml
@@ -80,9 +80,11 @@ jobs:
         run: .circleci/python_job.bash run build_glean
       - name: Commit changed file
         run: |
+          git diff-index --quiet HEAD
+          if $? -eq 0; then echo "no changes"; fi
           git config user.email "<>"
           git config user.name "GitHub Actions - Run new glean-parser"
           git diff
           git add privaterelay/glean/server_events.py
           git commit --message="Re-generate code with glean-parser $GLEAN_VERSION" || echo "No changes to commit"
-          git push
+          git push origin HEAD:pull/${{ github.ref_name }}

--- a/.github/workflows/dependabot-glean-parser.yml
+++ b/.github/workflows/dependabot-glean-parser.yml
@@ -6,6 +6,54 @@ permissions:
   pull-requests: write
 
 jobs:
+  debug-variables:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print some variables
+        run: |
+          echo "GITHUB_ACTOR=$GITHUB_ACTOR"
+          echo "GITHUB_ACTOR_ID=$GITHUB_ACTOR_ID"
+          echo "GITHUB_BASE_REF=$GITHUB_BASE_REF"
+          echo "GITHUB_HEAD_REF=$GITHUB_HEAD_REF"
+          echo "GITHUB_REF=$GITHUB_REF"
+          echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"
+          echo "github.actor=${{github.actor}}"
+          echo "github.actor_id=${{github.actor_id}}"
+          echo "github.base_ref=${{ github.base_ref }}"
+          echo "github.head_ref=${{ github.head_ref }}"
+          echo "github.ref=${{ github.ref }}"
+          echo "github.ref_name=${{ github.ref_name }}"
+  has-glean-parser:
+    runs-on: ubuntu-latest
+    if: ${{ contains( github.ref, 'glean-parser' ) }}
+    steps:
+      - name: Success
+        run: echo "${{ github.ref }} contains 'glean-parser'"
+  is-dependabot-name:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: success
+        run: echo "${{ github.actor }} is 'dependabot[bot]'"
+  is-dependabot-id:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor_id == 49699333 }}
+    steps:
+      - name: success
+        run: echo "${{ github.actor_d }} is 4969933 (dependabot[bot])"
+  is-jwhitlock-name:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'jwhitlock' }}
+    steps:
+      - name: success
+        run: echo "${{ github.actor }} is 'jwhitlock'"
+  is-jwhitlock-id:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor_id == 286017 }}
+    steps:
+      - name: success
+        run: echo "${{ github.actor_d }} is 286017 (jwhitlock)"
+
   regen-with-new-glean-parser:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' && contains( github.ref, 'glean-parser' ) }}

--- a/.github/workflows/dependabot-glean-parser.yml
+++ b/.github/workflows/dependabot-glean-parser.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           exit_code=0
           git diff-index --quiet HEAD || exit_code=$?
-          if (( exit_code == 0 )); then echo "no changes"; fi
+          if (( exit_code == 0 )); then echo "no changes, exit_code=$exit_code"; else echo "change, exit_code=$exit_code"; fi
           git config user.email "<>"
           git config user.name "GitHub Actions - Run new glean-parser"
           git diff


### PR DESCRIPTION
*WIP: This will require a few rounds of experimentation before it is ready to review.*

The action `dependabot-glean-parser` is supposed to re-generate the folder https://github.com/mozilla/fx-private-relay/tree/main/privaterelay/glean when `glean-parser` is updated. This removes a manual step, and still allows us to check in our generated file (and skip a developer setup step). It did not run on the latest update (PR #4868). 