### PR TITLE
MPP-3976 'Get Relay' Button Loop

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -124,3 +124,5 @@ upsell-banner-4-masks-us-cta = Upgrade to { -brand-name-relay-premium }
 
 -brand-name-mozilla-monitor = Mozilla Monitor
 moz-monitor = { -brand-name-mozilla-monitor }
+
+plan-matrix-your-plan = Your Plan

--- a/frontend/src/components/Button.module.scss
+++ b/frontend/src/components/Button.module.scss
@@ -67,3 +67,26 @@
     }
   }
 }
+
+.disabled {
+  cursor: not-allowed;
+  background-color: $color-light-gray-80;
+  color: $color-dark-gray-60; // darker text
+  opacity: 0.4; // much more faded
+  pointer-events: none;
+  box-shadow: none;
+  border-color: transparent;
+  text-shadow: none;
+  transition: none;
+  filter: grayscale(100%);
+}
+
+.button.is-destructive.disabled {
+  background-color: $color-red-10;
+}
+
+.button.is-secondary.disabled {
+  background-color: transparent;
+  color: $color-blue-50;
+  opacity: 0.4;
+}

--- a/frontend/src/components/Button.test.tsx
+++ b/frontend/src/components/Button.test.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Button } from "./Button";
+
+describe("<Button>", () => {
+  it("respects the disabled prop", () => {
+    render(<Button disabled>Click me</Button>);
+
+    const button = screen.getByRole("button", { name: "Click me" });
+
+    expect(button).toBeDisabled();
+  });
+});

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -10,6 +10,7 @@ import styles from "./Button.module.scss";
 export type Props = {
   children: ReactNode;
   variant?: "destructive" | "secondary";
+  disabled?: boolean;
 };
 
 const variants = {
@@ -46,29 +47,39 @@ export const LinkButton = forwardRef<
   HTMLAnchorElement,
   Props & AnchorHTMLAttributes<HTMLAnchorElement>
 >((props, ref) => {
-  if (props.href?.startsWith("/")) {
+  const classes = `${styles.button} ${props.className ?? ""} ${
+    props.variant === "destructive" ? styles["is-destructive"] : ""
+  } ${props.disabled ? styles["disabled"] : ""}`;
+
+  if (props.href?.startsWith("/") && !props.disabled) {
     const propsWithoutHref = { ...props };
     delete propsWithoutHref.href;
+
     return (
       <Link
         href={props.href}
         {...propsWithoutHref}
         ref={ref}
-        className={`${styles.button} ${props.className} ${
-          props.variant === "destructive" ? styles["is-destructive"] : ""
-        }`}
-      ></Link>
+        className={classes}
+      >
+        {props.children}
+      </Link>
+    );
+  }
+
+  if (props.disabled) {
+    return (
+      <span className={classes} aria-disabled="true">
+        {props.children}
+      </span>
     );
   }
 
   return (
-    <a
-      {...props}
-      ref={ref}
-      className={`${styles.button} ${props.className} ${
-        props.variant === "destructive" ? styles["is-destructive"] : ""
-      }`}
-    />
+    <a href={props.href} {...props} ref={ref} className={classes}>
+      {props.children}
+    </a>
   );
 });
+
 LinkButton.displayName = "LinkButton";

--- a/frontend/src/components/landing/PlanMatrix.tsx
+++ b/frontend/src/components/landing/PlanMatrix.tsx
@@ -30,6 +30,7 @@ import { useL10n } from "../../hooks/l10n";
 import { Localized } from "../Localized";
 import { LinkButton } from "../Button";
 import { VisuallyHidden } from "../VisuallyHidden";
+import { useIsLoggedIn } from "../../hooks/session";
 
 type FeatureList = {
   "email-masks": number;
@@ -104,6 +105,8 @@ export const PlanMatrix = (props: Props) => {
     setCookie("user-sign-in", "true", { maxAgeInSeconds: 60 * 60 });
   };
 
+  const isLoggedIn = useIsLoggedIn();
+
   const desktopView = (
     <table className={styles.desktop}>
       <thead>
@@ -167,8 +170,11 @@ export const PlanMatrix = (props: Props) => {
                   href={getRuntimeConfig().fxaLoginUrl}
                   onClick={() => countSignIn("plan-matrix-free-cta-desktop")}
                   className={styles["primary-pick-button"]}
+                  disabled={isLoggedIn === "logged-in"}
                 >
-                  {l10n.getString("plan-matrix-get-relay-cta")}
+                  {isLoggedIn === "logged-in"
+                    ? l10n.getString("plan-matrix-your-plan")
+                    : l10n.getString("plan-matrix-get-relay-cta")}
                 </LinkButton>
                 {/*
                 The <small> has space for price-related notices (e.g. "* billed


### PR DESCRIPTION
<!-- When fixing a bug: -->

This PR fixes [MPP-3976](https://mozilla-hub.atlassian.net/browse/MPP-3976?atlOrigin=eyJpIjoiMGMzMDQzN2IxMDczNDIxNjkwMjk3OGZkNGFkNWNjN2EiLCJwIjoiaiJ9)

How to test:
- navigate to landing page
- notice the free tier on the matrix has a blue button (active) that says 'Get Relay'
- log into an account 
- navigate to https://relay.firefox.com/premium/
- notice the same button is now disabled and read 'Your Plan'

- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

# Screenshot (if applicable)
![Screenshot 2025-04-02 at 10 36 40 AM](https://github.com/user-attachments/assets/69a9f040-f641-4e8d-a45d-2f2551bf0442)

[MPP-3976]: https://mozilla-hub.atlassian.net/browse/MPP-3976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ