### PR TITLE
Add setting for Redis TLS with self-signed certs

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -492,14 +492,20 @@ if TEST_DB_NAME:
     DATABASES["default"]["TEST"] = {"NAME": TEST_DB_NAME}
 
 REDIS_URL = config("REDIS_URL", "")
+REDIS_SELF_SIGNED_CERT = config("REDIS_SELF_SIGNED_CERT", False, bool)
 if REDIS_URL:
+    _redis_options: dict[str, Any] = {
+        "CLIENT_CLASS": "django_redis.client.DefaultClient"
+    }
+    # Heroku mini uses self-signed certificates
+    if REDIS_SELF_SIGNED_CERT:
+        _redis_options["CONNECTION_POOL_KWARGS"] = {"ssl_cert_reqs": None}
+
     CACHES = {
         "default": {
             "BACKEND": "django_redis.cache.RedisCache",
             "LOCATION": REDIS_URL,
-            "OPTIONS": {
-                "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            },
+            "OPTIONS": _redis_options,
         }
     }
     SESSION_ENGINE = "django.contrib.sessions.backends.cache"


### PR DESCRIPTION
Heroku is rolling out [secure TLS connection URLs](https://help.heroku.com/45F0AY28/what-are-the-upcoming-changes-to-the-redis_url-config-var-for-heroku-key-value-store-mini-add-ons) for mini Heroku Key-Value Store plans, between October and December 2024. This uses a self-signed certificate, and the Redis package needs an [additional setting](https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-python) `ssl_cert_reqs=None` to connect.

This PR was extracted from #5115.