### PR TITLE
MPP-4175 Revert prompt=none Silent Auth Logic

### DIFF
--- a/frontend/src/components/layout/navigation/AppPicker.tsx
+++ b/frontend/src/components/layout/navigation/AppPicker.tsx
@@ -37,7 +37,7 @@ const getProducts = (referringSiteUrl: string) => ({
     id: "monitor",
     url: `https://monitor.firefox.com/?utm_source=${encodeURIComponent(
       referringSiteUrl,
-    )}&utm_medium=referral&utm_campaign=bento&utm_content=desktop&prompt=none`,
+    )}&utm_medium=referral&utm_campaign=bento&utm_content=desktop`,
     gaLabel: "moz-monitor",
   },
   pocket: {


### PR DESCRIPTION
**DO NOT MERGE W/O TONY GO-AHEAD**

- During testing it was discovered that silent auth showed issues with users who have 2FA
- removing prompt=none silent auth logic until this is resolved
