### PR TITLE
update(node): update node to 22

### DIFF
--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -18,4 +18,4 @@ publish = "out/"
 # Default build command.
 command = "npm install; npm run build:mocked"
 
-environment = { NODE_VERSION = "18.20.6", NPM_VERSION = "9.9.4" }
+environment = { NODE_VERSION = "22.15.0", NPM_VERSION = "10.9.2" }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,8 +66,8 @@
     "typescript": "^5.8.3"
   },
   "volta": {
-    "node": "18.20.6",
-    "npm": "9.9.4"
+    "node": "22.15.0",
+    "npm": "10.9.2"
   },
   "msw": {
     "workerDirectory": "public"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "dotenv": "^16.5.0"
   },
   "volta": {
-    "node": "18.20.6",
-    "npm": "9.9.4"
+    "node": "22.15.0",
+    "npm": "10.9.2"
   },
   "license": "MPL-2.0",
   "private": true,


### PR DESCRIPTION
Node 18 is reaching EOL and a number of our frontend dependencies are requiring node >= 20. Node 22 is the new LTS.

How to test:

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).