### PR TITLE
MPP-3901: update content for disable-mask email

### DIFF
--- a/emails/templates/emails/disabled_mask_for_spam.html
+++ b/emails/templates/emails/disabled_mask_for_spam.html
@@ -8,23 +8,62 @@
 
 {% include "emails/direct_email_header.html" %}
 
-    <table role="presentation" border="0" cellpadding="0" cellspacing="10px" style="padding: 60px 30px 120px 30px;" align="center">
+  <style>
+    .button {
+      box-sizing: border-box;
+      padding: 15px 25px;
+      display: inline-block;
+      font-family: 'metropolis medium', system-ui, sans-serif;
+      text-decoration: none;
+      -webkit-text-size-adjust: none;
+      text-align: center;
+      color: #FFFFFF;
+      background-color: #0060df;
+      border-radius: 4px;
+      -webkit-border-radius: 4px;
+      -moz-border-radius: 4px;
+      width: auto;
+      max-width: 100%;
+      overflow-wrap: break-word;
+      word-break: break-word;
+      word-wrap: break-word;
+      font-size: 16px;
+    }
+  </style>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="10px" style="padding: 30px;" align="center">
+    {% with mask|striptags|urlencode as mask_for_url %}
+        {% with "/accounts/profile/#"|add:mask_for_url as mask_url%}
         <tr>
             <td style="max-width:850px; padding-top: 0px; padding-bottom: 0px; text-align: center;">
-                {% with mask|striptags|urlencode as mask_url %}
-                <h2 style="font-family: inter medium, Arial, system-ui, sans-serif;"> 
+                <h2 style="font-family: inter medium, Arial, system-ui, sans-serif;">
                     <img width="18" src="{{ SITE_ORIGIN }}/static/images/email-images/warning.png" style="margin: 0 5px;" alt="warning icon"/>
-                    {% ftlmsg 'relay-disabled-your-mask' %}
+                    {% ftlmsg 'reactivate-your-mask' %}
                 </h2>
-                <p style="line-height: 200%; margin-bottom: 30px; padding: 20px 60px 20px 60px">
-                {% ftlmsg 'relay-received-spam-complaint-html' mask=mask %} {% ftlmsg 'relay-disabled-your-mask-detail-html' mask=mask %}
-                </p> 
-                <a href="{{ SITE_ORIGIN }}/accounts/profile/#{{ mask_url }}">
-                    {% ftlmsg 're-enable-your-mask' %}
-                </a>
-                {% endwith %}
-            </td> 
+            </td>
         </tr>
+        <tr>
+            <td style="max-width:850px; padding-top: 0px; padding-bottom: 0px;">
+                <p style="line-height: 1.5; margin-bottom: 1.5em">
+                {% ftlmsg 'relay-received-spam-complaint-and-deactivated-mask-html' mask=mask %} {% ftlmsg 'relay-disabled-your-mask-detail-html' mask=mask %}
+                </p>
+                <p style="line-height: 1.5; margin-bottom: 1.5em">
+                    {% ftlmsg 'reactivate-mask-detail-html' mask_url=mask_url %}
+                </p>
+                <p style="line-height: 1.5; margin-bottom: 1.5em">
+                    {% ftlmsg 'learn-about-blocking-html' learn_more_url='https://support.mozilla.org/kb/disable-email-forwarding-stop-receiving-emails-sent-through-masks' %}
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <td style="max-width:850px; padding-top: 20px; padding-bottom: 20px; text-align: center;">
+              <a href="{{ mask_url }}"
+                  target="_blank" class="button" style="color: #FFFFFF;" rel="noreferrer">
+                  {% ftlmsg 'reactivate-your-mask' %}
+                </a>
+            </td>
+        </tr>
+        {% endwith %}
+    {% endwith %}
     </table>
 
     {% include "emails/direct_email_footer.html" %}

--- a/emails/templates/emails/disabled_mask_for_spam.txt
+++ b/emails/templates/emails/disabled_mask_for_spam.txt
@@ -1,11 +1,13 @@
 {% load ftl %}
 {% load email_extras %}
 {% withftl bundle='privaterelay.ftl_bundles.main' language=language %}
-{% ftlmsg 'relay-disabled-your-mask' %}
+{% ftlmsg 'relay-deactivated-your-mask' %}
 
-{% ftlmsg 'relay-received-spam-complaint' mask=mask %} {% ftlmsg 'relay-disabled-your-mask-detail' mask=mask %}
+{% ftlmsg 'relay-received-spam-complaint-and-deactivated-mask' mask=mask %}
 {% with mask|striptags|urlencode as mask_url %}
-{% ftlmsg 're-enable-your-mask' %}
+{% ftlmsg 'reactivate-mask-detail' %}
 {{ SITE_ORIGIN }}/accounts/profile/#{{ mask_url }}
 {% endwith %}
+
+{% ftlmsg 'learn-about-blocking' learn_more_url='https://support.mozilla.org/kb/disable-email-forwarding-stop-receiving-emails-sent-through-masks' %}
 {% endwithftl %}

--- a/emails/tests/fixtures/disabled_mask_for_spam_expected.email
+++ b/emails/tests/fixtures/disabled_mask_for_spam_expected.email
@@ -1,5 +1,5 @@
-Subject: =?utf-8?q?=E2=81=A8Firefox_Relay=E2=81=A9?= has disabled one of your
- email masks.
+Subject: =?utf-8?q?=E2=81=A8Firefox_Relay=E2=81=A9?= has deactivated one of
+ your email masks.
 From: reply@relay.example.com
 To: testreal@email.com
 MIME-Version: 1.0
@@ -13,16 +13,20 @@ Content-Transfer-Encoding: quoted-printable
 
 
 
-=E2=81=A8Firefox Relay=E2=81=A9 has disabled one of your email masks.
+=E2=81=A8Firefox Relay=E2=81=A9 has deactivated one of your email masks.
 
-=E2=81=A8Firefox Relay=E2=81=A9 received a spam complaint for an email sent t=
-o =E2=81=A8w41fwbt4q@test.com=E2=81=A9. This usually happens if you or your e=
-mail provider mark an email as spam. To prevent further spam, =E2=81=A8Firefo=
-x Relay=E2=81=A9 has disabled your =E2=81=A8w41fwbt4q@test.com=E2=81=A9 mask.
+An email from your mask address, =E2=81=A8w41fwbt4q@test.com=E2=81=A9, was ma=
+rked as spam. When this happens, =E2=81=A8Firefox Relay=E2=81=A9 deactivates =
+the mask and stops forwarding emails.
 
-Visit your =E2=81=A8Firefox Relay=E2=81=A9 dashboard to re-enable this mask.
+To reactivate your mask, remove email blocking on your =E2=81=A8Firefox Relay=
+=E2=81=A9 dashboard.
 http://127.0.0.1:8000/accounts/profile/#w41fwbt4q%40test.com
 
+
+Learn about blocking and email forwarding at =E2=81=A8https://support.mozilla=
+.org/kb/disable-email-forwarding-stop-receiving-emails-sent-through-masks=E2=
+=81=A9
 
 
 --==[BOUNDARY0]==
@@ -224,34 +228,74 @@ ail" style=3D"color: white;">Upgrade for more protection</a>=20
     </table> =20
 
 
+  <style>
+    .button {
+      box-sizing: border-box;
+      padding: 15px 25px;
+      display: inline-block;
+      font-family: 'metropolis medium', system-ui, sans-serif;
+      text-decoration: none;
+      -webkit-text-size-adjust: none;
+      text-align: center;
+      color: #FFFFFF;
+      background-color: #0060df;
+      border-radius: 4px;
+      -webkit-border-radius: 4px;
+      -moz-border-radius: 4px;
+      width: auto;
+      max-width: 100%;
+      overflow-wrap: break-word;
+      word-break: break-word;
+      word-wrap: break-word;
+      font-size: 16px;
+    }
+  </style>
     <table role=3D"presentation" border=3D"0" cellpadding=3D"0" cellspacing=
-=3D"10px" style=3D"padding: 60px 30px 120px 30px;" align=3D"center">
+=3D"10px" style=3D"padding: 30px;" align=3D"center">
+   =20
+       =20
         <tr>
             <td style=3D"max-width:850px; padding-top: 0px; padding-bottom: 0=
 px; text-align: center;">
-               =20
                 <h2 style=3D"font-family: inter medium, Arial, system-ui, san=
-s-serif;">=20
+s-serif;">
                     <img width=3D"18" src=3D"http://127.0.0.1:8000/static/ima=
 ges/email-images/warning.png" style=3D"margin: 0 5px;" alt=3D"warning icon"/>
-                    =E2=81=A8Firefox Relay=E2=81=A9 has disabled one of your =
-email masks.
+                    Reactivate your email mask
                 </h2>
-                <p style=3D"line-height: 200%; margin-bottom: 30px; padding: =
-20px 60px 20px 60px">
-                Firefox Relay received a spam complaint for an email sent to =
-<strong>w41fwbt4q@test.com</strong>. This usually happens if you or your emai=
-l provider mark an email as spam. To prevent further spam, Firefox Relay has =
-disabled your <strong>w41fwbt4q@test.com</strong> mask.
-                </p>=20
-                <a href=3D"http://127.0.0.1:8000/accounts/profile/#w41fwbt4q%=
-40test.com">
-                    Visit your =E2=81=A8Firefox Relay=E2=81=A9 dashboard to r=
-e-enable this mask.
-                </a>
-               =20
-            </td>=20
+            </td>
         </tr>
+        <tr>
+            <td style=3D"max-width:850px; padding-top: 0px; padding-bottom: 0=
+px;">
+                <p style=3D"line-height: 1.5; margin-bottom: 1.5em">
+                An email from your mask address, w41fwbt4q@test.com, was mark=
+ed as spam. When this happens, Firefox Relay deactivates the mask and stops f=
+orwarding emails. ???
+                </p>
+                <p style=3D"line-height: 1.5; margin-bottom: 1.5em">
+                    To reactivate your mask, <a href=3D"/accounts/profile/#w4=
+1fwbt4q%40test.com">remove email blocking</a> on your Firefox Relay dashboard.
+                </p>
+                <p style=3D"line-height: 1.5; margin-bottom: 1.5em">
+                    <a href=3D"https://support.mozilla.org/kb/disable-email-f=
+orwarding-stop-receiving-emails-sent-through-masks">Learn about blocking and =
+email forwarding</a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <td style=3D"max-width:850px; padding-top: 20px; padding-bottom: =
+20px; text-align: center;">
+              <a href=3D"/accounts/profile/#w41fwbt4q%40test.com"
+                  target=3D"_blank" class=3D"button" style=3D"color: #FFFFFF;=
+" rel=3D"noreferrer">
+                  Reactivate your email mask
+                </a>
+            </td>
+        </tr>
+       =20
+   =20
     </table>
 
    =20

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -1249,7 +1249,7 @@ class ComplaintHandlingTest(TestCase):
         assert call.kwargs["Source"] == settings.RELAY_FROM_ADDRESS
         assert call.kwargs["Destinations"] == [self.user.email]
         msg_without_newlines = call.kwargs["RawMessage"]["Data"].replace("\n", "")
-        assert "To prevent further spam" in msg_without_newlines
+        assert "deactivated one of your email masks" in msg_without_newlines
         assert self.ra.full_address in msg_without_newlines
 
         mm.assert_incr_once(
@@ -1312,7 +1312,7 @@ class ComplaintHandlingTest(TestCase):
 
         msg = _build_disabled_mask_for_spam_email(relay_address, original_spam_email)
 
-        assert msg["Subject"] == main.format("relay-disabled-your-mask")
+        assert msg["Subject"] == main.format("relay-deactivated-your-mask")
         assert msg["From"] == settings.RELAY_FROM_ADDRESS
         assert msg["To"] == free_user.email
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -1686,7 +1686,7 @@ def _build_disabled_mask_for_spam_email(
 
     # Create the message
     msg = EmailMessage()
-    msg["Subject"] = ftl_bundle.format("relay-disabled-your-mask")
+    msg["Subject"] = ftl_bundle.format("relay-deactivated-your-mask")
     msg["From"] = settings.RELAY_FROM_ADDRESS
     msg["To"] = mask.user.email
     msg.set_content(text_body)

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -4,20 +4,33 @@
 
 # This is the Django equivalent of frontend/pendingTranslations.ftl
 
-## Email sent to users when Relay disables their mask after the user marks a forwarded
+## Email sent to users when Relay deactivates their mask after the user marks a forwarded
 ## email as spam.
 
-relay-disabled-your-mask = { -brand-name-firefox-relay } has disabled one of your email masks.
+relay-deactivated-your-mask = { -brand-name-firefox-relay } has deactivated one of your email masks.
+
+reactivate-your-mask = Reactivate your email mask
+
 # Variables
 #   $mask (string) - the Relay email mask that sent a spam complaint
-relay-received-spam-complaint-html = { -brand-name-firefox-relay } received a spam complaint for an email sent to <strong>{ $mask }</strong>. This usually happens if you or your email provider mark an email as spam.
+relay-received-spam-complaint-and-deactivated-mask-html = An email from your mask address, { $mask }, was marked as spam. When this happens, { -brand-name-firefox-relay } deactivates the mask and stops forwarding emails.
+
 # Variables
 #   $mask (string) - the Relay email mask that sent a spam complaint
-relay-received-spam-complaint = { -brand-name-firefox-relay } received a spam complaint for an email sent to { $mask }. This usually happens if you or your email provider mark an email as spam.
+relay-received-spam-complaint-and-deactivated-mask = An email from your mask address, { $mask }, was marked as spam. When this happens, { -brand-name-firefox-relay } deactivates the mask and stops forwarding emails.
+
 # Variables
-#   $mask (string) - the Relay email mask that sent a spam complaint
-relay-disabled-your-mask-detail-html = To prevent further spam, { -brand-name-firefox-relay } has disabled your <strong>{ $mask }</strong> mask.
+#   $mask_url (string) - url takes user to Relay dashboard with mask selected
+reactivate-mask-detail-html = To reactivate your mask, <a href="{ $mask_url }">remove email blocking</a> on your { -brand-name-firefox-relay } dashboard.
+
+reactivate-mask-detail = To reactivate your mask, remove email blocking on your { -brand-name-firefox-relay } dashboard.
+
 # Variables
-#   $mask (string) - the Relay email mask that sent a spam complaint
-relay-disabled-your-mask-detail = To prevent further spam, { -brand-name-firefox-relay } has disabled your { $mask } mask.
+#   $learn_more_url (string) - support.mozilla.org page with more information
+learn-about-blocking-html = <a href="{ $learn_more_url }">Learn about blocking and email forwarding</a>
+
+# Variables
+#   $learn_more_url (string) - support.mozilla.org page with more information
+learn-about-blocking = Learn about blocking and email forwarding at { $learn_more_url }
+
 re-enable-your-mask = Visit your { -brand-name-firefox-relay } dashboard to re-enable this mask.


### PR DESCRIPTION
This PR fixes #MPP-3901.

![image](https://github.com/user-attachments/assets/3542ae76-d9de-42b9-beaa-764e5e68289f)

How to test:
1. Go to http://127.0.0.1:8000/emails/disabled_mask_for_spam_test and http://127.0.0.1:8000/emails/disabled_mask_for_spam_test?content-type=text/plain
   * [ ] Verify content matches https://www.figma.com/design/5n1LkFnQrgyykS0hqBBMXZ/Relay-email-updates?node-id=7128-869&t=QRCHUCpbDZ2nyjN4-4
     * Note: small tweaks were made to simplify implementation and translation; ping llopez on Slack to verify changes are okay

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).