### PR TITLE
fix MPP-4093: ensure data-has-premium always has an explicit string value

### DIFF
--- a/frontend/src/components/dashboard/AddonData.tsx
+++ b/frontend/src/components/dashboard/AddonData.tsx
@@ -18,7 +18,7 @@ export const AddonData = (props: Props) => {
     // TODO: Make it look for this custom element instead.
     id: "profile-main",
     "data-api-token": props.profile.api_token,
-    "data-has-premium": props.profile.has_premium,
+    "data-has-premium": String(props.profile.has_premium),
     "data-fxa-subscriptions-url": `${props.runtimeData.FXA_ORIGIN}/subscriptions`,
     "data-aliases-used-val": props.aliases.length,
     "data-emails-forwarded-val": props.totalForwardedEmails,


### PR DESCRIPTION
This PR fixes #MPP-4093.

Our new `createElement` call does not implicitly convert booleans. `createElement` treats `true` as a boolean *attribute*, which results in `<firefox-private-relay-addon-data data-has-premium ...>`. [In the add-on code, we don't handle the attribute as a boolean - we treat it as a string](https://github.com/mozilla/fx-private-relay-add-on/blob/f5ad09dffb0c7391c1dd55903ccfed7a6b748ef7/src/js/relay.firefox.com/get_profile_data.js#L174-L176), so the empty attribute value returns as falsy, which makes the add-on think the user is not premium when they really are.


## How to test:
### With dev server
1. Push this branch to the dev server
2. Download `firefox_relay-2.8.1-dev-server.zip` from https://github.com/mozilla/fx-private-relay-add-on/releases/tag/2.8.1
3. In a new Firefox profile, go to `about:debugging` and install the `firefox_relay-2.8.1-dev-server.zip` add-on as described [here](https://extensionworkshop.com/documentation/develop/browser-extension-development-tools/#testing-and-debugging-tools).
   * [ ] The browser should open to the relay add-on "first run" page
3. Click the sign up/in button
   * [ ] You should be sent to the sign up/in page at https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/accounts/profile/
4. Sign up/in to a premium account
   * Either sign up/in to an account with your @mozilla.com address to get Premium, or go thru the purchase flow on a new account
5. With the add-on, generate 6 masks
   * [ ] Expected result: you CAN create more than 5 masks!


### Locally
#### In this repo:
1. Check out this branch which includes React 19 and the fix
6. `cd frontend && npm run build`
7. `python manage.py collectstatic`
8. `python manage.py runserver`

#### In the add-on repo:
1. Check out `2.8.1` tag
2. `web-ext run -s src/ -f /Applications/Firefox.app/Contents/MacOS/firefox`
   * [ ] The browser should open to the relay add-on "first run" page
3. Click the sign up/in button
   * [ ] You should be sent to the sign up/in page at 127.0.0.1:8000/accounts/profile
4. Sign into an account that has premium (note: any @mozilla.com account will have premium)
5. With the add-on, generate 6 masks
   * [ ] Expected result: you CAN create more than 5 masks!

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).