### PR TITLE
fix MPP-4152 - refactor(e2e-tests): v2+v3 `SubscriptionPaymentPage`

### DIFF
--- a/e2e-tests/pages/subscriptionPaymentPage.ts
+++ b/e2e-tests/pages/subscriptionPaymentPage.ts
@@ -13,9 +13,12 @@ export class SubscriptionPaymentPage {
   readonly postalCodeField: Locator;
   readonly authorizationCheckbox: Locator;
   readonly subscriptionTitle: Locator;
+  readonly subscription3Title: Locator;
   readonly subscriptionType: Locator;
   readonly planDetails: Locator;
+  readonly planDetails3: Locator;
   readonly planType: Locator;
+  readonly planType3: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -40,7 +43,41 @@ export class SubscriptionPaymentPage {
     this.subscriptionTitle = page.locator(
       '[data-testid="subscription-create-title"]',
     );
+    this.subscription3Title = page.getByRole("heading", {
+      name: "Set up your subscription",
+    });
     this.planDetails = page.locator("#plan-details-product");
+    this.planDetails3 = page
+      .getByLabel("Purchase details")
+      .first()
+      .getByRole("heading")
+      .first();
     this.planType = page.locator(".plan-details-description");
+    this.planType3 = page.getByTestId("total-price");
+  }
+
+  private isVersion3(): boolean {
+    return this.page.url().includes("payments-next");
+  }
+
+  async getSubscriptionTitleText(): Promise<string> {
+    if (this.isVersion3()) {
+      return await this.subscription3Title.textContent();
+    }
+    return await this.subscriptionTitle.textContent();
+  }
+
+  async getPlanDetailsText(): Promise<string> {
+    if (this.isVersion3()) {
+      return await this.planDetails3.textContent();
+    }
+    return await this.planDetails.textContent();
+  }
+
+  async getPriceDetailsText(): Promise<string> {
+    if (this.isVersion3()) {
+      return await this.planType3.textContent();
+    }
+    return await this.planType.textContent();
   }
 }

--- a/e2e-tests/specs/relay-e2e.spec.ts
+++ b/e2e-tests/specs/relay-e2e.spec.ts
@@ -105,13 +105,13 @@ test.describe("Subscription flows @health_check", () => {
 
     await landingPage.selectYearlyEmailsPlan();
     // verify redirect to subscription page
-    expect(await subscriptionPage.subscriptionTitle.textContent()).toContain(
+    expect(await subscriptionPage.getSubscriptionTitleText()).toContain(
       "Set up your subscription",
     );
-    expect(await subscriptionPage.planDetails.textContent()).toEqual(
+    expect(await subscriptionPage.getPlanDetailsText()).toEqual(
       expectedEmailsPlansDetails,
     );
-    expect(await subscriptionPage.planType.textContent()).toContain("yearly");
+    expect(await subscriptionPage.getPriceDetailsText()).toContain("yearly");
   });
 
   test('Verify that the monthly emails plan "Sign Up" button works correctly, C1818792', async ({
@@ -125,13 +125,13 @@ test.describe("Subscription flows @health_check", () => {
 
     await landingPage.selectMonthlyEmailsPlan();
     // verify redirect to subscription page
-    expect(await subscriptionPage.subscriptionTitle.textContent()).toContain(
+    expect(await subscriptionPage.getSubscriptionTitleText()).toContain(
       "Set up your subscription",
     );
-    expect(await subscriptionPage.planDetails.textContent()).toEqual(
+    expect(await subscriptionPage.getPlanDetailsText()).toEqual(
       expectedEmailsPlansDetails,
     );
-    expect(await subscriptionPage.planType.textContent()).toContain("monthly");
+    expect(await subscriptionPage.getPriceDetailsText()).toContain("monthly");
   });
 
   test('Verify that the yearly emails and phones bundle plan "Sign Up" button works correctly, C1818792', async ({
@@ -141,13 +141,13 @@ test.describe("Subscription flows @health_check", () => {
     await landingPage.selectYearlyPhonesEmailsBundle();
 
     // verify redirect to subscription page
-    expect(await subscriptionPage.subscriptionTitle.textContent()).toContain(
+    expect(await subscriptionPage.getSubscriptionTitleText()).toContain(
       "Set up your subscription",
     );
-    expect(await subscriptionPage.planDetails.textContent()).toEqual(
+    expect(await subscriptionPage.getPlanDetailsText()).toEqual(
       expectedPhonesEmailsPlanDetails,
     );
-    expect(await subscriptionPage.planType.textContent()).toContain("yearly");
+    expect(await subscriptionPage.getPriceDetailsText()).toContain("yearly");
   });
 
   test('Verify that the monthly emails and phones bundle plan "Sign Up" button works correctly, C1818792', async ({
@@ -161,13 +161,13 @@ test.describe("Subscription flows @health_check", () => {
 
     await landingPage.selectMonthlyPhonesEmailsBundle();
     // verify redirect to subscription page
-    expect(await subscriptionPage.subscriptionTitle.textContent()).toContain(
+    expect(await subscriptionPage.getSubscriptionTitleText()).toContain(
       "Set up your subscription",
     );
-    expect(await subscriptionPage.planDetails.textContent()).toEqual(
+    expect(await subscriptionPage.getPlanDetailsText()).toEqual(
       expectedPhonesEmailsPlanDetails,
     );
-    expect(await subscriptionPage.planType.textContent()).toContain("monthly");
+    expect(await subscriptionPage.getPriceDetailsText()).toContain("monthly");
   });
 
   test('Verify that the VPN bundle "Sign Up" button works correctly, C1818792', async ({
@@ -177,12 +177,12 @@ test.describe("Subscription flows @health_check", () => {
     await landingPage.selectVpnBundlePlan();
 
     // verify redirect to subscription page
-    expect(await subscriptionPage.subscriptionTitle.textContent()).toContain(
+    expect(await subscriptionPage.getSubscriptionTitleText()).toContain(
       "Set up your subscription",
     );
-    expect(await subscriptionPage.planDetails.textContent()).toEqual(
+    expect(await subscriptionPage.getPlanDetailsText()).toEqual(
       expectedVPNBundleDetails,
     );
-    expect(await subscriptionPage.planType.textContent()).toContain("yearly");
+    expect(await subscriptionPage.getPriceDetailsText()).toContain("yearly");
   });
 });


### PR DESCRIPTION
* Adds `isVersion3` check and new text getters to `SubscriptionPaymentPage`.
* Updates `relay-e2e.spec.ts` to use new getters so the tests will pass on both v2 + v3 SubPlat checkout pages.

This PR fixes #MPP-4152.

How to test:
(Either locally or with the GitHub Action)
* `npx playwright test e2e-tests/specs/relay-e2e.spec.ts` while SubPlat stage is on V3 or V2
   * [ ] Tests should pass

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).