### PR TITLE
Update to Django 4.2.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.35.97
 codetiming==1.4.0
 cryptography==44.0.0
-Django==4.2.17
+Django==4.2.18
 dj-database-url==2.3.0
 django-allauth[socialaccount]==65.3.1
 django-cors-headers==4.6.0


### PR DESCRIPTION
This is a [security update](https://www.djangoproject.com/weblog/2025/jan/14/security-releases/). We do not appear to use the feature, so I'm not proposing a patch to the production release.