### PR TITLE
Fix types, CSS import in frontend

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,6 +22,9 @@ coverage
 .DS_Store
 *.pem
 
+# typescript
+tsconfig.tsbuildinfo
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/frontend/__mocks__/configMock.ts
+++ b/frontend/__mocks__/configMock.ts
@@ -8,6 +8,7 @@ export const mockConfigModule = {
       fxaOrigin: "https://accounts.example.com",
       fxaLoginUrl: "https://accounts.example.com/login/",
       fxaLogoutUrl: "https://accounts.example.com/logout/",
+      supportUrl: "https://support.example.com/products/relay",
       premiumProductId: "prod_X00XXXX0xXX0Xx",
       emailSizeLimitNumber: 10,
       emailSizeLimitUnit: "MB",
@@ -15,8 +16,13 @@ export const mockConfigModule = {
       mozmailDomain: "mozmail.com",
       googleAnalyticsId: "UA-00000000-00",
       maxOnboardingAvailable: 3,
+      maxOnboardingFreeAvailable: 3,
       featureFlags: {
-        generateCustomAlias: false,
+        tips: false,
+        generateCustomAliasMenu: false,
+        generateCustomAliasSubdomain: false,
+        interviewRecruitment: false,
+        csatSurvey: false,
       },
     };
   }),

--- a/frontend/__mocks__/hooks/api/aliases.ts
+++ b/frontend/__mocks__/hooks/api/aliases.ts
@@ -28,7 +28,7 @@ const mockedGetFullAddress = getFullAddress as jest.MockedFunction<
 // We only need to mock out the functions that make HTTP requests;
 // restore the rest:
 const actualModule = jest.requireActual(
-  "../../../src/hooks/api/aliases"
+  "../../../src/hooks/api/aliases",
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ) as any;
 mockedIsRandomAlias.mockImplementation(actualModule.isRandomAlias);
@@ -36,7 +36,7 @@ mockedGetAllAliases.mockImplementation(actualModule.getAllAliases);
 mockedGetFullAddress.mockImplementation(actualModule.getFullAddress);
 
 export function getMockRandomAlias(
-  alias?: Partial<RandomAliasData>
+  alias?: Partial<RandomAliasData>,
 ): RandomAliasData {
   return {
     mask_type: "random",
@@ -62,7 +62,7 @@ export function getMockRandomAlias(
   };
 }
 export function getMockCustomAlias(
-  alias?: Partial<CustomAliasData>
+  alias?: Partial<CustomAliasData>,
 ): CustomAliasData {
   return {
     mask_type: "custom",
@@ -98,23 +98,27 @@ type Callbacks = {
 };
 function getReturnValue(
   aliasesData?: MockData,
-  callbacks?: Callbacks
+  callbacks?: Callbacks,
 ): ReturnType<typeof useAliases> {
   const randomAliasData = (aliasesData?.random || [{}]).map((alias) =>
-    getMockRandomAlias(alias)
+    getMockRandomAlias(alias),
   );
   const customAliasData = (aliasesData?.custom || [{}]).map((alias) =>
-    getMockCustomAlias(alias)
+    getMockCustomAlias(alias),
   );
 
   return {
     randomAliasData: {
       isValidating: false,
+      isLoading: false,
+      error: undefined,
       mutate: jest.fn(),
       data: randomAliasData,
     },
     customAliasData: {
       isValidating: false,
+      isLoading: false,
+      error: undefined,
       mutate: jest.fn(),
       data: customAliasData,
     },
@@ -132,14 +136,14 @@ function getReturnValue(
 
 export const setMockAliasesData = (
   aliasesData?: MockData,
-  callbacks?: Callbacks
+  callbacks?: Callbacks,
 ) => {
   mockedUseAliases.mockReturnValue(getReturnValue(aliasesData, callbacks));
 };
 
 export const setMockAliasesDataOnce = (
   aliasesData?: MockData,
-  callbacks?: Callbacks
+  callbacks?: Callbacks,
 ) => {
   mockedUseAliases.mockReturnValueOnce(getReturnValue(aliasesData, callbacks));
 };

--- a/frontend/__mocks__/hooks/api/inboundContact.ts
+++ b/frontend/__mocks__/hooks/api/inboundContact.ts
@@ -13,7 +13,7 @@ const mockedUseInboundContact = useInboundContact as jest.MockedFunction<
 >;
 
 export function getMockInboundContact(
-  inboundContact: Partial<InboundContact>
+  inboundContact: Partial<InboundContact> | undefined,
 ): InboundContact {
   return {
     id: 0,
@@ -23,8 +23,10 @@ export function getMockInboundContact(
     last_inbound_type: "call",
     num_calls: 45,
     num_calls_blocked: 3,
+    last_call_date: "2024-12-09T10:18:01.801Z",
     num_texts: 13,
     num_texts_blocked: 18,
+    last_text_date: "2024-12-09T01:18:01.801Z",
     blocked: false,
     ...inboundContact,
   };
@@ -35,35 +37,39 @@ type Callbacks = {
 };
 
 function getReturnValue(
-  inboundContacts: Array<Partial<InboundContact>> = [getMockInboundContact()],
-  callbacks?: Callbacks
+  inboundContacts: Array<Partial<InboundContact>> = [
+    getMockInboundContact(undefined),
+  ],
+  callbacks?: Callbacks,
 ): ReturnType<typeof useInboundContact> {
   return {
     isValidating: false,
     mutate: jest.fn(),
     data: inboundContacts.map((partialInboundContact) =>
-      getMockInboundContact(partialInboundContact)
+      getMockInboundContact(partialInboundContact),
     ),
     setForwardingState:
       callbacks?.setForwardingState ??
       jest.fn(() => Promise.resolve({ ok: true } as unknown as Response)),
+    error: undefined,
+    isLoading: false,
   };
 }
 
 export const setMockInboundContactData = (
   inboundContacts?: Array<Partial<InboundContact>>,
-  callbacks?: Callbacks
+  callbacks?: Callbacks,
 ) => {
   mockedUseInboundContact.mockReturnValue(
-    getReturnValue(inboundContacts, callbacks)
+    getReturnValue(inboundContacts, callbacks),
   );
 };
 
 export const setMockRelayNumberDataOnce = (
   inboundContacts?: Array<Partial<InboundContact>>,
-  callbacks?: Callbacks
+  callbacks?: Callbacks,
 ) => {
   mockedUseInboundContact.mockReturnValueOnce(
-    getReturnValue(inboundContacts, callbacks)
+    getReturnValue(inboundContacts, callbacks),
   );
 };

--- a/frontend/__mocks__/hooks/api/profile.ts
+++ b/frontend/__mocks__/hooks/api/profile.ts
@@ -26,6 +26,8 @@ export function getMockProfileData(profileData?: MockData): ProfileData {
     remove_level_one_email_trackers: false,
     subdomain: null,
     onboarding_state: 3,
+    onboarding_free_state: 3,
+    forwarded_first_reply: true,
     avatar: "",
     date_subscribed: null,
     bounce_status: [false, ""],
@@ -35,6 +37,7 @@ export function getMockProfileData(profileData?: MockData): ProfileData {
     emails_forwarded: 0,
     emails_replied: 0,
     level_one_trackers_blocked: 0,
+    metrics_enabled: false,
     ...profileData,
   };
 }
@@ -45,7 +48,7 @@ type Callbacks = {
 };
 function getReturnValue(
   profileData?: MockData | null,
-  callbacks?: Callbacks
+  callbacks?: Callbacks,
 ): ReturnType<typeof useProfiles> {
   return {
     isValidating: false,
@@ -53,19 +56,21 @@ function getReturnValue(
     update: callbacks?.updater ?? jest.fn(),
     data: profileData === null ? undefined : [getMockProfileData(profileData)],
     setSubdomain: callbacks?.setSubdomain ?? jest.fn(),
+    isLoading: false,
+    error: undefined,
   };
 }
 
 export const setMockProfileData = (
   profileData?: MockData | null,
-  callbacks?: Callbacks
+  callbacks?: Callbacks,
 ) => {
   mockedUseProfiles.mockReturnValue(getReturnValue(profileData, callbacks));
 };
 
 export const setMockProfileDataOnce = (
   profileData?: MockData | null,
-  callbacks?: Callbacks
+  callbacks?: Callbacks,
 ) => {
   mockedUseProfiles.mockReturnValueOnce(getReturnValue(profileData, callbacks));
 };

--- a/frontend/__mocks__/hooks/api/realPhone.ts
+++ b/frontend/__mocks__/hooks/api/realPhone.ts
@@ -5,12 +5,14 @@ import {
   useRealPhonesData,
   PhoneNumberRequestVerificationFn,
   PhoneNumberSubmitVerificationFn,
+  RequestPhoneRemovalFn,
+  ResendWelcomeSMSFn,
 } from "../../../src/hooks/api/realPhone";
 
 jest.mock("../../../src/hooks/api/realPhone", () => {
   // Do not mock functions like `isVerified`:
   const actualUseRealPhonesModule = jest.requireActual(
-    "../../../src/hooks/api/realPhone"
+    "../../../src/hooks/api/realPhone",
   );
   return {
     ...actualUseRealPhonesModule,
@@ -25,7 +27,7 @@ const mockedUseRealPhonesData = useRealPhonesData as jest.MockedFunction<
 >;
 
 export function getMockVerifiedRealPhone(
-  realPhone?: Partial<VerifiedPhone>
+  realPhone?: Partial<VerifiedPhone>,
 ): VerifiedPhone {
   return {
     id: 0,
@@ -40,7 +42,7 @@ export function getMockVerifiedRealPhone(
 }
 
 export function getMockVerificationPendingRealPhone(
-  realPhone?: Partial<UnverifiedPhone>
+  realPhone?: Partial<UnverifiedPhone>,
 ): UnverifiedPhone {
   return {
     id: 0,
@@ -55,7 +57,7 @@ export function getMockVerificationPendingRealPhone(
 }
 
 export function getMockUnverifiedRealPhone(
-  realPhone?: Partial<UnverifiedPhone>
+  realPhone?: Partial<UnverifiedPhone>,
 ): UnverifiedPhone {
   return {
     id: 0,
@@ -70,7 +72,7 @@ export function getMockUnverifiedRealPhone(
 }
 
 export function getMockRealPhone(
-  realPhone?: Partial<RealPhone>
+  realPhone?: Partial<RealPhone>,
 ): UnverifiedPhone {
   return getMockUnverifiedRealPhone(realPhone as Partial<UnverifiedPhone>);
 }
@@ -78,17 +80,21 @@ export function getMockRealPhone(
 type Callbacks = {
   requestPhoneVerification: PhoneNumberRequestVerificationFn;
   submitPhoneVerification: PhoneNumberSubmitVerificationFn;
+  requestPhoneRemoval: RequestPhoneRemovalFn;
+  resendWelcomeSMS: ResendWelcomeSMSFn;
 };
 
 function getReturnValue(
   realPhones: Array<Partial<RealPhone>> = [getMockRealPhone()],
-  callbacks?: Callbacks
+  callbacks?: Callbacks,
 ): ReturnType<typeof useRealPhonesData> {
   return {
     isValidating: false,
+    isLoading: false,
+    error: undefined,
     mutate: jest.fn(),
     data: realPhones.map((partialRealPhone) =>
-      getMockRealPhone(partialRealPhone)
+      getMockRealPhone(partialRealPhone),
     ),
     requestPhoneVerification:
       callbacks?.requestPhoneVerification ??
@@ -96,23 +102,29 @@ function getReturnValue(
     submitPhoneVerification:
       callbacks?.submitPhoneVerification ??
       jest.fn(() => Promise.resolve({ ok: true } as unknown as Response)),
+    requestPhoneRemoval:
+      callbacks?.requestPhoneRemoval ??
+      jest.fn(() => Promise.resolve({ ok: true } as unknown as Response)),
+    resendWelcomeSMS:
+      callbacks?.resendWelcomeSMS ??
+      jest.fn(() => Promise.resolve({ ok: true } as unknown as Response)),
   };
 }
 
 export const setMockRealPhonesData = (
   realPhones?: Array<Partial<RealPhone>>,
-  callbacks?: Callbacks
+  callbacks?: Callbacks,
 ) => {
   mockedUseRealPhonesData.mockReturnValue(
-    getReturnValue(realPhones, callbacks)
+    getReturnValue(realPhones, callbacks),
   );
 };
 
 export const setMockRealPhonesDataOnce = (
   realPhones?: Array<Partial<RealPhone>>,
-  callbacks?: Callbacks
+  callbacks?: Callbacks,
 ) => {
   mockedUseRealPhonesData.mockReturnValueOnce(
-    getReturnValue(realPhones, callbacks)
+    getReturnValue(realPhones, callbacks),
   );
 };

--- a/frontend/__mocks__/hooks/api/relayNumber.ts
+++ b/frontend/__mocks__/hooks/api/relayNumber.ts
@@ -1,6 +1,7 @@
 import {
   PhoneNumberRegisterRelayNumberFn,
   RelayNumber,
+  UpdateForwardingToPhone,
   useRelayNumber,
 } from "../../../src/hooks/api/relayNumber";
 
@@ -13,48 +14,64 @@ const mockedUseRelayNumber = useRelayNumber as jest.MockedFunction<
 >;
 
 export function getMockRelayNumber(
-  relayNumber?: Partial<RelayNumber>
+  relayNumber?: Partial<RelayNumber>,
 ): RelayNumber {
   return {
+    id: 1,
     location: "Hilo",
     number: "+18089251571",
     country_code: "US",
+    enabled: true,
+    remaining_texts: 50,
+    remaining_minutes: 60,
+    calls_forwarded: 5,
+    calls_blocked: 2,
+    texts_forwarded: 10,
+    texts_blocked: 3,
+    calls_and_texts_forwarded: 15,
+    calls_and_texts_blocked: 5,
     ...relayNumber,
   };
 }
 
 type Callbacks = {
   registerRelayNumber: PhoneNumberRegisterRelayNumberFn;
+  setForwardingState: UpdateForwardingToPhone;
 };
 
 function getReturnValue(
   relayNumbers: Array<Partial<RelayNumber>> = [getMockRelayNumber()],
-  callbacks?: Callbacks
+  callbacks?: Callbacks,
 ): ReturnType<typeof useRelayNumber> {
   return {
     isValidating: false,
+    isLoading: false,
+    error: undefined,
     mutate: jest.fn(),
     data: relayNumbers.map((partialRelayNumber) =>
-      getMockRelayNumber(partialRelayNumber)
+      getMockRelayNumber(partialRelayNumber),
     ),
     registerRelayNumber:
       callbacks?.registerRelayNumber ??
+      jest.fn(() => Promise.resolve({ ok: true } as unknown as Response)),
+    setForwardingState:
+      callbacks?.setForwardingState ??
       jest.fn(() => Promise.resolve({ ok: true } as unknown as Response)),
   };
 }
 
 export const setMockRelayNumberData = (
   relayNumbers?: Array<Partial<RelayNumber>>,
-  callbacks?: Callbacks
+  callbacks?: Callbacks,
 ) => {
   mockedUseRelayNumber.mockReturnValue(getReturnValue(relayNumbers, callbacks));
 };
 
 export const setMockRelayNumberDataOnce = (
   relayNumbers?: Array<Partial<RelayNumber>>,
-  callbacks?: Callbacks
+  callbacks?: Callbacks,
 ) => {
   mockedUseRelayNumber.mockReturnValueOnce(
-    getReturnValue(relayNumbers, callbacks)
+    getReturnValue(relayNumbers, callbacks),
   );
 };

--- a/frontend/__mocks__/hooks/api/runtimeData.ts
+++ b/frontend/__mocks__/hooks/api/runtimeData.ts
@@ -47,61 +47,65 @@ function getUnavailableProductData(): ProductData {
 export function getMockRuntimeDataWithBundle(): RuntimeData {
   return {
     FXA_ORIGIN: "https://fxa-mock.com",
-    BASKET_ORIGIN: "https://basket-mock.com",
     GOOGLE_ANALYTICS_ID: "UA-123456789-0",
+    GA4_MEASUREMENT_ID: "G-4-measurement-id",
     PERIODICAL_PREMIUM_PRODUCT_ID: "prod_123456789",
     PHONE_PRODUCT_ID: "prod_123456789",
     BUNDLE_PRODUCT_ID: "prod_123456789",
     PERIODICAL_PREMIUM_PLANS: getAvailableProductData(),
     PHONE_PLANS: getAvailableProductData(),
     BUNDLE_PLANS: getAvailableProductData(),
-    MAX_MINUTES_TO_VERIFY_REAL_PHONE: 5,
+    BASKET_ORIGIN: "https://basket-mock.com",
     WAFFLE_FLAGS: [],
+    MAX_MINUTES_TO_VERIFY_REAL_PHONE: 5,
   };
 }
 export function getMockRuntimeDataWithPhones(): RuntimeData {
   return {
     FXA_ORIGIN: "https://fxa-mock.com",
-    BASKET_ORIGIN: "https://basket-mock.com",
     GOOGLE_ANALYTICS_ID: "UA-123456789-0",
+    GA4_MEASUREMENT_ID: "G-4-measurement-id",
     PERIODICAL_PREMIUM_PRODUCT_ID: "prod_123456789",
     PHONE_PRODUCT_ID: "prod_123456789",
     BUNDLE_PRODUCT_ID: "prod_123456789",
     PERIODICAL_PREMIUM_PLANS: getAvailableProductData(),
     PHONE_PLANS: getAvailableProductData(),
     BUNDLE_PLANS: getUnavailableProductData(),
-    MAX_MINUTES_TO_VERIFY_REAL_PHONE: 5,
+    BASKET_ORIGIN: "https://basket-mock.com",
     WAFFLE_FLAGS: [],
+    MAX_MINUTES_TO_VERIFY_REAL_PHONE: 5,
   };
 }
 export function getMockRuntimeDataWithPeriodicalPremium(): RuntimeData {
   return {
     FXA_ORIGIN: "https://fxa-mock.com",
-    BASKET_ORIGIN: "https://basket-mock.com",
     GOOGLE_ANALYTICS_ID: "UA-123456789-0",
+    GA4_MEASUREMENT_ID: "G-4-measurement-id",
     PERIODICAL_PREMIUM_PRODUCT_ID: "prod_123456789",
     PHONE_PRODUCT_ID: "prod_123456789",
     BUNDLE_PRODUCT_ID: "prod_123456789",
     PERIODICAL_PREMIUM_PLANS: getAvailableProductData(),
     PHONE_PLANS: getUnavailableProductData(),
     BUNDLE_PLANS: getUnavailableProductData(),
-    MAX_MINUTES_TO_VERIFY_REAL_PHONE: 5,
+    BASKET_ORIGIN: "https://basket-mock.com",
     WAFFLE_FLAGS: [],
+    MAX_MINUTES_TO_VERIFY_REAL_PHONE: 5,
   };
 }
 export function getMockRuntimeDataWithoutPremium(): RuntimeData {
   return {
     FXA_ORIGIN: "https://fxa-mock.com",
-    BASKET_ORIGIN: "https://basket-mock.com",
     GOOGLE_ANALYTICS_ID: "UA-123456789-0",
+    GA4_MEASUREMENT_ID: "G-4-measurement-id",
     PERIODICAL_PREMIUM_PRODUCT_ID: "prod_123456789",
     PHONE_PRODUCT_ID: "prod_123456789",
     BUNDLE_PRODUCT_ID: "prod_123456789",
     PERIODICAL_PREMIUM_PLANS: getUnavailableProductData(),
     PHONE_PLANS: getUnavailableProductData(),
     BUNDLE_PLANS: getUnavailableProductData(),
-    MAX_MINUTES_TO_VERIFY_REAL_PHONE: 5,
+    BASKET_ORIGIN: "https://basket-mock.com",
     WAFFLE_FLAGS: [],
+    MAX_MINUTES_TO_VERIFY_REAL_PHONE: 5,
   };
 }
 

--- a/frontend/__mocks__/hooks/api/user.ts
+++ b/frontend/__mocks__/hooks/api/user.ts
@@ -7,10 +7,12 @@ jest.mock("../../../src/hooks/api/user");
 const mockedUseUsers = useUsers as jest.MockedFunction<typeof useUsers>;
 
 function getReturnValue(
-  userData?: Partial<UserData>
+  userData?: Partial<UserData>,
 ): ReturnType<typeof useUsers> {
   return {
     isValidating: false,
+    isLoading: false,
+    error: undefined,
     mutate: jest.fn(),
     data: [
       {

--- a/frontend/__mocks__/hooks/localLabels.ts
+++ b/frontend/__mocks__/hooks/localLabels.ts
@@ -16,33 +16,33 @@ const mockedUseLocalLabels = useLocalLabels as jest.MockedFunction<
 
 export function getReturnValueWithAddon(
   localLabels: Array<Partial<LocalLabel>> = [],
-  callback: SetLocalLabel = jest.fn()
+  callback: SetLocalLabel = jest.fn(),
 ): LocalLabelHook {
   return [
     localLabels.map((localLabel, i) => ({
       description: "Arbitrary description",
       generated_for: "https://example.com",
       id: i,
-      type: "random",
+      mask_type: "random",
       ...localLabel,
     })),
     callback,
   ];
 }
 export function getReturnValueWithoutAddon(
-  callback: SetLocalLabel = jest.fn()
+  callback: SetLocalLabel = jest.fn(),
 ): NotEnabled {
   return [null, callback];
 }
 
 export const setMockLocalLabels = (
-  returnValue: LocalLabelHook | NotEnabled = getReturnValueWithoutAddon()
+  returnValue: LocalLabelHook | NotEnabled = getReturnValueWithoutAddon(),
 ) => {
   mockedUseLocalLabels.mockReturnValue(returnValue);
 };
 
 export const setMockLocalLabelsOnce = (
-  returnValue: LocalLabelHook | NotEnabled = getReturnValueWithoutAddon()
+  returnValue: LocalLabelHook | NotEnabled = getReturnValueWithoutAddon(),
 ) => {
   mockedUseLocalLabels.mockReturnValueOnce(returnValue);
 };

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,28 +1,28 @@
-/** @type { Record<string, import("./src/config").RuntimeConfig> } */
-const runtimeConfigs = {
-  production: {
-    // The front-end and back-end are served from the same domain in production,
-    // so relative URLs can be used:
-    backendOrigin: "",
-    frontendOrigin: "",
-    fxaLoginUrl: "/accounts/fxa/login/?process=login",
-    fxaLogoutUrl: "/accounts/logout/",
-    supportUrl: "https://support.mozilla.org/products/relay",
-    emailSizeLimitNumber: 10,
-    emailSizeLimitUnit: "MB",
-    maxFreeAliases: 5,
-    mozmailDomain: "mozmail.com",
-    googleAnalyticsId: "UA-77033033-33",
-    maxOnboardingAvailable: 3,
-    maxOnboardingFreeAvailable: 3,
-    featureFlags: {
-      // Also add keys here to RuntimeConfig in src/config.ts
-      tips: true,
-      generateCustomAliasMenu: true,
-      generateCustomAliasSubdomain: false,
-      interviewRecruitment: true,
-      csatSurvey: true,
-    },
+import type { NextConfig } from "next";
+import type { RuntimeConfig } from "./src/config";
+
+const productionConfig: RuntimeConfig = {
+  // The front-end and back-end are served from the same domain in production,
+  // so relative URLs can be used:
+  backendOrigin: "",
+  frontendOrigin: "",
+  fxaLoginUrl: "/accounts/fxa/login/?process=login",
+  fxaLogoutUrl: "/accounts/logout/",
+  supportUrl: "https://support.mozilla.org/products/relay",
+  emailSizeLimitNumber: 10,
+  emailSizeLimitUnit: "MB",
+  maxFreeAliases: 5,
+  mozmailDomain: "mozmail.com",
+  googleAnalyticsId: "UA-77033033-33",
+  maxOnboardingAvailable: 3,
+  maxOnboardingFreeAvailable: 3,
+  featureFlags: {
+    // Also add keys here to RuntimeConfig in src/config.ts
+    tips: true,
+    generateCustomAliasMenu: true,
+    generateCustomAliasSubdomain: false,
+    interviewRecruitment: true,
+    csatSurvey: true,
   },
 };
 
@@ -30,8 +30,8 @@ const runtimeConfigs = {
 // is running concurrently with the Django server.
 // Due to not running on the same server as the back-end,
 // login and logout needs to be simulated using the `/mock/` pages.
-runtimeConfigs.development = {
-  ...runtimeConfigs.production,
+const developmentConfig: RuntimeConfig = {
+  ...productionConfig,
   backendOrigin: "http://127.0.0.1:8000",
   frontendOrigin: "http://localhost:3000",
   fxaLoginUrl: "http://localhost:3000/mock/login",
@@ -41,12 +41,18 @@ runtimeConfigs.development = {
 // This configuration is for the setup where the front-end is built and served
 // on its own, with the back-end mocked out using Mock Service Worker.
 // Login and logout need to be simulated using the `/mock/` pages.
-runtimeConfigs.apimock = {
-  ...runtimeConfigs.production,
+const apimockConfig: RuntimeConfig = {
+  ...productionConfig,
   backendOrigin: "",
   frontendOrigin: "",
   fxaLoginUrl: "/mock/login",
   fxaLogoutUrl: "/mock/logout",
+};
+
+const runtimeConfigs: Record<string, RuntimeConfig> = {
+  production: productionConfig,
+  development: developmentConfig,
+  apimock: apimockConfig,
 };
 
 let applicableConfig = "production";
@@ -57,8 +63,7 @@ if (process.env.NODE_ENV === "development") {
   applicableConfig = "development";
 }
 
-/** @type {import('next').NextConfig} */
-module.exports = {
+const nextConfig: NextConfig = {
   reactStrictMode: true,
   // This custom value for `pageExtensions` ensures that
   // test files are not picked up as pages to render by Next.js.
@@ -125,3 +130,5 @@ module.exports = {
     quietDeps: true,
   },
 };
+
+export default nextConfig;

--- a/frontend/src/components/dashboard/aliases/AliasGenerationButton.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasGenerationButton.test.tsx
@@ -21,8 +21,11 @@ describe("<AliasGenerationButton>", () => {
       <AliasGenerationButton
         aliases={[getMockRandomAlias()]}
         profile={getMockProfileData({ has_premium: false })}
-        onCreate={jest.fn()}
         runtimeData={getMockRuntimeDataWithoutPremium()}
+        onCreate={jest.fn()}
+        onUpdate={jest.fn()}
+        findAliasDataFromPrefix={jest.fn()}
+        setGeneratedAlias={jest.fn()}
       />,
     );
 
@@ -46,8 +49,11 @@ describe("<AliasGenerationButton>", () => {
           getMockRandomAlias(),
         ]}
         profile={getMockProfileData({ has_premium: true })}
-        onCreate={jest.fn()}
         runtimeData={getMockRuntimeDataWithoutPremium()}
+        onCreate={jest.fn()}
+        onUpdate={jest.fn()}
+        findAliasDataFromPrefix={jest.fn()}
+        setGeneratedAlias={jest.fn()}
       />,
     );
 
@@ -70,8 +76,11 @@ describe("<AliasGenerationButton>", () => {
           getMockRandomAlias(),
         ]}
         profile={getMockProfileData({ has_premium: false })}
-        onCreate={jest.fn()}
         runtimeData={getMockRuntimeDataWithPeriodicalPremium()}
+        onCreate={jest.fn()}
+        onUpdate={jest.fn()}
+        findAliasDataFromPrefix={jest.fn()}
+        setGeneratedAlias={jest.fn()}
       />,
     );
 
@@ -93,8 +102,11 @@ describe("<AliasGenerationButton>", () => {
           getMockRandomAlias(),
         ]}
         profile={getMockProfileData({ has_premium: false })}
-        onCreate={jest.fn()}
         runtimeData={getMockRuntimeDataWithoutPremium()}
+        onCreate={jest.fn()}
+        onUpdate={jest.fn()}
+        findAliasDataFromPrefix={jest.fn()}
+        setGeneratedAlias={jest.fn()}
       />,
     );
 
@@ -117,8 +129,11 @@ describe("<AliasGenerationButton>", () => {
           has_premium: false,
           subdomain: "mydomain",
         })}
-        onCreate={jest.fn()}
         runtimeData={getMockRuntimeDataWithoutPremium()}
+        onCreate={jest.fn()}
+        onUpdate={jest.fn()}
+        findAliasDataFromPrefix={jest.fn()}
+        setGeneratedAlias={jest.fn()}
       />,
     );
 
@@ -140,8 +155,11 @@ describe("<AliasGenerationButton>", () => {
             getMockRandomAlias(),
           ]}
           profile={getMockProfileData({ has_premium: true, subdomain: null })}
-          onCreate={jest.fn()}
           runtimeData={getMockRuntimeDataWithoutPremium()}
+          onCreate={jest.fn()}
+          onUpdate={jest.fn()}
+          findAliasDataFromPrefix={jest.fn()}
+          setGeneratedAlias={jest.fn()}
         />,
       );
 
@@ -178,8 +196,11 @@ describe("<AliasGenerationButton>", () => {
             has_premium: true,
             subdomain: "mydomain",
           })}
-          onCreate={jest.fn()}
           runtimeData={getMockRuntimeDataWithoutPremium()}
+          onCreate={jest.fn()}
+          onUpdate={jest.fn()}
+          findAliasDataFromPrefix={jest.fn()}
+          setGeneratedAlias={jest.fn()}
         />,
       );
 

--- a/frontend/src/components/dashboard/aliases/AliasList.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.test.tsx
@@ -152,7 +152,13 @@ describe("<AliasList>", () => {
     const mockAlias = { ...getMockRandomAlias(), description: "" };
     LocalLabelsMock.setMockLocalLabels(
       LocalLabelsMock.getReturnValueWithAddon(
-        [{ ...mockAlias, description: "some local description" }],
+        [
+          {
+            ...mockAlias,
+            used_on: undefined,
+            description: "some local description",
+          },
+        ],
         jest.fn(),
       ),
     );

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 import Link from "next/link";
 import { ToastContainer, Slide } from "react-toastify";
-import "react-toastify/scss/main.scss";
+import "react-toastify/dist/ReactToastify.css";
 import styles from "./Layout.module.scss";
 import logoTypeLight from "./images/fx-private-relay-logotype-light.svg";
 import logoTypeDark from "./images/fx-private-relay-logotype-dark.svg";

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.test.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.test.tsx
@@ -158,12 +158,17 @@ describe("The 'What's new' dashboard", () => {
       />,
     );
 
-    expect(screen.queryByText(allEntries[1].content)).not.toBeInTheDocument();
+    expect(typeof allEntries[1].content).toBe("string");
+    if (typeof allEntries[1].content !== "string") {
+      return;
+    }
+    const new_entry_content = allEntries[1].content;
+    expect(screen.queryByText(new_entry_content)).not.toBeInTheDocument();
 
     const menuItems = screen.getAllByRole("menuitem");
     await userEvent.click(menuItems[1]);
 
-    expect(screen.getByText(allEntries[1].content)).toBeInTheDocument();
+    expect(screen.getByText(new_entry_content)).toBeInTheDocument();
   });
 
   it("can go back to overview of all new features after clicking one of them", async () => {
@@ -182,7 +187,12 @@ describe("The 'What's new' dashboard", () => {
       />,
     );
 
-    expect(screen.queryByText(allEntries[1]?.content)).not.toBeInTheDocument();
+    expect(typeof allEntries[1].content).toBe("string");
+    if (typeof allEntries[1].content !== "string") {
+      return;
+    }
+    const new_entry_content = allEntries[1].content;
+    expect(screen.queryByText(new_entry_content)).not.toBeInTheDocument();
 
     const menuItems = screen.getAllByRole("menuitem");
     await userEvent.click(menuItems[1]);

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -6,6 +6,14 @@ export function getRuntimeConfig(): RuntimeConfig {
   return getConfig().publicRuntimeConfig;
 }
 
+type FeatureFlags = {
+  tips: boolean;
+  generateCustomAliasMenu: boolean;
+  generateCustomAliasSubdomain: boolean;
+  interviewRecruitment: boolean;
+  csatSurvey: boolean;
+};
+
 export type RuntimeConfig = {
   backendOrigin: string;
   frontendOrigin: string;
@@ -19,4 +27,5 @@ export type RuntimeConfig = {
   googleAnalyticsId: `UA-${number}-${number}`;
   maxOnboardingAvailable: number;
   maxOnboardingFreeAvailable: number;
+  featureFlags: FeatureFlags;
 };

--- a/frontend/src/hooks/fxaFlowTracker.test.ts
+++ b/frontend/src/hooks/fxaFlowTracker.test.ts
@@ -3,6 +3,8 @@ import { getLoginUrl } from "./fxaFlowTracker";
 
 jest.mock("../config.ts", () => mockConfigModule);
 
+const mockFlowBeginTime = new Date("1990-11-12T13:37:42.000Z").getTime();
+
 describe("getLoginUrl", () => {
   it("appends flow data", () => {
     const mockRuntimeConfig = mockConfigModule.getRuntimeConfig();
@@ -12,11 +14,12 @@ describe("getLoginUrl", () => {
     });
     expect(
       getLoginUrl("some_entrypoint", {
-        flowBeginTime: "1990-11-12T13:37:42.000Z",
+        flowBeginTime: mockFlowBeginTime,
         flowId: "some_flow_id",
       }),
     ).toBe(
-      "https://mock-login.com/?form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=1990-11-12T13%3A37%3A42.000Z",
+      "https://mock-login.com/?form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=" +
+        mockFlowBeginTime,
     );
   });
 
@@ -28,11 +31,12 @@ describe("getLoginUrl", () => {
     });
     expect(
       getLoginUrl("some_entrypoint", {
-        flowBeginTime: "1990-11-12T13:37:42.000Z",
+        flowBeginTime: mockFlowBeginTime,
         flowId: "some_flow_id",
       }),
     ).toBe(
-      "https://mock-login.com/?some_query=param&form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=1990-11-12T13%3A37%3A42.000Z",
+      "https://mock-login.com/?some_query=param&form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=" +
+        mockFlowBeginTime,
     );
   });
 
@@ -44,11 +48,12 @@ describe("getLoginUrl", () => {
     });
     expect(
       getLoginUrl("some_entrypoint", {
-        flowBeginTime: "1990-11-12T13:37:42.000Z",
+        flowBeginTime: mockFlowBeginTime,
         flowId: "some_flow_id",
       }),
     ).toBe(
-      "/login?form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=1990-11-12T13%3A37%3A42.000Z",
+      "/login?form_type=button&entrypoint=some_entrypoint&flowId=some_flow_id&flowBeginTime=" +
+        mockFlowBeginTime,
     );
   });
 });

--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -732,7 +732,7 @@ describe("The dashboard", () => {
     const updateFn: ProfileUpdateFn = jest.fn();
     setMockProfileDataOnce(
       { id: 42, has_premium: true, onboarding_state: 1 },
-      { updater: updateFn },
+      { updater: updateFn, setSubdomain: jest.fn() },
     );
     render(<Profile />);
 
@@ -748,7 +748,7 @@ describe("The dashboard", () => {
     const updateFn: ProfileUpdateFn = jest.fn();
     setMockProfileDataOnce(
       { id: 42, has_premium: true, onboarding_state: 2 },
-      { updater: updateFn },
+      { updater: updateFn, setSubdomain: jest.fn() },
     );
     render(<Profile />);
 


### PR DESCRIPTION
When attempting to fix PR #5248, I found several typescript errors, and continued to get style warnings. This PR fixes those errors, most of which are in test code.

* Convert `next.config.js` to `next.config.ts`, pass type checking
* Add missing object members to mocked API calls, re-arrange object members to match type definition order
* Switch `fxaFlowTracker.test.ts` to use a number for the time parameter instead of a string, matching the code
* Switch to importing as `import "react-toastify/dist/ReactToastify.css"`, to avoid dart sass warnings. This has the same declarations but with some additional space, which caused the CSS hash to change.
* Reformat touched files

## How to test:

* `cd frontend`
* [x] `npx tsc --noEmit` runs with no warnings or errors
* [x] `npm run test` runs with all tests passing
