### PR TITLE
for MPP-4177: set monitor stage domain for local and dev tests

### DIFF
--- a/e2e-tests/e2eTestUtils/helpers.ts
+++ b/e2e-tests/e2eTestUtils/helpers.ts
@@ -15,6 +15,8 @@ export const ENV_URLS = {
 };
 
 export const ENV_MONITOR = {
+  dev: "https://monitor-stage.allizom.org/",
+  local: "https://monitor-stage.allizom.org/",
   stage: "https://monitor-stage.allizom.org/",
   prod: "https://monitor.mozilla.org/",
 };


### PR DESCRIPTION
This PR fixes #MPP-4177.

How to test:
1. Run [the Relay e2e tests workflow](https://github.com/mozilla/fx-private-relay/actions/workflows/playwright.yml) from this branch against the dev environment.
   * [ ] It should succeed. (See [this run](https://github.com/mozilla/fx-private-relay/actions/runs/14796687847) I already ran.)

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).