### PR TITLE
MPP-4012 - feat(glean): log API access as Glean server event

### DIFF
--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -62,6 +62,7 @@ from phones.models import (
     suggested_numbers,
 )
 from privaterelay.ftl_bundles import main as ftl_bundle
+from privaterelay.utils import glean_logger
 
 from ..exceptions import ConflictError
 from ..permissions import HasPhoneService
@@ -721,6 +722,7 @@ def inbound_sms(request):
             template_name="twiml_empty_response.xml",
         )
 
+    glean_logger().log_text_received(user=real_phone.user)
     _check_remaining(relay_number, "texts")
 
     if inbound_from == real_phone.number:
@@ -1004,6 +1006,7 @@ def inbound_call(request):
             template_name="twiml_empty_response.xml",
         )
 
+    glean_logger().log_call_received(user=real_phone.user)
     number_disabled = _check_disabled(relay_number, "calls")
     if number_disabled:
         say = "Sorry, that number is not available."

--- a/privaterelay/glean/server_events.py
+++ b/privaterelay/glean/server_events.py
@@ -90,6 +90,37 @@ class EventsServerEventLogger:
 
         print(ping_envelope_serialized)
 
+    def record_api_accessed(
+        self,
+        user_agent: str,
+        ip_address: str,
+        endpoint: str,
+        method: str,
+        fxa_id: str,
+    ) -> None:
+        """
+        Record and submit a api_accessed event:
+        An API endpoint was accessed.
+        Event is logged to STDOUT via `print`.
+
+        :param str user_agent: The user agent.
+        :param str ip_address: The IP address. Will be used to decode Geo information
+            and scrubbed at ingestion.
+        :param str endpoint: The name of the endpoint accessed
+        :param str method: HTTP method used
+        :param str fxa_id: Mozilla accounts user ID
+        """
+        event = {
+            "category": "api",
+            "name": "accessed",
+            "extra": {
+                "endpoint": str(endpoint),
+                "method": str(method),
+                "fxa_id": str(fxa_id),
+            },
+        }
+        self._record(user_agent, ip_address, event)
+
     def record_email_blocked(
         self,
         user_agent: str,

--- a/privaterelay/glean/server_events.py
+++ b/privaterelay/glean/server_events.py
@@ -426,6 +426,56 @@ class EventsServerEventLogger:
         }
         self._record(user_agent, ip_address, event)
 
+    def record_phone_call_received(
+        self,
+        user_agent: str,
+        ip_address: str,
+        fxa_id: str,
+    ) -> None:
+        """
+        Record and submit a phone_call_received event:
+        A Relay user receives a phone call.
+        Event is logged to STDOUT via `print`.
+
+        :param str user_agent: The user agent.
+        :param str ip_address: The IP address. Will be used to decode Geo information
+            and scrubbed at ingestion.
+        :param str fxa_id: Mozilla accounts user ID
+        """
+        event = {
+            "category": "phone",
+            "name": "call_received",
+            "extra": {
+                "fxa_id": str(fxa_id),
+            },
+        }
+        self._record(user_agent, ip_address, event)
+
+    def record_phone_text_received(
+        self,
+        user_agent: str,
+        ip_address: str,
+        fxa_id: str,
+    ) -> None:
+        """
+        Record and submit a phone_text_received event:
+        A Relay user receives a text message.
+        Event is logged to STDOUT via `print`.
+
+        :param str user_agent: The user agent.
+        :param str ip_address: The IP address. Will be used to decode Geo information
+            and scrubbed at ingestion.
+        :param str fxa_id: Mozilla accounts user ID
+        """
+        event = {
+            "category": "phone",
+            "name": "text_received",
+            "extra": {
+                "fxa_id": str(fxa_id),
+            },
+        }
+        self._record(user_agent, ip_address, event)
+
 
 def create_events_server_event_logger(
     application_id: str,

--- a/privaterelay/glean_interface.py
+++ b/privaterelay/glean_interface.py
@@ -298,3 +298,17 @@ class RelayGleanLogger(EventsServerEventLogger):
             is_reply=is_reply,
             reason=reason,
         )
+
+    def log_api_accessed(self, request: HttpRequest) -> None:
+        """Log that any Relay API endpoint was accessed."""
+        if not request.user or not request.user.is_authenticated:
+            return
+        request_data = RequestData.from_request(request)
+        user_data = UserData.from_user(request.user)
+        self.record_api_accessed(
+            user_agent=_opt_str_to_glean(request_data.user_agent),
+            ip_address=_opt_str_to_glean(request_data.ip_address),
+            endpoint=request.path,
+            method=_opt_str_to_glean(request.method),
+            fxa_id=_opt_str_to_glean(user_data.fxa_id),
+        )

--- a/privaterelay/glean_interface.py
+++ b/privaterelay/glean_interface.py
@@ -312,3 +312,35 @@ class RelayGleanLogger(EventsServerEventLogger):
             method=_opt_str_to_glean(request.method),
             fxa_id=_opt_str_to_glean(user_data.fxa_id),
         )
+
+    def log_text_received(
+        self,
+        *,
+        user: User,
+    ) -> None:
+        """Log that a text message was received."""
+        user_data = UserData.from_user(user)
+        if not user_data.metrics_enabled:
+            return
+        request_data = RequestData()
+        self.record_phone_text_received(
+            user_agent=_opt_str_to_glean(request_data.user_agent),
+            ip_address=_opt_str_to_glean(request_data.ip_address),
+            fxa_id=_opt_str_to_glean(user_data.fxa_id),
+        )
+
+    def log_call_received(
+        self,
+        *,
+        user: User,
+    ) -> None:
+        """Log that a phone call was received."""
+        user_data = UserData.from_user(user)
+        if not user_data.metrics_enabled:
+            return
+        request_data = RequestData()
+        self.record_phone_call_received(
+            user_agent=_opt_str_to_glean(request_data.user_agent),
+            ip_address=_opt_str_to_glean(request_data.ip_address),
+            fxa_id=_opt_str_to_glean(user_data.fxa_id),
+        )

--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -13,6 +13,8 @@ import markus
 from csp.middleware import CSPMiddleware
 from whitenoise.middleware import WhiteNoiseMiddleware
 
+from privaterelay.utils import glean_logger
+
 metrics = markus.get_metrics()
 
 
@@ -197,3 +199,13 @@ class RelayStaticFilesMiddleware(WhiteNoiseMiddleware):
         else:
             static_file = self.files.get(path_info)
         return static_file is not None
+
+
+class GleanApiAccessMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path.startswith("/api/"):
+            glean_logger().log_api_accessed(request)
+        return self.get_response(request)

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -395,6 +395,7 @@ MIDDLEWARE += [
     "waffle.middleware.WaffleMiddleware",
     "privaterelay.middleware.AddDetectedCountryToRequestAndResponseHeaders",
     "privaterelay.middleware.StoreFirstVisit",
+    "privaterelay.middleware.GleanApiAccessMiddleware",
 ]
 
 ROOT_URLCONF = "privaterelay.urls"

--- a/privaterelay/tests/glean_tests.py
+++ b/privaterelay/tests/glean_tests.py
@@ -582,3 +582,43 @@ def test_log_api_accessed(
     assert payload_event["extra"]["endpoint"] == path
     assert payload_event["extra"]["method"] == "GET"
     assert payload_event["extra"]["fxa_id"] == user.profile.metrics_fxa_id
+
+
+@pytest.mark.django_db
+def test_log_text_received(
+    glean_logger: RelayGleanLogger,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Check that log_text_received emits a Glean server-side log."""
+    user = make_free_test_user()
+    with caplog.at_level("INFO"):
+        glean_logger.log_text_received(user=user)
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert_glean_record(record)
+    payload = json.loads(getattr(record, "payload"))
+    event = payload["events"][0]
+    assert event["category"] == "phone"
+    assert event["name"] == "text_received"
+    assert event["extra"]["fxa_id"] == user.profile.metrics_fxa_id
+
+
+@pytest.mark.django_db
+def test_log_call_received(
+    glean_logger: RelayGleanLogger,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Check that log_call_received emits a Glean server-side log."""
+    user = make_free_test_user()
+    with caplog.at_level("INFO"):
+        glean_logger.log_call_received(user=user)
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert_glean_record(record)
+    payload = json.loads(getattr(record, "payload"))
+    event = payload["events"][0]
+    assert event["category"] == "phone"
+    assert event["name"] == "call_received"
+    assert event["extra"]["fxa_id"] == user.profile.metrics_fxa_id

--- a/telemetry/glean/relay-server-metrics.yaml
+++ b/telemetry/glean/relay-server-metrics.yaml
@@ -142,7 +142,7 @@ api:
     description: An API endpoint was accessed.
     expires: never
     data_reviews:
-      - https://example.com/data-review
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
     notification_emails:
       - relay-team@mozilla.com
     data_sensitivity:
@@ -156,6 +156,41 @@ api:
       method:
         description: HTTP method used
         type: string
+      fxa_id:
+        description: Mozilla accounts user ID
+        type: string
+
+phone:
+  text_received:
+    type: event
+    description: A Relay user receives a text message.
+    expires: never
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/MPP-4014
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
+    notification_emails:
+      - relay-team@mozilla.com
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      fxa_id:
+        description: Mozilla accounts user ID
+        type: string
+
+  call_received:
+    type: event
+    description: A Relay user receives a phone call.
+    expires: never
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/MPP-4014
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
+    notification_emails:
+      - relay-team@mozilla.com
+    data_sensitivity:
+      - interaction
+    extra_keys:
       fxa_id:
         description: Mozilla accounts user ID
         type: string

--- a/telemetry/glean/relay-server-metrics.yaml
+++ b/telemetry/glean/relay-server-metrics.yaml
@@ -142,7 +142,7 @@ api:
     description: An API endpoint was accessed.
     expires: never
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
+      - https://github.com/mozilla/fx-private-relay/pull/5500
     notification_emails:
       - relay-team@mozilla.com
     data_sensitivity:
@@ -168,7 +168,7 @@ phone:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/MPP-4014
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
+      - https://github.com/mozilla/fx-private-relay/pull/5500
     notification_emails:
       - relay-team@mozilla.com
     data_sensitivity:
@@ -185,7 +185,7 @@ phone:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/MPP-4014
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
+      - https://github.com/mozilla/fx-private-relay/pull/5500
     notification_emails:
       - relay-team@mozilla.com
     data_sensitivity:

--- a/telemetry/glean/relay-server-metrics.yaml
+++ b/telemetry/glean/relay-server-metrics.yaml
@@ -22,7 +22,7 @@ email_mask:
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
     notification_emails:
-      - jwhitlock@mozilla.com
+      - relay-team@mozilla.com
     data_sensitivity:
       - interaction
     extra_keys: &default_mask_extra_keys
@@ -72,7 +72,7 @@ email_mask:
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
     notification_emails:
-      - jwhitlock@mozilla.com
+      - relay-team@mozilla.com
     data_sensitivity:
       - interaction
     extra_keys:
@@ -93,7 +93,7 @@ email_mask:
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
     notification_emails:
-      - jwhitlock@mozilla.com
+      - relay-team@mozilla.com
     data_sensitivity:
       - interaction
     extra_keys: *default_mask_extra_keys
@@ -109,7 +109,7 @@ email:
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
     notification_emails:
-      - jwhitlock@mozilla.com
+      - relay-team@mozilla.com
     data_sensitivity:
       - interaction
     extra_keys: &default_email_extra_keys
@@ -127,11 +127,35 @@ email:
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
     notification_emails:
-      - jwhitlock@mozilla.com
+      - relay-team@mozilla.com
     data_sensitivity:
       - interaction
     extra_keys:
       <<: *default_email_extra_keys
       reason:
         description: Code describing why the email was blocked
+        type: string
+
+api:
+  accessed:
+    type: event
+    description: An API endpoint was accessed.
+    expires: never
+    data_reviews:
+      - https://example.com/data-review
+    notification_emails:
+      - relay-team@mozilla.com
+    data_sensitivity:
+      - interaction
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/MPP-4012
+    extra_keys:
+      endpoint:
+        description: The name of the endpoint accessed
+        type: string
+      method:
+        description: HTTP method used
+        type: string
+      fxa_id:
+        description: Mozilla accounts user ID
         type: string

--- a/telemetry/glean/relay-server-metrics.yaml
+++ b/telemetry/glean/relay-server-metrics.yaml
@@ -22,6 +22,7 @@ email_mask:
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
     notification_emails:
+      - lcrouch@mozilla.com
       - relay-team@mozilla.com
     data_sensitivity:
       - interaction
@@ -72,6 +73,7 @@ email_mask:
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
     notification_emails:
+      - lcrouch@mozilla.com
       - relay-team@mozilla.com
     data_sensitivity:
       - interaction
@@ -93,6 +95,7 @@ email_mask:
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
     notification_emails:
+      - lcrouch@mozilla.com
       - relay-team@mozilla.com
     data_sensitivity:
       - interaction
@@ -109,6 +112,7 @@ email:
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
     notification_emails:
+      - lcrouch@mozilla.com
       - relay-team@mozilla.com
     data_sensitivity:
       - interaction
@@ -127,6 +131,7 @@ email:
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565
     notification_emails:
+      - lcrouch@mozilla.com
       - relay-team@mozilla.com
     data_sensitivity:
       - interaction
@@ -144,6 +149,7 @@ api:
     data_reviews:
       - https://github.com/mozilla/fx-private-relay/pull/5500
     notification_emails:
+      - lcrouch@mozilla.com
       - relay-team@mozilla.com
     data_sensitivity:
       - interaction
@@ -170,6 +176,7 @@ phone:
     data_reviews:
       - https://github.com/mozilla/fx-private-relay/pull/5500
     notification_emails:
+      - lcrouch@mozilla.com
       - relay-team@mozilla.com
     data_sensitivity:
       - interaction
@@ -187,6 +194,7 @@ phone:
     data_reviews:
       - https://github.com/mozilla/fx-private-relay/pull/5500
     notification_emails:
+      - lcrouch@mozilla.com
       - relay-team@mozilla.com
     data_sensitivity:
       - interaction


### PR DESCRIPTION
### TODO
* [x] Get data review from data stewards. (https://mozilla.slack.com/archives/C07LMRQ5Q6B/p1744656526638039)
      - https://bugzilla.mozilla.org/show_bug.cgi?id=1882565#c16

Introduce a new `api.accessed` Glean event to capture accesses to Relay API endpoints. This includes the HTTP method and endpoint path, and logs events for all `/api/` prefixed routes via a new middleware component.

- Added `record_api_accessed()` to `EventsServerEventLogger`
- Extended `RelayGleanLogger` with `log_api_accessed()` for easier integration
- Registered `GleanApiAccessMiddleware` to log access for all API routes
- Added corresponding unit test for API access logging
- Updated `relay-server-metrics.yaml` to define the `api.accessed` metric
- Updated notification email for several existing metrics to use relay-team@mozilla.com

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #MPP-4012 and #MPP-4014.

How to test:

1. [x] Run `pytest` should test that glean logging is working
       - https://app.circleci.com/pipelines/github/mozilla/fx-private-relay/21940/workflows/94f38d67-3f2c-4c0a-baac-19fb47402351/jobs/251876
3. [x] The glean probe scraper GitHub workflow should pass
       - https://github.com/mozilla/fx-private-relay/actions/runs/14453273732/job/40530682690?pr=5500

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).