### PR TITLE
MPP-3942: Fix `log_group_id` in `developer_mode` log

### DIFF
--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -832,6 +832,7 @@ class SNSNotificationIncomingTest(SNSNotificationTestBase):
             if log_group_id is None:
                 log_group_id = extra["log_group_id"]
                 assert log_group_id
+                assert isinstance(log_group_id, str)
             else:
                 assert extra["log_group_id"] == log_group_id
             parts[extra["part"]] = extra["notification_gza85"]

--- a/emails/views.py
+++ b/emails/views.py
@@ -993,7 +993,7 @@ def _log_dev_notification(
 
     notification_gza85 = encode_dict_gza85(notification)
     total_parts = notification_gza85.count("\n") + 1
-    log_group_id = uuid4()
+    log_group_id = str(uuid4())
     for partnum, part in enumerate(notification_gza85.splitlines()):
         info_logger.info(
             log_message,

--- a/package-lock.json
+++ b/package-lock.json
@@ -945,10 +945,12 @@
       "license": "MIT"
     },
     "node_modules/@bundled-es-modules/cookie": {
-      "version": "2.0.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
       "license": "ISC",
       "dependencies": {
-        "cookie": "^0.5.0"
+        "cookie": "^0.7.2"
       }
     },
     "node_modules/@bundled-es-modules/statuses": {


### PR DESCRIPTION
This PR ensures the `log_group_id` in the `developer_mode` logs is a string instead of a `UUID`. 

Currently, it looks like this in the logs:

```
"log_group_id": "UUID('97e53c11-6819-41e2-982b-361ce200e177')"
```

After this PR, it looks like this:

```
"log_group_id": "97e53c11-6819-41e2-982b-361ce200e177"
```

How to test:

- [x] I've added a unit test to test for potential regressions of this bug.
