### PR TITLE
MPP-4236 - show megabundle only to premium users

### DIFF
--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.test.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.test.tsx
@@ -25,12 +25,10 @@ const l10nMock = {
   ),
 };
 
-const mockedRuntimeDataWithNoBundle = {
-  ...mockedRuntimeData,
-  BUNDLE_PLANS: {
-    ...mockedRuntimeData.BUNDLE_PLANS,
-    available_in_country: false,
-  },
+const mockedProfileswithMegabundle = {
+  ...mockedProfiles.full,
+  has_phone: false,
+  has_vpn: false,
 };
 
 beforeAll(() => {
@@ -68,8 +66,8 @@ describe("WhatsNewMenu", () => {
 
     render(
       <WhatsNewMenu
-        profile={mockedProfiles.full}
-        runtimeData={mockedRuntimeDataWithNoBundle}
+        profile={mockedProfileswithMegabundle}
+        runtimeData={mockedRuntimeData}
         style="test-style"
       />,
     );
@@ -87,8 +85,8 @@ describe("WhatsNewMenu", () => {
 
     render(
       <WhatsNewMenu
-        profile={mockedProfiles.full}
-        runtimeData={mockedRuntimeDataWithNoBundle}
+        profile={mockedProfileswithMegabundle}
+        runtimeData={mockedRuntimeData}
         style="test-style"
       />,
     );
@@ -104,8 +102,8 @@ describe("WhatsNewMenu", () => {
 
     render(
       <WhatsNewMenu
-        profile={mockedProfiles.full}
-        runtimeData={mockedRuntimeDataWithNoBundle}
+        profile={mockedProfileswithMegabundle}
+        runtimeData={mockedRuntimeData}
         style="test-style"
       />,
     );

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -650,7 +650,9 @@ export const WhatsNewMenu = (props: Props) => {
 
   if (
     isMegabundleAvailableInCountry(props.runtimeData) &&
-    props.profile.has_premium
+    props.profile.has_premium &&
+    !props.profile.has_phone &&
+    !props.profile.has_vpn
   ) {
     const isPremium = isPeriodicalPremiumAvailableInCountry(props.runtimeData);
 

--- a/privaterelay/fxa_utils.py
+++ b/privaterelay/fxa_utils.py
@@ -59,7 +59,7 @@ def _get_oauth2_session(social_account: SocialAccount) -> OAuth2Session:
         "client_secret": client_secret,
     }
 
-    expires_in = (social_token.expires_at - datetime.now(UTC)).total_seconds()
+    expires_in = int((social_token.expires_at - datetime.now(UTC)).total_seconds())
     token = {
         "access_token": social_token.token,
         "refresh_token": social_token.token_secret,

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -251,6 +251,7 @@ def setup_fxa_rp_events(
         "avatar": "https://profile.stage.mozaws.net/v1/avatar/t",
         "avatarDefault": False,
         "subscriptions": [premium_subscription(), "test-phone"],
+        "expires_in": 60,
     }
     fxa_acct: SocialAccount = baker.make(
         SocialAccount,


### PR DESCRIPTION
# This PR fixes [MPP-4236](https://mozilla-hub.atlassian.net/browse/MPP-4236)

# How to test:
- Click on the News button from the header
- Observe announcements
- Megabundle promo should only appear for PREMIUM users

# Screenshot

# Checklist:
- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).


[MPP-4236]: https://mozilla-hub.atlassian.net/browse/MPP-4236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ