### PR TITLE
fix MPP-4336 update(allowlist): add subdomains to allowlist domains

### DIFF
--- a/privaterelay/fxrelay-allowlist-domains.txt
+++ b/privaterelay/fxrelay-allowlist-domains.txt
@@ -302,9 +302,17 @@ yout.com
 idp.carmax.com
 picsart.com
 verizon.com
+secure.verizon.com
 aliexpress.com
+www.aliexpress.com
+www.aliexpress.us
 battle.net
+account.battle.net
 theverge.com
+www.theverge.com
 tillys.com
+www.tillys.com
 digitalocean.com
+cloud.digitalocean.com
 ynab.com
+www.ynab.com


### PR DESCRIPTION
Follow-up to https://github.com/mozilla/fx-private-relay/pull/5794. 

This PR fixes MPP-4336.

How to test:
* [x] I went thru https://github.com/mozilla/fx-private-relay/blob/main/docs/update-remote-settings-lists.md to update the collection on both dev and stage servers and it went fine.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).