### PR TITLE
MPP-4282: (bugfix) Removed Hardcoded Domain in PROD

### DIFF
--- a/frontend/src/apiMocks/handlers.ts
+++ b/frontend/src/apiMocks/handlers.ts
@@ -535,7 +535,7 @@ export function getHandlers(
   });
 
   handlers.push(
-    http.post("https://basket-mock.com/news/subscribe/", (_info) => {
+    http.post("http://localhost/mock/news/subscribe", (_info) => {
       return HttpResponse.json({ status: "ok" }, { status: 200 });
     }),
   );

--- a/frontend/src/apiMocks/initialise.ts
+++ b/frontend/src/apiMocks/initialise.ts
@@ -1,14 +1,13 @@
-import { initialiseWorker } from "./browser";
-import { initialiseServer } from "./server";
-
 export async function initialiseApiMocks() {
   if (typeof window === "undefined") {
+    const { initialiseServer } = await import("./server");
     const server = initialiseServer();
     await server.listen();
   } else {
+    const { initialiseWorker } = await import("./browser");
     const worker = initialiseWorker();
     await worker.start({
-      // This custom handler supresses the default warnings about not mocking expected requests:
+      // This custom handler suppresses the default warnings about not mocking expected requests:
       onUnhandledRequest: (req, print) => {
         const requestUrl = new URL(req.url);
         if (

--- a/frontend/src/apiMocks/mockData.ts
+++ b/frontend/src/apiMocks/mockData.ts
@@ -10,8 +10,9 @@ export const mockIds = ["demo", "empty", "onboarding", "some", "full"] as const;
 
 // This is the same for all mock users, at this time:
 export const mockedRuntimeData: RuntimeData = {
-  FXA_ORIGIN: "https://fxa-mock.com",
-  BASKET_ORIGIN: "https://basket-mock.com",
+  // not sure if this is the mock url we want to use
+  FXA_ORIGIN: "http://localhost/mock/fxa",
+  BASKET_ORIGIN: "http://localhost/mock/basket",
   GOOGLE_ANALYTICS_ID: "UA-123456789-0",
   GA4_MEASUREMENT_ID: "G-YXT33S87LT",
   PERIODICAL_PREMIUM_PRODUCT_ID: "prod_123456789",

--- a/frontend/src/components/phones/onboarding/RelayNumberPicker.test.tsx
+++ b/frontend/src/components/phones/onboarding/RelayNumberPicker.test.tsx
@@ -3,6 +3,7 @@ import { RelayNumberPicker } from "../onboarding/RelayNumberPicker";
 import { OverlayProvider } from "react-aria";
 import { useL10n } from "../../../hooks/l10n";
 import * as relayNumberHooks from "../../../hooks/api/relayNumber";
+import { formatPhone } from "../../../functions/formatPhone";
 
 jest.mock("../../../hooks/l10n", () => ({
   useL10n: jest.fn(),
@@ -165,7 +166,8 @@ describe("RelayNumberPicker", () => {
       expect(relayNumberHooks.search).toHaveBeenCalledWith("999");
     });
 
-    const label = screen.getByLabelText("(999) 888 - 7777");
+    const formatted = formatPhone("+19998887777");
+    const label = await screen.findByLabelText(formatted);
     expect(label).toBeInTheDocument();
   });
 

--- a/frontend/src/functions/getPlan.test.ts
+++ b/frontend/src/functions/getPlan.test.ts
@@ -158,7 +158,7 @@ describe("Megabundle Tests", () => {
       );
 
       const expectedLink =
-        "https://fxa-mock.com/subscriptions/products/prod_123456789?plan=price_1RMAopKb9q6OnNsLSGe1vLtt";
+        "http://localhost/mock/fxa/subscriptions/products/prod_123456789?plan=price_1RMAopKb9q6OnNsLSGe1vLtt";
 
       expect(link).toBe(expectedLink);
     });

--- a/frontend/src/pages/_app.page.tsx
+++ b/frontend/src/pages/_app.page.tsx
@@ -9,8 +9,6 @@ import ReactGa from "react-ga";
 import { getL10n } from "../functions/getL10n";
 import { AddonDataContext, useAddonElementWatcher } from "../hooks/addon";
 import { ReactAriaI18nProvider } from "../components/ReactAriaI18nProvider";
-import { initialiseApiMocks } from "../apiMocks/initialise";
-import { mockIds } from "../apiMocks/mockData";
 import { useIsLoggedIn } from "../hooks/session";
 import { useMetrics } from "../hooks/metrics";
 import {
@@ -60,6 +58,9 @@ function MyApp({ Component, pageProps }: AppProps) {
       return;
     }
     (async () => {
+      const { initialiseApiMocks } = await import("../apiMocks/initialise");
+      const { mockIds } = await import("../apiMocks/mockData");
+
       await initialiseApiMocks();
 
       if (

--- a/frontend/src/pages/mock/login.page.tsx
+++ b/frontend/src/pages/mock/login.page.tsx
@@ -5,7 +5,6 @@ import styles from "./mockSession.module.scss";
 import { getRuntimeConfig } from "../../config";
 import { apiFetch } from "../../hooks/api/api";
 import { UsersData } from "../../hooks/api/user";
-import { mockIds } from "../../apiMocks/mockData";
 
 type UsedToken = {
   token: string;
@@ -20,15 +19,18 @@ const MockLogin: NextPage = () => {
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_MOCK_API === "true") {
-      // When the API is mocked out, the API tokens are fake as well:
-      const mockIdsAsTokens: UsedToken[] = mockIds.map((id) => ({
-        lastUsed: 0,
-        token: id,
-        user: `${id}@example.com`,
-      }));
-      setUsedTokens(mockIdsAsTokens);
+      (async () => {
+        const { mockIds } = await import("../../apiMocks/mockData");
+        const mockIdsAsTokens: UsedToken[] = mockIds.map((id) => ({
+          lastUsed: 0,
+          token: id,
+          user: `${id}@example.com`,
+        }));
+        setUsedTokens(mockIdsAsTokens);
+      })();
       return;
     }
+
     const usedTokensString = localStorage.getItem("usedTokens") ?? "[]";
     setUsedTokens(JSON.parse(usedTokensString).sort(byUseDate));
   }, []);


### PR DESCRIPTION
This PR fixes [MPP-4282](https://mozilla-hub.atlassian.net/browse/MPP-4282)

- Removed fxa-mock.com and basket-mock.com from mock data to prevent leaking them into production.
- Replaced those domains with safe local URLs like http://localhost/mock/fxa.
- Changed static imports of mock files in _app.page.tsx to dynamic import() so they’re only loaded in mock mode.
- This keeps test-only code and URLs out of the production JavaScript bundle.

How to test:
- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

[MPP-4282]: https://mozilla-hub.atlassian.net/browse/MPP-4282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ