### PR TITLE
Added a user allow list to ignore abuse metrics, avoid race conditions in abuse metrics

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -929,5 +929,8 @@ SILENCED_SYSTEM_CHECKS = sorted(
 # django-ftl settings
 AUTO_RELOAD_BUNDLES = False  # Requires pyinotify
 
+# accounts that should not have abuse metrics
+ALLOWED_ACCOUNTS = ["relay-team+e2e@mozilla.com"]
+
 # Patching for django-types
 django_stubs_ext.monkeypatch()


### PR DESCRIPTION

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3720, MPP-3806.

<!-- When adding a new feature: -->

# Description

Adds atomic transaction and row locking for updating abuse metrics.

Also adds an 'allow' list so that our e2e test accounts do not get flagged. 


# Screenshot (if applicable)

Not applicable.


# Checklist (Definition of Done)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] Customer Experience team has seen or waived a demo of functionality.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
