### PR TITLE
Use pull request user login to detect "dependabot[bot]"

### DIFF
--- a/.github/workflows/dependabot-glean-parser.yml
+++ b/.github/workflows/dependabot-glean-parser.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   regen-with-new-glean-parser:
     runs-on: ubuntu-latest
-    if: ${{ (github.actor == 'jwhitlock' || github.actor == 'dependabot[bot]') && startsWith( github.head_ref, 'dependabot/pip/glean-parser' ) }}
+    if: ${{ (github.event.pull_request.user.login == 'jwhitlock' || github.event.pull_request.user.login == 'dependabot[bot]') && startsWith( github.head_ref, 'dependabot/pip/glean-parser' ) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/dependabot-glean-parser.yml
+++ b/.github/workflows/dependabot-glean-parser.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   regen-with-new-glean-parser:
     runs-on: ubuntu-latest
-    if: ${{ (github.event.pull_request.user.login == 'jwhitlock' || github.event.pull_request.user.login == 'dependabot[bot]') && startsWith( github.head_ref, 'dependabot/pip/glean-parser' ) }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && startsWith( github.head_ref, 'dependabot/pip/glean-parser' ) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
According to a recent article by [synacktiv](https://www.synacktiv.com/publications/github-actions-exploitation-dependabot), the Dependabot credentials can be hijacked and used to create new jobs with:

```
github.actor == 'dependabot[bot]'
```

A way to check if dependabot is the real origin is to instead check:

```
github.event.pull_request.user.login == 'dependabot[bot]'
```

This check is repeated by the "dependabot/fetch-metadata@v2" code, so Relay has a partial mitigation:

https://github.com/dependabot/fetch-metadata/blob/efb8718212b9b67ae628ffc209cccb93af694cd7/src/dependabot/verified_commits.ts#L26-L30

This PR will more completely mitigate the issue.