### PR TITLE
MPP-3852: Use `cryptography` for SNS signature validation, remove `pyopenssl` and `pem`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,7 +69,6 @@ updates:
         patterns:
           - "django-stubs"
           - "djangorestframework-stubs"
-          - "types-pyOpenSSL"
           - "types-requests"
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/emails/management/commands/process_emails_from_sqs.py
+++ b/emails/management/commands/process_emails_from_sqs.py
@@ -25,7 +25,6 @@ from django.db import connection
 from django.http import HttpResponse
 
 import boto3
-import OpenSSL
 from botocore.exceptions import ClientError
 from codetiming import Timer
 from markus.utils import generate_tag
@@ -37,7 +36,7 @@ from emails.management.command_from_django_settings import (
     CommandFromDjangoSettings,
     SettingToLocal,
 )
-from emails.sns import verify_from_sns
+from emails.sns import VerificationFailed, verify_from_sns
 from emails.utils import gauge_if_enabled, incr_if_enabled
 from emails.views import _sns_inbound_logic, validate_sns_arn_and_type
 
@@ -395,7 +394,7 @@ class Command(CommandFromDjangoSettings):
             return results
         try:
             verified_json_body = verify_from_sns(json_body)
-        except (KeyError, OpenSSL.crypto.Error) as e:
+        except (KeyError, VerificationFailed) as e:
             logger.error("Failed SNS verification", extra={"error": str(e)})
             results["success"] = False
             results["error"] = f"Failed SNS verification: {e}"

--- a/emails/sns.py
+++ b/emails/sns.py
@@ -18,7 +18,8 @@ from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 logger = logging.getLogger("events")
 
-NOTIFICATION_HASH_FORMAT = """Message
+NOTIFICATION_HASH_FORMAT = """\
+Message
 {Message}
 MessageId
 {MessageId}
@@ -32,7 +33,8 @@ Type
 {Type}
 """
 
-NOTIFICATION_WITHOUT_SUBJECT_HASH_FORMAT = """Message
+NOTIFICATION_WITHOUT_SUBJECT_HASH_FORMAT = """\
+Message
 {Message}
 MessageId
 {MessageId}
@@ -44,7 +46,8 @@ Type
 {Type}
 """
 
-SUBSCRIPTION_HASH_FORMAT = """Message
+SUBSCRIPTION_HASH_FORMAT = """\
+Message
 {Message}
 MessageId
 {MessageId}

--- a/emails/sns.py
+++ b/emails/sns.py
@@ -12,7 +12,7 @@ from django.core.exceptions import SuspiciousOperation
 
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 logger = logging.getLogger("events")
@@ -112,6 +112,11 @@ def _get_hash_format(json_body: dict[str, Any]) -> str:
 
 
 def _get_signing_public_key(cert_url: str) -> rsa.RSAPublicKey:
+    """
+    Download the signing certificate and return the public key.
+
+    Or, return the cached public key from a previous call.
+    """
     cert_url_origin = f"https://sns.{settings.AWS_REGION}.amazonaws.com/"
     if not (cert_url.startswith(cert_url_origin)):
         raise SuspiciousOperation(
@@ -119,27 +124,35 @@ def _get_signing_public_key(cert_url: str) -> rsa.RSAPublicKey:
         )
 
     key_cache = caches[getattr(settings, "AWS_SNS_KEY_CACHE", "default")]
-    pemfile = key_cache.get(cert_url)
+    cache_key = f"{cert_url}:public_key"
+    public_pem = key_cache.get(cache_key)
 
     set_cache = False
-    if not pemfile:
+    if public_pem:
+        cert_pubkey = serialization.load_pem_public_key(public_pem)
+    else:
         set_cache = True
         response = urlopen(cert_url)  # noqa: S310 (check for custom scheme)
-        pemfile = response.read()
+        cert_pem = response.read()
 
-    # Extract the first certificate in the file and confirm it's a valid
-    # PEM certificate
-    certs = x509.load_pem_x509_certificates(pemfile)
+        # Extract the first certificate in the file and confirm it's a valid
+        # PEM certificate
+        certs = x509.load_pem_x509_certificates(cert_pem)
 
-    # A proper certificate file will contain 1 certificate
-    if len(certs) != 1:
-        raise VerificationFailed(
-            f"SigningCertURL {cert_url} has {len(certs)} certificates."
+        # A proper certificate file will contain 1 certificate
+        if len(certs) != 1:
+            raise VerificationFailed(
+                f"SigningCertURL {cert_url} has {len(certs)} certificates."
+            )
+        cert_pubkey = certs[0].public_key()
+        public_pem = cert_pubkey.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
         )
-    cert_pubkey = certs[0].public_key()
+
     if not isinstance(cert_pubkey, rsa.RSAPublicKey):
         raise VerificationFailed(f"SigningCertURL {cert_url} is not an RSA key")
 
     if set_cache:
-        key_cache.set(cert_url, pemfile)
+        key_cache.set(cache_key, public_pem)
     return cert_pubkey

--- a/emails/tests/sns_tests.py
+++ b/emails/tests/sns_tests.py
@@ -131,7 +131,8 @@ def test_grab_keyfile_cert_chain_fails(
     cert_pem = cert.public_bytes(serialization.Encoding.PEM)
     two_cert_pem = b"\n".join((cert_pem, cert_pem))
     mock_urlopen.return_value = BytesIO(two_cert_pem)
-    with pytest.raises(ValueError, match="Invalid Certificate File"):
+    expected = f"SigningCertURL {cert_url} has 2 certificates."
+    with pytest.raises(VerificationFailed, match=expected):
         _grab_keyfile(cert_url)
 
 

--- a/emails/tests/sns_tests.py
+++ b/emails/tests/sns_tests.py
@@ -14,13 +14,13 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.x509.oid import NameOID
-from OpenSSL.crypto import Error
 from pytest_django.fixtures import SettingsWrapper
 
 from ..sns import (
     NOTIFICATION_HASH_FORMAT,
     NOTIFICATION_WITHOUT_SUBJECT_HASH_FORMAT,
     SUBSCRIPTION_HASH_FORMAT,
+    VerificationFailed,
     _grab_keyfile,
     verify_from_sns,
 )
@@ -174,7 +174,7 @@ def test_verify_from_sns_notification_with_subject_ver1_fails(
     signature = key.sign(text_to_sign.encode(), padding.PKCS1v15(), hashes.SHA1())
     json_body["Signature"] = b64encode(signature).decode()
     json_body["Message"] = "different message"
-    with pytest.raises(Error):
+    with pytest.raises(VerificationFailed):
         verify_from_sns(json_body)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ pem==23.1.0
 psycopg[c]==3.2.3
 PyJWT==2.10.1
 python-decouple==3.8
-pyOpenSSL==24.2.1
 requests==2.32.3
 sentry-sdk==2.19.0
 whitenoise==6.8.2
@@ -58,5 +57,4 @@ mypy-boto3-ses==1.35.68
 mypy-boto3-sns==1.35.68
 mypy-boto3-sqs==1.35.0
 mypy==1.13.0
-types-pyOpenSSL==24.1.0.20240722
 types-requests==2.32.0.20241016

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ google-cloud-profiler==4.1.0; python_version < '3.13'
 gunicorn==23.0.0
 jwcrypto==1.5.6
 markus[datadog]==5.1.0
-pem==23.1.0
 psycopg[c]==3.2.3
 PyJWT==2.10.1
 python-decouple==3.8


### PR DESCRIPTION
This builds on PR #5234. It changes `emails/sns.py` to use `cryptography` for PEM loading, certificate validation, and signature verification. It removes the dependencies `pyopenssl` and `pem`, which are no longer needed.

It adds a new exception `VerificationFailed` for exceptions, rather than replace `OpenSSL.crypto.Error` with `cryptography.exceptions.InvalidSignature`. This requires updating some tests and `try` blocks, which would have needed to update anyway, but does insulate the code from future changes.

Once this merges, I expect 
* @dependabot to close PR #5228 after rebase as no longer needed
* CI to pass in PR #5223 now that pyopenssl is no longer a blocker

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).