### PR TITLE
MPP-4033: Fix Relay user replies to be case insensitve to their stored email

### DIFF
--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -969,6 +969,15 @@ class SNSNotificationRepliesTest(SNSNotificationTestBase):
             expected_fixture_name="s3_stored_replies_with_emoji",
         )
 
+    def test_reply_case_insensitive_relay_user_email(self) -> None:
+        """Casing of a Relay user's email doesn't prevent outgoing replies"""
+        self.user.email = "sOuRcE@sender.com"
+        self.user.save()
+        self.successful_reply_test_implementation(
+            text="this is a text reply",
+            expected_fixture_name="s3_stored_replies",
+        )
+
     @patch("emails.views._reply_allowed")
     def test_reply_not_allowed(self, mocked_reply_allowed: Mock) -> None:
         mocked_reply_allowed.return_value = False

--- a/emails/views.py
+++ b/emails/views.py
@@ -1331,10 +1331,10 @@ def _send_reply_requires_premium_email(
 def _reply_allowed(
     from_address, to_address, reply_record, message_id=None, decrypted_metadata=None
 ):
-    stripped_from_address = _strip_localpart_tag(from_address)
-    reply_record_email = reply_record.address.user.email
+    stripped_from_address = _strip_localpart_tag(from_address).lower()
+    reply_record_email = reply_record.address.user.email.lower()
     stripped_reply_record_address = _strip_localpart_tag(reply_record_email)
-    if (from_address == reply_record_email) or (
+    if (from_address.lower() == reply_record_email) or (
         stripped_from_address == stripped_reply_record_address
     ):
         # This is a Relay user replying to an external sender;


### PR DESCRIPTION
This PR fixes [MPP-4033](https://mozilla-hub.atlassian.net/browse/MPP-4033)

I've both reproduced, tested this fix with a local E2E email setup, and added a unit tests.
How to test:

1. Create a user with an uppercase email address in FXA and enable premium subscription
2. Create a mask for the user
3. Send an email to the mask, the user should receive it, but not be able to reply
4. After deploy, user can reply to the email

- [x] Reproduced in staging and can test this well after a deploy

Checklist:
- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

[MPP-4033]: https://mozilla-hub.atlassian.net/browse/MPP-4033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ