### PR TITLE
MPP-3932: Move developer mode logging inside complaint loop

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -1839,14 +1839,16 @@ def _handle_complaint(message_json: AWS_SNSMessageJSON) -> HttpResponse:
 
         _disable_masks_for_complaint(message_json, user)
 
+        if flag_is_active_in_task("developer_mode", user):
+            # MPP-3932: We need more information to match complaints to masks
+            dev_action = DeveloperModeAction(mask_id="unknown", action="log")
+            _log_dev_notification(
+                "_handle_complaint: MPP-3932", dev_action, message_json
+            )
+
     if not complaint_data:
         # Data when there are no identified recipients
         complaint_data = [{"user_match": "no_recipients", "relay_action": "no_action"}]
-
-    if flag_is_active_in_task("developer_mode", user):
-        # MPP-3932: We need more information to match complaints to masks
-        dev_action = DeveloperModeAction(mask_id="unknown", action="log")
-        _log_dev_notification("_handle_complaint: MPP-3932", dev_action, message_json)
 
     for data in complaint_data:
         tags = {


### PR DESCRIPTION
Heroku is raising an error ([RELAY-ZZ](https://mozilla.sentry.io/issues/5993744206/)) during processing that isn't found in the tests:

```
UnboundLocalError('cannot access local variable 'user' where it is not associated with a value')
```

Moving the logging inside the loop should fix this.