### PR TITLE
MPP-4203 Free Onboarding Mobile Flow Missing 'Finish' Button

### DIFF
--- a/frontend/src/components/dashboard/FreeOnboarding.tsx
+++ b/frontend/src/components/dashboard/FreeOnboarding.tsx
@@ -268,7 +268,7 @@ export const FreeOnboarding = (props: Props) => {
       <LinkButton
         ref={nextStepTwoButtonRef}
         target="_blank"
-        className={`is-hidden-with-addon ${styles["get-addon-button"]}`}
+        className={`is-hidden-with-addon`}
         onClick={finish}
       >
         {l10n.getString("profile-free-onboarding-addon-finish")}


### PR DESCRIPTION
# Fixes [MPP-4203](https://mozilla-hub.atlassian.net/browse/MPP-4203)

# How to test:
- Navigate to the Relay Landing page;
- Sign up with the non-Mozilla account;
- In the Free user onboarding, go to the third step (“Generate new mask” on the first step, “Next >” on the second step);
- Observe the contents of the step --> Finish button should now be showing

# Screenshots
![Screenshot 2025-05-19 at 1 38 02 PM](https://github.com/user-attachments/assets/8bd8df7c-b4b9-47c3-b06a-d30fde3d836e)

# Checklist
- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

[MPP-4203]: https://mozilla-hub.atlassian.net/browse/MPP-4203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ