### PR TITLE
Fix e2e password locator

### DIFF
--- a/e2e-tests/pages/authPage.ts
+++ b/e2e-tests/pages/authPage.ts
@@ -79,7 +79,7 @@ export class AuthPage {
       await this.enterEmail(email);
     }
     await this.page
-      .getByText("Set your password")
+      .getByTestId("new-password-input-field")
       .waitFor({ state: "attached", timeout: TIMEOUTS.LONG });
     await this.passwordSignupInputField.fill(
       process.env.E2E_TEST_ACCOUNT_PASSWORD as string,

--- a/e2e-tests/pages/subscriptionPaymentPage.ts
+++ b/e2e-tests/pages/subscriptionPaymentPage.ts
@@ -47,11 +47,7 @@ export class SubscriptionPaymentPage {
       name: "Set up your subscription",
     });
     this.planDetails = page.locator("#plan-details-product");
-    this.planDetails3 = page
-      .getByLabel("Purchase details")
-      .first()
-      .getByRole("heading")
-      .first();
+    this.planDetails3 = page.locator("#product-details-heading");
     this.planType = page.locator(".plan-details-description");
     this.planType3 = page.getByTestId("total-price");
   }

--- a/e2e-tests/pages/subscriptionPaymentPage.ts
+++ b/e2e-tests/pages/subscriptionPaymentPage.ts
@@ -43,9 +43,7 @@ export class SubscriptionPaymentPage {
     this.subscriptionTitle = page.locator(
       '[data-testid="subscription-create-title"]',
     );
-    this.subscription3Title = page.getByRole("heading", {
-      name: "Set up your subscription",
-    });
+    this.subscription3Title = page.locator("#subscription-heading");
     this.planDetails = page.locator("#plan-details-product");
     this.planDetails3 = page.locator("#product-details-heading");
     this.planType = page.locator(".plan-details-description");


### PR DESCRIPTION
This PR fixes e2e tests with new locators for FXA + SubPlat elements.

How to test:
https://github.com/mozilla/fx-private-relay/actions/runs/15786264704

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).