### PR TITLE
MPP-3946: Silence deprecration warnings added in sass 1.80, fix division

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -114,4 +114,19 @@ module.exports = {
 
     return config;
   },
+  sassOptions: {
+    // TODO MPP-3946: Fix deprecation warnings in sass 1.80.x
+    // https://github.com/mozilla/protocol/releases/tag/v18.0.0
+    silenceDeprecations: [
+      // Issues we can fix in our code
+      "import", // https://sass-lang.com/documentation/breaking-changes/import/
+      "mixed-decls", // https://sass-lang.com/d/mixed-decls
+      "slash-div", // https://sass-lang.com/d/slash-div
+
+      // Upstream issues
+      "legacy-js-api", // vercel/next.js issue #71638
+    ],
+    // TODO MPP-3946: Update to mozilla-protocol 18.0.0
+    quietDeps: true,
+  },
 };

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -121,7 +121,6 @@ module.exports = {
       // Issues we can fix in our code
       "import", // https://sass-lang.com/documentation/breaking-changes/import/
       "mixed-decls", // https://sass-lang.com/d/mixed-decls
-      "slash-div", // https://sass-lang.com/d/slash-div
 
       // Upstream issues
       "legacy-js-api", // vercel/next.js issue #71638

--- a/frontend/src/components/landing/PlanMatrix.module.scss
+++ b/frontend/src/components/landing/PlanMatrix.module.scss
@@ -95,7 +95,7 @@ table.desktop {
       //   border-collapse: separate;
       //   border-spacing: $spacing-md 0;
       // then we wouldn't have been able to apply a bottom border at all.
-      border-inline: $spacing-md / 2 solid $color-light-gray-10;
+      border-inline: $spacing-md * 0.5 solid $color-light-gray-10;
 
       &:last-child {
         border-right-style: none;


### PR DESCRIPTION
This PR configures Dart Sass to silence deprecation warnings that appear after the upgrade to sass 1.80.x. This will prevent other errors and warnings from getting lost in the noise as we incrementally fix the issues.

This PR does fix the easiest issue, the deprecation of [slash as division](https://sass-lang.com/documentation/breaking-changes/slash-div/). The automated fix was applied with:

```sh
cd frontend
npx sass-migrator division **/*.scss
```

# How to test:
This can be confirmed in local dev or by looking at the CI build for this PR:

* Run `cd frontend; npm run build`
  * [ ] Instead of 24,000 warning lines, no warning lines
  * [ ] The file `frontend/out/_next/static/css/7b7332110014f2b1.css` still exists, since the contents did not change and the filename is based on a hash of the contents. The file `7b7332110014f2b1.css.map` is different, since the source changed.