### PR TITLE
MPP-4232 bugfix(relay-bento): prevent double tab/popup 

### DIFF
--- a/frontend/src/components/layout/navigation/AppPicker.tsx
+++ b/frontend/src/components/layout/navigation/AppPicker.tsx
@@ -16,7 +16,7 @@ import {
   useFocus,
 } from "react-aria";
 import { Key, ReactNode, useRef, useState, useEffect, RefObject } from "react";
-import { AriaMenuItemProps } from "@react-aria/menu";
+import { AriaMenuItemProps, AriaMenuOptions } from "@react-aria/menu";
 import styles from "./AppPicker.module.scss";
 import FirefoxLogo from "../images/fx.png";
 import MonitorLogo from "../images/monitor.png";
@@ -98,9 +98,8 @@ export const AppPicker = (props: Props) => {
   const mozillaLinkRef = useRef<HTMLAnchorElement>(null);
 
   const onSelect = (itemKey: Key) => {
-    Object.entries(products).forEach(([key, productData]) => {
+    Object.values(products).forEach((productData) => {
       if (itemKey === productData.id) {
-        linkRefs[key as keyof typeof products].current?.click();
         gaEvent({
           category: "bento",
           action: "bento-app-link-click",
@@ -109,7 +108,6 @@ export const AppPicker = (props: Props) => {
       }
     });
     if (itemKey === "mozilla") {
-      mozillaLinkRef.current?.click();
       gaEvent({
         category: "bento",
         action: "bento-app-link-click",
@@ -213,7 +211,7 @@ type AppPickerTriggerProps = Parameters<typeof useMenuTriggerState>[0] & {
   label: string;
   style: string;
   children: TreeProps<Record<string, never>>["children"];
-  onAction: AriaMenuItemProps["onAction"];
+  onAction: AriaMenuOptions<Record<string, never>>["onAction"];
   theme?: LayoutProps["theme"];
 };
 const AppPickerTrigger = ({
@@ -335,7 +333,6 @@ const AppPickerPopup = (props: AppPickerPopupProps) => {
                 // TODO: Fix the typing (likely: report to react-aria that the type does not include an isDisabled prop)
                 item={item as unknown as AppPickerItemProps["item"]}
                 state={popupState}
-                onAction={props.onAction}
                 onClose={props.onClose}
               />
             ))}
@@ -355,7 +352,6 @@ type AppPickerItemProps = {
     rendered?: ReactNode;
   };
   state: TreeState<unknown>;
-  onAction: AriaMenuItemProps["onAction"];
   onClose: AriaMenuItemProps["onClose"];
 };
 
@@ -365,7 +361,6 @@ const AppPickerItem = (props: AppPickerItemProps) => {
     {
       key: props.item.key,
       isDisabled: props.item.isDisabled,
-      onAction: props.onAction,
       onClose: props.onClose,
     },
     props.state,

--- a/frontend/src/components/layout/navigation/UserMenu.tsx
+++ b/frontend/src/components/layout/navigation/UserMenu.tsx
@@ -73,18 +73,6 @@ export const UserMenu = (props: Props) => {
   }
 
   const onSelect = (itemKey: Key) => {
-    if (itemKey === itemKeys.account) {
-      accountLinkRef.current?.click();
-    }
-    if (itemKey === itemKeys.settings) {
-      settingsLinkRef.current?.click();
-    }
-    if (itemKey === itemKeys.contact) {
-      contactLinkRef.current?.click();
-    }
-    if (itemKey === itemKeys.help) {
-      helpLinkRef.current?.click();
-    }
     if (itemKey === itemKeys.signout) {
       gaEvent({
         category: "Sign Out",


### PR DESCRIPTION
# This PR fixes [MPP-4232](https://mozilla-hub.atlassian.net/browse/MPP-4232)

# How to test:
- login to Relay
- click any item on bento box menu
- observe there in only one tab that opens

# Screenshots:
https://github.com/user-attachments/assets/226bb241-0eb9-4c5b-b348-e08e0a917bda

# Checklist:
- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

[MPP-4232]: https://mozilla-hub.atlassian.net/browse/MPP-4232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ