### PR TITLE
MPP-4308: remove outdated forwarding size string from dashboard

### DIFF
--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -596,12 +596,6 @@ const Profile: NextPage = () => {
               runtimeData={runtimeData.data}
               setModalOpenedState={setModalOpenedState}
             />
-            <p className={styles["size-information"]}>
-              {l10n.getString("profile-supports-email-forwarding", {
-                size: getRuntimeConfig().emailSizeLimitNumber,
-                unit: getRuntimeConfig().emailSizeLimitUnit,
-              })}
-            </p>
           </section>
           {bottomBanners}
         </main>


### PR DESCRIPTION
# [MPP-4308](https://mozilla-hub.atlassian.net/browse/MPP-4308) 

# Screenshot (if applicable)
<img width="3440" height="1324" alt="Screenshot 2025-08-12 at 10 14 58 AM" src="https://github.com/user-attachments/assets/029135e3-691e-4eeb-bfe7-7fce1b487edf" />

# How to test
- navigate to profile dashboard
- notice string is no longer present

# Checklist (Definition of Done)

- [X] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [X] Customer Experience team has seen or waived a demo of functionality.
- [X] All acceptance criteria are met.
- [X] Jira ticket has been updated (if needed) to match changes made during the development process.
- [X] I've added or updated relevant docs in the docs/ directory
- [X] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [X] l10n changes have been submitted to the l10n repository, if any.
