### PR TITLE
MPP-3927: Pre-fetch profile for domain address

### DIFF
--- a/api/tests/emails_views_tests.py
+++ b/api/tests/emails_views_tests.py
@@ -32,8 +32,6 @@ def settings_without_sqlcommenter(settings: SettingsWrapper) -> SettingsWrapper:
     First query: "SELECT id, ...
     Second query: {"sql": "SELECT id, ..."}A
     """
-
-    # The sqlcommenter middleware records queries twice for sqlite
     try:
         settings.MIDDLEWARE.remove(
             "google.cloud.sqlcommenter.django.middleware.SqlCommenter"

--- a/api/views/emails.py
+++ b/api/views/emails.py
@@ -151,7 +151,9 @@ class DomainAddressViewSet(AddressViewSet[DomainAddress]):
 
     def get_queryset(self) -> QuerySet[DomainAddress]:
         if isinstance(self.request.user, User):
-            return DomainAddress.objects.filter(user=self.request.user)
+            return DomainAddress.objects.filter(
+                user=self.request.user
+            ).prefetch_related("user", "user__profile")
         return DomainAddress.objects.none()
 
 


### PR DESCRIPTION
The API for domain address uses the subdomain on the Profile to construct the full domain address. Previously, this required 1 query to get all the domain addresses, then 2 queries _per address_ to get the subdomain. So, a user with 100 domain addresses would use 201 queries to get their list of addresses when they visited the dashboard. This may contribute to some users getting a 30 second timeout when viewing the dashboard.

With this change, the user and profile query is done once, so a user needs 1 query if they have no domain addresses, and 3 total queries for any number of domain addresses.

The relay addresses API does not use user or profile data, so it continues to use 1 query for any number of addresses.

## How to test:

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).