### PR TITLE
MPP-4157 Remove Get Relay Extension Banner

### DIFF
--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -11,7 +11,6 @@ import {
 } from "../../functions/getPlan";
 import {
   isUsingFirefox,
-  supportsChromeExtension,
   supportsFirefoxExtension,
 } from "../../functions/userAgent";
 import { ProfileData } from "../../hooks/api/profile";
@@ -81,7 +80,7 @@ export const ProfileBanners = (props: Props) => {
 
   // Don't show the "Get Firefox" banner if we have an extension available,
   // to avoid banner overload:
-  if (!isUsingFirefox() && (!supportsChromeExtension() || !isLargeScreen)) {
+  if (!isUsingFirefox() || !isLargeScreen) {
     banners.push(<NoFirefoxBanner key="firefox-banner" />);
   }
 
@@ -97,18 +96,6 @@ export const ProfileBanners = (props: Props) => {
     // so we'll just let the add-on hide it:
     banners.push(
       <NoAddonBanner profileData={props.profile} key="addon-banner" />,
-    );
-  }
-
-  if (supportsChromeExtension() && isLargeScreen) {
-    // This pushes a banner promoting the add-on - detecting the add-on
-    // and determining whether to show it based on that is a bit slow,
-    // so we'll just let the add-on hide it:
-    banners.push(
-      <NoChromeExtensionBanner
-        profileData={props.profile}
-        key="chrome-extension-banner"
-      />,
     );
   }
 
@@ -210,51 +197,6 @@ const NoAddonBanner = (props: NoAddonBannerProps) => {
       hiddenWithAddon={true}
     >
       <p>{l10n.getString("banner-download-install-extension-copy-2")}</p>
-    </Banner>
-  );
-};
-
-type NoChromeExtensionBannerProps = {
-  profileData: ProfileData;
-};
-
-// make dismissble
-const NoChromeExtensionBanner = (props: NoChromeExtensionBannerProps) => {
-  const l10n = useL10n();
-  const gaEvent = useGaEvent();
-
-  return (
-    <Banner
-      type="promo"
-      title={l10n.getString(
-        "banner-download-install-chrome-extension-headline",
-      )}
-      illustration={{
-        img: <Image src={AddonIllustration} alt="" width={60} height={60} />,
-      }}
-      cta={{
-        target:
-          "https://chrome.google.com/webstore/detail/firefox-relay/lknpoadjjkjcmjhbjpcljdednccbldeb?utm_source=fx-relay&utm_medium=banner&utm_campaign=install-addon",
-        content: l10n.getString("banner-download-install-chrome-extension-cta"),
-        size: "large",
-        gaViewPing: {
-          category: "Download Extension",
-          label: "profile-banner-download-chrome-extension",
-        },
-        onClick: () => {
-          gaEvent({
-            category: "Download Firefox",
-            action: "Engage",
-            label: "profile-banner-download-chrome-extension",
-          });
-        },
-      }}
-      hiddenWithAddon={true}
-      dismissal={{
-        key: `no-chrome-extension-banner-${props.profileData.id}`,
-      }}
-    >
-      <p>{l10n.getString("banner-download-install-chrome-extension-copy-2")}</p>
     </Banner>
   );
 };

--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -300,25 +300,6 @@ describe("The dashboard", () => {
     expect(firefoxBanner).toBeInTheDocument();
   });
 
-  it("shows a banner to download the Chrome extension if using a different browser that supports Chrome extensions", () => {
-    // navigator.userAgent is read-only, so we use `Object.defineProperty`
-    // as a workaround to be able to replace it with mock data anyway:
-    const previousUserAgent = navigator.userAgent;
-    Object.defineProperty(navigator, "userAgent", {
-      value:
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
-      configurable: true,
-    });
-    render(<Profile />);
-    Object.defineProperty(navigator, "userAgent", { value: previousUserAgent });
-
-    const chromeExtensionBanner = screen.getByRole("link", {
-      name: "l10n string: [banner-download-install-chrome-extension-cta], with vars: {}",
-    });
-
-    expect(chromeExtensionBanner).toBeInTheDocument();
-  });
-
   it("shows a banner to download Firefox if using a different browser that on desktop supports Chrome extensions, but is running on a small screen and thus probably does not support extensions", () => {
     // navigator.userAgent is read-only, so we use `Object.defineProperty`
     // as a workaround to be able to replace it with mock data anyway:
@@ -333,14 +314,10 @@ describe("The dashboard", () => {
     setMockMinViewportWidth(true);
     Object.defineProperty(navigator, "userAgent", { value: previousUserAgent });
 
-    const chromeExtensionBanner = screen.queryByRole("link", {
-      name: "l10n string: [banner-download-install-chrome-extension-cta], with vars: {}",
-    });
     const firefoxBanner = screen.getByRole("link", {
       name: "l10n string: [banner-download-firefox-cta], with vars: {}",
     });
 
-    expect(chromeExtensionBanner).not.toBeInTheDocument();
     expect(firefoxBanner).toBeInTheDocument();
   });
 


### PR DESCRIPTION
<!-- When adding a new feature: -->

# New feature description
When visiting the Firefox Relay Dashboard as a new user, using Chrome, the banner promoting the extension is no longer displayed.

# Screenshot (if applicable)


# How to test

- sign up as a new user on Chrome
- you will be navigated to user dashboard
- the banner to add the Relay add on (for Chrome) should NOT be displayed

# Checklist (Definition of Done)

- [X] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [X] Customer Experience team has seen or waived a demo of functionality.
- [X] All acceptance criteria are met.
- [X] Jira ticket has been updated (if needed) to match changes made during the development process.
- [X] I've added or updated relevant docs in the docs/ directory
- [X] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [X] l10n changes have been submitted to the l10n repository, if any.