### PR TITLE
fix(whatsnewmenu): fix frontend test preventing deployment to stage

### DIFF
--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.test.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.test.tsx
@@ -56,6 +56,8 @@ describe("WhatsNewMenu", () => {
     (useAddonData as jest.Mock).mockReturnValue({ present: false });
     (isUsingFirefox as jest.Mock).mockReturnValue(false);
     (isFlagActive as unknown as jest.Mock).mockReturnValue(true);
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2025-06-10T12:00:00Z"));
   });
 
   it("renders trigger when there are visible announcements", () => {


### PR DESCRIPTION
This PR fixes - WhatsNewMenu test were failing, preventing a deploy to Stage env

- WhatsNewMenu test file was using real time dates to run tests which caused it to break

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
