### PR TITLE
fix MPP-4189: change debug report filter to allow-list

### DIFF
--- a/privaterelay/debug.py
+++ b/privaterelay/debug.py
@@ -5,36 +5,30 @@ from django.views.debug import SafeExceptionReporterFilter
 
 class RelaySaferExceptionReporterFilter(SafeExceptionReporterFilter):
     """
-    Add more settings values that should be hidden in debug and exception reports.
-
-    This is also used by the Django Debug Toolbar settings panel.
+    Hide all settings EXCEPT ones explicitly allowed by SAFE_PREFIXES or SAFE_NAMES.
     """
 
-    # Hide any variable value that starts with these prefixes
-    UNSAFE_PREFIXES = ["AWS_", "IQ_", "TWILIO_", "REDIS_"]
+    # Allow variable values that start with these prefixes
+    SAFE_PREFIXES: list = []
 
-    # Hide any variable value named in this list
-    UNSAFE_NAMES = [
-        # Settings
-        "ALLOWED_ACCOUNTS",
-        "ALLOWED_HOSTS",
-        "DJANGO_ALLOWED_HOSTS",
-        "INTERNAL_IPS",
-        # Environment Variables / META
-        "CSRF_COOKIE",
-        "DATABASE_URL",
-        "DJANGO_ALLOWED_HOST",
-        "DJANGO_ALLOWED_SUBNET",
-        "DJANGO_INTERNAL_IPS",
-        "GOOGLE_APPLICATION_CREDENTIALS",
-        "GOOGLE_CLOUD_PROFILER_CREDENTIALS_B64",
-        "SENTRY_DSN",
+    # Allow variable values named in this list
+    SAFE_NAMES = [
+        "BUNDLE_PLAN_ID_US",
+        "BUNDLE_PROD_ID",
+        "RELAY_CHANNEL",
+        "RELAY_CHANNEL_NAME",
+        "RELAY_FROM_ADDRESS",
+        "SUBPLAT3_BUNDLE_PRODUCT_KEY",
+        "SUBPLAT3_PHONES_PRODUCT_KEY",
+        "SUBPLAT3_PREMIUM_PRODUCT_KEY",
     ]
 
+    # Match everything EXCEPT safe names and safe prefixes
     hidden_settings = re.compile(
-        "API|TOKEN|KEY|SECRET|PASS|SIGNATURE|HTTP_COOKIE|"
-        + "|".join(f"^{prefix}" for prefix in UNSAFE_PREFIXES)
+        r"^(?!("
+        + "|".join(f"{re.escape(name)}" for name in SAFE_NAMES)
         + "|"
-        + "|".join(f"^{name}$" for name in UNSAFE_NAMES),
+        + "|".join(f"{re.escape(prefix)}.*" for prefix in SAFE_PREFIXES)
+        + r")$).+",
         re.IGNORECASE,
     )

--- a/privaterelay/tests/debug_tests.py
+++ b/privaterelay/tests/debug_tests.py
@@ -17,8 +17,13 @@ def test_default_filter() -> None:
 @pytest.mark.parametrize(
     "name",
     (
-        "ACCOUNT_ADAPTER",
-        "LOGGING_CONFIG",
+        "BUNDLE_PLAN_ID_US",
+        "BUNDLE_PROD_ID",
+        "RELAY_CHANNEL",
+        "RELAY_FROM_ADDRESS",
+        "SUBPLAT3_BUNDLE_PRODUCT_KEY",
+        "SUBPLAT3_PHONES_PRODUCT_KEY",
+        "SUBPLAT3_PREMIUM_PRODUCT_KEY",
     ),
 )
 def test_safe_settings(name: str) -> None:
@@ -31,6 +36,7 @@ def test_safe_settings(name: str) -> None:
 @pytest.mark.parametrize(
     "name",
     (
+        "ACCOUNT_ADAPTER",
         "ALLOWED_ACCOUNTS",
         "ALLOWED_HOSTS",
         "AUTH_PASSWORD_VALIDATORS",
@@ -43,6 +49,7 @@ def test_safe_settings(name: str) -> None:
         "AWS_SQS_EMAIL_DLQ_URL",
         "AWS_SQS_EMAIL_QUEUE_URL",
         "AWS_SQS_QUEUE_URL",
+        "CACHES",
         "DJANGO_ALLOWED_HOSTS",
         "IQ_ENABLED",
         "IQ_FOR_NEW_NUMBERS",
@@ -53,6 +60,7 @@ def test_safe_settings(name: str) -> None:
         "IQ_MESSAGE_PATH",
         "IQ_OUTBOUND_API_KEY",
         "IQ_PUBLISH_MESSAGE_URL",
+        "LOGGING_CONFIG",
         "PASSWORD_HASHERS",
         "PASSWORD_RESET_TIMEOUT",
         "SECRET_KEY",
@@ -80,6 +88,9 @@ def test_unsafe_settings(name: str) -> None:
 def meta_request(rf: RequestFactory) -> HttpRequest:
     request = rf.get(
         path="/meta-test",
+        BUNDLE_PLAN_ID_US="price_1LwoSDJNcmPzuWtR6wPJZeoh",
+        BUNDLE_PROD_ID="bundle-relay-vpn-dev",
+        CACHES={"default": {"LOCATION": "rediss://user:pass@redis.example.com:10001"}},
         CSRF_COOKIE="cross-site-request-forgery-cookie",
         DATABASE_URL="postgres://user:pass@db.example.com:5432/relay_db",
         DJANGO_ALLOWED_HOST="relay.example.com",
@@ -95,9 +106,8 @@ def meta_request(rf: RequestFactory) -> HttpRequest:
 @pytest.mark.parametrize(
     "name",
     (
-        "REMOTE_ADDR",
-        "SCRIPT_NAME",
-        "wsgi.version",
+        "BUNDLE_PLAN_ID_US",
+        "BUNDLE_PROD_ID",
     ),
 )
 def test_safe_meta(name: str, meta_request: HttpRequest) -> None:
@@ -109,6 +119,7 @@ def test_safe_meta(name: str, meta_request: HttpRequest) -> None:
 @pytest.mark.parametrize(
     "name",
     (
+        "CACHES",
         "CSRF_COOKIE",
         "DATABASE_URL",
         "DJANGO_ALLOWED_HOST",


### PR DESCRIPTION
This PR fixes #MPP-4189.
![image](https://github.com/user-attachments/assets/e8383f91-8fc4-4e01-800b-aeccd1beb0b4)

How to test:
1. `pytest` includes tests for this
2. Make sure `DEBUG=True` in your local environment
3. Visit http://127.0.0.1:8000/accounts/
   * [ ] It should show a 404 page with DEBUG output
4. Expand the DjDT sidebar on the right
5. Click "Settings" to open the settings panel
   * [ ] Nearly every setting value should now be `'********************'`

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).