### PR TITLE
MPP-4226-cta-to-pricing-grid

### DIFF
--- a/frontend/src/components/landing/PlanGrid.tsx
+++ b/frontend/src/components/landing/PlanGrid.tsx
@@ -76,7 +76,11 @@ export const PlanGrid = (props: Props) => {
   });
 
   return (
-    <div className={styles.content} data-testid="plan-grid-megabundle">
+    <div
+      id="pricing"
+      className={styles.content}
+      data-testid="plan-grid-megabundle"
+    >
       <div className={styles.header}>
         <h2>
           <b>{l10n.getString("plan-grid-title")}</b>
@@ -165,6 +169,7 @@ export const PlanGrid = (props: Props) => {
               <LinkButton
                 href={getMegabundleSubscribeLink(props.runtimeData)}
                 className={styles["megabundle-pick-button"]}
+                data-testid="plan-cta-megabundle"
               >
                 {l10n.getString("plan-grid-card-btn")}
               </LinkButton>
@@ -450,6 +455,7 @@ const PricingToggle = (props: PricingToggleProps) => {
           }
           tabIndex={0}
           className={styles["pick-button"]}
+          data-testid={`plan-cta-${props.yearlyBilled.plan.plan}-yearly`}
         >
           {l10n.getString("plan-grid-card-btn")}
         </a>
@@ -476,6 +482,7 @@ const PricingToggle = (props: PricingToggleProps) => {
           }
           tabIndex={0}
           className={styles["pick-button"]}
+          data-testid={`plan-cta-${props.monthlyBilled.plan.plan}-monthly`}
         >
           {l10n.getString("plan-grid-card-btn")}
         </a>


### PR DESCRIPTION
This PR fixes [#MPP-4226](https://mozilla-hub.atlassian.net/browse/MPP-4226)

How to test:
- navigate to landing page
- select 'Get started' button
- url/#pricing should navigate user to pricing grid

- [X] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).