### PR TITLE
for MPP-4020: fix(settings): correct env var names for SP3 product keys

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -639,10 +639,10 @@ SUBPLAT3_PREMIUM_PRODUCT_KEY = config(
     "SUBPLAT3_PREMIUM_PRODUCT_KEY", "relay-premium-127", cast=str
 )
 SUBPLAT3_PHONES_PRODUCT_KEY = config(
-    "SUBPLAT3_PREMIUM_PRODUCT_KEY", "relay-premium-127-phone", cast=str
+    "SUBPLAT3_PHONES_PRODUCT_KEY", "relay-premium-127-phone", cast=str
 )
 SUBPLAT3_BUNDLE_PRODUCT_KEY = config(
-    "SUBPLAT3_PREMIUM_PRODUCT_KEY", "bundle-relay-vpn-dev", cast=str
+    "SUBPLAT3_BUNDLE_PRODUCT_KEY", "bundle-relay-vpn-dev", cast=str
 )
 
 LOGGING = {

--- a/privaterelay/tests/sp3_plans_tests.py
+++ b/privaterelay/tests/sp3_plans_tests.py
@@ -1,0 +1,130 @@
+"""
+Tests for privaterelay/sp3_plans.py
+"""
+
+import pytest
+
+from privaterelay.sp3_plans import (
+    CountryStr,  # for type annotation
+    _cached_country_language_mapping,
+    get_sp3_country_language_mapping,
+    get_subscription_url,
+)
+
+
+# Fixture to set SP3 settings; these can be overridden by individual tests
+@pytest.fixture(autouse=True)
+def sp3_plan_settings(settings):
+    settings.USE_SUBPLAT3 = True
+    settings.SUBPLAT3_HOST = "https://payments-test.example.com"
+    settings.SUBPLAT3_PREMIUM_PRODUCT_KEY = "premium-key"
+    settings.SUBPLAT3_PHONES_PRODUCT_KEY = "phones-key"
+    settings.SUBPLAT3_BUNDLE_PRODUCT_KEY = "bundle-key"
+    return settings
+
+
+@pytest.mark.parametrize(
+    "plan, period, expected_product_key",
+    [
+        ("premium", "monthly", "premium-key"),
+        ("premium", "yearly", "premium-key"),
+        ("phones", "monthly", "phones-key"),
+        ("phones", "yearly", "phones-key"),
+        ("bundle", "monthly", "bundle-key"),
+        ("bundle", "yearly", "bundle-key"),
+    ],
+)
+def test_get_subscription_url_parametrized(
+    settings, plan, period, expected_product_key
+):
+    """
+    Test that get_subscription_url produces the correct URL for each plan and period.
+    """
+    expected_url = f"{settings.SUBPLAT3_HOST}/{expected_product_key}/{period}/landing"
+    url = get_subscription_url(plan, period)
+    assert url == expected_url
+
+
+@pytest.mark.parametrize(
+    "key1, key2, label1, label2",
+    [
+        (
+            "SUBPLAT3_PREMIUM_PRODUCT_KEY",
+            "SUBPLAT3_PHONES_PRODUCT_KEY",
+            "Premium",
+            "Phones",
+        ),
+        (
+            "SUBPLAT3_PREMIUM_PRODUCT_KEY",
+            "SUBPLAT3_BUNDLE_PRODUCT_KEY",
+            "Premium",
+            "Bundle",
+        ),
+        (
+            "SUBPLAT3_PHONES_PRODUCT_KEY",
+            "SUBPLAT3_BUNDLE_PRODUCT_KEY",
+            "Phones",
+            "Bundle",
+        ),
+    ],
+)
+def test_sp3_product_keys_are_different(settings, key1, key2, label1, label2):
+    """Test that the two SP3 product keys are different."""
+    key_val1 = getattr(settings, key1)
+    key_val2 = getattr(settings, key2)
+    assert key_val1 != key_val2, f"{label1} and {label2} product keys should differ"
+
+
+@pytest.mark.parametrize(
+    "plan, setting_attr, new_key",
+    [
+        ("premium", "SUBPLAT3_PREMIUM_PRODUCT_KEY", "new-premium-key"),
+        ("phones", "SUBPLAT3_PHONES_PRODUCT_KEY", "new-phones-key"),
+        ("bundle", "SUBPLAT3_BUNDLE_PRODUCT_KEY", "new-bundle-key"),
+    ],
+)
+def test_sp3_overrides_parametrized(settings, plan, setting_attr, new_key):
+    """
+    Test that overriding the SP3 product keys in settings updates the subscription URLs.
+    Since the mapping is cached, we clear the cache after overriding.
+    """
+    setattr(settings, setting_attr, new_key)
+    _cached_country_language_mapping.cache_clear()
+    mapping = get_sp3_country_language_mapping(plan)
+    country: CountryStr = "US"
+    expected_url = f"{settings.SUBPLAT3_HOST}/{new_key}/monthly/landing"
+    assert mapping[country]["*"]["monthly"]["url"] == expected_url
+
+
+@pytest.mark.parametrize(
+    "plan, expected_product_key, expected_monthly_price, expected_yearly_price",
+    [
+        ("premium", "premium-key", 1.99, 0.99),
+        ("phones", "phones-key", 4.99, 3.99),
+        ("bundle", "bundle-key", 6.99, 6.99),
+    ],
+)
+def test_sp3_country_language_mapping_parametrized(
+    settings, plan, expected_product_key, expected_monthly_price, expected_yearly_price
+):
+    """
+    For each plan type, verify that for country 'US' the generated URLs and pricing
+    match the settings.
+    """
+    _cached_country_language_mapping.cache_clear()
+    mapping = get_sp3_country_language_mapping(plan)
+    country: CountryStr = "US"
+    plan_mapping = mapping[country]["*"]
+    expected_monthly_url = (
+        f"{settings.SUBPLAT3_HOST}/{expected_product_key}/monthly/landing"
+    )
+    expected_yearly_url = (
+        f"{settings.SUBPLAT3_HOST}/{expected_product_key}/yearly/landing"
+    )
+    assert plan_mapping["monthly"]["url"] == expected_monthly_url
+    assert plan_mapping["yearly"]["url"] == expected_yearly_url
+    assert plan_mapping["monthly"]["price"] == expected_monthly_price
+    assert plan_mapping["yearly"]["price"] == expected_yearly_price
+    # All SP3 plans use USD for US.
+    assert plan_mapping["monthly"]["currency"] == "USD"
+    assert plan_mapping["yearly"]["currency"] == "USD"


### PR DESCRIPTION
The `SUBPLAT3_PHONES_PRODUCT_KEY` and `SUBPLAT3_BUNDLE_PRODUCT_KEY` variables in settings.py were incorrectly assigned from `SUBPLAT3_PREMIUM_PRODUCT_KEY`. This patch fixes the typo so each config line uses the correct environment variable name.

Also adds parametrized tests in `sp3_plans_tests.py` to verify correct behavior of product key usage, including distinctness of keys and proper URL/price generation per plan.

These changes ensure correct config values are loaded and improve test coverage around SP3 plan behavior.

This PR fixes #MPP-4020.

How to test:
1. Go to https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/premium/#pricing
   * [ ] Verify that the different products (premium, phones, bundle) go to different SP3 links.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).