### PR TITLE
MPP-3722, MPP-3513, MPP-3890, MPP-3373: Handle more errors when relaying SMS messages

### DIFF
--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -55,6 +55,7 @@ class RelayAPIException(APIException):
     default_detail: str
     status_code: int
     ftl_id: str
+    ftl_id_prefix = "api-error-"
 
     def __init__(
         self, detail: _APIExceptionInput = None, code: str | None = None
@@ -79,9 +80,8 @@ class RelayAPIException(APIException):
         error_code = self.get_codes()
         if not isinstance(error_code, str):
             raise TypeError("error_code must be type str")
-        ftl_id_sub = "api-error-"
         ftl_id_error = error_code.replace("_", "-")
-        expected_ftl_id = ftl_id_sub + ftl_id_error
+        expected_ftl_id = self.ftl_id_prefix + ftl_id_error
         if expected_ftl_id != self.ftl_id:
             raise ValueError(f'ftl_id is "{self.ftl_id}", expected "{expected_ftl_id}"')
 

--- a/api/tests/iq_views_tests.py
+++ b/api/tests/iq_views_tests.py
@@ -84,7 +84,7 @@ def test_iq_endpoint_invalid_hash():
 
     assert response.status_code == 401
     response_body = response.json()
-    assert "verficiationToken != computed sha256" in response_body["detail"]
+    assert "verificationToken != computed sha256" in response_body["detail"]
 
 
 @pytest.mark.django_db

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -1077,7 +1077,7 @@ def test_inbound_sms_reply(phone_user: User, mocked_twilio_client: Client) -> No
     real_phone = _make_real_phone(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user, enabled=True)
 
-    # Setup: Recieve a text from a contact
+    # Setup: Receive a text from a contact
     client = APIClient()
     path = "/api/v1/inbound_sms"
     contact_number = "+15556660000"
@@ -1109,7 +1109,7 @@ def test_inbound_sms_reply_to_first_caller(
     real_phone = _make_real_phone(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user, enabled=True)
 
-    # Setup: Recieve a text from a contact
+    # Setup: Receive a text from a contact
     client = APIClient()
     sms_path = "/api/v1/inbound_sms"
     contact_number = "+15556660000"
@@ -1119,7 +1119,7 @@ def test_inbound_sms_reply_to_first_caller(
     relay_number.refresh_from_db()
     assert relay_number.texts_forwarded == 1
 
-    # Setup: Recieve a call from the same contact
+    # Setup: Receive a call from the same contact
     voice_path = "/api/v1/inbound_call"
     data = {"Caller": contact_number, "Called": relay_number.number}
     response = client.post(voice_path, data, HTTP_X_TWILIO_SIGNATURE="valid")
@@ -1149,7 +1149,7 @@ def test_inbound_sms_reply_to_caller(
     real_phone = _make_real_phone(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user, enabled=True)
 
-    # Setup: Recieve a text from first contact
+    # Setup: Receive a text from first contact
     client = APIClient()
     sms_path = "/api/v1/inbound_sms"
     contact1_number = "+13015550000"
@@ -1163,7 +1163,7 @@ def test_inbound_sms_reply_to_caller(
     relay_number.refresh_from_db()
     assert relay_number.texts_forwarded == 1
 
-    # Setup: Recieve a text from second contact
+    # Setup: Receive a text from second contact
     contact2_number = "+13025550001"
     data = {
         "From": contact2_number,
@@ -1175,7 +1175,7 @@ def test_inbound_sms_reply_to_caller(
     relay_number.refresh_from_db()
     assert relay_number.texts_forwarded == 2
 
-    # Setup: Recieve a call from second contact
+    # Setup: Receive a call from second contact
     voice_path = "/api/v1/inbound_call"
     data = {"Caller": contact2_number, "Called": relay_number.number}
     response = client.post(voice_path, data, HTTP_X_TWILIO_SIGNATURE="valid")

--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -1041,7 +1041,7 @@ def test_inbound_sms_reply_not_storing_phone_log(
 
     assert response.status_code == 400
     decoded_content = response.content.decode()
-    assert "To Reply, You Must Allow " in decoded_content
+    assert "The reply feature requires " in decoded_content
     mocked_twilio_client.messages.create.assert_called_once()
     call_kwargs = mocked_twilio_client.messages.create.call_args.kwargs
     assert call_kwargs["to"] == real_phone.number
@@ -1062,7 +1062,7 @@ def test_inbound_sms_reply_no_previous_sender(phone_user, mocked_twilio_client):
 
     assert response.status_code == 400
     decoded_content = response.content.decode()
-    assert "You Can Only Reply To Phone Numbers" in decoded_content
+    assert "You can only reply to phone numbers " in decoded_content
     mocked_twilio_client.messages.create.assert_called_once()
     call_kwargs = mocked_twilio_client.messages.create.call_args.kwargs
     assert call_kwargs["to"] == real_phone.number

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -1431,7 +1431,11 @@ def _match_senders_by_prefix(relay_number: RelayNumber, text: str) -> MatchData 
         contacts_by_number: dict[str, InboundContact] = {}
         for contact in contacts:
             # TODO: don't default to US when we support other regions
-            pn = phonenumbers.parse(contact.inbound_number, DEFAULT_REGION)
+            try:
+                pn = phonenumbers.parse(contact.inbound_number, DEFAULT_REGION)
+            except phonenumbers.phonenumberutil.NumberParseException:
+                # Invalid number like '1', skip it
+                continue
             e164 = phonenumbers.format_number(pn, phonenumbers.PhoneNumberFormat.E164)
             if e164 not in contacts_by_number:
                 contacts_by_number[e164] = contact

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -407,7 +407,7 @@ class RelayNumberViewSet(SaveToRequestUser, viewsets.ModelViewSet):
                 ],
             ),
             "404": OpenApiResponse(
-                description="Neither location or area_code was speciifed"
+                description="Neither location or area_code was specified"
             ),
         },
     )
@@ -1741,7 +1741,7 @@ def _validate_iq_request(request: Request) -> None:
     token = request._request.headers["verificationToken"]
 
     if mac != token:
-        raise exceptions.AuthenticationFailed("verficiationToken != computed sha256")
+        raise exceptions.AuthenticationFailed("verificationToken != computed sha256")
 
 
 def convert_twilio_messages_to_dict(twilio_messages):

--- a/emails/exceptions.py
+++ b/emails/exceptions.py
@@ -12,12 +12,14 @@ class CannotMakeAddressException(RelayAPIException):
 class AccountIsPausedException(CannotMakeAddressException):
     default_code = "account_is_paused"
     default_detail = "Your account is on pause."
+    ftl_id = "api-error-account-is-paused"
     status_code = 403
 
 
 class AccountIsInactiveException(CannotMakeAddressException):
     default_code = "account_is_inactive"
     default_detail = "Your account is not active."
+    ftl_id = "api-error-account-is-inactive"
     status_code = 403
 
 
@@ -28,6 +30,7 @@ class RelayAddrFreeTierLimitException(CannotMakeAddressException):
         " You can reuse an existing mask, but using a unique mask for each account is"
         " the most secure option."
     )
+    ftl_id = "api-error-free-tier-limit"
     status_code = 403
 
     def __init__(self, free_tier_limit: int | None = None):
@@ -44,12 +47,14 @@ class DomainAddrFreeTierException(CannotMakeAddressException):
         "Your free account does not include custom subdomains for masks."
         " To create custom masks, upgrade to Relay Premium."
     )
+    ftl_id = "api-error-free-tier-no-subdomain-masks"
     status_code = 403
 
 
 class DomainAddrNeedSubdomainException(CannotMakeAddressException):
     default_code = "need_subdomain"
     default_detail = "Please select a subdomain before creating a custom email address."
+    ftl_id = "api-error-need-subdomain"
     status_code = 400
 
 
@@ -58,6 +63,7 @@ class DomainAddrUpdateException(CannotMakeAddressException):
 
     default_code = "address_not_editable"
     default_detail = "You cannot edit an existing domain address field."
+    ftl_id = "api-error-address-not-editable"
     status_code = 400
 
 
@@ -67,6 +73,7 @@ class DomainAddrUnavailableException(CannotMakeAddressException):
         "“{unavailable_address}” could not be created."
         " Please try again with a different mask name."
     )
+    ftl_id = "api-error-address-unavailable"
     status_code = 400
 
     def __init__(self, unavailable_address: str):
@@ -83,6 +90,7 @@ class DomainAddrDuplicateException(CannotMakeAddressException):
         "“{duplicate_address}” already exists."
         " Please try again with a different mask name."
     )
+    ftl_id = "api-error-duplicate-address"
     status_code = 409
 
     def __init__(self, duplicate_address: str):

--- a/phones/exceptions.py
+++ b/phones/exceptions.py
@@ -1,0 +1,109 @@
+"""Exceptions raised by phones app"""
+
+from django.conf import settings
+
+from api.exceptions import ErrorContextType, RelayAPIException
+
+
+class RelaySMSException(RelayAPIException):
+    """Base exception for SMS text issues"""
+
+    ftl_id_prefix = "sms-error-"
+
+
+class NoPhoneLog(RelaySMSException):
+    default_code = "no_phone_log"
+    default_detail_template = (
+        "The reply feature requires Firefox Relay to keep a log of your callers"
+        " and text senders. You can reply to future messages by enabling “Caller and"
+        " texts log” in Settings: {account_settings_url}"
+    )
+    ftl_id = "sms-error-no-phone-log"
+    status_code = 400
+
+    def error_context(self) -> ErrorContextType:
+        return {
+            "account_settings_url": f"{settings.SITE_ORIGIN or ''}/accounts/settings/"
+        }
+
+
+class NoPreviousSender(RelaySMSException):
+    default_code = "no_previous_sender"
+    default_detail = (
+        "Message failed to send. You can only reply to phone numbers that have sent"
+        " you a text message."
+    )
+    ftl_id = "sms-error-no-previous-sender"
+    status_code = 400
+
+
+class ShortPrefixException(RelaySMSException):
+    """Base exception for short prefix exceptions"""
+
+    status_code = 200
+
+    def __init__(self, short_prefix: str):
+        self.short_prefix = short_prefix
+        super().__init__()
+
+    def error_context(self) -> ErrorContextType:
+        return {"short_prefix": self.short_prefix}
+
+
+class FullNumberException(RelaySMSException):
+    """Base exception for full number exceptions"""
+
+    status_code = 200
+
+    def __init__(self, full_number: str):
+        self.full_number = full_number
+        super().__init__()
+
+    def error_context(self) -> ErrorContextType:
+        return {"full_number": self.full_number}
+
+
+class ShortPrefixMatchesNoSenders(ShortPrefixException):
+    default_code = "short_prefix_matches_no_senders"
+    default_detail_template = (
+        "Message failed to send. There is no phone number in this thread ending"
+        " in {short_prefix}. Please check the number and try again."
+    )
+    ftl_id = "sms-error-short-prefix-matches-no-senders"
+
+
+class FullNumberMatchesNoSenders(FullNumberException):
+    default_code = "full_number_matches_no_senders"
+    default_detail_template = (
+        "Message failed to send. There is no previous sender with the phone"
+        " number {full_number}. Please check the number and try again."
+    )
+    ftl_id = "sms-error-full-number-matches-no-senders"
+
+
+class MultipleNumberMatches(ShortPrefixException):
+    default_code = "multiple_number_matches"
+    default_detail_template = (
+        "Message failed to send. There is more than one phone number in this"
+        " thread ending in {short_prefix}. To retry, start your message with"
+        " the complete number."
+    )
+    ftl_id = "sms-error-multiple-number-matches"
+
+
+class NoBodyAfterShortPrefix(ShortPrefixException):
+    default_code = "no_body_after_short_prefix"
+    default_detail_template = (
+        "Message failed to send. Please include a message after the sender identifier"
+        " {short_prefix}."
+    )
+    ftl_id = "sms-error-no-body-after-short-prefix"
+
+
+class NoBodyAfterFullNumber(FullNumberException):
+    default_code = "no_body_after_full_number"
+    default_detail_template = (
+        "Message failed to send. Please include a message after the phone number"
+        " {full_number}."
+    )
+    ftl_id = "sms-error-no-body-after-full-number"

--- a/privaterelay/glean_interface.py
+++ b/privaterelay/glean_interface.py
@@ -73,7 +73,7 @@ class UserData(NamedTuple):
         if not metrics_enabled:
             return cls(metrics_enabled=False)
 
-        fxa_id = user.profile.fxa.uid if user.profile.fxa else None
+        fxa_id = user.profile.metrics_fxa_id or None
         n_random_masks = user.relayaddress_set.count()
         n_domain_masks = user.domainaddress_set.count()
         n_deleted_random_masks = user.profile.num_deleted_relay_addresses

--- a/privaterelay/models.py
+++ b/privaterelay/models.py
@@ -426,12 +426,12 @@ class Profile(models.Model):
             midnight_utc_today = datetime.combine(
                 datetime.now(UTC).date(), datetime.min.time()
             ).astimezone(UTC)
-            midnight_utc_tomorow = midnight_utc_today + timedelta(days=1)
+            midnight_utc_tomorrow = midnight_utc_today + timedelta(days=1)
             abuse_metric = (
                 self.user.abusemetrics_set.select_for_update()
                 .filter(
                     first_recorded__gte=midnight_utc_today,
-                    first_recorded__lt=midnight_utc_tomorow,
+                    first_recorded__lt=midnight_utc_tomorrow,
                 )
                 .first()
             )

--- a/privaterelay/models.py
+++ b/privaterelay/models.py
@@ -559,6 +559,13 @@ class Profile(models.Model):
             return "free"
         return f"{plan}_{self.plan_term}"
 
+    @property
+    def metrics_fxa_id(self) -> str:
+        """Return Mozilla Accounts ID if user has metrics enabled, else empty string"""
+        if (fxa := self.fxa) and self.metrics_enabled and isinstance(fxa.uid, str):
+            return fxa.uid
+        return ""
+
 
 class RegisteredSubdomain(models.Model):
     subdomain_hash = models.CharField(max_length=64, db_index=True, unique=True)

--- a/privaterelay/tests/model_tests.py
+++ b/privaterelay/tests/model_tests.py
@@ -810,3 +810,21 @@ class ProfileMetricsPremiumStatus(ProfileTestCase):
     def test_vpn_bundle_user(self) -> None:
         self.upgrade_to_vpn_bundle()
         assert self.profile.metrics_premium_status == "bundle_unknown"
+
+
+class ProfileMetricsFxaID(ProfileTestCase):
+    def test_metrics_fxa_id_no_social_account(self) -> None:
+        assert not SocialAccount.objects.filter(user=self.profile.user).exists()
+        assert self.profile.metrics_fxa_id == ""
+
+    def test_metrics_fxa_id_metrics_enabled(self) -> None:
+        social_account = self.get_or_create_social_account()
+        assert self.profile.metrics_enabled
+        assert self.profile.metrics_fxa_id == social_account.uid
+
+    def test_metrics_fxa_id_metrics_disabled(self) -> None:
+        social_account = self.get_or_create_social_account()
+        social_account.extra_data["metricsEnabled"] = False
+        social_account.save()
+        assert not self.profile.metrics_enabled
+        assert self.profile.metrics_fxa_id == ""

--- a/privaterelay/tests/utils.py
+++ b/privaterelay/tests/utils.py
@@ -168,7 +168,7 @@ def create_expected_glean_event(
 
     # Get values from the user object
     if user.profile.fxa:
-        user_extra_items["fxa_id"] = user.profile.fxa.uid
+        user_extra_items["fxa_id"] = user.profile.metrics_fxa_id
         user_extra_items["premium_status"] = user.profile.metrics_premium_status
     user_extra_items["date_joined_relay"] = str(int(user.date_joined.timestamp()))
     if user.profile.date_subscribed:


### PR DESCRIPTION
This PR addresses a few tickets, to remove some 500 errors from the service:

* MPP-3722: Changes the `RelaySMSException` classes to be based on `RelayAPIException`
  - Also sets `ftl_id` on the exception classes, to make it easier to cross-reference exceptions to the translated versions
  - Also move exceptions to `/phones/exceptions.py`
  - Sync `NoPhoneLog` message with translations
  - Update `TemplateTwiMLRenderer` to handle `RelaySMSException` without having to wrap in `rest_framework.exceptions.ValidationError`
  - Skip title case for `RelaySMSException`, keep for `ValidationError`
* MPP-3513: `ShortPrefixMatchesNoSenders` - Log at INFO instead of sending an exception to Sentry. This is done for all exceptions derived from `RelaySMSException`, for Twilio and iQ
* MPP-3890: When the number for a previous contact can not be parsed by the `phonenumbers`, skip it rather than raise the exception
* MPP-3373 (addressed but not fixed) - When a Relay user has sent `STOP` to their Relay number, we can't send them any more messages. Log this as INFO and reply with an empty "OK" response to Twilio. This prevents the 500 error, but doesn't help the Relay user discover the issue. An obvious next step is to set a flag on the `RelayNumber` or `RealNumber` that the user has blocked their Relay number, so we can show that in the frontend.
* Fix some typos detected by [typos](https://github.com/crate-ci/typos)

If this is too much for one PR, I can break it up.

How to test:

- [x] l10n changes have been submitted to the l10n repository, if any - https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/174
- [x] I've added a unit test to test for potential regressions of this bug.
- ~I've added or updated relevant docs in the docs/ directory.~
- ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
