### PR TITLE
For first mask, look for any masks

### DIFF
--- a/e2e-tests/pages/dashboardPage.ts
+++ b/e2e-tests/pages/dashboardPage.ts
@@ -260,10 +260,16 @@ export class DashboardPage {
       await this.premiumRandomMask.click();
     }
 
-    // Wait for the mask card count to increase, or the error banner
-    expect(
-      this.bannerEmailError.or(maskCards.nth(preMaskCardsCount)),
-    ).toBeVisible({ timeout: 3000 });
+    if (preMaskCardsCount === 0) {
+      // Wait for the first mask card
+      expect(maskCards).toBeVisible({ timeout: 3000 });
+    } else {
+      // Wait for the mask card count to increase, or the error banner
+      expect(
+        this.bannerEmailError.or(maskCards.nth(preMaskCardsCount)),
+      ).toBeVisible({ timeout: 3000 });
+    }
+
     expect(
       this.bannerEmailError,
       "No mask error banner. If fails, maybe rate-limited?",


### PR DESCRIPTION
Some E2E tests appear to fail when adding the first mask, because the `nth(1)` check has an exception when there are no masks. Handle this by looking for any mask, which should be the first one.