### PR TITLE
fix MPP-4189: force RelaySaferExceptionReporterFilter.is_active = True

### DIFF
--- a/privaterelay/debug.py
+++ b/privaterelay/debug.py
@@ -1,5 +1,6 @@
 import re
 
+from django.http.request import HttpRequest
 from django.views.debug import SafeExceptionReporterFilter
 
 
@@ -7,6 +8,14 @@ class RelaySaferExceptionReporterFilter(SafeExceptionReporterFilter):
     """
     Hide all settings EXCEPT ones explicitly allowed by SAFE_PREFIXES or SAFE_NAMES.
     """
+
+    # By default, Django disables the filter if DEBUG=True.
+    # Django correctly assumes "If DEBUG is True then your site is not safe anyway."
+    # (https://github.com/django/django/blob/1520d18/django/views/debug.py#L175)
+    # But, we sometimes temporarily set DEBUG=True in our dev environment to help debug.
+    # And even in that case, we want as much additional safety as we can get.
+    def is_active(self, request: HttpRequest | None) -> bool:
+        return True
 
     # Allow variable values that start with these prefixes
     SAFE_PREFIXES: list = []

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -489,7 +489,10 @@ if REDIS_URL:
     }
     # Heroku mini uses self-signed certificates
     if REDIS_SELF_SIGNED_CERT:
-        _redis_options["CONNECTION_POOL_KWARGS"] = {"ssl_cert_reqs": None}
+        _redis_options["CONNECTION_POOL_KWARGS"] = {
+            "ssl_cert_reqs": None,
+            "ssl_check_hostname": False,
+        }
 
     CACHES = {
         "default": {


### PR DESCRIPTION
This PR fixes #MPP-4189 on the dev server. (See https://mozilla-hub.atlassian.net/browse/MPP-4189?focusedCommentId=1058111)

How to test:
I deployed this branch to the dev server, so:
1. Visit https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/fxa-rp-events 
   * [ ] Check that the `CACHES` values is now properly filtered to `'********************'`

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).