### PR TITLE
⚠️ DNM: Add GitHub Actions workflow to update FxRelay allowlist collection

### DIFF
--- a/.github/workflows/update-allowlist.yml
+++ b/.github/workflows/update-allowlist.yml
@@ -1,0 +1,32 @@
+name: Update FxRelay Allowlist Collection
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'privaterelay/fxrelay-allowlist-domains.txt'
+
+jobs:
+  update-allowlist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5.6.0
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Run update_fxrelay_allowlist_collection
+        env:
+          REMOTE_SETTINGS_SERVER: ${{ secrets.REMOTE_SETTINGS_SERVER }}
+          REMOTE_SETTINGS_AUTH: ${{ secrets.REMOTE_SETTINGS_AUTH }}
+          REMOTE_SETTINGS_BUCKET: ${{ secrets.REMOTE_SETTINGS_BUCKET }}
+          REMOTE_SETTINGS_COLLECTION: ${{ secrets.REMOTE_SETTINGS_COLLECTION }}
+          ALLOWLIST_INPUT_URL: ${{ secrets.ALLOWLIST_INPUT_URL }}
+        run: |
+          python manage.py update_fxrelay_allowlist_collection

--- a/.github/workflows/update-allowlist.yml
+++ b/.github/workflows/update-allowlist.yml
@@ -6,6 +6,21 @@ on:
       - main
     paths:
       - 'privaterelay/fxrelay-allowlist-domains.txt'
+  workflow_dispatch:
+    inputs:
+      remote_settings_env:
+        description: 'Remote Settings Server to update'
+        required: true
+        default: 'prod'
+        type: choice
+        options:
+          - dev
+          - stage
+          - prod
+      branch:
+        description: 'Branch from which to fetch fxrelay-allowlist-domains.txt'
+        required: true
+        default: 'main'
 
 jobs:
   update-allowlist:
@@ -13,20 +28,46 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5.6.0
         with:
           python-version: '3.11'
           cache: 'pip'
+
       - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Set environment-specific variables
+        id: set-env
         run: |
-          pip install -r requirements.txt
+          case "${{ github.event.inputs.remote_settings_env }}" in
+            dev)
+              echo "REMOTE_SETTINGS_SERVER=https://remote-settings-dev.allizom.org/v1/" >> $GITHUB_ENV
+              echo "REMOTE_SETTINGS_AUTH=${{ secrets.REMOTE_SETTINGS_AUTH_DEV }}" >> $GITHUB_ENV
+              ;;
+            stage)
+              echo "REMOTE_SETTINGS_SERVER=https://remote-settings.allizom.org/v1/" >> $GITHUB_ENV
+              echo "REMOTE_SETTINGS_AUTH=${{ secrets.REMOTE_SETTINGS_AUTH_STAGE }}" >> $GITHUB_ENV
+              ;;
+            prod)
+              echo "REMOTE_SETTINGS_SERVER=https://remote-settings.mozilla.org/v1/" >> $GITHUB_ENV
+              echo "REMOTE_SETTINGS_AUTH=${{ secrets.REMOTE_SETTINGS_AUTH_PROD }}" >> $GITHUB_ENV
+              ;;
+            *)
+              echo "Invalid remote_settings_env value" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "ALLOWLIST_INPUT_URL=https://raw.githubusercontent.com/mozilla/fx-private-relay/refs/heads/${{ github.event.inputs.branch }}/privaterelay/fxrelay-allowlist-domains.txt" >> $GITHUB_ENV
+
       - name: Run update_fxrelay_allowlist_collection
         env:
-          REMOTE_SETTINGS_SERVER: ${{ secrets.REMOTE_SETTINGS_SERVER }}
-          REMOTE_SETTINGS_AUTH: ${{ secrets.REMOTE_SETTINGS_AUTH }}
-          REMOTE_SETTINGS_BUCKET: ${{ secrets.REMOTE_SETTINGS_BUCKET }}
-          REMOTE_SETTINGS_COLLECTION: ${{ secrets.REMOTE_SETTINGS_COLLECTION }}
-          ALLOWLIST_INPUT_URL: ${{ secrets.ALLOWLIST_INPUT_URL }}
+          REMOTE_SETTINGS_SERVER: ${{ env.REMOTE_SETTINGS_SERVER }}
+          REMOTE_SETTINGS_AUTH: ${{ env.REMOTE_SETTINGS_AUTH }}
+          REMOTE_SETTINGS_BUCKET: ${{ env.REMOTE_SETTINGS_BUCKET }}
+          REMOTE_SETTINGS_COLLECTION: ${{ env.REMOTE_SETTINGS_COLLECTION }}
+          ALLOWLIST_INPUT_URL: ${{ env.ALLOWLIST_INPUT_URL }}
         run: |
           python manage.py update_fxrelay_allowlist_collection

--- a/docs/fxrelay-allowlist.md
+++ b/docs/fxrelay-allowlist.md
@@ -1,0 +1,75 @@
+# Maintaining the FxRelay Allowlist Collection
+
+This document describes how the Firefox Relay allowlist Remote Settings collection
+(`fxrelay-allowlist`) is maintained and updated.
+
+## Overview
+
+The `fxrelay-allowlist` is a collection of domains managed via
+[Mozilla Remote Settings][rs-docs]. Updates to the allowlist are automated using a
+Django management command and a GitHub Actions workflow.
+
+## Source of Truth
+
+- The list of allowed domains is stored in a text file:  
+  `privaterelay/fxrelay-allowlist-domains.txt`
+- Each line in this file represents a domain to be included in the allowlist.
+
+## Update Process
+
+### 1. Trigger
+
+- Any push to the `main` branch that modifies `privaterelay/fxrelay-allowlist-domains.txt`
+  triggers the update workflow.
+
+### 2. GitHub Actions Workflow
+
+- The workflow is defined in `.github/workflows/update-allowlist.yml`.
+- It performs the following steps:
+  1. Checks out the repository.
+  2. Sets up Python (version 3.11).
+  3. Installs dependencies from `requirements.txt`.
+  4. Runs the management command `update_fxrelay_allowlist_collection` with the necessary environment variables.
+
+### 3. Management Command
+
+- The command is implemented in `privaterelay/management/commands/update_fxrelay_allowlist_collection.py`.
+- It performs the following actions:
+  1. Downloads the latest allowlist from a configured URL (`ALLOWLIST_INPUT_URL`).
+  2. Connects to the Remote Settings server using credentials and collection details provided via environment variables.
+  3. Ensures the target bucket and collection exist.
+  4. Compares the new allowlist with the existing records:
+     - Removes domains no longer present or with mismatched IDs.
+     - Adds new domains.
+  5. If changes are made, requests a review for the updated collection.
+
+#### Required Environment Variables
+
+- `REMOTE_SETTINGS_SERVER`: URL of the Remote Settings server.
+- `REMOTE_SETTINGS_AUTH`: Authentication credentials for the server.
+- `REMOTE_SETTINGS_BUCKET`: Name of the bucket.
+- `REMOTE_SETTINGS_COLLECTION`: Name of the collection.
+- `ALLOWLIST_INPUT_URL`: URL to fetch the latest allowlist (typically points to the raw GitHub file).
+
+These are provided as GitHub secrets in the workflow.
+
+## Manual Execution
+
+To run the update manually (with the correct environment variables set):
+
+```sh
+python manage.py update_fxrelay_allowlist_collection
+```
+
+## Review and Approval
+
+- After changes are made, the collection status is set to `to-review` to request a review in Remote Settings.
+
+---
+
+**Summary:**  
+The allowlist is maintained by editing a text file and pushing to `main`.
+An automated workflow updates the Remote Settings collection accordingly,
+ensuring the allowlist is always in sync with the repository.
+
+[rs-docs]: https://remote-settings.readthedocs.io/en/latest/


### PR DESCRIPTION
# `update_fxrelay_allowlist_collection` command

# Screenshot (if applicable)
<img width="1190" alt="image" src="https://github.com/user-attachments/assets/1483f65d-c900-40b0-9af1-1de634c0cea1" />

# How to test
1. Merge this PR so the GitHub Action is available.
2. Go to [the action secrets](https://github.com/mozilla/fx-private-relay/settings/secrets/actions) for this repo to set the required variables to the RS dev server:
   * `REMOTE_SETTINGS_SERVER`: `https://remote-settings-dev.allizom.org` (See [the RS environment doc](https://remote-settings.readthedocs.io/en/latest/getting-started.html#environments))
   * `REMOTE_SETTINGS_AUTH`: `fxrelay-publisher:<redacted>` (Retrieve from 1Password Relay vault item for `dev - fxrelay-publisher`)
   * `REMOTE_SETTINGS_BUCKET`: `main-workspace`
   * `REMOTE_SETTINGS_COLLECTION`: `fxrelay-allowlist`
   * `ALLOWLIST_INPUT_URL`: `https://raw.githubusercontent.com/mozilla/fx-private-relay/refs/heads/main/privaterelay/fxrelay-allowlist-domains.txt`
3. Run the action.
   * [ ] It should show ` ⚪️ No changes found.` because the dev server is up-to-date
4. **STAGE CHECK** Change [the action secrets](https://github.com/mozilla/fx-private-relay/settings/secrets/actions) for this repo to set the required variables to the RS stage server.
   * `REMOTE_SETTINGS_SERVER`: `https://remote-settings.allizom.org` (See [the RS environment doc](https://remote-settings.readthedocs.io/en/latest/getting-started.html#environments))
   * `REMOTE_SETTINGS_AUTH`: `fxrelay-publisher:<redacted>` (Retrieve from 1Password Relay vault item for `stage - fxrelay-publisher`)
5. Run the action.
   * [ ] It MAY show some changes, if the stage server is not up-to-date.
   * [ ] Go to [the fxrelay-allowlist collection in the RS STAGE admin UI](https://remote-settings.allizom.org/v1/admin/#/buckets/main-workspace/collections/fxrelay-allowlist/records).
   * [ ] If necessary, review and approve the changes to the collection.
6. **PRODUCTION CHECK** Change [the action secrets](https://github.com/mozilla/fx-private-relay/settings/secrets/actions) for this repo to set the required variables to the RS prod server.
   * `REMOTE_SETTINGS_SERVER`: `https://remote-settings.mozilla.org` (See [the RS environment doc](https://remote-settings.readthedocs.io/en/latest/getting-started.html#environments))
   * `REMOTE_SETTINGS_AUTH`: `fxrelay-publisher:<redacted>` (Retrieve from 1Password Relay vault item for `prod - fxrelay-publisher`)
7. Run the action.
   * [ ] It SHOULD show some changes, because the prod server is not up-to-date.
   * [ ] Go to [the fxrelay-allowlist collection in the RS PROD admin UI](https://remote-settings.mozilla.org/v1/admin/#/buckets/main-workspace/collections/fxrelay-allowlist/records).
   * [ ] Review and approve the changes to the collection.

# Checklist (Definition of Done)

- [x] ~Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.~
   * On PTO; will demo when back.
- [x] Customer Experience team has seen or waived a demo of functionality.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] ~l10n changes have been submitted to the l10n repository, if any.~