### PR TITLE
MPP-3831: Send metrics_event data to influxdb, logs instead of UA

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -1492,19 +1492,21 @@ The Google Analytics events:
 The Relay Extension makes it easier to use Relay email masks on websites. It is
 available as a [Firefox Extension][] and a [Chrome Extension][].
 
+The Relay Extension uses a background listener to send interaction events to
+the Relay API server. These events are then recorded as statsd-style statistics
+and in server logs.
+
+The Relay Extension generates a [random UUID][] for the extension identifier
+that is [stored locally in the browser][]. A different ID will be generated for
+each browser and machine. A truncated hash of this identifier is included in the
+system logs to estimate the count of unique extension installations.
+
 <!-- References in this paragraph are defined in section "Google Analytics" -->
 
-The Relay Extension uses a background listener to send interaction events to
-the Relay API server. The API server forwards the events to Google Analytics.
-Events are reported using the [Universal Measurement Protocol][].
+Before October 2024, the API server forwarded the events
+to Google Analytics, using the [Universal Measurement Protocol][].
 Google [replaced Universal Analytics with Google Analytics 4][] (GA4) on July 1, 2024,
-and these events are no longer recorded. Relay is in the process of switching
-to [GA4][].
-
-The Relay Extension generates a [random UUID][] for the Google Analytics
-identifier that is [stored locally in the browser][]. This ID is different from
-the GA identifier on the Relay webpage. A different ID will be generated for
-each browser and machine.
+and these events stopped being recorded.
 
 [Chrome Extension]: https://chromewebstore.google.com/detail/firefox-relay/lknpoadjjkjcmjhbjpcljdednccbldeb "The Firefox Relay extension on the Chrome Web Store"
 [Firefox Extension]: https://addons.mozilla.org/en-US/firefox/addon/private-relay/ "The Firefox Relay extension on Firefox Browser Add-Ons"

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -106,8 +106,6 @@ def metrics_event(request: HttpRequest) -> JsonResponse:
         return JsonResponse({"msg": "Could not decode JSON"}, status=415)
     if "ga_uuid" not in request_data:
         return JsonResponse({"msg": "No GA uuid found"}, status=404)
-
-        # "real_address": sha256(new_emddail.encode("utf-8")).hexdigest(),
     event_data = {
         "ga_uuid_hash": sha256(request_data["ga_uuid"].encode()).hexdigest()[:16],
         "category": request_data.get("category", None),

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import threading
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from functools import cache
@@ -21,7 +20,7 @@ import sentry_sdk
 from allauth.socialaccount.models import SocialAccount, SocialApp
 from allauth.socialaccount.providers.fxa.views import FirefoxAccountsOAuth2Adapter
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
-from google_measurement_protocol import event, report
+from markus.utils import generate_tag
 from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
 from rest_framework.decorators import api_view, schema
 
@@ -91,40 +90,40 @@ def profile_subdomain(request):
         return JsonResponse({"message": e.message, "subdomain": subdomain}, status=400)
 
 
-def send_ga_ping(ga_id: str, ga_uuid: str, data: Any) -> None:
-    try:
-        report(ga_id, ga_uuid, data)
-    except Exception as e:
-        logger.error("metrics_event", extra={"error": e})
-
-
 @csrf_exempt
 @require_http_methods(["POST"])
 def metrics_event(request: HttpRequest) -> JsonResponse:
+    """
+    Handle metrics events from the Relay extension.
+
+    This used to forward data to Google Analytics, but was not updated for GA4.
+
+    Now it logs the information and updates statsd counters.
+    """
     try:
         request_data = json.loads(request.body)
     except json.JSONDecodeError:
         return JsonResponse({"msg": "Could not decode JSON"}, status=415)
     if "ga_uuid" not in request_data:
         return JsonResponse({"msg": "No GA uuid found"}, status=404)
-    # "dimension5" is a Google Analytics-specific variable to track a custom dimension,
-    # used to determine which browser vendor the add-on is using: Firefox or Chrome
-    # "dimension7" is a Google Analytics-specific variable to track a custom dimension,
-    # used to determine where the ping is coming from: website (default), add-on or app
-    event_data = event(
-        request_data.get("category", None),
-        request_data.get("action", None),
-        request_data.get("label", None),
-        request_data.get("value", None),
-        dimension5=request_data.get("dimension5", None),
-        dimension7=request_data.get("dimension7", "website"),
-    )
-    t = threading.Thread(
-        target=send_ga_ping,
-        args=[settings.GOOGLE_ANALYTICS_ID, request_data.get("ga_uuid"), event_data],
-        daemon=True,
-    )
-    t.start()
+
+        # "real_address": sha256(new_emddail.encode("utf-8")).hexdigest(),
+    event_data = {
+        "ga_uuid_hash": sha256(request_data["ga_uuid"].encode()).hexdigest()[:16],
+        "category": request_data.get("category", None),
+        "action": request_data.get("action", None),
+        "label": request_data.get("label", None),
+        "value": request_data.get("value", None),
+        "browser": request_data.get("browser", None),  # dimension5 in GA
+        "source": request_data.get("dimension7", "website"),
+    }
+    info_logger.info("metrics_event", extra=event_data)
+    tags = [
+        generate_tag(key, val)
+        for key, val in event_data.items()
+        if val is not None and key != "ga_uuid_hash"
+    ]
+    incr_if_enabled("metrics_event", tags=tags)
     return JsonResponse({"msg": "OK"}, status=200)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ dockerflow==2024.4.2
 drf-spectacular==0.27.2
 drf-spectacular-sidecar==2024.7.1
 glean_parser==15.0.1
-google-measurement-protocol==1.1.0
 google-cloud-profiler==4.1.0
 google-cloud-sqlcommenter==2.0.0; python_version < '3.12'
 gunicorn==23.0.0


### PR DESCRIPTION
For MPP-3831, send the `/metrics-event` data to InfluxDB (tagged counter metric) and logs instead of Universal Analytics, which was retired July 1, 2024. The metric is `fx.private.relay.metrics_event`, and has the UA data as tags. The info-level log has the message `metrics_event`, with the UA data as extra JSON-encoded data. The log includes a truncated hash of the UUID4 generated by the extension, so that we can continue to estimate active installations. We could just log the UUID4 as well, but this ensures we can't easily go from logs to an extension.

I removed the thread code that was talking to Universal Analytics. Since we're talking to in-cluster services instead of a remote service, the data collection should be fast again. It was a cool hack.