### PR TITLE
MPP-3905: Filter more settings / environment variables

### DIFF
--- a/privaterelay/debug.py
+++ b/privaterelay/debug.py
@@ -1,0 +1,25 @@
+import re
+
+from django.views.debug import SafeExceptionReporterFilter
+
+
+class RelaySaferExceptionReporterFilter(SafeExceptionReporterFilter):
+    """
+    Add more settings values that should be hidden in debug and exception reports.
+
+    This is also used by the Django Debug Toolbar settings panel.
+    """
+
+    # Hide any variable value that starts with these prefixes
+    UNSAFE_PREFIXES = ["AWS_", "IQ_", "TWILIO_"]
+
+    # Hide any variable value named in this list
+    UNSAFE_NAMES = ["ALLOWED_ACCOUNTS", "ALLOWED_HOSTS", "DJANGO_ALLOWED_HOSTS"]
+
+    hidden_settings = re.compile(
+        "API|TOKEN|KEY|SECRET|PASS|SIGNATURE|HTTP_COOKIE|"
+        + "|".join(f"^{prefix}" for prefix in UNSAFE_PREFIXES)
+        + "|"
+        + "|".join(f"^{name}$" for name in UNSAFE_NAMES),
+        re.IGNORECASE,
+    )

--- a/privaterelay/debug.py
+++ b/privaterelay/debug.py
@@ -19,10 +19,14 @@ class RelaySaferExceptionReporterFilter(SafeExceptionReporterFilter):
         "ALLOWED_ACCOUNTS",
         "ALLOWED_HOSTS",
         "DJANGO_ALLOWED_HOSTS",
+        "INTERNAL_IPS",
         # Environment Variables / META
         "CSRF_COOKIE",
         "DATABASE_URL",
         "DJANGO_ALLOWED_HOST",
+        "DJANGO_ALLOWED_SUBNET",
+        "DJANGO_INTERNAL_IPS",
+        "GOOGLE_APPLICATION_CREDENTIALS",
         "GOOGLE_CLOUD_PROFILER_CREDENTIALS_B64",
         "SENTRY_DSN",
     ]

--- a/privaterelay/debug.py
+++ b/privaterelay/debug.py
@@ -11,10 +11,21 @@ class RelaySaferExceptionReporterFilter(SafeExceptionReporterFilter):
     """
 
     # Hide any variable value that starts with these prefixes
-    UNSAFE_PREFIXES = ["AWS_", "IQ_", "TWILIO_"]
+    UNSAFE_PREFIXES = ["AWS_", "IQ_", "TWILIO_", "REDIS_"]
 
     # Hide any variable value named in this list
-    UNSAFE_NAMES = ["ALLOWED_ACCOUNTS", "ALLOWED_HOSTS", "DJANGO_ALLOWED_HOSTS"]
+    UNSAFE_NAMES = [
+        # Settings
+        "ALLOWED_ACCOUNTS",
+        "ALLOWED_HOSTS",
+        "DJANGO_ALLOWED_HOSTS",
+        # Environment Variables / META
+        "CSRF_COOKIE",
+        "DATABASE_URL",
+        "DJANGO_ALLOWED_HOST",
+        "GOOGLE_CLOUD_PROFILER_CREDENTIALS_B64",
+        "SENTRY_DSN",
+    ]
 
     hidden_settings = re.compile(
         "API|TOKEN|KEY|SECRET|PASS|SIGNATURE|HTTP_COOKIE|"

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -91,6 +91,9 @@ if DEBUG:
     INTERNAL_IPS = config("DJANGO_INTERNAL_IPS", default="", cast=Csv())
 IN_PYTEST: bool = "pytest" in sys.modules
 USE_SILK = DEBUG and HAS_SILK and not IN_PYTEST
+DEFAULT_EXCEPTION_REPORTER_FILTER = (
+    "privaterelay.debug.RelaySaferExceptionReporterFilter"
+)
 
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/privaterelay/tests/debug_tests.py
+++ b/privaterelay/tests/debug_tests.py
@@ -1,0 +1,74 @@
+from django.conf import settings
+from django.views.debug import get_default_exception_reporter_filter
+
+import pytest
+
+from privaterelay.debug import RelaySaferExceptionReporterFilter
+
+
+def test_default_filter() -> None:
+    assert isinstance(
+        get_default_exception_reporter_filter(), RelaySaferExceptionReporterFilter
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        "ACCOUNT_ADAPTER",
+        "LOGGING_CONFIG",
+    ),
+)
+def test_safe_settings(name: str) -> None:
+    assert hasattr(settings, name)
+    safe_settings = RelaySaferExceptionReporterFilter().get_safe_settings()
+    assert name in safe_settings
+    assert safe_settings[name] == getattr(settings, name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        "ALLOWED_ACCOUNTS",
+        "ALLOWED_HOSTS",
+        "AUTH_PASSWORD_VALIDATORS",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_REGION",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SES_CONFIGSET",
+        "AWS_SNS_KEY_CACHE",
+        "AWS_SNS_TOPIC",
+        "AWS_SQS_EMAIL_DLQ_URL",
+        "AWS_SQS_EMAIL_QUEUE_URL",
+        "AWS_SQS_QUEUE_URL",
+        "DJANGO_ALLOWED_HOSTS",
+        "IQ_ENABLED",
+        "IQ_FOR_NEW_NUMBERS",
+        "IQ_FOR_VERIFICATION",
+        "IQ_INBOUND_API_KEY",
+        "IQ_MAIN_NUMBER",
+        "IQ_MESSAGE_API_ORIGIN",
+        "IQ_MESSAGE_PATH",
+        "IQ_OUTBOUND_API_KEY",
+        "IQ_PUBLISH_MESSAGE_URL",
+        "PASSWORD_HASHERS",
+        "PASSWORD_RESET_TIMEOUT",
+        "SECRET_KEY",
+        "SECRET_KEY_FALLBACKS",
+        "TWILIO_ACCOUNT_SID",
+        "TWILIO_ALLOWED_COUNTRY_CODES",
+        "TWILIO_AUTH_TOKEN",
+        "TWILIO_MAIN_NUMBER",
+        "TWILIO_MESSAGING_SERVICE_SID",
+        "TWILIO_NEEDS_10DLC_CAMPAIGN",
+        "TWILIO_SMS_APPLICATION_SID",
+        "TWILIO_TEST_ACCOUNT_SID",
+        "TWILIO_TEST_AUTH_TOKEN",
+    ),
+)
+def test_unsafe_settings(name: str) -> None:
+    assert hasattr(settings, name)
+    safe_settings = RelaySaferExceptionReporterFilter().get_safe_settings()
+    assert name in safe_settings
+    assert safe_settings[name] != getattr(settings, name)
+    assert safe_settings[name] == RelaySaferExceptionReporterFilter.cleansed_substitute


### PR DESCRIPTION
Extend the Django default filter to prevent showing sensitive values when `DEBUG=True`. This is enabled on local development machines and occasionally in a development deployment.

# How to test

Run the service with `DEBUG=True`, and go to a URL that will raise an exception like http://127.0.0.1:8000/__debug__/render_panel/. The debug exception handler should run, and the META and SETTINGS sections should have more entries with `'********************'` values.