### PR TITLE
MPP-3852: Test `verify_from_sns`

### DIFF
--- a/emails/sns.py
+++ b/emails/sns.py
@@ -64,6 +64,13 @@ SUPPORTED_SNS_TYPES = [
 
 
 def verify_from_sns(json_body):
+    """
+    Check that the SNS message was signed by the cetificate.
+
+    https://docs.aws.amazon.com/sns/latest/dg/sns-verify-signature-of-message.html
+
+    TODO MPP-3852: Stop using OpenSSL.crypto
+    """
     pemfile = _grab_keyfile(json_body["SigningCertURL"])
     cert = crypto.load_certificate(crypto.FILETYPE_PEM, pemfile)
     signature = base64.decodebytes(json_body["Signature"].encode("utf-8"))

--- a/emails/sns.py
+++ b/emails/sns.py
@@ -69,6 +69,9 @@ def verify_from_sns(json_body):
 
     https://docs.aws.amazon.com/sns/latest/dg/sns-verify-signature-of-message.html
 
+    Only supports SignatureVersion 1. SignatureVersion 2 (SHA256) was added in
+    September 2022, and requires opt-in.
+
     TODO MPP-3852: Stop using OpenSSL.crypto
     """
     pemfile = _grab_keyfile(json_body["SigningCertURL"])

--- a/emails/tests/sns_tests.py
+++ b/emails/tests/sns_tests.py
@@ -58,12 +58,12 @@ def key_and_cert() -> tuple[rsa.RSAPrivateKey, x509.Certificate]:
 
 
 @pytest.fixture
-def cached_signing_key(
+def signing_cert_url_and_private_key(
     key_and_cert: tuple[rsa.RSAPrivateKey, x509.Certificate],
     key_cache: BaseCache,
     settings: SettingsWrapper,
 ) -> tuple[str, rsa.RSAPrivateKey]:
-    """Store the signing certificate in the cache."""
+    """Return the URL and private key for a cached signing certificate."""
     cert_url = f"https://sns.{settings.AWS_REGION}.amazonaws.com/cert.pem"
     key, cert = key_and_cert
     cert_pem = cert.public_bytes(serialization.Encoding.PEM)
@@ -129,9 +129,9 @@ def test_grab_keyfile_cert_chain_fails(
 
 
 def test_verify_from_sns_notification_with_subject_ver1(
-    cached_signing_key: tuple[str, rsa.RSAPrivateKey],
+    signing_cert_url_and_private_key: tuple[str, rsa.RSAPrivateKey],
 ) -> None:
-    cert_url, key = cached_signing_key
+    cert_url, key = signing_cert_url_and_private_key
     json_body = {
         "Type": "Notification",
         "Message": "message",

--- a/emails/tests/sns_tests.py
+++ b/emails/tests/sns_tests.py
@@ -1,11 +1,51 @@
 from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from io import BytesIO
 from unittest.mock import Mock, patch
 
+from django.core.cache import BaseCache, caches
 from django.core.exceptions import SuspiciousOperation
 
 import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from pytest_django.fixtures import SettingsWrapper
 
 from ..sns import _grab_keyfile
+
+
+@pytest.fixture(autouse=True)
+def pem_cache(settings: SettingsWrapper) -> Iterator[BaseCache]:
+    pem_cache = caches[getattr(settings, "AWS_SNS_KEY_CACHE", "default")]
+    pem_cache.clear()
+    yield pem_cache
+    pem_cache.clear()
+
+
+@pytest.fixture
+def key_and_cert() -> tuple[rsa.RSAPrivateKey, x509.Certificate]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name_attributes = [
+        x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
+        x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Oklahoma"),
+        x509.NameAttribute(NameOID.LOCALITY_NAME, "Tulsa"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Firefox Private Relay Test"),
+        x509.NameAttribute(NameOID.COMMON_NAME, "github.com/mozilla/fx-private-relay/"),
+    ]
+    subject = issuer = x509.Name(name_attributes)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(UTC) - timedelta(seconds=1))
+        .not_valid_after(datetime.now(UTC) + timedelta(seconds=60))
+        .sign(key, hashes.SHA256())
+    )
+    return key, cert
 
 
 @pytest.fixture
@@ -19,3 +59,47 @@ def test_grab_keyfile_checks_cert_url_origin(mock_urlopen: Mock) -> None:
     with pytest.raises(SuspiciousOperation):
         _grab_keyfile(cert_url)
     mock_urlopen.assert_not_called()
+
+
+def test_grab_keyfile_downloads_valid_certificate(
+    mock_urlopen: Mock,
+    key_and_cert: tuple[rsa.RSAPrivateKey, x509.Certificate],
+    pem_cache: BaseCache,
+    settings: SettingsWrapper,
+) -> None:
+    cert_url = f"https://sns.{settings.AWS_REGION}.amazonaws.com/cert.pem"
+    key, cert = key_and_cert
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    mock_urlopen.return_value = BytesIO(cert_pem)
+    ret_value = _grab_keyfile(cert_url)
+    mock_urlopen.assert_called_once_with(cert_url)
+    assert ret_value == cert_pem
+    assert pem_cache.get(cert_url) == cert_pem
+
+
+def test_grab_keyfile_reads_from_cache(
+    mock_urlopen: Mock,
+    pem_cache: BaseCache,
+    settings: SettingsWrapper,
+) -> None:
+    cert_url = f"https://sns.{settings.AWS_REGION}.amazonaws.com/cert.pem"
+    fake_pem = b"I am fake"
+    pem_cache.set(cert_url, fake_pem)
+    ret_value = _grab_keyfile(cert_url)
+    assert ret_value == fake_pem
+    mock_urlopen.assert_not_called()
+
+
+def test_grab_keyfile_cert_chain_fails(
+    mock_urlopen: Mock,
+    key_and_cert: tuple[rsa.RSAPrivateKey, x509.Certificate],
+    pem_cache: BaseCache,
+    settings: SettingsWrapper,
+) -> None:
+    cert_url = f"https://sns.{settings.AWS_REGION}.amazonaws.com/cert.pem"
+    key, cert = key_and_cert
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    two_cert_pem = b"\n".join((cert_pem, cert_pem))
+    mock_urlopen.return_value = BytesIO(two_cert_pem)
+    with pytest.raises(ValueError, match="Invalid Certificate File"):
+        _grab_keyfile(cert_url)

--- a/emails/tests/sns_tests.py
+++ b/emails/tests/sns_tests.py
@@ -21,6 +21,11 @@ from ..sns import NOTIFICATION_HASH_FORMAT, _grab_keyfile, verify_from_sns
 
 @pytest.fixture(autouse=True)
 def key_cache(settings: SettingsWrapper) -> Iterator[BaseCache]:
+    """
+    Return the cache used for signing certificates.
+
+    Clear the cache before and after tests.
+    """
     key_cache = caches[getattr(settings, "AWS_SNS_KEY_CACHE", "default")]
     key_cache.clear()
     yield key_cache
@@ -29,6 +34,7 @@ def key_cache(settings: SettingsWrapper) -> Iterator[BaseCache]:
 
 @pytest.fixture
 def key_and_cert() -> tuple[rsa.RSAPrivateKey, x509.Certificate]:
+    """Generate an RSA key and a signing certificate"""
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     name_attributes = [
         x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
@@ -49,6 +55,20 @@ def key_and_cert() -> tuple[rsa.RSAPrivateKey, x509.Certificate]:
         .sign(key, hashes.SHA256())
     )
     return key, cert
+
+
+@pytest.fixture
+def cached_signing_key(
+    key_and_cert: tuple[rsa.RSAPrivateKey, x509.Certificate],
+    key_cache: BaseCache,
+    settings: SettingsWrapper,
+) -> tuple[str, rsa.RSAPrivateKey]:
+    """Store the signing certificate in the cache."""
+    cert_url = f"https://sns.{settings.AWS_REGION}.amazonaws.com/cert.pem"
+    key, cert = key_and_cert
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_cache.set(cert_url, cert_pem)
+    return cert_url, key
 
 
 @pytest.fixture
@@ -109,15 +129,9 @@ def test_grab_keyfile_cert_chain_fails(
 
 
 def test_verify_from_sns_notification_with_subject_ver1(
-    key_and_cert: tuple[rsa.RSAPrivateKey, x509.Certificate],
-    key_cache: BaseCache,
-    settings: SettingsWrapper,
+    cached_signing_key: tuple[str, rsa.RSAPrivateKey],
 ) -> None:
-    cert_url = f"https://sns.{settings.AWS_REGION}.amazonaws.com/cert.pem"
-    key, cert = key_and_cert
-    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
-    key_cache.set(cert_url, cert_pem)
-
+    cert_url, key = cached_signing_key
     json_body = {
         "Type": "Notification",
         "Message": "message",

--- a/emails/tests/sns_tests.py
+++ b/emails/tests/sns_tests.py
@@ -1,15 +1,21 @@
-from unittest.mock import patch
+from collections.abc import Iterator
+from unittest.mock import Mock, patch
 
 from django.core.exceptions import SuspiciousOperation
-from django.test import TestCase
+
+import pytest
 
 from ..sns import _grab_keyfile
 
 
-class GrabKeyfileTest(TestCase):
-    @patch("emails.sns.urlopen")
-    def test_grab_keyfile_checks_cert_url_origin(self, mock_urlopen):
-        cert_url = "https://attacker.com/cert.pem"
-        with self.assertRaises(SuspiciousOperation):
-            _grab_keyfile(cert_url)
-        mock_urlopen.assert_not_called()
+@pytest.fixture
+def mock_urlopen() -> Iterator[Mock]:
+    with patch("emails.sns.urlopen") as mock_urlopen:
+        yield mock_urlopen
+
+
+def test_grab_keyfile_checks_cert_url_origin(mock_urlopen: Mock) -> None:
+    cert_url = "https://attacker.com/cert.pem"
+    with pytest.raises(SuspiciousOperation):
+        _grab_keyfile(cert_url)
+    mock_urlopen.assert_not_called()


### PR DESCRIPTION
This PR adds tests for `verify_from_sns`, which verifies the signature in an SNS JSON body against the signing certificate. Previously, this code was untested, and mocked whenever called. This hides that `OpenSSL.crypto.verify` has been removed in 24.3.0 (see https://github.com/mozilla/fx-private-relay/pull/5228). When running the tests, `pytest` will now report:

```
DeprecationWarning: verify() is deprecated. Use the equivalent APIs in cryptography.
```

My plan is to rebase PR #5228 after this merges, and we should then see test failures. I'll then replace `pyopenssl` and `pem` with the `cryptography` equivalents. The change will be the exception raised when verification fails.