### PR TITLE
MPP-3936: Make AcceptLanguageError picklable, handle for upgrade link

### DIFF
--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -676,5 +676,12 @@ def test_get_subplat_upgrade_link_by_language_unsupported_region(
 def test_get_subplat_upgrade_link_by_language_invalid_header(
     get_subplat_link_settings: SettingsWrapper,
 ) -> None:
-    with pytest.raises(AcceptLanguageError, match="Invalid Accept-Language string"):
-        get_subplat_upgrade_link_by_language("en-gb;q=1.0000")
+    country_lang_mapping = get_premium_country_language_mapping()
+    expected_plan = country_lang_mapping["US"]["*"]["yearly"]["id"]
+    expected_link = (
+        "https://accounts.example.com/subscriptions/products/prod_xyz?plan="
+        + expected_plan
+    )
+
+    link = get_subplat_upgrade_link_by_language("en-gb;q=1.0000")
+    assert link == expected_link

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -280,7 +280,7 @@ _LANGUAGE_TAG_TO_COUNTRY_OVERRIDE = {
 class AcceptLanguageError(ValueError):
     """There was an issue processing the Accept-Language header."""
 
-    def __init__(self, message: str, accept_lang: str):
+    def __init__(self, message: str, accept_lang: str | None = None):
         super().__init__(message)
         self.accept_lang = accept_lang
 

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -72,8 +72,11 @@ def get_countries_info_from_lang_and_mapping(
 def get_subplat_upgrade_link_by_language(
     accept_language: str, period: PeriodStr = "yearly"
 ) -> str:
-    country_str = guess_country_from_accept_lang(accept_language)
-    country = cast(CountryStr, country_str)
+    try:
+        country_str = guess_country_from_accept_lang(accept_language)
+        country = cast(CountryStr, country_str)
+    except AcceptLanguageError:
+        country = "US"
     language_str = accept_language.split("-")[0].lower()
     language = cast(LanguageStr, language_str)
     country_lang_mapping = get_premium_country_language_mapping()

--- a/privaterelay/utils.py
+++ b/privaterelay/utils.py
@@ -280,7 +280,7 @@ _LANGUAGE_TAG_TO_COUNTRY_OVERRIDE = {
 class AcceptLanguageError(ValueError):
     """There was an issue processing the Accept-Language header."""
 
-    def __init__(self, message, accept_lang):
+    def __init__(self, message: str, accept_lang: str):
         super().__init__(message)
         self.accept_lang = accept_lang
 


### PR DESCRIPTION
For [MPP-3936](https://mozilla-hub.atlassian.net/browse/MPP-3936), make `AcceptLanguageError` picklable, so that if the email handling code raises it, it can be passed from the subprocess to the cronjob's main process.

The most likely cause of the exception is `get_subplat_upgrade_link_by_language`. This PR adds tests and uses `US` as the default if the `Accept-Language` header stored in Mozilla accounts is invalid.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).


[MPP-3936]: https://mozilla-hub.atlassian.net/browse/MPP-3936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ