### PR TITLE
MPP-3901: update disabled mask email content

### DIFF
--- a/emails/templates/emails/direct_email_header.html
+++ b/emails/templates/emails/direct_email_header.html
@@ -159,7 +159,11 @@
             }
         }
     </style>
-
+{% if pretext_ftlmsg_id %}
+    <div style="display:none !important; color: #ffffff; font-size: 0px; line-height: 0; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden; mso-hide: all;">
+        {% ftlmsg pretext_ftlmsg_id %}
+    </div>
+{% endif %}
     <!-- temporary header -->
     <table id="relay-email-header" width="100%" bgcolor="#3D3D3D" style="background: #3D3D3D; padding: 12px; margin-bottom: 30px; margin-top: 30px; width: 96%; border-radius: 6px; max-width: 1200px;" align="center">
         <tr>

--- a/emails/templates/emails/disabled_mask_for_spam.html
+++ b/emails/templates/emails/disabled_mask_for_spam.html
@@ -6,7 +6,7 @@
 {% load email_extras %}
 {% withftl bundle='privaterelay.ftl_bundles.main' language=language %}
 
-{% include "emails/direct_email_header.html" %}
+{% include "emails/direct_email_header.html" with pretext_ftlmsg_id="relay-deactivated-mask-email-pretext" %}
 
   <style>
     .button {
@@ -37,20 +37,20 @@
             <td style="max-width:850px; padding-top: 0px; padding-bottom: 0px; text-align: center;">
                 <h2 style="font-family: inter medium, Arial, system-ui, sans-serif;">
                     <img width="18" src="{{ SITE_ORIGIN }}/static/images/email-images/warning.png" style="margin: 0 5px;" alt="warning icon"/>
-                    {% ftlmsg 'reactivate-your-mask' %}
+                    {% ftlmsg 'relay-deactivated-mask-email-subject' %}
                 </h2>
             </td>
         </tr>
         <tr>
             <td style="max-width:850px; padding-top: 0px; padding-bottom: 0px;">
                 <p style="line-height: 1.5; margin-bottom: 1.5em">
-                    {% ftlmsg 'relay-received-spam-complaint-and-deactivated-mask-html' mask=mask %}
+                    {% ftlmsg 'relay-received-spam-complaint-and-deactivated-mask' mask=mask %}
                 </p>
                 <p style="line-height: 1.5; margin-bottom: 1.5em">
-                    {% ftlmsg 'reactivate-mask-detail-html' mask_url=mask_url %}
+                    {% ftlmsg 'relay-remove-email-blocking-html' mask_url=mask_url %}
                 </p>
                 <p style="line-height: 1.5; margin-bottom: 1.5em">
-                    {% ftlmsg 'learn-about-blocking-html' learn_more_url='https://support.mozilla.org/kb/disable-email-forwarding-stop-receiving-emails-sent-through-masks' %}
+                    {% ftlmsg 'detailed-instructions-about-blocking-html' learn_more_url='https://support.mozilla.org/kb/disable-email-forwarding-stop-receiving-emails-sent-through-masks' %}
                 </p>
             </td>
         </tr>
@@ -58,7 +58,7 @@
             <td style="max-width:850px; padding-top: 20px; padding-bottom: 20px; text-align: center;">
               <a href="{{ mask_url }}"
                   target="_blank" class="button" style="color: #FFFFFF;" rel="noreferrer">
-                  {% ftlmsg 'reactivate-your-mask' %}
+                  {% ftlmsg 'remove-email-blocking' %}
                 </a>
             </td>
         </tr>

--- a/emails/templates/emails/disabled_mask_for_spam.txt
+++ b/emails/templates/emails/disabled_mask_for_spam.txt
@@ -1,13 +1,14 @@
 {% load ftl %}
 {% load email_extras %}
 {% withftl bundle='privaterelay.ftl_bundles.main' language=language %}
-{% ftlmsg 'relay-deactivated-your-mask' %}
+{% ftlmsg 'relay-deactivated-mask-email-subject' %}
 
 {% ftlmsg 'relay-received-spam-complaint-and-deactivated-mask' mask=mask %}
 {% with mask|striptags|urlencode as mask_url %}
-{% ftlmsg 'reactivate-mask-detail' %}
+{% ftlmsg 'relay-remove-email-blocking' %}
+
 {{ SITE_ORIGIN }}/accounts/profile/#{{ mask_url }}
 {% endwith %}
 
-{% ftlmsg 'learn-about-blocking' learn_more_url='https://support.mozilla.org/kb/disable-email-forwarding-stop-receiving-emails-sent-through-masks' %}
+{% ftlmsg 'detailed-instructions-about-blocking' learn_more_url='https://support.mozilla.org/kb/disable-email-forwarding-stop-receiving-emails-sent-through-masks' %}
 {% endwithftl %}

--- a/emails/tests/fixtures/disabled_mask_for_spam_expected.email
+++ b/emails/tests/fixtures/disabled_mask_for_spam_expected.email
@@ -1,5 +1,4 @@
-Subject: =?utf-8?q?=E2=81=A8Firefox_Relay=E2=81=A9?= has deactivated one of
- your email masks.
+Subject: This mask has been deactivated
 From: reply@relay.example.com
 To: testreal@email.com
 MIME-Version: 1.0
@@ -13,20 +12,23 @@ Content-Transfer-Encoding: quoted-printable
 
 
 
-=E2=81=A8Firefox Relay=E2=81=A9 has deactivated one of your email masks.
+This mask has been deactivated
 
 An email from your mask address, =E2=81=A8w41fwbt4q@test.com=E2=81=A9, was ma=
 rked as spam. When this happens, =E2=81=A8Firefox Relay=E2=81=A9 deactivates =
-the mask and stops forwarding emails.
+the mask and blocks emails from forwarding to protect your inbox from future =
+spam.
 
-To reactivate your mask, remove email blocking on your =E2=81=A8Firefox Relay=
-=E2=81=A9 dashboard.
+To remove email blocking:
+1. Go to your =E2=81=A8Relay=E2=81=A9 dashboard and find this email mask
+2. Remove email blocking by updating blocking from all to none
+
 http://127.0.0.1:8000/accounts/profile/#w41fwbt4q%40test.com
 
 
-Learn about blocking and email forwarding at =E2=81=A8https://support.mozilla=
-.org/kb/disable-email-forwarding-stop-receiving-emails-sent-through-masks=E2=
-=81=A9
+Detailed instructions to remove email blocking: =E2=81=A8https://support.mozi=
+lla.org/kb/disable-email-forwarding-stop-receiving-emails-sent-through-masks=
+=E2=81=A9
 
 
 --==[BOUNDARY0]==
@@ -208,6 +210,12 @@ lay.firefox.com/fonts/Inter/Inter-Medium.027d14e7d35b.woff2?v=3D3.18) format(=
         }
     </style>
 
+    <div style=3D"display:none !important; color: #ffffff; font-size: 0px; li=
+ne-height: 0; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden; =
+mso-hide: all;">
+        Remove email blocking to use your email mask
+    </div>
+
     <!-- temporary header -->
     <table id=3D"relay-email-header" width=3D"100%" bgcolor=3D"#3D3D3D" style=
 =3D"background: #3D3D3D; padding: 12px; margin-bottom: 30px; margin-top: 30px=
@@ -261,7 +269,7 @@ px; text-align: center;">
 s-serif;">
                     <img width=3D"18" src=3D"http://127.0.0.1:8000/static/ima=
 ges/email-images/warning.png" style=3D"margin: 0 5px;" alt=3D"warning icon"/>
-                    Reactivate your email mask
+                    This mask has been deactivated
                 </h2>
             </td>
         </tr>
@@ -269,19 +277,23 @@ ges/email-images/warning.png" style=3D"margin: 0 5px;" alt=3D"warning icon"/>
             <td style=3D"max-width:850px; padding-top: 0px; padding-bottom: 0=
 px;">
                 <p style=3D"line-height: 1.5; margin-bottom: 1.5em">
-                    An email from your mask address, w41fwbt4q@test.com, was =
-marked as spam. When this happens, Firefox Relay deactivates the mask and sto=
-ps forwarding emails.
+                    An email from your mask address, =E2=81=A8w41fwbt4q@test.=
+com=E2=81=A9, was marked as spam. When this happens, =E2=81=A8Firefox Relay=
+=E2=81=A9 deactivates the mask and blocks emails from forwarding to protect y=
+our inbox from future spam.
                 </p>
                 <p style=3D"line-height: 1.5; margin-bottom: 1.5em">
-                    To reactivate your mask, <a href=3D"http://127.0.0.1:8000=
-/accounts/profile/#w41fwbt4q%40test.com">remove email blocking</a> on your Fi=
-refox Relay dashboard.
+                    To remove email blocking:
+<ol>
+<li><a href=3D"http://127.0.0.1:8000/accounts/profile/#w41fwbt4q%40test.com">=
+Go to your Relay dashboard</a> and find this email mask</li>
+<li>Remove email blocking by updating blocking from all to none</li>
+</ol>
                 </p>
                 <p style=3D"line-height: 1.5; margin-bottom: 1.5em">
                     <a href=3D"https://support.mozilla.org/kb/disable-email-f=
-orwarding-stop-receiving-emails-sent-through-masks">Learn about blocking and =
-email forwarding</a>
+orwarding-stop-receiving-emails-sent-through-masks">Detailed instructions to =
+remove email blocking</a>
                 </p>
             </td>
         </tr>
@@ -292,7 +304,7 @@ email forwarding</a>
 test.com"
                   target=3D"_blank" class=3D"button" style=3D"color: #FFFFFF;=
 " rel=3D"noreferrer">
-                  Reactivate your email mask
+                  Remove email blocking
                 </a>
             </td>
         </tr>

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -1305,7 +1305,7 @@ class ComplaintHandlingTest(TestCase):
         assert call.kwargs["Source"] == settings.RELAY_FROM_ADDRESS
         assert call.kwargs["Destinations"] == [self.user.email]
         msg_without_newlines = call.kwargs["RawMessage"]["Data"].replace("\n", "")
-        assert "deactivated one of your email masks" in msg_without_newlines
+        assert "This mask has been deactivated" in msg_without_newlines
         assert self.ra.full_address in msg_without_newlines
 
         mm.assert_incr_once("fx.private.relay.send_disabled_mask_email")
@@ -1401,7 +1401,7 @@ class ComplaintHandlingTest(TestCase):
 
         msg = _build_disabled_mask_for_spam_email(relay_address)
 
-        assert msg["Subject"] == main.format("relay-deactivated-your-mask")
+        assert msg["Subject"] == main.format("relay-deactivated-mask-email-subject")
         assert msg["From"] == settings.RELAY_FROM_ADDRESS
         assert msg["To"] == free_user.email
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -1689,7 +1689,7 @@ def _build_disabled_mask_for_spam_email(
 
     # Create the message
     msg = EmailMessage()
-    msg["Subject"] = ftl_bundle.format("relay-deactivated-your-mask")
+    msg["Subject"] = ftl_bundle.format("relay-deactivated-mask-email-subject")
     msg["From"] = settings.RELAY_FROM_ADDRESS
     msg["To"] = mask.user.email
     msg.set_content(text_body)

--- a/privaterelay/pending_locales/en/pending.ftl
+++ b/privaterelay/pending_locales/en/pending.ftl
@@ -7,30 +7,32 @@
 ## Email sent to users when Relay deactivates their mask after the user marks a forwarded
 ## email as spam.
 
-relay-deactivated-your-mask = { -brand-name-firefox-relay } has deactivated one of your email masks.
+relay-deactivated-mask-email-subject = This mask has been deactivated
 
-reactivate-your-mask = Reactivate your email mask
-
-# Variables
-#   $mask (string) - the Relay email mask that sent a spam complaint
-relay-received-spam-complaint-and-deactivated-mask-html = An email from your mask address, { $mask }, was marked as spam. When this happens, { -brand-name-firefox-relay } deactivates the mask and stops forwarding emails.
+relay-deactivated-mask-email-pretext = Remove email blocking to use your email mask
 
 # Variables
 #   $mask (string) - the Relay email mask that sent a spam complaint
-relay-received-spam-complaint-and-deactivated-mask = An email from your mask address, { $mask }, was marked as spam. When this happens, { -brand-name-firefox-relay } deactivates the mask and stops forwarding emails.
+relay-received-spam-complaint-and-deactivated-mask = An email from your mask address, { $mask }, was marked as spam. When this happens, { -brand-name-firefox-relay } deactivates the mask and blocks emails from forwarding to protect your inbox from future spam.
 
-# Variables
-#   $mask_url (string) - url takes user to Relay dashboard with mask selected
-reactivate-mask-detail-html = To reactivate your mask, <a href="{ $mask_url }">remove email blocking</a> on your { -brand-name-firefox-relay } dashboard.
+relay-remove-email-blocking-html =
+    To remove email blocking:
+    <ol>
+    <li><a href="{ $mask_url }">Go to your { -brand-name-relay } dashboard</a> and find this email mask</li>
+    <li>Remove email blocking by updating blocking from all to none</li>
+    </ol>
 
-reactivate-mask-detail = To reactivate your mask, remove email blocking on your { -brand-name-firefox-relay } dashboard.
+relay-remove-email-blocking =
+    To remove email blocking:
+    1. Go to your { -brand-name-relay } dashboard and find this email mask
+    2. Remove email blocking by updating blocking from all to none
 
 # Variables
 #   $learn_more_url (string) - support.mozilla.org page with more information
-learn-about-blocking-html = <a href="{ $learn_more_url }">Learn about blocking and email forwarding</a>
+detailed-instructions-about-blocking-html = <a href="{ $learn_more_url }">Detailed instructions to remove email blocking</a>
 
 # Variables
 #   $learn_more_url (string) - support.mozilla.org page with more information
-learn-about-blocking = Learn about blocking and email forwarding at { $learn_more_url }
+detailed-instructions-about-blocking = Detailed instructions to remove email blocking: { $learn_more_url }
 
-re-enable-your-mask = Visit your { -brand-name-firefox-relay } dashboard to re-enable this mask.
+remove-email-blocking = Remove email blocking


### PR DESCRIPTION
This PR fixes MPP-3901.

How to test:
1. Open https://www.figma.com/design/5n1LkFnQrgyykS0hqBBMXZ/Relay-email-updates?node-id=7191-1179&node-type=instance&t=gEqKzYCBNFE1mwHK-0 for the reference text
2. Open http://127.0.0.1:8000/emails/disabled_mask_for_spam_test?content-type=text/plain
3. Open http://127.0.0.1:8000/emails/disabled_mask_for_spam_test
   * [x] Verify the text in the email tests matches the figma

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).