### PR TITLE
for MPP-4257 - fix(sp3): add production product keys to valid keys

### DIFF
--- a/privaterelay/sp3_plans.py
+++ b/privaterelay/sp3_plans.py
@@ -107,15 +107,22 @@ CountryStr = Literal[
 ]
 # See https://docs.google.com/spreadsheets/d/1qThASP94f4KBSwc4pOJRcb09cSInw7vUy_SE8y4KKPc/edit?usp=sharing for valid product keys  # noqa: E501  # ignore long line for URL
 ProductKey = Literal[
+    # local product keys
     "relay-premium-127",
     "relay-premium-127-phone",
     "relay-email-phone-protection-127",
+    # dev product keys
     "relay-premium-dev",
     "relay-email-phone-protection-dev",
     "bundle-relay-vpn-dev",
+    # stage product keys
     "relaypremiumemailstage",
     "relaypremiumphonestage",
     "vpnrelaybundlestage",
+    # production product keys
+    "relaypremium",
+    "relaypremiumphone",
+    "vpn-relay-bundle",
     "privacyprotectionplan",
 ]
 


### PR DESCRIPTION
This PR fixes MPP-4257.

How to test:

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
