### PR TITLE
MPP-3897: Add managers to RealPhone to handle multiple phones per user

### DIFF
--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -162,9 +162,9 @@ class RealPhoneViewSet(SaveToRequestUser, viewsets.ModelViewSet):
             try:
                 valid_record = (
                     RealPhone.recent_objects.get_for_user_number_and_verification_code(
-                        user=request.user,
-                        number=serializer.validated_data["number"],
-                        verification_code=verification_code,
+                        request.user,
+                        serializer.validated_data["number"],
+                        verification_code,
                     )
                 )
             except RealPhone.DoesNotExist:

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -1168,7 +1168,7 @@ def outbound_call(request):
             {"detail": "Requires outbound_phone waffle flag."}, status=403
         )
     try:
-        real_phone = RealPhone.objects.get(user=request.user, verified=True)
+        real_phone = RealPhone.verified_objects.get_for_user(user=request.user)
     except RealPhone.DoesNotExist:
         return response.Response(
             {"detail": "Requires a verified real phone and phone mask."}, status=400

--- a/phones/models.py
+++ b/phones/models.py
@@ -391,7 +391,7 @@ def relaynumber_post_save(sender, instance, created, **kwargs):
 
 
 def send_welcome_message(user, relay_number):
-    real_phone = RealPhone.objects.get(user=user)
+    real_phone = RealPhone.objects.get(user=user, verified=True)
     if not settings.SITE_ORIGIN:
         raise ValueError(
             "settings.SITE_ORIGIN must contain a value when calling "

--- a/phones/models.py
+++ b/phones/models.py
@@ -117,6 +117,9 @@ class ExpiredRealPhoneManager(models.Manager["RealPhone"]):
             )
         )
 
+    def delete_for_number(self, number: str) -> tuple[int, dict[str, int]]:
+        return self.filter(number=number).delete()
+
 
 class RecentRealPhoneManager(models.Manager["RealPhone"]):
     """Return RealPhone records where the sent verification is still valid."""
@@ -188,7 +191,7 @@ class RealPhone(models.Model):
         # note: it doesn't matter which user is trying to create a new
         # RealPhone record - any expired unverified record for the number
         # should be deleted
-        RealPhone.expired_objects.filter(number=self.number).delete()
+        RealPhone.expired_objects.delete_for_number(self.number)
 
         # We are not ready to support multiple real phone numbers per user,
         # so raise an exception if this save() would create a second

--- a/phones/tests/models_tests.py
+++ b/phones/tests/models_tests.py
@@ -655,7 +655,7 @@ def test_relaynumber_remaining_minutes_returns_properly_formats_remaining_second
     relay_number_obj.save()
     assert relay_number_obj.remaining_minutes == 8
 
-    # If more call time is spent than alotted (negative remaining_seconds),
+    # If more call time is spent than allotted (negative remaining_seconds),
     # the remaining_minutes property should return zero
     relay_number_obj.remaining_seconds = -522
     relay_number_obj.save()

--- a/phones/tests/models_tests.py
+++ b/phones/tests/models_tests.py
@@ -25,7 +25,6 @@ if settings.PHONES_ENABLED:
         RealPhone,
         RelayNumber,
         area_code_numbers,
-        get_expired_unverified_realphone_records,
         get_last_text_sender,
         get_valid_realphone_verification_record,
         iq_fmt,
@@ -205,13 +204,13 @@ def test_create_realphone_deletes_expired_unverified_records(
             - timedelta(0, 60 * settings.MAX_MINUTES_TO_VERIFY_REAL_PHONE + 1)
         ),
     )
-    expired_verification_records = get_expired_unverified_realphone_records(number)
+    expired_verification_records = RealPhone.expired_objects.filter(number=number)
     assert len(expired_verification_records) >= 1
     mock_twilio_client.messages.create.assert_called_once()
 
     # now try to create the new record
     RealPhone.objects.create(user=baker.make(User), number=number)
-    expired_verification_records = get_expired_unverified_realphone_records(number)
+    expired_verification_records = RealPhone.expired_objects.filter(number=number)
     assert len(expired_verification_records) == 0
     mock_twilio_client.messages.create.assert_called()
 

--- a/privaterelay/models.py
+++ b/privaterelay/models.py
@@ -378,7 +378,7 @@ class Profile(models.Model):
         from phones.models import RealPhone, RelayNumber
 
         try:
-            real_phone = RealPhone.objects.get(user=self.user, verified=True)
+            real_phone = RealPhone.verified_objects.get(user=self.user)
             relay_number = RelayNumber.objects.get(user=self.user)
         except RealPhone.DoesNotExist:
             return None

--- a/privaterelay/models.py
+++ b/privaterelay/models.py
@@ -378,7 +378,7 @@ class Profile(models.Model):
         from phones.models import RealPhone, RelayNumber
 
         try:
-            real_phone = RealPhone.objects.get(user=self.user)
+            real_phone = RealPhone.objects.get(user=self.user, verified=True)
             relay_number = RelayNumber.objects.get(user=self.user)
         except RealPhone.DoesNotExist:
             return None

--- a/privaterelay/models.py
+++ b/privaterelay/models.py
@@ -378,7 +378,7 @@ class Profile(models.Model):
         from phones.models import RealPhone, RelayNumber
 
         try:
-            real_phone = RealPhone.verified_objects.get(user=self.user)
+            real_phone = RealPhone.verified_objects.get_for_user(self.user)
             relay_number = RelayNumber.objects.get(user=self.user)
         except RealPhone.DoesNotExist:
             return None

--- a/privaterelay/tests/model_tests.py
+++ b/privaterelay/tests/model_tests.py
@@ -263,6 +263,20 @@ class ProfileDatePhoneRegisteredTest(ProfileTestCase):
         )
         assert self.profile.date_phone_registered == datetime_now
 
+    def test_two_real_phones_returns_verified_date(self) -> None:
+        self.upgrade_to_phone()
+        datetime_now = datetime.now(UTC)
+        RealPhone.objects.create(
+            user=self.profile.user, number="+12223335555", verified=False
+        )
+        RealPhone.objects.create(
+            user=self.profile.user,
+            number="+12223334444",
+            verified=True,
+            verified_date=datetime_now,
+        )
+        assert self.profile.date_phone_registered == datetime_now
+
     def test_real_phone_and_relay_number_w_created_at_returns_created_at_date(
         self,
     ) -> None:


### PR DESCRIPTION
This PR adds managers with helper methods to `RealPhone`, and updates the code to use them. The managers and methods:

* `RealPhone.objects` - The original, can still be used in tests or when working with all `RealPhone` objects.
* `RealPhone.verified_objects` - `RealPhone` objects that the user has verified via a texted verification code.
   - `.get_for_user(user)` - Return the verified `RealPhone` object for the user, or raise `DoesNotExist`. Used to get the `RealPhone` for a requesting user.
   - `.exists_for_number(number)` - Returns True if there is a verified `RealPhone` object for the phone number. Used to determine if a number is already claimed.
   - `.country_code_for_user(user)` - Returns the country code of the user's verified `RealPhone`. Used to limit the suggested Relay numbers to the user's country code.
* `RealPhone.recent_objects` - `RealPhone` objects where a verification code was recently sent
  - `.get_for_user_number_and_verification_code(user, number, code)` - Used to check that a verification code is the one sent by the authorized user to their phone number, and that it hasn't been too long since it was sent. To keep double submissions from being errors, the `RealPhone` can already be verified.
* `RealPhone.pending_objects` - Similar to `RealPhone.recent_objects`, except only the unverified `RealPhone` objects.
  - `exists_for_number(number)` - Check if a pending verification code is currently active for this number, to prevent having two pending codes at the same time and a potential abuse vector.
* `RealPhone.expired_objects` - The opposite of `RealPhone.recent_objects` - `RealPhone` objects where the verification code was sent a long time ago and is no longer valid.
  - `delete_for_number(number)` - Delete any expired records for a particular number. Used in the `RealPhone` save method for ... reasons.
  
This PR fixes a few bugs around `RealPhone` queries when a user has multiple `RealPhone` records, like a verified `RealPhone` and some unverified `RealPhone` for other numbers they tried:

* `/api/v1/profiles/` returns a 500 error, trying to determine when they subscribed to  The code now only queries for the verified `RealPhone`, and there should be one per user (enforced by code, not the database)
* Calls to `send_welcome_message`, to send them their Relay number and contact info, fail. The codenow only queries for the verified `RealPhone`.
* Using `./manage.py delete_phone_data` will fail. Now it deletes all the user's `RealPhone` records, and reports one per line.

How to test: Unit tests should be sufficient. If you want to try live tests, ensure you add an unverified `RealPhone` before a verified `RealPhone`. The code will not allow you to register a new `RealPhone` if you have a verified one.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
