### PR TITLE
Use docs version of probe-scraper

### DIFF
--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -3,13 +3,7 @@ name: Glean probe-scraper
 # See:
 # https://mozilla.github.io/glean/book/user/adding-glean-to-your-project/enable-data-ingestion.html#validate-and-publish-metrics
 on:
-  # Since probe-scraper is sometimes unreliable, only call when we need to
-  push:
-    branches: ["main"]
-    paths: ["telemetry/glean/relay-server-metrics.yaml"]
-  pull_request:
-    branches: ["main"]
-    paths: ["telemetry/glean/relay-server-metrics.yaml"]
+  [push, pull_request]
 jobs:
   glean-probe-scraper:
     uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main


### PR DESCRIPTION
My version of `glean-probe-scraper.yml` is never running, even when `telemetry/glean/relay-server-metrics.yaml` updates due to `glean-parser` update. Revert to the [action definition in the docs](https://mozilla.github.io/glean/book/user/adding-glean-to-your-project/enable-data-ingestion.html#validate-and-publish-metrics).

