### PR TITLE
MPP-4175 - prompt=none Added to Monitor Url via Bento Box

### DIFF
--- a/frontend/src/components/layout/navigation/AppPicker.tsx
+++ b/frontend/src/components/layout/navigation/AppPicker.tsx
@@ -37,7 +37,7 @@ const getProducts = (referringSiteUrl: string) => ({
     id: "monitor",
     url: `https://monitor.firefox.com/?utm_source=${encodeURIComponent(
       referringSiteUrl,
-    )}&utm_medium=referral&utm_campaign=bento&utm_content=desktop`,
+    )}&utm_medium=referral&utm_campaign=bento&utm_content=desktop&prompt=none`,
     gaLabel: "moz-monitor",
   },
   pocket: {


### PR DESCRIPTION
# [MPP-4175](https://mozilla-hub.atlassian.net/browse/MPP-4175)

# How to test:
- log into Relay app 
- navigate to bento box dropdown 
- select Monitor icon 
- user should be navigated to Monitor without having to log in (again)

# Checklist
- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

[MPP-4175]: https://mozilla-hub.atlassian.net/browse/MPP-4175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ