### PR TITLE
Update Base Load Engineer playbook

### DIFF
--- a/docs/base-load-engineer-playbook.md
+++ b/docs/base-load-engineer-playbook.md
@@ -56,19 +56,23 @@ another more appropriate party.
 2. SRE processes ticket to release the tag to production
 3. Update [Github Release][github-releases] to current release
 4. Monitor [Sentry Releases][sentry-releases] for new production issues
-5. (On your 1st Tuesday) Before releasing to Stage, [run e2e tests][run-e2e-tests] against the dev environment via GitHub Actions.
+5. (On your 3rd Tuesday) Hand-off base load duties to next engineer in rotation
+
+## Wednesdays
+
+1. Daily routine
+2. Before releasing to Stage, [run e2e tests][run-e2e-tests] against the dev environment via GitHub Actions.
    - Ensure that the e2e tests are passing.
    - If e2e Playwright tests are flaky--fails to pass for reasons outside of legitimate Relay bug--consider making the tests more reliable by using the [locators][playwright-locators], [auto-retrying assertions][playwright-auto-retrying-assertions], or [fixtures][playwright-fixtures]. For more suggestions on making Playwright tests more reliable or efficient, see [documentation on FxA test improvements][fxa-test-improvements].
-6. (On your 1st Tuesday) [Release to stage][Release-to-stage] (tag, Github release notes)
+3. [Release to stage][Release-to-stage] (tag, Github release notes)
    - Ping all the engineers who have changes in the release to:
      - Move cards to “Ready to Test” if necessary
      - Include instructions for QA to test
    - Confirm any hotfixes are also in the new tag
-7. (On your 2nd Tuesday) Hand-off base load duties to next engineer in rotation
 
-## Wednesdays - Fridays
+## Thursday and Fridays
 
-Daily routine
+1. Daily routine
 
 [security-dependabot-alerts]: https://github.com/mozilla/fx-private-relay/security/dependabot
 [whats-deployed]: https://whatsdeployed.io/s/60j/mozilla/fx-private-relay


### PR DESCRIPTION
This updates the playbook for some items that we discussed in Slack:

* The base load engineer (BLE) has 3 Tuesdays:
  - The Tuesday where the previous BLE releases to production and hands over BLE duties
  - The Tuesday where the BLE releases to production
  - The Tuesday where the BLE releases to production and hands over BLE duties to the next BLE
* Tag on Wednesdays, so that the BLE is releasing a tag that they created