### PR TITLE
MPP-4153 - increase frontend test coverage for mask management

### DIFF
--- a/frontend/src/components/InfoModal.test.tsx
+++ b/frontend/src/components/InfoModal.test.tsx
@@ -1,0 +1,41 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { InfoModal } from "./InfoModal";
+
+const defaultProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  modalTitle: "Test Title",
+  modalBodyText: "This is the modal body",
+};
+
+// Helper function to render InfoModal with custom props if needed
+function renderInfoModal(props = {}) {
+  return render(<InfoModal {...defaultProps} {...props} />);
+}
+
+describe("InfoModal", () => {
+  it("renders modal title and body when isOpen is true", () => {
+    renderInfoModal();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(defaultProps.modalTitle)).toBeInTheDocument();
+    expect(screen.getByText(defaultProps.modalBodyText)).toBeInTheDocument();
+  });
+
+  it("calls onClose when dismiss button is clicked", async () => {
+    const user = userEvent.setup();
+    renderInfoModal();
+    await user.click(screen.getByRole("button"));
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it("renders custom React elements for title and body", () => {
+    renderInfoModal({
+      modalTitle: <span data-testid="custom-title">Custom Title</span>,
+      modalBodyText: <div data-testid="custom-body">Custom Body</div>,
+    });
+    expect(screen.getByTestId("custom-title")).toBeInTheDocument();
+    expect(screen.getByTestId("custom-body")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/InfoTooltip.test.tsx
+++ b/frontend/src/components/InfoTooltip.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { InfoTooltip } from "./InfoTooltip";
+
+jest.mock("react-stately", () => {
+  const actual = jest.requireActual("react-stately");
+  return {
+    ...actual,
+    useTooltipTriggerState: jest.fn(() => ({
+      isOpen: true,
+      open: jest.fn(),
+      close: jest.fn(),
+      toggle: jest.fn(),
+    })),
+  };
+});
+
+describe("InfoTooltip (with mocked state)", () => {
+  const alt = "Information";
+  const iconColor = "#000";
+  const tooltipText = "This is a tooltip";
+
+  function renderTooltip() {
+    render(
+      <InfoTooltip alt={alt} iconColor={iconColor}>
+        {tooltipText}
+      </InfoTooltip>,
+    );
+  }
+
+  test("renders the info icon with correct props", () => {
+    renderTooltip();
+
+    const icon = screen.getByLabelText(alt);
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute("width", "18");
+    expect(icon).toHaveAttribute("height", "18");
+  });
+
+  test("renders the tooltip content when open", () => {
+    renderTooltip();
+
+    const tooltip = screen.getByText(tooltipText);
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toBeVisible();
+    expect(tooltip).toHaveClass("tooltip");
+  });
+
+  test("renders both trigger and tooltip with expected classNames", () => {
+    renderTooltip();
+
+    const trigger = screen.getByTestId("trigger");
+    expect(trigger).toHaveClass("trigger");
+
+    const tooltip = screen.getByText(tooltipText);
+    expect(tooltip).toHaveClass("tooltip");
+  });
+});

--- a/frontend/src/components/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip.tsx
@@ -26,6 +26,7 @@ export const InfoTooltip = (props: Props) => {
         ref={triggerRef}
         {...tooltipTrigger.triggerProps}
         className={styles.trigger}
+        data-testid="trigger"
       >
         <InfoIcon
           alt={props.alt}

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.test.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.test.tsx
@@ -50,6 +50,8 @@ describe("WhatsNewMenu", () => {
     (useAddonData as jest.Mock).mockReturnValue({ present: false });
     (isUsingFirefox as jest.Mock).mockReturnValue(false);
     (isFlagActive as unknown as jest.Mock).mockReturnValue(true);
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2025-06-10T12:00:00Z"));
   });
 
   it("renders trigger when there are visible announcements", () => {

--- a/frontend/src/components/phones/dashboard/PhoneDashboard.tsx
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.tsx
@@ -291,6 +291,7 @@ export const PhoneDashboard = (props: Props) => {
         ) : (
           // Caller and SMS Senders Panel
           <SendersPanelView
+            data-testid="senders-panel-view"
             type={getSendersPanelType()}
             back_btn={toggleSendersPanel}
           />

--- a/frontend/src/components/phones/onboarding/PhoneOnboarding.test.tsx
+++ b/frontend/src/components/phones/onboarding/PhoneOnboarding.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import { PhoneOnboarding } from "./PhoneOnboarding";
+import * as realPhoneHook from "../../../hooks/api/realPhone";
+import {
+  mockedProfiles,
+  mockedRuntimeData,
+  mockedRealphones,
+} from "frontend/src/apiMocks/mockData";
+import { RuntimeDataWithPhonesAvailable } from "../../../functions/getPlan";
+import { useL10n } from "../../../hooks/l10n";
+
+// Mocks
+jest.mock("../../../hooks/l10n");
+jest.mock("../../../hooks/api/realPhone");
+
+const mockUseRealPhonesData = realPhoneHook.useRealPhonesData as jest.Mock;
+
+const l10nMock = {
+  bundles: [{ locales: ["en"] }],
+  getString: jest.fn((key, vars) =>
+    vars
+      ? `l10n string: [${key}], with vars: ${JSON.stringify(vars)}`
+      : `l10n string: [${key}], with vars: {}`,
+  ),
+  getFragment: jest.fn((key) => `l10n fragment: [${key}]`),
+};
+
+const renderComponent = (profileKey: keyof typeof mockedProfiles) =>
+  render(
+    <PhoneOnboarding
+      onComplete={jest.fn()}
+      profile={mockedProfiles[profileKey]}
+      runtimeData={mockedRuntimeData as RuntimeDataWithPhonesAvailable}
+    />,
+  );
+
+describe("PhoneOnboarding", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useL10n as jest.Mock).mockReturnValue(l10nMock);
+  });
+
+  it("renders nothing if realPhoneData is undefined", () => {
+    mockUseRealPhonesData.mockReturnValue({ data: undefined });
+
+    const { container } = renderComponent("empty");
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders RealPhoneSetup if no verified phones", async () => {
+    mockUseRealPhonesData.mockReturnValue({
+      data: mockedRealphones.empty,
+      error: null,
+      requestPhoneVerification: jest.fn(),
+      requestPhoneRemoval: jest.fn(),
+      submitPhoneVerification: jest.fn(),
+    });
+
+    renderComponent("empty");
+
+    expect(
+      await screen.findByText((text) =>
+        text.includes("phone-onboarding-step2-headline"),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders RealPhoneSetup if realPhoneData has error", async () => {
+    mockUseRealPhonesData.mockReturnValue({
+      data: [],
+      error: true,
+      requestPhoneVerification: jest.fn(),
+      requestPhoneRemoval: jest.fn(),
+      submitPhoneVerification: jest.fn(),
+    });
+
+    renderComponent("empty");
+
+    expect(
+      await screen.findByText((text) =>
+        text.includes("phone-onboarding-step2-headline"),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders RelayNumberIntro if there are verified phones", async () => {
+    mockUseRealPhonesData.mockReturnValue({
+      data: mockedRealphones.full as realPhoneHook.VerifiedPhone[],
+      error: null,
+    });
+
+    renderComponent("full");
+
+    expect(
+      await screen.findByTestId("relay-number-intro-cta"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/phones/onboarding/PurchasePhonesPlan.test.tsx
+++ b/frontend/src/components/phones/onboarding/PurchasePhonesPlan.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PurchasePhonesPlan } from "./PurchasePhonesPlan";
+import { RuntimeDataWithPhonesAvailable } from "../../../functions/getPlan";
+import { mockedRuntimeData } from "frontend/src/apiMocks/mockData";
+
+jest.mock("../../../hooks/l10n", () => ({
+  useL10n: () => ({
+    getString: (id: string, vars?: Record<string, string>) =>
+      vars
+        ? `l10n string: [${id}] with vars: ${JSON.stringify(vars)}`
+        : `l10n string: [${id}]`,
+  }),
+}));
+
+jest.mock("../../../hooks/gaViewPing", () => ({
+  useGaViewPing: () => ({ current: null }),
+}));
+
+jest.mock("../../../hooks/gaEvent", () => ({
+  useGaEvent: () => jest.fn(),
+}));
+
+jest.mock("../../../functions/trackPurchase", () => ({
+  trackPlanPurchaseStart: jest.fn(),
+}));
+
+jest.mock("../../../functions/getPlan", () => {
+  const actual = jest.requireActual("../../../functions/getPlan");
+  return {
+    ...actual,
+    getPhonesPrice: jest.fn(() => "$9.99"),
+    getPhoneSubscribeLink: jest.fn((_, period) => `/subscribe/${period}`),
+  };
+});
+
+describe("PurchasePhonesPlan", () => {
+  const runtimeData = mockedRuntimeData as RuntimeDataWithPhonesAvailable;
+
+  it("renders the onboarding headline and benefits list", () => {
+    render(<PurchasePhonesPlan runtimeData={runtimeData} />);
+
+    expect(
+      screen.getByText(/phone-onboarding-step1-headline/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/phone-onboarding-step1-body/)).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(4);
+  });
+
+  it("renders both yearly and monthly pricing options", () => {
+    render(<PurchasePhonesPlan runtimeData={runtimeData} />);
+
+    expect(
+      screen.getByText(/phone-onboarding-step1-period-toggle-yearly/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/phone-onboarding-step1-period-toggle-monthly/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/phone-onboarding-step1-button-price/),
+    ).toHaveLength(2);
+  });
+
+  it("has clickable links for yearly and monthly subscription", () => {
+    render(<PurchasePhonesPlan runtimeData={runtimeData} />);
+
+    // Yearly is selected by default
+    const yearlyLink = screen.getByRole("link", {
+      name: /phone-onboarding-step1-button-cta-2/,
+    });
+    expect(yearlyLink).toHaveAttribute("href", "/subscribe/yearly");
+
+    // Switch to monthly tab
+    const monthlyTab = screen.getByText(
+      /phone-onboarding-step1-period-toggle-monthly/,
+    );
+    fireEvent.click(monthlyTab);
+
+    const monthlyLink = screen.getByRole("link", {
+      name: /phone-onboarding-step1-button-cta-2/,
+    });
+    expect(monthlyLink).toHaveAttribute("href", "/subscribe/monthly");
+  });
+});

--- a/frontend/src/components/phones/onboarding/RealPhoneSetup.test.tsx
+++ b/frontend/src/components/phones/onboarding/RealPhoneSetup.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { RealPhoneSetup } from "./RealPhoneSetup";
+import {
+  mockedRuntimeData,
+  mockedRealphones,
+} from "frontend/src/apiMocks/mockData";
+import { UnverifiedPhone } from "../../../hooks/api/realPhone";
+import React from "react";
+
+jest.mock("../../../hooks/l10n", () => ({
+  useL10n: () => ({
+    getString: (id: string) => id,
+  }),
+}));
+
+jest.mock("../../Localized", () => ({
+  Localized: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+jest.mock("../../../hooks/api/realPhone", () => {
+  const actual = jest.requireActual("../../../hooks/api/realPhone");
+  return {
+    ...actual,
+    useRealPhonesData: () => ({ data: [] }),
+  };
+});
+
+describe("RealPhoneSetup", () => {
+  const onRequestVerification = jest.fn(() =>
+    Promise.resolve({ status: 201, ok: true } as Response),
+  );
+  const onRequestPhoneRemoval = jest.fn(() =>
+    Promise.resolve({ status: 204, ok: true } as Response),
+  );
+  const onSubmitVerification = jest.fn(() =>
+    Promise.resolve({ status: 200, ok: true } as Response),
+  );
+
+  const baseProps = {
+    runtimeData: mockedRuntimeData,
+    onRequestVerification,
+    onRequestPhoneRemoval,
+    onSubmitVerification,
+  };
+
+  it("renders RealPhoneForm when no phonesPendingVerification", () => {
+    render(<RealPhoneSetup {...baseProps} unverifiedRealPhones={[]} />);
+
+    expect(
+      screen.getByText(/phone-onboarding-step2-headline/),
+    ).toBeInTheDocument();
+  });
+
+  it("submits phone number for verification", async () => {
+    render(<RealPhoneSetup {...baseProps} unverifiedRealPhones={[]} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "4155552671" } });
+
+    const submit = screen.getByRole("button", {
+      name: /phone-onboarding-step2-button-cta/,
+    });
+
+    fireEvent.click(submit);
+
+    await waitFor(() => {
+      expect(onRequestVerification).toHaveBeenCalled();
+    });
+  });
+
+  it("renders RealPhoneVerification when phones are pending verification", () => {
+    const recentPhone: UnverifiedPhone = {
+      ...mockedRealphones.full[0],
+      verified: false,
+      verified_date: null,
+      verification_sent_date: new Date().toISOString(),
+    };
+
+    render(
+      <RealPhoneSetup {...baseProps} unverifiedRealPhones={[recentPhone]} />,
+    );
+
+    expect(
+      screen.getByText(/phone-onboarding-step2-headline/),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", {
+        name: /phone-onboarding-step3-button-cta/,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
+++ b/frontend/src/components/phones/onboarding/RealPhoneSetup.tsx
@@ -178,7 +178,11 @@ const RealPhoneForm = (props: RealPhoneFormProps) => {
           />
         </div>
 
-        <Button className={styles.button} type="submit">
+        <Button
+          className={styles.button}
+          type="submit"
+          data-testid="relay-number-intro-cta"
+        >
           {l10n.getString("phone-onboarding-step2-button-cta")}
         </Button>
       </form>

--- a/frontend/src/components/phones/onboarding/RelayNumberConfirmationModal.test.tsx
+++ b/frontend/src/components/phones/onboarding/RelayNumberConfirmationModal.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RelayNumberConfirmationModal } from "../onboarding/RelayNumberConfirmationModal";
+import { useL10n } from "../../../hooks/l10n";
+import { OverlayProvider } from "react-aria";
+
+jest.mock("../../../hooks/l10n", () => ({
+  useL10n: jest.fn(),
+}));
+
+jest.mock("react-aria", () => {
+  const original = jest.requireActual("react-aria");
+  return {
+    ...original,
+    OverlayContainer: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="overlay-container">{children}</div>
+    ),
+  };
+});
+
+describe("RelayNumberConfirmationModal", () => {
+  const mockOnClose = jest.fn();
+  const mockConfirm = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useL10n as jest.Mock).mockReturnValue({
+      getString: (key: string) => `translated(${key})`,
+    });
+  });
+
+  const renderWithProvider = (ui: React.ReactElement) =>
+    render(<OverlayProvider>{ui}</OverlayProvider>);
+
+  const defaultProps = {
+    onClose: mockOnClose,
+    confirm: mockConfirm,
+    isOpen: true,
+    relayNumber: "+12345678900",
+  };
+
+  it("renders modal when isOpen is true", () => {
+    renderWithProvider(<RelayNumberConfirmationModal {...defaultProps} />);
+    expect(
+      screen.getByText(
+        "translated(phone-onboarding-step4-body-confirm-relay-number)",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((text) => text.includes("234") && text.includes("8900")),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onClose when close icon is clicked", () => {
+    renderWithProvider(<RelayNumberConfirmationModal {...defaultProps} />);
+    const closeButton = screen.getByRole("button", { name: /Close/ });
+    fireEvent.click(closeButton);
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it("calls confirm when confirm button is clicked", () => {
+    renderWithProvider(<RelayNumberConfirmationModal {...defaultProps} />);
+    const confirmButton = screen.getByRole("button", {
+      name: "translated(phone-onboarding-step4-button-confirm-relay-number)",
+    });
+    fireEvent.click(confirmButton);
+    expect(mockConfirm).toHaveBeenCalled();
+  });
+
+  it("disables confirm button if relayNumber is empty", () => {
+    renderWithProvider(
+      <RelayNumberConfirmationModal {...defaultProps} relayNumber="" />,
+    );
+    const confirmButton = screen.getByRole("button", {
+      name: "translated(phone-onboarding-step4-button-confirm-relay-number)",
+    });
+    expect(confirmButton).toBeDisabled();
+  });
+});

--- a/frontend/src/components/phones/onboarding/RelayNumberPicker.test.tsx
+++ b/frontend/src/components/phones/onboarding/RelayNumberPicker.test.tsx
@@ -1,0 +1,183 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { RelayNumberPicker } from "../onboarding/RelayNumberPicker";
+import { OverlayProvider } from "react-aria";
+import { useL10n } from "../../../hooks/l10n";
+import * as relayNumberHooks from "../../../hooks/api/relayNumber";
+
+jest.mock("../../../hooks/l10n", () => ({
+  useL10n: jest.fn(),
+}));
+
+jest.mock("../../../hooks/api/relayNumber", () => ({
+  useRelayNumber: jest.fn(),
+  useRelayNumberSuggestions: jest.fn(),
+  search: jest.fn(),
+}));
+
+describe("RelayNumberPicker", () => {
+  const mockRegisterRelayNumber = jest.fn();
+  const mockOnComplete = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useL10n as jest.Mock).mockReturnValue({
+      getString: (key: string) => `translated(${key})`,
+    });
+
+    (relayNumberHooks.useRelayNumber as jest.Mock).mockReturnValue({
+      data: null,
+      registerRelayNumber: mockRegisterRelayNumber,
+    });
+
+    (relayNumberHooks.useRelayNumberSuggestions as jest.Mock).mockReturnValue({
+      data: {
+        same_area_options: [
+          { phone_number: "+12345678900" },
+          { phone_number: "+12345678901" },
+          { phone_number: "+12345678902" },
+          { phone_number: "+12345678903" }, // extra for cycling
+        ],
+        other_areas_options: [],
+        same_prefix_options: [],
+        random_options: [],
+      },
+    });
+
+    (relayNumberHooks.search as jest.Mock).mockResolvedValue([
+      { phone_number: "+19998887777" },
+    ]);
+  });
+
+  const renderWithProvider = (ui: React.ReactElement) => {
+    return render(<OverlayProvider>{ui}</OverlayProvider>);
+  };
+
+  it("starts with intro and progresses to selection", () => {
+    renderWithProvider(<RelayNumberPicker onComplete={mockOnComplete} />);
+
+    expect(
+      screen.getByText("translated(phone-onboarding-step3-code-success-title)"),
+    ).toBeInTheDocument();
+
+    const startButton = screen.getByRole("button", {
+      name: "translated(phone-onboarding-step3-code-success-cta-2)",
+    });
+    fireEvent.click(startButton);
+
+    expect(
+      screen.getByText("translated(phone-onboarding-step4-country)"),
+    ).toBeInTheDocument();
+  });
+
+  it("opens confirmation modal after selecting and submitting a number", async () => {
+    renderWithProvider(<RelayNumberPicker onComplete={mockOnComplete} />);
+
+    const startButton = screen.getByRole("button", {
+      name: "translated(phone-onboarding-step3-code-success-cta-2)",
+    });
+    fireEvent.click(startButton);
+
+    const radios = await screen.findAllByRole("radio");
+    fireEvent.click(radios[0]);
+
+    const submitBtn = screen.getByRole("button", {
+      name: "translated(phone-onboarding-step4-button-register-phone-number)",
+    });
+    fireEvent.click(submitBtn);
+
+    expect(
+      await screen.findByText(
+        "translated(phone-onboarding-step4-body-confirm-relay-number)",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not open modal if no number selected", () => {
+    renderWithProvider(<RelayNumberPicker onComplete={mockOnComplete} />);
+
+    const startButton = screen.getByRole("button", {
+      name: "translated(phone-onboarding-step3-code-success-cta-2)",
+    });
+    fireEvent.click(startButton);
+
+    const submitBtn = screen.getByRole("button", {
+      name: "translated(phone-onboarding-step4-button-register-phone-number)",
+    });
+    fireEvent.click(submitBtn);
+
+    expect(
+      screen.queryByText(
+        "translated(phone-onboarding-step4-body-confirm-relay-number)",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("cycles relay number suggestions when clicking 'more options'", async () => {
+    renderWithProvider(<RelayNumberPicker onComplete={mockOnComplete} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "translated(phone-onboarding-step3-code-success-cta-2)",
+      }),
+    );
+
+    // Get all visible labels for the current radio suggestions
+    const initialRadios = screen.getAllByRole("radio");
+    const initialLabels = initialRadios.map((radio) => {
+      const label = screen.getByLabelText(
+        radio.getAttribute("aria-label") || "",
+      );
+      return label.textContent?.trim();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "translated(phone-onboarding-step4-button-more-options)",
+      }),
+    );
+
+    const newRadios = screen.getAllByRole("radio");
+    const newLabels = newRadios.map((radio) => {
+      const label = screen.getByLabelText(
+        radio.getAttribute("aria-label") || "",
+      );
+      return label.textContent?.trim();
+    });
+
+    expect(newLabels).not.toEqual(initialLabels);
+  });
+
+  it("handles search input and updates suggestions", async () => {
+    renderWithProvider(<RelayNumberPicker onComplete={mockOnComplete} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "translated(phone-onboarding-step3-code-success-cta-2)",
+      }),
+    );
+
+    const searchInput = screen.getByRole("searchbox");
+    fireEvent.change(searchInput, { target: { value: "999" } });
+    fireEvent.submit(searchInput);
+
+    await waitFor(() => {
+      expect(relayNumberHooks.search).toHaveBeenCalledWith("999");
+    });
+
+    const label = screen.getByLabelText("(999) 888 - 7777");
+    expect(label).toBeInTheDocument();
+  });
+
+  it("renders confirmation component when relayNumberData has data", () => {
+    (relayNumberHooks.useRelayNumber as jest.Mock).mockReturnValue({
+      data: ["+12223334444"],
+      registerRelayNumber: mockRegisterRelayNumber,
+    });
+
+    renderWithProvider(<RelayNumberPicker onComplete={mockOnComplete} />);
+
+    const successHeader = screen.getByTestId("confirmation-success-title");
+    expect(successHeader).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/phones/onboarding/RelayNumberPicker.tsx
+++ b/frontend/src/components/phones/onboarding/RelayNumberPicker.tsx
@@ -71,7 +71,10 @@ const RelayNumberIntro = (props: RelayNumberIntroProps) => {
 
       {/* TODO: Add logic to display success message */}
 
-      <div className={`${styles["step-input-verificiation-code-success"]} `}>
+      <div
+        data-testid="confirmation-success-title"
+        className={`${styles["step-input-verificiation-code-success"]} `}
+      >
         <h3>
           {l10n.getString("phone-onboarding-step3-code-success-subhead-title")}
         </h3>

--- a/frontend/src/pages/phone/waitlist.page.test.tsx
+++ b/frontend/src/pages/phone/waitlist.page.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import PhoneWaitlist from "../../../src/pages/phone/waitlist.page";
+import { useL10n } from "../../../src/hooks/l10n";
+import { WaitlistPage } from "../../../src/components/waitlist/WaitlistPage";
+
+// Mock Localized to avoid needing <LocalizationProvider>
+jest.mock("../../../src/components/Localized", () => ({
+  Localized: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("../../../src/hooks/l10n");
+jest.mock("../../../src/components/waitlist/WaitlistPage", () => ({
+  WaitlistPage: jest.fn(() => <div data-testid="mock-waitlist-page" />),
+}));
+
+describe("PhoneWaitlist page", () => {
+  const mockGetString = jest.fn();
+
+  beforeEach(() => {
+    (useL10n as jest.Mock).mockReturnValue({
+      getString: mockGetString,
+    });
+
+    mockGetString.mockImplementation((id: string) => {
+      const strings: Record<string, string> = {
+        "waitlist-heading-phone": "Get a private phone number",
+        "waitlist-lead-phone": "Be the first to try Relay phone masking",
+        "waitlist-privacy-policy-use-phone":
+          "We will use your phone only to notify you.",
+      };
+      return strings[id] ?? id;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the WaitlistPage with correct props", () => {
+    render(<PhoneWaitlist />);
+
+    const props = (WaitlistPage as jest.Mock).mock.calls[0][0];
+
+    expect(props.supportedLocales).toEqual(["en", "es", "pl", "pt", "ja"]);
+    expect(props.headline).toBe("Get a private phone number");
+    expect(props.lead).toBe("Be the first to try Relay phone masking");
+    expect(props.newsletterId).toBe("relay-phone-masking-waitlist");
+    expect(props.legalese).toBeDefined();
+
+    expect(screen.getByTestId("mock-waitlist-page")).toBeInTheDocument();
+  });
+
+  it("renders legalese content", () => {
+    render(<PhoneWaitlist />);
+    const legalese = (WaitlistPage as jest.Mock).mock.calls[0][0].legalese;
+
+    render(<>{legalese}</>);
+
+    expect(
+      screen.getByText("We will use your phone only to notify you."),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/premium/waitlist.page.test.tsx
+++ b/frontend/src/pages/premium/waitlist.page.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import PremiumWaitlist from "../../../src/pages/premium/waitlist.page";
+import { useL10n } from "../../../src/hooks/l10n";
+import { WaitlistPage } from "../../../src/components/waitlist/WaitlistPage";
+
+// Mock Localized to avoid needing <LocalizationProvider>
+jest.mock("../../../src/components/Localized", () => ({
+  Localized: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("../../../src/hooks/l10n");
+jest.mock("../../../src/components/waitlist/WaitlistPage", () => ({
+  WaitlistPage: jest.fn(() => <div data-testid="mock-waitlist-page" />),
+}));
+
+describe("PremiumWaitlist page", () => {
+  const mockGetString = jest.fn();
+
+  beforeEach(() => {
+    (useL10n as jest.Mock).mockReturnValue({
+      getString: mockGetString,
+    });
+
+    mockGetString.mockImplementation((id: string) => {
+      const strings: Record<string, string> = {
+        "waitlist-heading-2": "Get Mozilla Relay Premium",
+        "waitlist-lead-2": "Premium features, coming soon",
+        "waitlist-privacy-policy-use": "We will only email you about premium.",
+      };
+      return strings[id] ?? id;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the WaitlistPage with correct props", () => {
+    render(<PremiumWaitlist />);
+
+    const props = (WaitlistPage as jest.Mock).mock.calls[0][0];
+
+    expect(props.supportedLocales).toEqual(["en", "es", "pl", "pt", "ja"]);
+    expect(props.headline).toBe("Get Mozilla Relay Premium");
+    expect(props.lead).toBe("Premium features, coming soon");
+    expect(props.newsletterId).toBe("relay-waitlist");
+    expect(props.legalese).toBeDefined();
+
+    expect(screen.getByTestId("mock-waitlist-page")).toBeInTheDocument();
+  });
+
+  it("renders legalese content", () => {
+    render(<PremiumWaitlist />);
+    const legalese = (WaitlistPage as jest.Mock).mock.calls[0][0].legalese;
+
+    render(<>{legalese}</>);
+
+    expect(
+      screen.getByText("We will only email you about premium."),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/vpn-relay/waitlist.page.test.tsx
+++ b/frontend/src/pages/vpn-relay/waitlist.page.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import BundleWaitlist from "../../../src/pages/vpn-relay/waitlist.page";
+import { useL10n } from "../../../src/hooks/l10n";
+import { WaitlistPage } from "../../../src/components/waitlist/WaitlistPage";
+
+// Mock Localized to avoid needing <LocalizationProvider>
+jest.mock("../../../src/components/Localized", () => ({
+  Localized: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("../../../src/hooks/l10n");
+jest.mock("../../../src/components/waitlist/WaitlistPage", () => ({
+  WaitlistPage: jest.fn(() => <div data-testid="mock-waitlist-page" />),
+}));
+
+describe("BundleWaitlist page", () => {
+  const mockGetString = jest.fn();
+
+  beforeEach(() => {
+    (useL10n as jest.Mock).mockReturnValue({
+      getString: mockGetString,
+    });
+
+    mockGetString.mockImplementation((id: string) => {
+      const strings: Record<string, string> = {
+        "waitlist-heading-bundle": "Bundle up with VPN and Relay",
+        "waitlist-lead-bundle": "Get notified when our privacy bundle is ready",
+        "waitlist-privacy-policy-use-bundle":
+          "We’ll only use your info for bundle updates.",
+      };
+      return strings[id] ?? id;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the WaitlistPage with correct props", () => {
+    render(<BundleWaitlist />);
+
+    const props = (WaitlistPage as jest.Mock).mock.calls[0][0];
+
+    expect(props.supportedLocales).toEqual(["en", "es", "pl", "pt", "ja"]);
+    expect(props.headline).toBe("Bundle up with VPN and Relay");
+    expect(props.lead).toBe("Get notified when our privacy bundle is ready");
+    expect(props.newsletterId).toBe("relay-vpn-bundle-waitlist");
+    expect(props.legalese).toBeDefined();
+
+    expect(screen.getByTestId("mock-waitlist-page")).toBeInTheDocument();
+  });
+
+  it("renders legalese content", () => {
+    render(<BundleWaitlist />);
+    const legalese = (WaitlistPage as jest.Mock).mock.calls[0][0].legalese;
+
+    render(<>{legalese}</>);
+
+    expect(
+      screen.getByText("We’ll only use your info for bundle updates."),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# [MPP-4153](https://mozilla-hub.atlassian.net/browse/MPP-4153) - Part One

Test code coverage improved on the following: 
- waitlist
- phone components
- infomodal
- infotooltip
- phone page

### **Part Two will contain test coverage improvement for components/dashboard & pages/accounts**

# OLD COVERAGE
![Screenshot 2025-06-11 at 10 53 33 PM](https://github.com/user-attachments/assets/ba0d2b5b-8093-4069-9fbd-e594f04da9bc)


# NEW COVERAGE (still a WIP)
- waitlist --> 100%
- infomodal --> 100%
- infotooltip --> 100%
- phone components (onboarding) --> 86.12%
- phone components (dashboard) --> 65.55%
- phone (page) --> 86.27%


[MPP-4153]: https://mozilla-hub.atlassian.net/browse/MPP-4153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ