### PR TITLE
MPP-4177-auth-page-e2e-test-failing

### DIFF
--- a/e2e-tests/e2eTestUtils/helpers.ts
+++ b/e2e-tests/e2eTestUtils/helpers.ts
@@ -14,6 +14,11 @@ export const ENV_URLS = {
   local: process.env.SITE_ORIGIN,
 };
 
+export const ENV_MONITOR = {
+  stage: "https://monitor-stage.allizom.org/",
+  prod: "https://monitor.mozilla.org/",
+};
+
 export const TIMEOUTS = {
   SHORT: 2000,
   MEDIUM: 5000,

--- a/e2e-tests/pages/authPage.ts
+++ b/e2e-tests/pages/authPage.ts
@@ -5,7 +5,6 @@ export class AuthPage {
   readonly page: Page;
   readonly emailInputField: Locator;
   readonly passwordInputField: Locator;
-  readonly passwordConfirmInputField: Locator;
   readonly ageInputField: Locator;
   readonly continueButton: Locator;
   readonly createAccountButton: Locator;
@@ -13,7 +12,6 @@ export class AuthPage {
   readonly confirmCodeButton: Locator;
   readonly newPasswordInputFieldSignIn: Locator;
   readonly passwordSignupInputField: Locator;
-  readonly passwordSignupConfirmInputField: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -21,9 +19,6 @@ export class AuthPage {
     this.passwordInputField = page.locator('[type="password"]').nth(0);
     this.passwordSignupInputField = page.getByTestId(
       "new-password-input-field",
-    );
-    this.passwordSignupConfirmInputField = page.getByTestId(
-      "verify-password-input-field",
     );
     this.ageInputField = page.getByTestId("age-input-field");
     this.continueButton = page.locator('[type="submit"]').first();
@@ -91,10 +86,7 @@ export class AuthPage {
     await this.passwordSignupInputField.fill(
       process.env.E2E_TEST_ACCOUNT_PASSWORD as string,
     );
-    await this.passwordSignupConfirmInputField.fill(
-      process.env.E2E_TEST_ACCOUNT_PASSWORD as string,
-    );
-    await this.ageInputField.type("31");
+    await this.ageInputField.fill("31");
     await this.createAccountButton.click();
   }
 }

--- a/e2e-tests/pages/mozillaMonitorPage.ts
+++ b/e2e-tests/pages/mozillaMonitorPage.ts
@@ -1,5 +1,5 @@
 import { Page, Locator } from "@playwright/test";
-import { TIMEOUTS } from "../e2eTestUtils/helpers";
+import { ENV_MONITOR, TIMEOUTS } from "../e2eTestUtils/helpers";
 import { AuthPage } from "./authPage";
 
 export class MozillaMonitorPage {
@@ -19,7 +19,7 @@ export class MozillaMonitorPage {
     if (randomMask === null) {
       return new Error("Mask could not be created.");
     }
-    await this.page.goto("https://monitor.mozilla.org/", {
+    await this.page.goto(ENV_MONITOR[process.env.E2E_TEST_ENV as string], {
       waitUntil: "networkidle",
     });
     await this.monitorSignUpInput.fill(randomMask as string);


### PR DESCRIPTION
This PR fixes [MPP-4177](https://mozilla-hub.atlassian.net/browse/MPP-4177)

[fxa removed an input field](https://mozilla-hub.atlassian.net/browse/FXA-10467) ([PR](https://github.com/mozilla/fxa/commit/2bd249cd1ce948a41944a75195eb832990c933a8)) and its causing [Relay e2e tests](https://github.com/mozilla/fx-private-relay/actions/runs/14749725182/job/41404134095) to fail.

How to test:

- run end to end tests via [GH actions against stage env](https://github.com/mozilla/fx-private-relay/actions/workflows/playwright.yml)


[MPP-4177]: https://mozilla-hub.atlassian.net/browse/MPP-4177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[E2E TESTS PASS](https://github.com/mozilla/fx-private-relay/actions/runs/14760219905)