### PR TITLE
MPP-4231 - fix(verbiage): update the verbiage on phone page

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -176,3 +176,6 @@ whatsnew-megabundle-cta = Get year-round protection
 whatsnew-megabundle-premium-snippet = For { $monthly_price }/month, combine { -brand-name-relay } with { -brand-name-vpn }‘s online activity protection and { -brand-name-monitor }‘s data…
 whatsnew-megabundle-premium-description = For { $monthly_price }/month, combine { -brand-name-relay } with { -brand-name-vpn }‘s online activity protection and { -brand-name-monitor }‘s protection from data brokers who sell your info online.
 whatsnew-megabundle-premium-cta = Upgrade my protection
+
+phone-onboarding-step1-button-cta-2 = Sign up
+phone-onboarding-step1-learn-more = Learn more

--- a/frontend/src/components/phones/onboarding/PurchasePhonesPlan.module.scss
+++ b/frontend/src/components/phones/onboarding/PurchasePhonesPlan.module.scss
@@ -138,4 +138,19 @@
       }
     }
   }
+  .learn-more {
+    background-color: transparent;
+    border-style: none;
+    border-radius: $border-radius-lg;
+    color: $color-blue-50;
+    padding-inline: $spacing-md;
+    font-family: $font-stack-base;
+    font-weight: 500;
+    font-size: 14px;
+    cursor: pointer;
+
+    &:hover {
+      background-color: color.$grey-10;
+    }
+  }
 }

--- a/frontend/src/components/phones/onboarding/PurchasePhonesPlan.tsx
+++ b/frontend/src/components/phones/onboarding/PurchasePhonesPlan.tsx
@@ -96,8 +96,16 @@ const PricingToggle = (props: PricingToggleProps) => {
           tabIndex={0}
           className={styles["pick-button"]}
         >
-          {l10n.getString("phone-onboarding-step1-button-cta")}
+          {l10n.getString("phone-onboarding-step1-button-cta-2")}
         </LinkButton>
+        <a
+          className={styles["learn-more"]}
+          href={
+            "https://support.mozilla.org/kb/how-do-i-upgrade-my-subscription"
+          }
+        >
+          {l10n.getString("phone-onboarding-step1-learn-more")}
+        </a>
       </Item>
       <Item
         key="monthly"
@@ -124,8 +132,16 @@ const PricingToggle = (props: PricingToggleProps) => {
           tabIndex={0}
           className={styles["pick-button"]}
         >
-          {l10n.getString("phone-onboarding-step1-button-cta")}
+          {l10n.getString("phone-onboarding-step1-button-cta-2")}
         </LinkButton>
+        <a
+          className={styles["learn-more"]}
+          href={
+            "https://support.mozilla.org/kb/how-do-i-upgrade-my-subscription"
+          }
+        >
+          {l10n.getString("phone-onboarding-step1-learn-more")}
+        </a>
       </Item>
     </PricingTabs>
   );


### PR DESCRIPTION
# This PR fixes [MPP-4231](https://mozilla-hub.atlassian.net/browse/MPP-4231)

# How to test:
- navigate to phone update screen
- CTA new text should read 'Sign up'
- Learn more subtext should navigate to info page

# Screenshot
![Screenshot 2025-06-09 at 3 22 54 PM](https://github.com/user-attachments/assets/182aa33b-c594-4725-8792-2fa4da7c3319)

# Checklist
- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).


[MPP-4231]: https://mozilla-hub.atlassian.net/browse/MPP-4231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ