### PR TITLE
MPP-4236 - show megabundle only to premium users

### DIFF
--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -650,7 +650,7 @@ export const WhatsNewMenu = (props: Props) => {
 
   if (
     isMegabundleAvailableInCountry(props.runtimeData) &&
-    !isBundleAvailableInCountry(props.runtimeData)
+    props.profile.has_premium
   ) {
     const isPremium = isPeriodicalPremiumAvailableInCountry(props.runtimeData);
 


### PR DESCRIPTION
# This PR fixes [MPP-4236](https://mozilla-hub.atlassian.net/browse/MPP-4236)

# How to test:
- Click on the News button from the header
- Observe announcements
- Megabundle promo should only appear for PREMIUM users

# Screenshot

# Checklist:
- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).


[MPP-4236]: https://mozilla-hub.atlassian.net/browse/MPP-4236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ