### PR TITLE
MPP-3932: Add flag 'developer_mode', use to simulate complaint and log notifications

### DIFF
--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -179,7 +179,9 @@ def create_notification_from_email(email_text: str) -> AWS_SNSMessageJSON:
     # This function cannot handle malformed To: addresses
     assert not getattr(email["To"], "defects")
     email_date = (
-        getattr(email["Date"], "datetime") if "Date" in email else datetime.now()
+        getattr(email["Date"], "datetime")
+        if "Date" in email
+        else (datetime.now() - timedelta(minutes=5))
     )
 
     sns_message = {

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -1122,6 +1122,8 @@ class ComplaintHandlingTest(TestCase):
         self.user.profile.refresh_from_db()
         assert self.user.profile.auto_block_spam is True
 
+        self.mock_ses_client.send_raw_email.assert_not_called()
+
         mm.assert_incr_once(
             "fx.private.relay.email_complaint",
             tags=[
@@ -1151,6 +1153,8 @@ class ComplaintHandlingTest(TestCase):
 
         with self.assertLogs(INFO_LOG) as logs:
             _sns_notification(self.complaint_body)
+
+        self.mock_ses_client.send_raw_email.assert_not_called()
 
         log_data = log_extra(logs.records[0])
         assert log_data["user_match"] == "found"

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -1115,6 +1115,8 @@ class ComplaintHandlingTest(TestCase):
         self.user.profile.refresh_from_db()
         assert self.user.profile.auto_block_spam is True
 
+        self.ra.refresh_from_db()
+        assert self.ra.enabled
         self.mock_ses_client.send_raw_email.assert_not_called()
 
         mm.assert_incr_once(
@@ -1147,6 +1149,11 @@ class ComplaintHandlingTest(TestCase):
         with self.assertLogs(INFO_LOG) as logs:
             _sns_notification(self.complaint_body)
 
+        self.user.profile.refresh_from_db()
+        assert self.user.profile.auto_block_spam is True
+
+        self.ra.refresh_from_db()
+        assert self.ra.enabled
         self.mock_ses_client.send_raw_email.assert_not_called()
 
         log_data = log_extra(logs.records[0])
@@ -1165,6 +1172,9 @@ class ComplaintHandlingTest(TestCase):
         with self.assertLogs(INFO_LOG) as logs, MetricsMock() as mm:
             response = _sns_notification(self.complaint_body)
         assert response.status_code == 200
+
+        self.user.profile.refresh_from_db()
+        assert self.user.profile.auto_block_spam is True
 
         self.ra.refresh_from_db()
         assert self.ra.enabled is False

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -1877,7 +1877,7 @@ class GetAddressTest(TestCase):
         An unknown but valid domain address is created.
 
         This supports creating domain addresses on third-party sites, when
-        emailing a checkout reciept, or other situations when the email
+        emailing a checkout receipt, or other situations when the email
         cannot be pre-created.
         """
         assert DomainAddress.objects.filter(user=self.user).count() == 1
@@ -1910,7 +1910,7 @@ class GetAddressTest(TestCase):
         This creates a new domain address with lower-cased letters. It supports
         creating domain addresses by third-parties that would not be allowed
         on the relay dashboard due to the upper-case characters, but are still
-        consistent with dashboard-created domain adddresses.
+        consistent with dashboard-created domain addresses.
         """
         assert DomainAddress.objects.filter(user=self.user).count() == 1
         with self.assertLogs(GLEAN_LOG, "INFO") as caplog:

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -1068,6 +1068,9 @@ class ComplaintHandlingTest(TestCase):
         self.sa: SocialAccount = baker.make(
             SocialAccount, user=self.user, provider="fxa", uid=str(uuid4())
         )
+        self.ra = baker.make(
+            RelayAddress, user=self.user, address="ebsbdsan7", domain=2
+        )
         complaint = {
             "notificationType": "Complaint",
             "complaint": {
@@ -1147,10 +1150,6 @@ class ComplaintHandlingTest(TestCase):
             1. sets enabled=False on the mask, and
             2. returns 200.
         """
-        self.ra = baker.make(
-            RelayAddress, user=self.user, address="ebsbdsan7", domain=2
-        )
-
         # The top-level JSON object for complaints includes a "mail" field
         # which contains information about the original mail to which the notification
         # pertains. So, add a "mail" field with content from our russian_spam fixture
@@ -1209,11 +1208,6 @@ class ComplaintHandlingTest(TestCase):
             "user_match": "found",
             "fxa_id": self.sa.uid,
         }
-
-        # re-enable the mask for other tests
-        self.ra.enabled = True
-        self.ra.save()
-        self.ra.refresh_from_db()
 
     def test_build_disabled_mask_for_spam_email(self):
         free_user = make_free_test_user("testreal@email.com")

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -331,7 +331,7 @@ def b64_lookup_key(lookup_key: bytes) -> str:
 
 
 def derive_reply_keys(message_id: bytes) -> tuple[bytes, bytes]:
-    """Derive the lookup key and encrytion key from an aliased message id."""
+    """Derive the lookup key and encryption key from an aliased message id."""
     algorithm = hashes.SHA256()
     hkdf = HKDFExpand(algorithm=algorithm, length=16, info=b"replay replies lookup key")
     lookup_key = hkdf.derive(message_id)

--- a/emails/views.py
+++ b/emails/views.py
@@ -500,7 +500,7 @@ def _get_relay_recipient_from_message_json(message_json):
     # Go thru all To, Cc, and Bcc fields and
     # return the one that has a Relay domain
 
-    # First check commmon headers for to or cc match
+    # First check common headers for to or cc match
     headers_to_check = "to", "cc"
     common_headers = message_json["mail"]["commonHeaders"]
     for header in headers_to_check:
@@ -831,7 +831,7 @@ def _handle_received(message_json: AWS_SNSMessageJSON) -> HttpResponse:
             message=forwarded_email,
         )
     except ClientError:
-        # 503 service unavailable reponse to SNS so it can retry
+        # 503 service unavailable response to SNS so it can retry
         log_email_dropped(reason="error_sending", mask=address, can_retry=True)
         return HttpResponse("SES client error on Raw Email", status=503)
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -1,10 +1,8 @@
-import base64
 import html
 import json
 import logging
 import re
 import shlex
-import zlib
 from copy import deepcopy
 from datetime import UTC, datetime
 from email import message_from_bytes
@@ -68,6 +66,7 @@ from .utils import (
     count_all_trackers,
     decrypt_reply_metadata,
     derive_reply_keys,
+    encode_dict_gza85,
     encrypt_reply_metadata,
     generate_from_header,
     get_domains_from_settings,
@@ -998,9 +997,7 @@ def _log_dev_notification(
     64KB limit per label value.
     """
 
-    notification_gza85 = base64.a85encode(
-        zlib.compress(json.dumps(notification).encode()), wrapcol=1024, pad=True
-    ).decode("ascii")
+    notification_gza85 = encode_dict_gza85(notification)
     total_parts = notification_gza85.count("\n") + 1
     for partnum, part in enumerate(notification_gza85.splitlines()):
         info_logger.info(

--- a/emails/views.py
+++ b/emails/views.py
@@ -1838,6 +1838,11 @@ def _handle_complaint(message_json: AWS_SNSMessageJSON) -> HttpResponse:
         # Data when there are no identified recipients
         complaint_data = [{"user_match": "no_recipients", "relay_action": "no_action"}]
 
+    if flag_is_active_in_task("developer_mode", user):
+        # MPP-3932: We need more information to match complaints to masks
+        dev_action = DeveloperModeAction(mask_id="unknown", action="log")
+        _log_dev_notification("_handle_complaint: MPP-3932", dev_action, message_json)
+
     for data in complaint_data:
         tags = {
             "complaint_subtype": subtype or "none",

--- a/emails/views.py
+++ b/emails/views.py
@@ -959,9 +959,17 @@ def _get_developer_mode_action(
     mask: RelayAddress | DomainAddress,
 ) -> DeveloperModeAction | None:
     """Get the developer mode actions for this mask, if enabled."""
+
+    flag_name = "developer_mode"
+    _, _ = get_waffle_flag_model().objects.get_or_create(
+        name=flag_name,
+        defaults={
+            "note": "MPP-3932: Enable logging and overrides for Relay developers."
+        },
+    )
+
     if not (
-        flag_is_active_in_task("developer_mode", mask.user)
-        and "DEV:" in mask.description
+        flag_is_active_in_task(flag_name, mask.user) and "DEV:" in mask.description
     ):
         return None
 


### PR DESCRIPTION
Add a new waffle flag 'developer_mode', that enables additional logging for the user. This logging goes beyond our user privacy policy, so it should only be enabled for Relay staff with consent. In addition, special mask labels are used to limit logging for forwarded emails.

For forwarded mail, the mask label is used to determine developer actions. If the mask contains `DEV:simulate_complaint` (no spaces), then the mail is forwarded to the [AWS complaint simulator address](https://docs.aws.amazon.com/ses/latest/dg/send-an-email-from-console.html#send-email-simulator) instead of the user's real address. If the mask contains `DEV:` (which includes (`DEV:simulate_complaint`)), the received notification itself is logged, using [zlib.compress](https://docs.python.org/3/library/zlib.html#zlib.compress) and [base64.a85encode](https://docs.python.org/3/library/base64.html#base64.a85encode) to reduce the size. If the encoded notification is more than 1024 bytes, the message is split over several log lines.

For complaints, any complaint notification for the user is logged. When we can reliably detect the mask, we may change this to use the mask label to further limit logging.

## How to test:
I wrote tests for the new functionality in handling forwards and complaints.
I refactored the `ComplaintHandlingTest` to add the `mail` element to all test complaint notifications, and to use the forwarded "russian spam" fixture instead of the incoming version. This required some other changes to mock a `Date` header, added by SES when forwarding the email.

I did not manually test this code. I plan to test it on the dev server, where we can set flags and debug the results.