### PR TITLE
Remove deprecated and unused react-test-renderer package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,6 @@ updates:
         patterns:
           - "react"
           - "react-dom"
-          - "react-test-renderer"
       testing-library:
         patterns:
           - "@testing-library/dom"

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -49,7 +49,7 @@ and both have their dependencies checked by Dependabot.
 
 What follows is a list of dependencies and how to check for potential breakage when they release new versions:
 
-### `*lint*`, `@types/*`, `typescript`, `*jest*`, `@testing-library/*`, `react-test-renderer`, `prettier`
+### `*lint*`, `@types/*`, `typescript`, `*jest*`, `@testing-library/*`, `prettier`
 
 For linters, type definitions, and non-Playwright testing-related packages, a
 successful CI run generally provides enough confidence that the upgrade is fine.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,6 @@
     "lint-staged": "^15.5.0",
     "next": "^15.2.4",
     "prettier": "3.5.3",
-    "react-test-renderer": "^19.1.0",
     "sass": "^1.86.3",
     "stylelint": "^16.18.0",
     "stylelint-config-recommended-scss": "^14.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
         "lint-staged": "^15.5.0",
         "next": "^15.2.4",
         "prettier": "3.5.3",
-        "react-test-renderer": "^19.1.0",
         "sass": "^1.86.3",
         "stylelint": "^16.18.0",
         "stylelint-config-recommended-scss": "^14.1.0",
@@ -12727,27 +12726,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
-    },
-    "node_modules/react-test-renderer": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
-      "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-is": "^19.1.0",
-        "scheduler": "^0.26.0"
-      },
-      "peerDependencies": {
-        "react": "^19.1.0"
-      }
-    },
-    "node_modules/react-test-renderer/node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/react-toastify": {
       "version": "11.0.5",


### PR DESCRIPTION
# What  
This PR removes references to react-test-renderer. Seems like the tests are already migrated to `@testing-library/react`. The package is not used anywhere (anymore).

- Docs: [React](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#deprecated-react-test-renderer)
- NPM: [react-test-renderer](https://www.npmjs.com/package/react-test-renderer)

# How to Test

- Ensure the pipeline passes successfully, especially the unit/component tests.  
- Check out this branch. 
- Run `npm run test` in the `frontend` dir to verify the tests still work.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated relevant docs in the docs/ directory.

