### PR TITLE
MPP-4223 Pricing Grid Discount

### DIFF
--- a/frontend/src/components/landing/PlanGrid.test.tsx
+++ b/frontend/src/components/landing/PlanGrid.test.tsx
@@ -21,7 +21,7 @@ jest.mock("../../functions/getPlan", () => ({
   getMegabundlePrice: jest.fn(() => "$10"),
   getMegabundleYearlyPrice: jest.fn(() => "$100"),
   getIndividualBundlePrice: jest.fn(() => 15),
-  getBundleDiscountPercentage: jest.fn(() => "33%"),
+  getBundleDiscountPercentage: jest.fn(() => 33),
   isMegabundleAvailableInCountry: jest.fn(() => true),
   getMegabundleSubscribeLink: jest.fn(
     () => "https://subscribe.megabundle.mock",

--- a/frontend/src/components/landing/PlanGrid.tsx
+++ b/frontend/src/components/landing/PlanGrid.tsx
@@ -97,7 +97,6 @@ export const PlanGrid = (props: Props) => {
                   vars: {
                     discountPercentage: getBundleDiscountPercentage(
                       props.runtimeData,
-                      l10n,
                     ),
                   },
                 })}

--- a/frontend/src/functions/getPlan.test.ts
+++ b/frontend/src/functions/getPlan.test.ts
@@ -204,22 +204,17 @@ describe("Megabundle Tests", () => {
     expect(formatted).toBe(expected);
   });
 
-  it("getBundleDiscountPercentage should return formatted discount", () => {
+  it("getBundleDiscountPercentage should return discount percentage as number", () => {
     const price = 8.25;
-    const currency = "USD";
     const plan = ensurePlan(mockedRuntimeData.MEGABUNDLE_PLANS, "yearly");
     plan.price = price;
-    plan.currency = currency;
 
     const individual = getIndividualBundlePrice("monthly");
-    const expectedDiscount = new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency,
-    }).format(Math.floor(1 - price / individual));
+    const ratio = price / individual;
+    const expectedDiscount = Math.ceil((1 - ratio) * 100);
 
     const result = getBundleDiscountPercentage(
       mockedRuntimeData as RuntimeDataWithBundleAvailable,
-      mockL10n,
     );
 
     expect(result).toBe(expectedDiscount);

--- a/frontend/src/functions/getPlan.ts
+++ b/frontend/src/functions/getPlan.ts
@@ -142,16 +142,12 @@ export const getMegabundleYearlyPrice = (
 
 export const getBundleDiscountPercentage = (
   runtimeData: RuntimeDataWithBundleAvailable,
-  l10n: ReactLocalization,
 ) => {
   const plan = getPlan(runtimeData.MEGABUNDLE_PLANS, "yearly");
   const individualBundlePrice = getIndividualBundlePrice("monthly");
-  const discount = Math.floor(1 - plan.price / individualBundlePrice);
-  const formatter = new Intl.NumberFormat(getLocale(l10n), {
-    style: "currency",
-    currency: plan.currency,
-  });
-  return formatter.format(discount);
+  const ratio = plan.price / individualBundlePrice;
+  const discount = Math.ceil((1 - ratio) * 100);
+  return discount;
 };
 
 export const getMegabundleSubscribeLink = (


### PR DESCRIPTION
## [MPP-4223](https://mozilla-hub.atlassian.net/browse/MPP-4223)
- fixes the discount value of the pricing grid

# How to test:
- discount should now populate as 45%

# Screenshots:
![Screenshot 2025-05-28 at 11 31 37 AM](https://github.com/user-attachments/assets/6f5fa771-1eb2-4cf0-b018-cc91ada332f1)


- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).


[MPP-4223]: https://mozilla-hub.atlassian.net/browse/MPP-4223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ