### PR TITLE
MPP-3948: `complaintFeedbackType` is not required

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -1866,8 +1866,8 @@ def _get_complaint_data(message_json: AWS_SNSMessageJSON) -> RawComplaintData:
         raw_from_addresses = []
     from_addresses = [parseaddr(addr)[1] for addr in raw_from_addresses]
 
-    feedback_type, _ = get_or_log("complaintFeedbackType", complaint, str)
-
+    # Only present when set
+    feedback_type = complaint.get("complaintFeedbackType", "")
     # Only present when destination is on account suppression list
     subtype = complaint.get("complaintSubType", "")
     # Only present for feedback reports


### PR DESCRIPTION
In production, there are complaints that omit the `complaintFeedbackType` key. This PR updates the code to not log this as an error.

## How to test:

- [x] I've updated unit tests to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).