### PR TITLE
MPP-3849: Add Puerto Rico to supported regions

### DIFF
--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -286,8 +286,8 @@ def test_realphone_post_valid_e164_number_in_unsupported_country(
     response = client.post(path, data, format="json", HTTP_X_CLIENT_REGION="nl")
     assert response.status_code == 400
     expected = [
-        "Relay Phone is currently only available for these country codes: ['CA', 'US']."
-        " Your phone number country code is: 'NL'."
+        "Relay Phone is currently only available for these country codes:"
+        " ['CA', 'PR', 'US']. Your phone number country code is: 'NL'."
     ]
     assert response.json() == expected
 

--- a/phones/models.py
+++ b/phones/models.py
@@ -293,7 +293,7 @@ class RelayNumber(models.Model):
         self.country_code = realphone.country_code.upper()
 
         # Add numbers to the Relay messaging service, so it goes into our
-        # US A2P 10DLC campaigns
+        # A2P 10DLC campaigns
         if use_twilio and self.country_code in settings.TWILIO_NEEDS_10DLC_CAMPAIGN:
             if settings.TWILIO_MESSAGING_SERVICE_SID:
                 register_with_messaging_service(client, twilio_incoming_number.sid)

--- a/privaterelay/plans.py
+++ b/privaterelay/plans.py
@@ -127,6 +127,7 @@ CountryStr = Literal[
     "NL",  # Netherlands
     "NZ",  # New Zealand
     "PL",  # Poland
+    "PR",  # Puerto Rico
     "PT",  # Portugal
     "RO",  # Romania
     "SE",  # Sweden
@@ -493,6 +494,7 @@ _RELAY_PLANS: _RelayPlans = {
             "CA": "US",  # Canada -> United States
             "MY": "GB",  # Malaysia -> United Kingdom
             "NZ": "GB",  # New Zealand -> United Kingdom
+            "PR": "US",  # Puerto Rico -> United States
             "SG": "GB",  # Singapore -> United Kingdom
         },
         "by_country_and_lang": {
@@ -510,11 +512,17 @@ _RELAY_PLANS: _RelayPlans = {
     },
     "phones": {
         "by_country": ["US"],  # United States
-        "by_country_override": {"CA": "US"},  # Canada -> United States
+        "by_country_override": {
+            "CA": "US",  # Canada -> United States
+            "PR": "US",  # Puerto Rico -> United States
+        },
     },
     "bundle": {
         "by_country": ["US"],  # United States
-        "by_country_override": {"CA": "US"},  # Canada -> United States
+        "by_country_override": {
+            "CA": "US",  # Canada -> United States
+            "PR": "US",  # Puerto Rico -> United States
+        },
     },
 }
 

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -282,7 +282,11 @@ TWILIO_MESSAGING_SERVICE_SID: list[str] = config(
 TWILIO_TEST_ACCOUNT_SID: str | None = config("TWILIO_TEST_ACCOUNT_SID", None)
 TWILIO_TEST_AUTH_TOKEN: str | None = config("TWILIO_TEST_AUTH_TOKEN", None)
 TWILIO_ALLOWED_COUNTRY_CODES = {
-    code.upper() for code in config("TWILIO_ALLOWED_COUNTRY_CODES", "US,CA", cast=Csv())
+    code.upper()
+    for code in config("TWILIO_ALLOWED_COUNTRY_CODES", "US,CA,PR", cast=Csv())
+}
+TWILIO_NEEDS_10DLC_CAMPAIGN = {
+    code.upper() for code in config("TWILIO_NEEDS_10DLC_CAMPAIGN", "US,PR", cast=Csv())
 }
 MAX_MINUTES_TO_VERIFY_REAL_PHONE: int = config(
     "MAX_MINUTES_TO_VERIFY_REAL_PHONE", 5, cast=int


### PR DESCRIPTION
[Puerto Rico](https://en.wikipedia.org/wiki/Puerto_Rico) is an unincorporated territory in the United States with the region code `PR`. Puerto Rico is supported by Mozilla VPN.

This adds Puerto Rico to the allowed regions for Relay Plans. Twilio supports [Puerto Rico](https://www.twilio.com/en-us/guidelines/pr/sms), and requires a 10 DLC campaign, like US numbers.