### PR TITLE
MPP-4222 Fix Megabundle Banner Mobile

### DIFF
--- a/frontend/src/components/landing/MegaBundleBanner.module.scss
+++ b/frontend/src/components/landing/MegaBundleBanner.module.scss
@@ -150,7 +150,7 @@
       );
     background-repeat: no-repeat;
     background-position:
-      376% 82%,
+      376% -23vh,
       center;
     background-size:
       90% auto,
@@ -291,7 +291,7 @@
       );
     background-repeat: no-repeat;
     background-position:
-      center -597%,
+      center -14vh,
       center;
     background-size:
       115% auto,
@@ -366,7 +366,7 @@
           li {
             border-radius: 24px;
             background: rgba(0, 96, 223, 0.12);
-            padding: $spacing-xs $spacing-md;
+            padding: $spacing-xs $spacing-sm;
             font-weight: 500;
             display: flex;
             flex-direction: row;


### PR DESCRIPTION
## [MPP-4222](https://mozilla-hub.atlassian.net/browse/MPP-4222)
- fixes the designs of the megabundle banner for mobile 

# How to test:
- notice megabundle banner on the landing page
- play around with screen size to test the design -- specifically mobile
**- FYI: number values are dummy numbers I put to see on my local** 

# Screenshot
![Screenshot 2025-05-30 at 12 07 30 PM](https://github.com/user-attachments/assets/118be219-9ae6-4426-9742-ca63426ea0d8)


- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).


[MPP-4222]: https://mozilla-hub.atlassian.net/browse/MPP-4222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ