### PR TITLE
Update locales for `api-error-account-is-inactive`

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -124,5 +124,3 @@ upsell-banner-4-masks-us-cta = Upgrade to { -brand-name-relay-premium }
 
 -brand-name-mozilla-monitor = Mozilla Monitor
 moz-monitor = { -brand-name-mozilla-monitor }
-
-api-error-account-is-inactive = Your account is not active.

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -3,4 +3,3 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # This is the Django equivalent of frontend/pendingTranslations.ftl
-api-error-account-is-inactive = Your account is not active.


### PR DESCRIPTION
The id `api-error-account-is-inactive` has been merged upstream, so remove it from pending translations.