### PR TITLE
MPP-4171 Megabundle Price Fix

### DIFF
--- a/privaterelay/plans.py
+++ b/privaterelay/plans.py
@@ -443,7 +443,7 @@ _STRIPE_PLAN_DATA: _StripePlanData = {
     "megabundle": {
         "periods": "yearly",
         "prices": {
-            "USD": {"monthly_when_yearly": 99},
+            "USD": {"monthly_when_yearly": 8.25},
         },
         "countries_and_regions": {
             "US": {  # United States


### PR DESCRIPTION
- megabundle monthly value was accidentally set to yearly total value (99)
- now updated to correct value ie 8.25

How to test:
- ensure all megabundle items list correct $8.25/month value on banner and pricing grid 


- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
