### PR TITLE
MPP-4293 - increase frontend test coverage for Mask Management pages and components (part 2) 

### DIFF
--- a/frontend/__mocks__/hooks/api/inboundContact.ts
+++ b/frontend/__mocks__/hooks/api/inboundContact.ts
@@ -73,3 +73,5 @@ export const setMockRelayNumberDataOnce = (
     getReturnValue(inboundContacts, callbacks),
   );
 };
+
+export { useInboundContact };

--- a/frontend/__mocks__/hooks/api/relayNumber.ts
+++ b/frontend/__mocks__/hooks/api/relayNumber.ts
@@ -75,3 +75,5 @@ export const setMockRelayNumberDataOnce = (
     getReturnValue(relayNumbers, callbacks),
   );
 };
+
+export { useRelayNumber };

--- a/frontend/src/components/dashboard/AddonData.test.tsx
+++ b/frontend/src/components/dashboard/AddonData.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { AddonData } from "./AddonData";
+import {
+  mockedProfiles,
+  mockedRuntimeData,
+  mockedRelayaddresses,
+  mockedDomainaddresses,
+} from "frontend/src/apiMocks/mockData";
+
+const mockProps = {
+  profile: mockedProfiles.demo,
+  runtimeData: mockedRuntimeData,
+  aliases: [...mockedRelayaddresses.demo, ...mockedDomainaddresses.demo],
+  totalForwardedEmails: 100,
+  totalBlockedEmails: 20,
+  totalEmailTrackersRemoved: 5,
+};
+
+describe("AddonData", () => {
+  it("renders the firefox-private-relay-addon-data element with correct attributes", () => {
+    render(<AddonData {...mockProps} />);
+    const element = screen.getByTestId("addon-element");
+
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveAttribute("id", "profile-main");
+    expect(element).toHaveAttribute(
+      "data-api-token",
+      mockProps.profile.api_token,
+    );
+    expect(element).toHaveAttribute(
+      "data-has-premium",
+      String(mockProps.profile.has_premium),
+    );
+    expect(element).toHaveAttribute(
+      "data-fxa-subscriptions-url",
+      `${mockProps.runtimeData.FXA_ORIGIN}/subscriptions`,
+    );
+    expect(element).toHaveAttribute(
+      "data-aliases-used-val",
+      String(mockProps.aliases.length),
+    );
+    expect(element).toHaveAttribute("data-emails-forwarded-val", "100");
+    expect(element).toHaveAttribute("data-emails-blocked-val", "20");
+    expect(element).toHaveAttribute("data-email-trackers-removed-val", "5");
+
+    const expectedSubdomain =
+      typeof mockProps.profile.subdomain === "string"
+        ? mockProps.profile.subdomain
+        : "None";
+    expect(element).toHaveAttribute(
+      "data-premium-subdomain-set",
+      expectedSubdomain,
+    );
+
+    expect(element).toHaveAttribute("data-premium-enabled", "True");
+  });
+
+  it("uses 'None' for subdomain if not a string", () => {
+    render(
+      <AddonData
+        {...mockProps}
+        profile={{ ...mockProps.profile, subdomain: null }}
+      />,
+    );
+
+    const element = screen.getByTestId("addon-element");
+    expect(element).toHaveAttribute("data-premium-subdomain-set", "None");
+  });
+});

--- a/frontend/src/components/dashboard/AddonData.tsx
+++ b/frontend/src/components/dashboard/AddonData.tsx
@@ -17,6 +17,7 @@ export const AddonData = (props: Props) => {
     // #profile-main is used by the add-on to look up the API token.
     // TODO: Make it look for this custom element instead.
     id: "profile-main",
+    "data-testid": "addon-element",
     "data-api-token": props.profile.api_token,
     "data-has-premium": String(props.profile.has_premium),
     "data-fxa-subscriptions-url": `${props.runtimeData.FXA_ORIGIN}/subscriptions`,

--- a/frontend/src/components/dashboard/CornerNotification.test.tsx
+++ b/frontend/src/components/dashboard/CornerNotification.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CornerNotification } from "./CornerNotification";
+import React from "react";
+import {
+  mockedRuntimeData,
+  mockedProfiles,
+  mockedRelayaddresses,
+} from "frontend/src/apiMocks/mockData";
+import { useL10n } from "frontend/src/hooks/l10n";
+import { useLocalDismissal } from "frontend/src/hooks/localDismissal";
+import { useGaEvent } from "frontend/src/hooks/gaEvent";
+import { isFlagActive } from "frontend/src/functions/waffle";
+
+jest.mock("frontend/src/functions/waffle", () => ({
+  isFlagActive: jest.fn(),
+}));
+jest.mock("frontend/src/hooks/l10n", () => ({
+  useL10n: jest.fn(),
+}));
+jest.mock("frontend/src/hooks/localDismissal", () => ({
+  useLocalDismissal: jest.fn(),
+}));
+jest.mock("frontend/src/hooks/gaEvent", () => ({
+  useGaEvent: jest.fn(),
+}));
+jest.mock("frontend/src/hooks/gaViewPing", () => ({
+  useGaViewPing: jest.fn(() => React.createRef()),
+}));
+
+beforeAll(() => {
+  class MockIntersectionObserver implements IntersectionObserver {
+    readonly root: Element | null = null;
+    readonly rootMargin: string = "";
+    readonly thresholds: ReadonlyArray<number> = [];
+
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+  }
+
+  global.IntersectionObserver = MockIntersectionObserver;
+});
+
+describe("CornerNotification", () => {
+  const mockL10n = {
+    getString: jest.fn((key) => key),
+  };
+
+  const mockDismiss = jest.fn();
+  const mockAlias = mockedRelayaddresses.full[0];
+
+  const defaultProps = {
+    profile: {
+      ...mockedProfiles.some,
+      has_premium: false,
+    },
+    runtimeData: mockedRuntimeData,
+    aliases: new Array(4).fill(mockAlias),
+  };
+
+  beforeEach(() => {
+    (useL10n as jest.Mock).mockReturnValue(mockL10n);
+    (useLocalDismissal as jest.Mock).mockReturnValue({
+      isDismissed: false,
+      dismiss: mockDismiss,
+    });
+    (useGaEvent as jest.Mock).mockReturnValue(jest.fn());
+    (isFlagActive as unknown as jest.Mock).mockReturnValue(true);
+    mockL10n.getString.mockClear();
+  });
+
+  it("renders when flag is active, user has 4 aliases, is not premium, and not dismissed", () => {
+    render(<CornerNotification {...defaultProps} />);
+    expect(
+      screen.getByText("upsell-banner-4-masks-us-heading-2"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("upsell-banner-4-masks-us-description-2"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "upsell-banner-4-masks-button-close-label",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "upsell-banner-4-masks-us-cta" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render if user is premium", () => {
+    render(
+      <CornerNotification
+        {...defaultProps}
+        profile={{ ...defaultProps.profile, has_premium: true }}
+      />,
+    );
+    expect(
+      screen.queryByText("upsell-banner-4-masks-us-heading-2"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render if dismissal is true", () => {
+    (useLocalDismissal as jest.Mock).mockReturnValue({
+      isDismissed: true,
+      dismiss: mockDismiss,
+    });
+    render(<CornerNotification {...defaultProps} />);
+    expect(
+      screen.queryByText("upsell-banner-4-masks-us-heading-2"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render if aliases are less than 4", () => {
+    render(
+      <CornerNotification {...defaultProps} aliases={[mockAlias, mockAlias]} />,
+    );
+    expect(
+      screen.queryByText("upsell-banner-4-masks-us-heading-2"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render if flag is inactive", () => {
+    (isFlagActive as unknown as jest.Mock).mockReturnValue(false);
+    render(<CornerNotification {...defaultProps} />);
+    expect(
+      screen.queryByText("upsell-banner-4-masks-us-heading-2"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("dismisses when close button is clicked", () => {
+    render(<CornerNotification {...defaultProps} />);
+    const closeButton = screen.getByRole("button", {
+      name: "upsell-banner-4-masks-button-close-label",
+    });
+    fireEvent.click(closeButton);
+    expect(mockDismiss).toHaveBeenCalled();
+  });
+
+  it("fires GA event when CTA is clicked", () => {
+    const mockGaEvent = jest.fn();
+    (useGaEvent as jest.Mock).mockReturnValue(mockGaEvent);
+    render(<CornerNotification {...defaultProps} />);
+    const cta = screen.getByRole("link", {
+      name: "upsell-banner-4-masks-us-cta",
+    });
+    fireEvent.click(cta);
+    expect(mockGaEvent).toHaveBeenCalledWith({
+      category: "Purchase Button",
+      action: "Engage",
+      label: "4-mask-limit-upsell",
+    });
+  });
+});

--- a/frontend/src/components/dashboard/EmailForwardingModal.test.tsx
+++ b/frontend/src/components/dashboard/EmailForwardingModal.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { EmailForwardingModal, Props } from "./EmailForwardingModal";
+import { useL10n } from "../../hooks/l10n";
+import { aliasEmailTest } from "../../hooks/api/aliases";
+import { useGaEvent } from "../../hooks/gaEvent";
+
+jest.mock("../../hooks/l10n", () => ({
+  useL10n: jest.fn(),
+}));
+jest.mock("../../hooks/api/aliases", () => ({
+  aliasEmailTest: jest.fn(),
+}));
+jest.mock("../../hooks/gaEvent", () => ({
+  useGaEvent: jest.fn(),
+}));
+
+const mockGetString = jest.fn((id) => id);
+const mockGaEvent = jest.fn();
+
+const defaultProps: Props = {
+  isOpen: true,
+  isSet: false,
+  onClose: jest.fn(),
+  onConfirm: jest.fn(),
+  onComplete: jest.fn(),
+};
+
+describe("EmailForwardingModal", () => {
+  beforeEach(() => {
+    (useL10n as jest.Mock).mockReturnValue({ getString: mockGetString });
+    (useGaEvent as jest.Mock).mockReturnValue(mockGaEvent);
+    jest.clearAllMocks();
+  });
+
+  it("renders ConfirmModal when isSet is false", () => {
+    render(<EmailForwardingModal {...defaultProps} />);
+    expect(
+      screen.getByText(
+        "profile-free-onboarding-copy-mask-try-out-email-forwarding",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("submits the email and triggers aliasEmailTest and gaEvent", async () => {
+    (aliasEmailTest as jest.Mock).mockResolvedValueOnce(true);
+
+    render(<EmailForwardingModal {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText(
+      "profile-free-onboarding-copy-mask-placeholder-relay-email-mask",
+    );
+
+    fireEvent.change(input, { target: { value: "test@relay.example" } });
+    fireEvent.click(
+      screen.getByText("profile-free-onboarding-copy-mask-send-email"),
+    );
+
+    await waitFor(() =>
+      expect(aliasEmailTest).toHaveBeenCalledWith("test@relay.example"),
+    );
+    await waitFor(() => expect(defaultProps.onConfirm).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mockGaEvent).toHaveBeenCalledWith({
+        category: "Free Onboarding",
+        action: "Engage",
+        label: "onboarding-step-2-forwarding-test",
+        value: 1,
+      }),
+    );
+  });
+
+  it("does not call onConfirm if aliasEmailTest fails", async () => {
+    (aliasEmailTest as jest.Mock).mockResolvedValueOnce(false);
+
+    render(<EmailForwardingModal {...defaultProps} />);
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "profile-free-onboarding-copy-mask-placeholder-relay-email-mask",
+      ),
+      { target: { value: "bad@relay.example" } },
+    );
+
+    fireEvent.click(
+      screen.getByText("profile-free-onboarding-copy-mask-send-email"),
+    );
+
+    await waitFor(() => expect(aliasEmailTest).toHaveBeenCalled());
+    await waitFor(() => expect(defaultProps.onConfirm).not.toHaveBeenCalled());
+    await waitFor(() => expect(mockGaEvent).not.toHaveBeenCalled());
+  });
+
+  it("calls onClose when Nevermind button is clicked", () => {
+    render(<EmailForwardingModal {...defaultProps} />);
+    fireEvent.click(
+      screen.getByText("profile-free-onboarding-copy-mask-nevermind"),
+    );
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it("renders SuccessModal when isSet is true", () => {
+    render(<EmailForwardingModal {...defaultProps} isSet={true} />);
+    expect(
+      screen.getByText("profile-free-onboarding-copy-mask-check-inbox"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onComplete when Continue button is clicked in SuccessModal", () => {
+    render(<EmailForwardingModal {...defaultProps} isSet={true} />);
+    fireEvent.click(
+      screen.getByText("profile-free-onboarding-copy-mask-continue"),
+    );
+    expect(defaultProps.onComplete).toHaveBeenCalled();
+  });
+
+  it("returns null when isOpen is false", () => {
+    render(<EmailForwardingModal {...defaultProps} isOpen={false} />);
+    expect(
+      screen.queryByText("profile-free-onboarding-copy-mask-check-inbox"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/Onboarding.test.tsx
+++ b/frontend/src/components/dashboard/Onboarding.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Onboarding, Props } from "./Onboarding";
+import { AliasData } from "../../hooks/api/aliases";
+
+jest.mock("../../hooks/l10n", () => ({
+  useL10n: () => ({
+    getString: (key: string) => `[${key}]`,
+  }),
+}));
+
+jest.mock("../Image", () => ({
+  __esModule: true,
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} data-testid="mocked-image" />
+  ),
+}));
+
+describe("Onboarding", () => {
+  const mockOnCreate = jest.fn();
+
+  const defaultProps: Props = {
+    aliases: [],
+    onCreate: mockOnCreate,
+  };
+
+  it("renders onboarding steps when no aliases are present", () => {
+    render(<Onboarding {...defaultProps} />);
+
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "[onboarding-headline-2]",
+    );
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+
+    expect(
+      screen.getByRole("button", {
+        name: "[profile-label-generate-new-alias-2]",
+      }),
+    ).toBeInTheDocument();
+
+    expect(screen.getAllByTestId("mocked-image")).toHaveLength(2);
+  });
+
+  it("does not render anything if aliases are present", () => {
+    const mockAlias: AliasData = {
+      id: 1,
+      mask_type: "random",
+      enabled: true,
+      block_list_emails: false,
+      block_level_one_trackers: false,
+      description: "",
+      address: "alias123",
+      full_address: "alias123@relay.firefox.com",
+      domain: 1,
+      created_at: "2024-01-01T00:00:00Z",
+      last_modified_at: "2024-01-02T00:00:00Z",
+      last_used_at: null,
+      num_forwarded: 0,
+      num_blocked: 0,
+      num_spam: 0,
+      num_replied: 0,
+      num_level_one_trackers_blocked: 0,
+      used_on: "",
+      generated_for: "",
+    };
+
+    render(<Onboarding {...defaultProps} aliases={[mockAlias]} />);
+    expect(screen.queryByRole("heading", { level: 2 })).not.toBeInTheDocument();
+  });
+
+  it("calls onCreate when the button is clicked", () => {
+    render(<Onboarding {...defaultProps} />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "[profile-label-generate-new-alias-2]",
+      }),
+    );
+    expect(mockOnCreate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/dashboard/PremiumOnboarding.test.tsx
+++ b/frontend/src/components/dashboard/PremiumOnboarding.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PremiumOnboarding } from "./PremiumOnboarding";
+import { mockedProfiles } from "../../apiMocks/mockData";
+import { useL10n } from "../../hooks/l10n";
+import { supportsFirefoxExtension } from "../../functions/userAgent";
+import { useMinViewportWidth } from "../../hooks/mediaQuery";
+
+import { LocalizationProvider, ReactLocalization } from "@fluent/react";
+import { FluentBundle, FluentResource } from "@fluent/bundle";
+
+jest.mock("../../hooks/l10n");
+jest.mock("../../hooks/gaViewPing", () => ({
+  useGaViewPing: () => undefined,
+}));
+jest.mock("../../hooks/gaEvent", () => ({
+  useGaEvent: () => jest.fn(),
+}));
+jest.mock("../../functions/userAgent");
+jest.mock("../../hooks/mediaQuery");
+jest.mock("../../config", () => ({
+  getRuntimeConfig: () => ({
+    mozmailDomain: "mozmail.test",
+  }),
+}));
+
+const MockL10nProvider = ({ children }: { children: React.ReactNode }) => {
+  const resource = new FluentResource("");
+  const bundle = new FluentBundle("en-US");
+  bundle.addResource(resource);
+  const l10n = new ReactLocalization([bundle]);
+
+  return <LocalizationProvider l10n={l10n}>{children}</LocalizationProvider>;
+};
+MockL10nProvider.displayName = "MockL10nProvider";
+
+const renderWithL10n = (ui: React.ReactElement) => {
+  return render(<MockL10nProvider>{ui}</MockL10nProvider>);
+};
+
+describe("PremiumOnboarding", () => {
+  const mockL10nGetString = jest.fn((id: string) => id);
+
+  beforeEach(() => {
+    (useL10n as jest.Mock).mockReturnValue({
+      getString: mockL10nGetString,
+    });
+
+    (supportsFirefoxExtension as jest.Mock).mockReturnValue(true);
+    (useMinViewportWidth as jest.Mock).mockReturnValue(true);
+  });
+
+  it("renders Step 1 and continues to Step 2", () => {
+    const onNextStep = jest.fn();
+    const onPickSubdomain = jest.fn();
+
+    renderWithL10n(
+      <PremiumOnboarding
+        profile={{ ...mockedProfiles.full, onboarding_state: 0 }}
+        onNextStep={onNextStep}
+        onPickSubdomain={onPickSubdomain}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: "multi-part-onboarding-premium-welcome-headline",
+      }),
+    ).toBeInTheDocument();
+
+    const button = screen.getByRole("button", {
+      name: "multi-part-onboarding-premium-welcome-feature-cta",
+    });
+    fireEvent.click(button);
+
+    expect(onNextStep).toHaveBeenCalledWith(1);
+  });
+
+  it("renders Step 2 with subdomain search when subdomain is null", () => {
+    const onNextStep = jest.fn();
+    const onPickSubdomain = jest.fn();
+    const profile = {
+      ...mockedProfiles.full,
+      onboarding_state: 1,
+      subdomain: null,
+    };
+
+    renderWithL10n(
+      <PremiumOnboarding
+        profile={profile}
+        onNextStep={onNextStep}
+        onPickSubdomain={onPickSubdomain}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: "multi-part-onboarding-premium-email-domain-headline",
+      }),
+    ).toBeInTheDocument();
+
+    const skipButton = screen.getByRole("button", {
+      name: "multi-part-onboarding-skip",
+    });
+    fireEvent.click(skipButton);
+
+    expect(onNextStep).toHaveBeenCalledWith(2);
+  });
+
+  it("renders Step 2 with continue button when subdomain is set", () => {
+    const onNextStep = jest.fn();
+
+    renderWithL10n(
+      <PremiumOnboarding
+        profile={{
+          ...mockedProfiles.full,
+          onboarding_state: 1,
+          subdomain: "test-sub",
+        }}
+        onNextStep={onNextStep}
+        onPickSubdomain={jest.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: "multi-part-onboarding-continue",
+    });
+    fireEvent.click(button);
+
+    expect(onNextStep).toHaveBeenCalledWith(2);
+  });
+
+  it("renders Step 3 and allows skipping extension", () => {
+    const onNextStep = jest.fn();
+
+    renderWithL10n(
+      <PremiumOnboarding
+        profile={{ ...mockedProfiles.full, onboarding_state: 2 }}
+        onNextStep={onNextStep}
+        onPickSubdomain={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: "multi-part-onboarding-premium-add-extension-headline",
+      }),
+    ).toBeInTheDocument();
+
+    const skipButton = screen.getByRole("button", {
+      name: "multi-part-onboarding-skip-download-extension",
+    });
+    fireEvent.click(skipButton);
+
+    expect(onNextStep).toHaveBeenCalledWith(3);
+  });
+
+  it("renders progress bar with correct value and max", () => {
+    renderWithL10n(
+      <PremiumOnboarding
+        profile={{ ...mockedProfiles.full, onboarding_state: 1 }}
+        onNextStep={jest.fn()}
+        onPickSubdomain={jest.fn()}
+      />,
+    );
+
+    const progress = screen.getByRole("progressbar");
+    expect(progress).toHaveValue(2);
+    expect(progress).toHaveAttribute("max", "3");
+  });
+});

--- a/frontend/src/components/dashboard/ProfileBanners.test.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from "@testing-library/react";
+import { ProfileBanners } from "./ProfileBanners";
+import {
+  mockedProfiles,
+  mockedUsers,
+  mockedRuntimeData,
+} from "../../apiMocks/mockData";
+import { useMinViewportWidth } from "../../hooks/mediaQuery";
+import {
+  isUsingFirefox,
+  supportsFirefoxExtension,
+} from "../../functions/userAgent";
+
+beforeAll(() => {
+  class MockIntersectionObserver implements IntersectionObserver {
+    readonly root: Element | Document | null = null;
+    readonly rootMargin: string = "";
+    readonly thresholds: ReadonlyArray<number> = [];
+
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+
+    constructor(
+      _callback: IntersectionObserverCallback,
+      _options?: IntersectionObserverInit,
+    ) {}
+  }
+
+  global.IntersectionObserver = MockIntersectionObserver;
+});
+
+jest.mock("../../hooks/l10n", () => ({
+  useL10n: jest.fn(() => ({
+    bundles: [{ locales: ["en-US"] }],
+    getString: (id: string) => id,
+    getFragment: (
+      _id: string,
+      {
+        vars,
+      }: {
+        vars: { username: string; bounce_type: string; date: string };
+      },
+    ) =>
+      `Bounced email to ${vars.username} failed due to ${vars.bounce_type} on ${vars.date}`,
+  })),
+}));
+
+jest.mock("../../hooks/mediaQuery", () => ({
+  useMinViewportWidth: jest.fn(),
+}));
+
+jest.mock("../../functions/userAgent", () => ({
+  isUsingFirefox: jest.fn(),
+  supportsFirefoxExtension: jest.fn(),
+  hasDoNotTrackEnabled: jest.fn(() => false),
+}));
+
+jest.mock("../../hooks/gaEvent", () => ({
+  useGaEvent: () => jest.fn(),
+}));
+
+jest.mock("./SubdomainPicker", () => ({
+  SubdomainPicker: () => <div data-testid="subdomain-picker" />,
+}));
+
+const renderComponent = (
+  overrides: Partial<typeof mockedProfiles.full> = {},
+) => {
+  const profile = mockedProfiles.full;
+  render(
+    <ProfileBanners
+      profile={{ ...profile, ...overrides }}
+      user={mockedUsers.full}
+      aliases={[]}
+      onCreateSubdomain={jest.fn()}
+      runtimeData={mockedRuntimeData}
+    />,
+  );
+};
+
+describe("ProfileBanners", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders bounce banner when bounce_status exists", () => {
+    (useMinViewportWidth as jest.Mock).mockReturnValue(true);
+    (isUsingFirefox as jest.Mock).mockReturnValue(true);
+    (supportsFirefoxExtension as jest.Mock).mockReturnValue(false);
+
+    renderComponent({
+      bounce_status: [true, "hard"],
+      next_email_try: "2025-12-25T00:00:00Z",
+    });
+
+    expect(screen.getByText(/banner-bounced-headline/)).toBeInTheDocument();
+    expect(screen.getByText(/Bounced email to/)).toBeInTheDocument();
+  });
+
+  it("always renders SubdomainPicker", () => {
+    renderComponent();
+    expect(screen.getByTestId("subdomain-picker")).toBeInTheDocument();
+  });
+
+  it("renders NoFirefoxBanner when not using Firefox or small screen", () => {
+    (isUsingFirefox as jest.Mock).mockReturnValue(false);
+    (useMinViewportWidth as jest.Mock).mockReturnValue(true);
+
+    renderComponent();
+    expect(
+      screen.getByText("banner-download-firefox-headline"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render NoFirefoxBanner when using Firefox and on large screen", () => {
+    (isUsingFirefox as jest.Mock).mockReturnValue(true);
+    (useMinViewportWidth as jest.Mock).mockReturnValue(true);
+
+    renderComponent();
+    expect(
+      screen.queryByText("banner-download-firefox-headline"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders NoAddonBanner when supports extension, large screen, and not demo profile", () => {
+    (isUsingFirefox as jest.Mock).mockReturnValue(true);
+    (supportsFirefoxExtension as jest.Mock).mockReturnValue(true);
+    (useMinViewportWidth as jest.Mock).mockReturnValue(true);
+
+    renderComponent({ api_token: "not_demo" });
+    expect(
+      screen.getByText("banner-download-install-extension-headline"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render NoAddonBanner if profile is demo", () => {
+    (isUsingFirefox as jest.Mock).mockReturnValue(true);
+    (supportsFirefoxExtension as jest.Mock).mockReturnValue(true);
+    (useMinViewportWidth as jest.Mock).mockReturnValue(true);
+
+    renderComponent({ api_token: "demo" });
+    expect(
+      screen.queryByText("banner-download-install-extension-headline"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/SubdomainPicker.test.tsx
+++ b/frontend/src/components/dashboard/SubdomainPicker.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, act } from "@testing-library/react";
+import { SubdomainPicker } from "./SubdomainPicker";
+import { mockedProfiles } from "../../apiMocks/mockData";
+import { useL10n } from "../../hooks/l10n";
+import { getRuntimeConfig } from "../../config";
+import { SubdomainSearchForm } from "./subdomain/SearchForm";
+import { SubdomainConfirmationModal } from "./subdomain/ConfirmationModal";
+
+jest.mock("../../hooks/l10n", () => ({
+  useL10n: jest.fn(),
+}));
+
+jest.mock("../../hooks/flaggedAnchorLinks", () => ({
+  useFlaggedAnchorLinks: jest.fn(),
+}));
+
+jest.mock("../../config", () => ({
+  getRuntimeConfig: jest.fn(),
+}));
+
+jest.mock("./subdomain/SearchForm", () => ({
+  SubdomainSearchForm: jest.fn(() => (
+    <div data-testid="subdomain-search-form" />
+  )),
+}));
+
+jest.mock("./subdomain/ConfirmationModal", () => ({
+  SubdomainConfirmationModal: jest.fn(() => (
+    <div data-testid="confirmation-modal" />
+  )),
+}));
+
+describe("SubdomainPicker", () => {
+  const mockL10nStrings = {
+    getString: (key: string, vars?: Record<string, string>) =>
+      `${key}${vars?.mozmail ? `: ${vars.mozmail}` : ""}`,
+  };
+
+  beforeEach(() => {
+    (useL10n as jest.Mock).mockReturnValue(mockL10nStrings);
+    (getRuntimeConfig as jest.Mock).mockReturnValue({
+      mozmailDomain: "mozmail.com",
+    });
+    jest.clearAllMocks();
+  });
+
+  it("does not render if user is not premium", () => {
+    render(
+      <SubdomainPicker
+        profile={{ ...mockedProfiles.demo, has_premium: false }}
+        onCreate={jest.fn()}
+      />,
+    );
+    expect(
+      screen.queryByTestId("subdomain-search-form"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render if user has a subdomain and modal is not open", () => {
+    render(
+      <SubdomainPicker
+        profile={{ ...mockedProfiles.full, subdomain: "myname" }}
+        onCreate={jest.fn()}
+      />,
+    );
+    expect(
+      screen.queryByTestId("subdomain-search-form"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders if user is premium and does not have a subdomain", () => {
+    const profile = { ...mockedProfiles.full, subdomain: null };
+    render(<SubdomainPicker profile={profile} onCreate={jest.fn()} />);
+    expect(screen.getByTestId("subdomain-search-form")).toBeInTheDocument();
+    expect(
+      screen.getByText("banner-set-email-domain-headline"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders placeholder subdomain if none typed", () => {
+    const profile = { ...mockedProfiles.full, subdomain: null };
+    render(<SubdomainPicker profile={profile} onCreate={jest.fn()} />);
+
+    const matches = screen.getAllByText(
+      (_, el) =>
+        el?.textContent ===
+        "***@banner-set-email-domain-placeholder.mozmail.com",
+    );
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders partial subdomain if typed", () => {
+    const profile = { ...mockedProfiles.full, subdomain: null };
+    const { rerender } = render(
+      <SubdomainPicker profile={profile} onCreate={jest.fn()} />,
+    );
+
+    const searchFormProps = (SubdomainSearchForm as jest.Mock).mock.calls[0][0];
+    act(() => {
+      searchFormProps.onType("customname");
+    });
+
+    rerender(<SubdomainPicker profile={profile} onCreate={jest.fn()} />);
+
+    const matches = screen.getAllByText(
+      (_, el) => el?.textContent === "***@customname.mozmail.com",
+    );
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("opens confirmation modal onPick and calls onCreate on confirm", () => {
+    const onCreate = jest.fn();
+    const profile = { ...mockedProfiles.full, subdomain: null };
+    const { rerender } = render(
+      <SubdomainPicker profile={profile} onCreate={onCreate} />,
+    );
+
+    const searchFormProps = (SubdomainSearchForm as jest.Mock).mock.calls[0][0];
+    act(() => {
+      searchFormProps.onPick("coolname");
+    });
+
+    rerender(<SubdomainPicker profile={profile} onCreate={onCreate} />);
+    expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
+
+    const modalProps = (SubdomainConfirmationModal as jest.Mock).mock
+      .calls[0][0];
+    modalProps.onConfirm();
+    expect(onCreate).toHaveBeenCalledWith("coolname");
+  });
+});

--- a/frontend/src/components/dashboard/aliases/AddressPickerModal.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AddressPickerModal.test.tsx
@@ -1,4 +1,12 @@
 import { getAddressValidationMessage } from "./AddressPickerModal";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AddressPickerModal } from "./AddressPickerModal";
+
+jest.mock("../../../hooks/l10n", () => ({
+  useL10n: () => ({
+    getString: (id: string) => `String for ${id}`,
+  }),
+}));
 
 describe("getAddressValidationMessage", () => {
   it("returns `null` for valid addresses", () => {
@@ -101,5 +109,106 @@ describe("getAddressValidationMessage", () => {
     expect(getAddressValidationMessage("-", mockL10n)).toBe(
       "String ID: modal-custom-alias-picker-form-prefix-invalid-warning-2",
     );
+  });
+});
+
+describe("AddressPickerModal", () => {
+  const onClose = jest.fn();
+  const onPick = jest.fn();
+
+  const setup = (isOpen = true) =>
+    render(
+      <AddressPickerModal
+        isOpen={isOpen}
+        onClose={onClose}
+        onPick={onPick}
+        subdomain="test"
+      />,
+    );
+
+  it("renders modal when open", () => {
+    setup();
+    expect(
+      screen.getByText("String for modal-custom-alias-picker-heading-2"),
+    ).toBeInTheDocument();
+  });
+
+  it("still renders modal even when isOpen is false", () => {
+    setup(false);
+    const heading = screen.queryByText(
+      "String for modal-custom-alias-picker-heading-2",
+    );
+    expect(heading).toBeInTheDocument();
+  });
+
+  it("calls onClose when cancel button is clicked", () => {
+    setup();
+    fireEvent.click(screen.getByText("String for profile-label-cancel"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("disables submit button when address is empty", () => {
+    setup();
+    expect(
+      screen.getByRole("button", {
+        name: "String for modal-custom-alias-picker-form-submit-label-2",
+      }),
+    ).toBeDisabled();
+  });
+
+  it("allows user to fill address and submit successfully", () => {
+    setup();
+    const input = screen.getByPlaceholderText(
+      "String for modal-custom-alias-picker-form-prefix-placeholder-2",
+    );
+    fireEvent.change(input, { target: { value: "valid-alias" } });
+
+    const checkbox = screen.getByLabelText(
+      "String for popover-custom-alias-explainer-promotional-block-checkbox",
+    );
+    fireEvent.click(checkbox);
+
+    const submit = screen.getByRole("button", {
+      name: "String for modal-custom-alias-picker-form-submit-label-2",
+    });
+    fireEvent.click(submit);
+
+    expect(onPick).toHaveBeenCalledWith("valid-alias", {
+      blockPromotionals: true,
+    });
+  });
+
+  it("does not submit and sets a validation message for an invalid address", () => {
+    const setCustomValiditySpy = jest.spyOn(
+      HTMLInputElement.prototype,
+      "setCustomValidity",
+    );
+    const reportValiditySpy = jest.spyOn(
+      HTMLInputElement.prototype,
+      "reportValidity",
+    );
+
+    setup();
+
+    const input = screen.getByPlaceholderText(
+      "String for modal-custom-alias-picker-form-prefix-placeholder-2",
+    ) as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "invalid alias" } });
+    fireEvent.blur(input);
+
+    const submit = screen.getByRole("button", {
+      name: "String for modal-custom-alias-picker-form-submit-label-2",
+    });
+    fireEvent.click(submit);
+
+    expect(onPick).not.toHaveBeenCalled();
+    expect(setCustomValiditySpy).toHaveBeenCalledWith(
+      "String for modal-custom-alias-picker-form-prefix-spaces-warning",
+    );
+    expect(reportValiditySpy).toHaveBeenCalled();
+
+    setCustomValiditySpy.mockRestore();
+    reportValiditySpy.mockRestore();
   });
 });

--- a/frontend/src/components/dashboard/aliases/Alias.test.tsx
+++ b/frontend/src/components/dashboard/aliases/Alias.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Alias } from "./Alias";
+import {
+  mockedUsers,
+  mockedProfiles,
+  mockedRuntimeData,
+} from "../../../apiMocks/mockData";
+import { AliasData } from "../../../hooks/api/aliases";
+
+jest.mock("../../../../public/illustrations/holiday.svg", () => ({
+  __esModule: true,
+  default: { src: "holiday.svg" },
+}));
+
+jest.mock("../../../hooks/l10n", () => ({
+  useL10n: () => ({
+    getString: (id: string, vars?: Record<string, string | number>) =>
+      id === "profile-label-click-to-copy-alt" && vars?.address
+        ? `Copy ${vars.address}`
+        : id,
+  }),
+}));
+
+jest.mock("./LabelEditor", () => ({
+  LabelEditor: ({
+    label,
+    onSubmit,
+  }: {
+    label: string;
+    onSubmit: (val: string) => void;
+  }) => (
+    <div data-testid="label-editor">
+      <button onClick={() => onSubmit("New Label")}>Submit Label</button>
+      <span>{label}</span>
+    </div>
+  ),
+}));
+
+jest.mock("./AliasDeletionButton", () => ({
+  AliasDeletionButton: ({ onDelete }: { onDelete: () => void }) => (
+    <button data-testid="delete-button" onClick={onDelete}>
+      Delete Alias
+    </button>
+  ),
+}));
+
+jest.mock("./BlockLevelSlider", () => ({
+  BlockLevelSlider: ({ onChange }: { onChange: (level: string) => void }) => (
+    <button data-testid="block-slider" onClick={() => onChange("all")}>
+      Set Block Level
+    </button>
+  ),
+}));
+
+jest.mock("../../../functions/waffle", () => ({
+  isFlagActive: () => true,
+}));
+
+jest.mock("../../../functions/getPlan", () => ({
+  isPeriodicalPremiumAvailableInCountry: () => true,
+}));
+
+jest.mock("../../../functions/getLocale", () => ({
+  getLocale: () => "en-US",
+}));
+
+jest.mock("../../../config");
+
+describe("Alias", () => {
+  const alias: AliasData = {
+    id: 123,
+    mask_type: "random",
+    domain: 1,
+    generated_for: "me@example.com",
+    enabled: true,
+    block_list_emails: false,
+    block_level_one_trackers: false,
+    description: "Holiday",
+    address: "abc123",
+    full_address: "abc123@relay.firefox.com",
+    created_at: "2023-01-01T00:00:00Z",
+    last_modified_at: "2023-01-01T01:00:00Z",
+    last_used_at: null,
+    num_blocked: 5,
+    num_forwarded: 3,
+    num_spam: 0,
+    num_replied: 1,
+    num_level_one_trackers_blocked: 2,
+    used_on: "",
+  };
+
+  const setup = (
+    aliasOverride: Partial<AliasData> = {},
+    showLabelEditor = true,
+  ) => {
+    const onUpdate = jest.fn();
+    const onDelete = jest.fn();
+    const onChangeOpen = jest.fn();
+
+    render(
+      <Alias
+        alias={{
+          ...alias,
+          ...aliasOverride,
+          mask_type: "random",
+          domain: 1,
+          generated_for: "me@example.com",
+        }}
+        user={mockedUsers.full}
+        profile={mockedProfiles.full}
+        onUpdate={onUpdate}
+        onDelete={onDelete}
+        isOpen={false}
+        onChangeOpen={onChangeOpen}
+        showLabelEditor={showLabelEditor}
+        runtimeData={mockedRuntimeData}
+      />,
+    );
+
+    return { onUpdate, onDelete, onChangeOpen };
+  };
+
+  it("renders alias address and label editor", () => {
+    setup();
+    expect(screen.getByText("abc123@relay.firefox.com")).toBeInTheDocument();
+    expect(screen.getByTestId("label-editor")).toBeInTheDocument();
+  });
+
+  it("calls onSubmit from label editor", () => {
+    const { onUpdate } = setup();
+    fireEvent.click(screen.getByText("Submit Label"));
+    expect(onUpdate).toHaveBeenCalledWith({ description: "New Label" });
+  });
+
+  it("copies address to clipboard and shows confirmation", async () => {
+    setup();
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn() },
+    });
+
+    fireEvent.click(screen.getByTitle("profile-label-click-to-copy"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "abc123@relay.firefox.com",
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("profile-label-copied")).toBeVisible(),
+    );
+  });
+
+  it("toggles expansion state", () => {
+    const { onChangeOpen } = setup();
+    fireEvent.click(
+      screen.getByRole("button", { name: "profile-details-expand" }),
+    );
+    expect(onChangeOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("sets block level to 'all' when block slider clicked", () => {
+    const { onUpdate } = setup();
+    fireEvent.click(screen.getByTestId("block-slider"));
+    expect(onUpdate).toHaveBeenCalledWith({
+      enabled: false,
+      block_list_emails: true,
+    });
+  });
+
+  it("renders deletion button and triggers deletion", () => {
+    const { onDelete } = setup();
+    fireEvent.click(screen.getByTestId("delete-button"));
+    expect(onDelete).toHaveBeenCalled();
+  });
+
+  it("renders tracker removal indicator when active", () => {
+    setup({ block_level_one_trackers: true });
+    expect(
+      screen.getByRole("button", {
+        name: "profile-indicator-tracker-removal-alt",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders holiday background image", () => {
+    setup();
+    const root = screen.getByTestId("alias-card");
+    expect(root.style.backgroundImage).toContain("holiday.svg");
+  });
+
+  it("renders forwarded and blocked stats", () => {
+    setup();
+    expect(screen.getAllByText("profile-label-forwarded")).toHaveLength(2);
+    expect(screen.getAllByText("profile-label-blocked")).toHaveLength(2);
+  });
+});

--- a/frontend/src/components/dashboard/aliases/Alias.tsx
+++ b/frontend/src/components/dashboard/aliases/Alias.tsx
@@ -144,6 +144,7 @@ export const Alias = (props: Props) => {
 
   return (
     <div
+      data-testid="alias-card"
       className={classNames}
       style={{
         backgroundImage: backgroundImage

--- a/frontend/src/components/dashboard/aliases/AliasDeletionButton.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButton.test.tsx
@@ -1,11 +1,11 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-
 import { mockConfigModule } from "../../../../__mocks__/configMock";
 import { mockLocalizedModule } from "../../../../__mocks__/components/Localized";
 import { getMockRandomAlias } from "../../../../__mocks__/hooks/api/aliases";
 import { mockUseL10nModule } from "../../../../__mocks__/hooks/l10n";
 
+import * as aliasApi from "../../../hooks/api/aliases";
 import { AliasDeletionButton } from "./AliasDeletionButton";
 
 jest.mock("../../../config.ts", () => mockConfigModule);
@@ -14,126 +14,181 @@ jest.mock("../../../hooks/l10n.ts", () => mockUseL10nModule);
 jest.mock("../../../components/Localized.tsx", () => mockLocalizedModule);
 
 describe("<AliasDeletionButton>", () => {
+  const openLabel = "l10n string: [profile-label-delete], with vars: {}";
+  const cancelLabel = "l10n string: [profile-label-cancel], with vars: {}";
+  const confirmLabel =
+    "l10n string: [modal-delete-confirmation-2], with vars: {}";
+  const titleLabel = "l10n string: [modal-delete-headline-2], with vars: {}";
+  const usageRandomLabel =
+    "l10n string: [modal-delete-warning-upgrade-2], with vars: {}";
+  const usageCustomLabel =
+    "l10n string: [modal-delete-domain-address-warning-upgrade-2], with vars: {}";
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const setup = (
+    overrides?: Partial<React.ComponentProps<typeof AliasDeletionButton>>,
+  ) => {
+    const onDelete = jest.fn();
+    const props: React.ComponentProps<typeof AliasDeletionButton> = {
+      alias: getMockRandomAlias(),
+      onDelete,
+      ...(overrides ?? {}),
+    };
+
+    render(<AliasDeletionButton {...props} />);
+
+    const getTrigger = () => screen.getByRole("button", { name: openLabel });
+
+    const open = async () => {
+      await userEvent.click(getTrigger());
+      return screen.getByRole("dialog");
+    };
+
+    const getPrompt = () => screen.getByRole("dialog");
+    const getCheckbox = () => within(getPrompt()).getByRole("checkbox");
+    const getDeleteButton = () =>
+      within(getPrompt()).getByRole("button", { name: openLabel });
+    const getCancelButton = () =>
+      within(getPrompt()).getByRole("button", { name: cancelLabel });
+
+    return {
+      onDelete,
+      getTrigger,
+      open,
+      getPrompt,
+      getCheckbox,
+      getDeleteButton,
+      getCancelButton,
+    };
+  };
+
   it("displays a usable button to delete an alias", () => {
-    render(
-      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />,
-    );
-
-    const button = screen.getByRole("button", {
-      name: "l10n string: [profile-label-delete], with vars: {}",
-      hidden: false,
-    });
-
-    expect(button).toBeInTheDocument();
+    const { getTrigger } = setup();
+    expect(getTrigger()).toBeInTheDocument();
   });
 
-  it("displays a confirmation prompt, with an unchecked checkbox and a disabled button", async () => {
-    render(
-      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />,
-    );
+  it("displays a confirmation prompt with an unchecked checkbox and a disabled delete button", async () => {
+    const { open, getCheckbox, getDeleteButton } = setup();
+    await open();
 
-    const button = screen.getByRole("button", {
-      name: "l10n string: [profile-label-delete], with vars: {}",
-      hidden: false,
-    });
-
-    await userEvent.click(button);
-
-    const prompt = screen.getByRole("dialog");
-    const promptCheckbox = within(prompt).getByRole("checkbox");
-    const promptButton = within(prompt).getByRole("button", {
-      name: "l10n string: [profile-label-delete], with vars: {}",
-    });
-
-    expect(promptCheckbox).not.toBeChecked();
-    expect(promptButton).toBeDisabled();
+    expect(getCheckbox()).not.toBeChecked();
+    expect(getDeleteButton()).toBeDisabled();
   });
 
-  it("enables the delete button on the confirmation prompt, once the checkbox is checked", async () => {
-    render(
-      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />,
-    );
+  it("enables the delete button once the checkbox is checked", async () => {
+    const { open, getCheckbox, getDeleteButton } = setup();
+    await open();
 
-    const button = screen.getByRole("button", {
-      name: "l10n string: [profile-label-delete], with vars: {}",
-    });
+    await userEvent.click(getCheckbox());
 
-    await userEvent.click(button);
-
-    const prompt = screen.getByRole("dialog");
-    const promptCheckbox = screen.getByRole("checkbox");
-    const promptButton = within(prompt).getByRole("button", {
-      name: "l10n string: [profile-label-delete], with vars: {}",
-    });
-
-    await userEvent.click(promptCheckbox);
-
-    expect(promptCheckbox).toBeChecked();
-    expect(promptButton).toBeEnabled();
+    expect(getCheckbox()).toBeChecked();
+    expect(getDeleteButton()).toBeEnabled();
   });
 
-  it("resets the inputs on the confirmation prompt when reopened, after clicking the Cancel button", async () => {
-    render(
-      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />,
+  it("resets inputs when reopened after clicking the Cancel button", async () => {
+    const { getTrigger, open, getCheckbox, getCancelButton } = setup();
+
+    await open();
+    await userEvent.click(getCheckbox());
+    await userEvent.click(getCancelButton());
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    await waitFor(() => expect(getTrigger()).toHaveFocus());
+
+    await userEvent.click(getTrigger());
+
+    const secondCheckbox = within(screen.getByRole("dialog")).getByRole(
+      "checkbox",
+    );
+    const secondDeleteButton = within(screen.getByRole("dialog")).getByRole(
+      "button",
+      { name: openLabel },
     );
 
-    const button = screen.getByRole("button", {
-      name: "l10n string: [profile-label-delete], with vars: {}",
-    });
+    expect(secondCheckbox).not.toBeChecked();
+    expect(secondDeleteButton).toBeDisabled();
+  });
 
-    await userEvent.click(button);
+  it("resets inputs when reopened after clicking off the prompt", async () => {
+    const { getTrigger, open } = setup();
 
+    await open();
     const firstPrompt = screen.getByRole("dialog");
-    const firstPromptCheckbox = within(firstPrompt).getByRole("checkbox");
-    const firstPromptCancelButton = within(firstPrompt).getByRole("button", {
-      name: "l10n string: [profile-label-cancel], with vars: {}",
-    });
-
-    // Click confirmation checkbox on modal
-    await userEvent.click(firstPromptCheckbox);
-    // Click cancel button to dismiss modal
-    await userEvent.click(firstPromptCancelButton);
-    // Click delete button again
-    await userEvent.click(button);
-
-    const secondPrompt = screen.getByRole("dialog");
-    const secondPromptDeleteButton = within(secondPrompt).getByRole("button", {
-      name: "l10n string: [profile-label-delete], with vars: {}",
-    });
-    const secondPromptCheckbox = within(secondPrompt).getByRole("checkbox");
-
-    expect(secondPromptCheckbox).not.toBeChecked();
-    expect(secondPromptDeleteButton).toBeDisabled();
-  });
-
-  it("resets the inputs on the confirmation prompt when reopened, after clicking off the propmt", async () => {
-    render(
-      <AliasDeletionButton alias={getMockRandomAlias()} onDelete={jest.fn()} />,
-    );
-
-    const button = screen.getByRole("button", {
-      name: "l10n string: [profile-label-delete], with vars: {}",
-    });
-
-    await userEvent.click(button);
-
-    const firstPrompt = screen.getByRole("dialog");
-    const firstPromptCheckbox = within(firstPrompt).getByRole("checkbox");
-
-    // Click confirmation checkbox on modal
-    await userEvent.click(firstPromptCheckbox);
-    // Click outside modal to dismiss modal
+    await userEvent.click(within(firstPrompt).getByRole("checkbox"));
     await userEvent.click(document.body);
-    // Click delete button again
-    await userEvent.click(button);
+
+    await userEvent.click(getTrigger());
 
     const secondPrompt = screen.getByRole("dialog");
-    const secondPromptDeleteButton = within(secondPrompt).getByRole("button", {
-      name: "l10n string: [profile-label-delete], with vars: {}",
+    const secondCheckbox = within(secondPrompt).getByRole("checkbox");
+    const secondDeleteButton = within(secondPrompt).getByRole("button", {
+      name: openLabel,
     });
-    const secondPromptCheckbox = within(secondPrompt).getByRole("checkbox");
 
-    expect(secondPromptCheckbox).not.toBeChecked();
-    expect(secondPromptDeleteButton).toBeDisabled();
+    expect(secondCheckbox).not.toBeChecked();
+    expect(secondDeleteButton).toBeDisabled();
+  });
+
+  it("closes the dialog when pressing Escape", async () => {
+    const { open } = setup();
+    await open();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("calls onDelete and closes when the form is submitted after confirming", async () => {
+    const { onDelete, open, getCheckbox, getDeleteButton } = setup();
+
+    await open();
+
+    expect(getDeleteButton()).toBeDisabled();
+
+    await userEvent.click(getCheckbox());
+    expect(getDeleteButton()).toBeEnabled();
+
+    await userEvent.click(getDeleteButton());
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders the modal title and the confirmation copy", async () => {
+    const { open } = setup();
+    await open();
+
+    expect(
+      screen.getByRole("heading", { level: 3, name: titleLabel }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(confirmLabel)).toBeInTheDocument();
+  });
+
+  it("shows the address from getFullAddress inside <samp> and uses the 'random' usage warning by default", async () => {
+    jest.spyOn(aliasApi, "getFullAddress").mockReturnValue("mask@relay.test");
+
+    const { open } = setup();
+    await open();
+
+    expect(screen.getByText("mask@relay.test")).toBeInTheDocument();
+    expect(screen.getByText(usageRandomLabel)).toBeInTheDocument();
+  });
+
+  it("uses the domain-address usage warning when isRandomAlias is false", async () => {
+    jest.spyOn(aliasApi, "isRandomAlias").mockReturnValue(false);
+    jest.spyOn(aliasApi, "getFullAddress").mockReturnValue("custom@you.test");
+
+    const { open } = setup({
+      // @ts-expect-error: stubbing behavior only; concrete alias fields not needed for this branch
+      alias: {},
+    });
+    await open();
+
+    expect(screen.getByText("custom@you.test")).toBeInTheDocument();
+    expect(screen.getByText(usageCustomLabel)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasDeletionButtonPermanent.test.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { render, screen, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AliasDeletionButtonPermanent } from "./AliasDeletionButtonPermanent";
+import type { AliasData } from "../../../hooks/api/aliases";
+
+jest.mock("./AliasDeletionButtonPermanent.module.scss", () => {
+  const proxy = new Proxy({}, { get: (_t, p) => String(p) });
+  return proxy;
+});
+
+jest.mock("../../Button", () => ({
+  Button: ({
+    children,
+    ...rest
+  }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <button {...rest}>{children}</button>
+  ),
+}));
+
+jest.mock("../../Icons", () => ({
+  ErrorTriangleIcon: (props: Record<string, unknown>) => (
+    <span data-testid="error-icon" {...props} />
+  ),
+}));
+
+const STRINGS: Record<string, string> = {
+  "profile-label-delete": "Delete",
+  "profile-label-cancel": "Cancel",
+  "mask-deletion-header": "Delete this mask?",
+  "mask-deletion-warning-no-recovery":
+    "This action is permanent. You can’t recover this mask.",
+  "mask-deletion-warning-sign-ins":
+    "If you use this mask to sign in anywhere, those sign-ins will break.",
+};
+
+jest.mock("../../../hooks/l10n", () => ({
+  useL10n: () => ({
+    getString: (id: string) => STRINGS[id] ?? id,
+  }),
+}));
+
+jest.mock("../../../hooks/api/aliases", () => {
+  const actual = jest.requireActual("../../../hooks/api/aliases");
+  return {
+    ...actual,
+    getFullAddress: jest.fn(() => "mask-123@example.com"),
+  };
+});
+
+describe("AliasDeletionButtonPermanent", () => {
+  const makeAlias = (): AliasData => ({}) as AliasData;
+
+  const makeProps = (
+    overrides?: Partial<
+      React.ComponentProps<typeof AliasDeletionButtonPermanent>
+    >,
+  ): React.ComponentProps<typeof AliasDeletionButtonPermanent> => ({
+    alias: makeAlias(),
+    onDelete: jest.fn(),
+    ...(overrides ?? {}),
+  });
+
+  const setup = (
+    overrides?: Partial<
+      React.ComponentProps<typeof AliasDeletionButtonPermanent>
+    >,
+  ) => {
+    const props = makeProps(overrides);
+    render(<AliasDeletionButtonPermanent {...props} />);
+
+    const getTrigger = () =>
+      screen.getByRole("button", { name: STRINGS["profile-label-delete"] });
+    const open = async () => {
+      await userEvent.click(getTrigger());
+      return screen.findByRole("dialog");
+    };
+    const getDialog = () => screen.getByRole("dialog");
+    const getCancelButton = () =>
+      within(getDialog()).getByRole("button", {
+        name: STRINGS["profile-label-cancel"],
+      });
+    const getConfirmButton = () =>
+      within(getDialog()).getByRole("button", {
+        name: STRINGS["profile-label-delete"],
+      });
+
+    return {
+      props,
+      getTrigger,
+      open,
+      getDialog,
+      getCancelButton,
+      getConfirmButton,
+    };
+  };
+
+  it("renders the trigger button", () => {
+    const { getTrigger } = setup();
+    expect(getTrigger()).toBeInTheDocument();
+  });
+
+  it("opens the confirmation modal and shows alias and warnings", async () => {
+    const { open, getDialog } = setup();
+
+    await open();
+
+    const dialog = getDialog();
+
+    expect(
+      within(dialog).getByRole("heading", {
+        name: STRINGS["mask-deletion-header"],
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      within(dialog).getByText("mask-123@example.com"),
+    ).toBeInTheDocument();
+
+    expect(
+      within(dialog).getByText(STRINGS["mask-deletion-warning-no-recovery"]),
+    ).toBeInTheDocument();
+
+    expect(
+      within(dialog).getByText(STRINGS["mask-deletion-warning-sign-ins"]),
+    ).toBeInTheDocument();
+
+    expect(within(dialog).getByTestId("error-icon")).toBeInTheDocument();
+  });
+
+  it("closes the modal when Cancel is clicked", async () => {
+    const { open, getCancelButton } = setup();
+
+    await open();
+    await userEvent.click(getCancelButton());
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("calls onDelete and closes the modal when Delete is confirmed", async () => {
+    const onDelete = jest.fn();
+    const { open, getConfirmButton } = setup({ onDelete });
+
+    await open();
+    await userEvent.click(getConfirmButton());
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("reports modal open and close via setModalOpenedState", async () => {
+    const setModalOpenedState = jest.fn();
+    const { open, getCancelButton } = setup({ setModalOpenedState });
+
+    await open();
+    expect(setModalOpenedState).toHaveBeenLastCalledWith(true);
+
+    await userEvent.click(getCancelButton());
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(setModalOpenedState).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.test.tsx
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { BlockLevelSlider, type BlockLevel } from "./BlockLevelSlider";
+import type { AliasData, RandomAliasData } from "../../../hooks/api/aliases";
+
+jest.mock("next/link", () => {
+  const MockLink = ({
+    href,
+    children,
+    ...rest
+  }: { href: string; children: React.ReactNode } & Omit<
+    React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    "href"
+  >) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  );
+  MockLink.displayName = "MockLink";
+  return { __esModule: true, default: MockLink };
+});
+
+jest.mock("../../Image", () => {
+  const MockImage = ({
+    alt = "",
+    ...rest
+  }: React.ImgHTMLAttributes<HTMLImageElement>) => <img alt={alt} {...rest} />;
+  MockImage.displayName = "MockImage";
+  return { __esModule: true, default: MockImage };
+});
+
+jest.mock("./BlockLevelSlider.module.scss", () => {
+  const styles = new Proxy({} as Record<string, string>, {
+    get: (_t, p: string) => p,
+  });
+  return { __esModule: true, default: styles };
+});
+
+const gaSpy = jest.fn();
+
+jest.mock("../../../hooks/gaEvent", () => ({
+  useGaEvent: () => gaSpy,
+}));
+
+jest.mock("../../../hooks/l10n", () => ({
+  useL10n: () => ({
+    getString: (id: string) => id,
+  }),
+}));
+
+function makeRandomAlias(
+  overrides: Partial<RandomAliasData> = {},
+): RandomAliasData {
+  const base: RandomAliasData = {
+    mask_type: "random",
+    domain: 1,
+    generated_for: "",
+    enabled: true,
+    block_list_emails: false,
+    block_level_one_trackers: false,
+    description: "",
+    id: 1,
+    address: "alias",
+    full_address: "alias@example.com",
+    created_at: "2024-01-01T00:00:00Z",
+    last_modified_at: "2024-01-01T00:00:00Z",
+    last_used_at: null,
+    num_forwarded: 0,
+    num_blocked: 0,
+    num_spam: 0,
+    num_replied: 0,
+    num_level_one_trackers_blocked: 0,
+    used_on: "",
+  };
+  return { ...base, ...overrides };
+}
+
+function renderSlider(
+  opts: {
+    alias?: AliasData;
+    hasPremium?: boolean;
+    premiumAvailableInCountry?: boolean;
+    onChange?: (b: BlockLevel) => void;
+  } = {},
+) {
+  const onChange = opts.onChange ?? jest.fn();
+  const alias = opts.alias ?? makeRandomAlias();
+  const hasPremium = opts.hasPremium ?? true;
+  const premiumAvailableInCountry = opts.premiumAvailableInCountry ?? true;
+  render(
+    <BlockLevelSlider
+      alias={alias}
+      hasPremium={hasPremium}
+      premiumAvailableInCountry={premiumAvailableInCountry}
+      onChange={onChange}
+    />,
+  );
+  return { onChange };
+}
+
+describe("BlockLevelSlider", () => {
+  beforeEach(() => {
+    gaSpy.mockClear();
+  });
+
+  test("renders initial state based on alias: none", () => {
+    renderSlider({
+      alias: makeRandomAlias({ enabled: true, block_list_emails: false }),
+    });
+    expect(
+      screen.getByText("profile-promo-email-blocking-title"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("profile-promo-email-blocking-description-none-2"),
+    ).toBeInTheDocument();
+  });
+
+  test("renders initial state based on alias: promotional", () => {
+    renderSlider({
+      alias: makeRandomAlias({ enabled: true, block_list_emails: true }),
+    });
+    expect(
+      screen.getByText("profile-promo-email-blocking-description-promotionals"),
+    ).toBeInTheDocument();
+  });
+
+  test("renders initial state based on alias: all", () => {
+    renderSlider({ alias: makeRandomAlias({ enabled: false }) });
+    expect(
+      screen.getByText("profile-promo-email-blocking-description-all-2"),
+    ).toBeInTheDocument();
+  });
+
+  test("premium user can move slider 0→50→100 and onChange fires with GA events", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderSlider({
+      hasPremium: true,
+      alias: makeRandomAlias({ enabled: true, block_list_emails: false }),
+    });
+
+    const slider = screen.getByRole("slider");
+    slider.focus();
+
+    await user.keyboard("{ArrowRight}");
+    expect(onChange).toHaveBeenLastCalledWith("promotional");
+    expect(gaSpy).toHaveBeenLastCalledWith({
+      category: "Dashboard Alias Settings",
+      action: "Toggle Forwarding",
+      label: "User enabled promotional emails blocking",
+    });
+
+    await user.keyboard("{ArrowRight}");
+    expect(onChange).toHaveBeenLastCalledWith("all");
+    expect(gaSpy).toHaveBeenLastCalledWith({
+      category: "Dashboard Alias Settings",
+      action: "Toggle Forwarding",
+      label: "User disabled forwarding",
+    });
+
+    await user.keyboard("{Home}");
+    expect(onChange).toHaveBeenLastCalledWith("none");
+    expect(gaSpy).toHaveBeenLastCalledWith({
+      category: "Dashboard Alias Settings",
+      action: "Toggle Forwarding",
+      label: "User enabled forwarding",
+    });
+  });
+
+  test("free user slider skips promotional and only toggles none↔all", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderSlider({
+      hasPremium: false,
+      alias: makeRandomAlias({ enabled: true, block_list_emails: false }),
+    });
+
+    const slider = screen.getByRole("slider");
+    slider.focus();
+
+    await user.keyboard("{ArrowRight}");
+    expect(onChange).toHaveBeenCalledWith("all");
+    expect(onChange).not.toHaveBeenCalledWith("promotional");
+  });
+
+  test("free user clicking promotional ghost shows locked tooltip and does not call onChange", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderSlider({
+      hasPremium: false,
+      premiumAvailableInCountry: true,
+    });
+
+    const ghostButton = screen.getByRole("button", {
+      name: /profile-promo-email-blocking-option-promotions/i,
+    });
+
+    await user.click(ghostButton);
+
+    expect(
+      screen.getByText(
+        "profile-promo-email-blocking-description-promotionals-locked-label",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("profile-promo-email-blocking-description-promotionals"),
+    ).toBeInTheDocument();
+
+    const cta = screen.getByRole("link", {
+      name: "profile-promo-email-blocking-description-promotionals-locked-cta",
+    });
+    expect(cta).toHaveAttribute("href", "/premium/");
+    expect(onChange).not.toHaveBeenCalledWith("promotional");
+  });
+
+  test("free user in unavailable country sees waitlist link in tooltip", async () => {
+    const user = userEvent.setup();
+    renderSlider({ hasPremium: false, premiumAvailableInCountry: false });
+
+    const ghostButton = screen.getByRole("button", {
+      name: /profile-promo-email-blocking-option-promotions/i,
+    });
+
+    await user.click(ghostButton);
+
+    const waitlistCta = screen.getByRole("link", {
+      name: "profile-promo-email-blocking-description-promotionals-locked-waitlist-cta",
+    });
+    expect(waitlistCta).toHaveAttribute("href", "/premium/waitlist");
+  });
+});

--- a/frontend/src/components/dashboard/aliases/CustomAddressGenerationModal.test.tsx
+++ b/frontend/src/components/dashboard/aliases/CustomAddressGenerationModal.test.tsx
@@ -1,0 +1,279 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  CustomAddressGenerationModal,
+  isAddressValid,
+} from "./CustomAddressGenerationModal";
+import type { ProfileData } from "../../../hooks/api/profile";
+import type { AliasData } from "../../../hooks/api/aliases";
+
+const TEST_SUBDOMAIN = "demo";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => <a href={href}>{children}</a>,
+}));
+
+jest.mock("../../../hooks/l10n", () => ({
+  useL10n: () => ({
+    getString: (id: string) => id,
+  }),
+}));
+
+const mockUseProfiles = jest.fn();
+jest.mock("../../../hooks/api/profile", () => ({
+  useProfiles: () => mockUseProfiles(),
+}));
+
+jest.mock("../../../config", () => ({
+  getRuntimeConfig: () => ({ mozmailDomain: "mozmail.com" }),
+}));
+
+function renderModal(
+  overrides: Partial<
+    React.ComponentProps<typeof CustomAddressGenerationModal>
+  > = {},
+) {
+  const onClose = jest.fn();
+  const onPick = jest.fn();
+  const onUpdate = jest.fn();
+
+  const defaultProps: React.ComponentProps<
+    typeof CustomAddressGenerationModal
+  > = {
+    isOpen: true,
+    onClose,
+    onPick,
+    onUpdate,
+    subdomain: TEST_SUBDOMAIN,
+    aliasGeneratedState: false,
+    findAliasDataFromPrefix: (_prefix: string) => ({}) as unknown as AliasData,
+  };
+
+  const utils = render(
+    <CustomAddressGenerationModal {...defaultProps} {...overrides} />,
+  );
+  return { ...utils, onClose, onPick, onUpdate };
+}
+
+beforeEach(() => {
+  mockUseProfiles.mockReturnValue({
+    data: [{ subdomain: TEST_SUBDOMAIN } as ProfileData],
+  });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("CustomAddressGenerationModal - creator flow", () => {
+  test("renders creator view with disabled submit when invalid and enables when valid", async () => {
+    const user = userEvent.setup();
+    const { onPick } = renderModal({ aliasGeneratedState: false });
+
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "modal-custom-alias-picker-heading-2",
+      }),
+    ).toBeInTheDocument();
+
+    const input = screen.getByPlaceholderText(
+      "modal-custom-alias-picker-form-prefix-placeholder-redesign",
+    ) as HTMLInputElement;
+
+    // invalid (symbols)
+    await user.type(input, "Bad!");
+    const submit = screen.getByRole("button", {
+      name: "modal-custom-alias-picker-form-submit-label-2",
+    });
+    expect(submit).toBeDisabled();
+
+    await user.click(submit);
+    expect(
+      screen.getByText("error-alias-picker-prefix-invalid"),
+    ).toBeInTheDocument();
+
+    // invalid (uppercase)
+    await user.clear(input);
+    await user.type(input, "myMask");
+    expect(submit).toBeDisabled();
+
+    // valid
+    await user.clear(input);
+    await user.type(input, "mymask");
+    expect(submit).toBeEnabled();
+
+    await user.click(submit);
+    expect(onPick).toHaveBeenCalledTimes(1);
+    const [addressArg, setErrorStateArg] = (onPick as jest.Mock).mock.calls[0];
+    expect(addressArg).toBe("mymask");
+    expect(typeof setErrorStateArg).toBe("function");
+  });
+
+  test("cancel button triggers onClose", async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderModal({ aliasGeneratedState: false });
+
+    const cancel = screen.getByRole("button", { name: "profile-label-cancel" });
+    await user.click(cancel);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("shows composed domain hint using profile subdomain and runtime mozmailDomain", () => {
+    renderModal({ aliasGeneratedState: false });
+    expect(
+      screen.getByText(`@${TEST_SUBDOMAIN}.mozmail.com`),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("CustomAddressGenerationModal - success flow", () => {
+  test("displays newly created mask and handles 'Copy mask' (copyToClipboard=true)", async () => {
+    const user = userEvent.setup();
+
+    const onUpdate = jest.fn();
+    const findAliasDataFromPrefix = jest
+      .fn()
+      .mockImplementation((_prefix: string) => ({}) as unknown as AliasData);
+
+    const { rerender } = render(
+      <CustomAddressGenerationModal
+        isOpen
+        onClose={jest.fn()}
+        onPick={jest.fn()}
+        onUpdate={onUpdate}
+        subdomain={TEST_SUBDOMAIN}
+        aliasGeneratedState={false}
+        findAliasDataFromPrefix={findAliasDataFromPrefix}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(
+      "modal-custom-alias-picker-form-prefix-placeholder-redesign",
+    );
+    await user.type(input, "mymask");
+
+    // simulate moving to success state
+    rerender(
+      <CustomAddressGenerationModal
+        isOpen
+        onClose={jest.fn()}
+        onPick={jest.fn()}
+        onUpdate={onUpdate}
+        subdomain={TEST_SUBDOMAIN}
+        aliasGeneratedState
+        findAliasDataFromPrefix={findAliasDataFromPrefix}
+      />,
+    );
+
+    expect(
+      screen.getByText(`mymask@${TEST_SUBDOMAIN}.mozmail.com`),
+    ).toBeInTheDocument();
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: /popover-custom-alias-explainer-promotional-block-checkbox-label/i,
+    });
+    await user.click(checkbox);
+
+    const copyBtn = screen.getByRole("button", { name: /copy-mask/i });
+    await user.click(copyBtn);
+
+    expect(findAliasDataFromPrefix).toHaveBeenCalledWith("mymask");
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    const [aliasArg, blockPromosArg, copyToClipboardArg] = (
+      onUpdate as jest.Mock
+    ).mock.calls[0];
+    expect(blockPromosArg).toBe(true);
+    expect(copyToClipboardArg).toBe(true);
+    expect(aliasArg).toBeDefined();
+  });
+
+  test("clicking 'Done' calls onUpdate with copyToClipboard undefined", async () => {
+    const user = userEvent.setup();
+
+    const onUpdate = jest.fn();
+    const findAliasDataFromPrefix = jest
+      .fn()
+      .mockReturnValue({} as unknown as AliasData);
+
+    const { rerender } = render(
+      <CustomAddressGenerationModal
+        isOpen
+        onClose={jest.fn()}
+        onPick={jest.fn()}
+        onUpdate={onUpdate}
+        subdomain={TEST_SUBDOMAIN}
+        aliasGeneratedState={false}
+        findAliasDataFromPrefix={findAliasDataFromPrefix}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(
+      "modal-custom-alias-picker-form-prefix-placeholder-redesign",
+    );
+    await user.type(input, "donecase");
+
+    rerender(
+      <CustomAddressGenerationModal
+        isOpen
+        onClose={jest.fn()}
+        onPick={jest.fn()}
+        onUpdate={onUpdate}
+        subdomain={TEST_SUBDOMAIN}
+        aliasGeneratedState
+        findAliasDataFromPrefix={findAliasDataFromPrefix}
+      />,
+    );
+
+    const doneBtn = screen.getByRole("button", { name: "done-msg" });
+    await user.click(doneBtn);
+
+    expect(findAliasDataFromPrefix).toHaveBeenCalledWith("donecase");
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    const [, , copyToClipboardArg] = (onUpdate as jest.Mock).mock.calls[0];
+    expect(copyToClipboardArg).toBeUndefined();
+  });
+});
+
+describe("isAddressValid", () => {
+  test("accepts simple lowercase alphanumeric", () => {
+    expect(isAddressValid("abc")).toBe(true);
+    expect(isAddressValid("a1b2c3")).toBe(true);
+  });
+
+  test("rejects uppercase and symbols", () => {
+    expect(isAddressValid("Abc")).toBe(false);
+    expect(isAddressValid("abc!")).toBe(false);
+    expect(isAddressValid("ab_c")).toBe(false);
+  });
+
+  test("handles hyphens/periods correctly", () => {
+    expect(isAddressValid("a-b")).toBe(true);
+    expect(isAddressValid("a.b")).toBe(true);
+    expect(isAddressValid("-abc")).toBe(false);
+    expect(isAddressValid("abc-")).toBe(false);
+    expect(isAddressValid("a--b")).toBe(true);
+  });
+
+  test("enforces 1-63 length, not starting/ending with hyphen", () => {
+    const sixtyThree = "a".repeat(63);
+    const sixtyFour = "a".repeat(64);
+    expect(isAddressValid(sixtyThree)).toBe(true);
+    expect(isAddressValid(sixtyFour)).toBe(false);
+  });
+
+  test("rejects unicode and emoji", () => {
+    expect(isAddressValid("café")).toBe(false);
+    expect(isAddressValid("ümlaut")).toBe(false);
+    expect(isAddressValid("mask😊")).toBe(false);
+    expect(isAddressValid("masк")).toBe(false); // Cyrillic 'k'
+  });
+});

--- a/frontend/src/components/dashboard/aliases/MaskCard.test.tsx
+++ b/frontend/src/components/dashboard/aliases/MaskCard.test.tsx
@@ -1,0 +1,461 @@
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MaskCard, Props } from "./MaskCard";
+import { AliasData } from "../../../hooks/api/aliases";
+import { UserData } from "../../../hooks/api/user";
+import { ProfileData } from "../../../hooks/api/profile";
+import { RuntimeData } from "../../../hooks/api/types";
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: jest.fn(),
+  },
+});
+
+jest.mock(
+  "./MaskCard.module.scss",
+  () => new Proxy({}, { get: (_: unknown, p: PropertyKey) => String(p) }),
+);
+
+jest.mock("next/link", () => {
+  const MockLink = ({
+    href,
+    className,
+    children,
+  }: {
+    href: string;
+    className?: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} className={className} data-testid="link">
+      {children}
+    </a>
+  );
+  MockLink.displayName = "MockLink";
+  return MockLink;
+});
+
+jest.mock("../../Icons", () => ({
+  ArrowDownIcon: ({ alt }: { alt?: string }) => (
+    <svg data-testid="arrow-down" aria-label={alt} />
+  ),
+  CopyIcon: () => <svg data-testid="copy-icon" />,
+  LockIcon: ({ alt }: { alt?: string }) => (
+    <svg data-testid="lock-icon" aria-label={alt} />
+  ),
+}));
+
+jest.mock("../../Image", () => {
+  const MockImage = ({ alt }: { alt?: string }) => (
+    <img alt={alt} data-testid="image" />
+  );
+  MockImage.displayName = "MockImage";
+  return MockImage;
+});
+
+jest.mock("./../../VisuallyHidden", () => ({
+  VisuallyHidden: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+jest.mock("./LabelEditor", () => ({
+  LabelEditor: ({
+    label,
+    placeholder,
+    onSubmit,
+  }: {
+    label: string;
+    placeholder?: string;
+    onSubmit: (val: string) => void;
+  }) => (
+    <div>
+      <input
+        aria-label="label-input"
+        defaultValue={label}
+        placeholder={placeholder}
+      />
+      <button
+        type="button"
+        onClick={() => onSubmit("New Label")}
+        aria-label="submit-label"
+      >
+        Save
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("./AliasDeletionButton", () => ({
+  AliasDeletionButton: ({ onDelete }: { onDelete: () => void }) => (
+    <button onClick={onDelete} aria-label="alias-delete">
+      Delete
+    </button>
+  ),
+}));
+
+jest.mock("./AliasDeletionButtonPermanent", () => ({
+  AliasDeletionButtonPermanent: ({ onDelete }: { onDelete: () => void }) => (
+    <button onClick={onDelete} aria-label="alias-delete-permanent">
+      DeleteP
+    </button>
+  ),
+}));
+
+jest.mock("../../../functions/getLocale", () => ({
+  getLocale: () => "en-US",
+}));
+
+jest.mock("../../../functions/renderDate", () => ({
+  renderDate: (iso: string) => `Rendered(${iso})`,
+}));
+
+type IsFlagActiveFn = (
+  runtimeData: RuntimeData | undefined,
+  name: string,
+) => boolean;
+
+const isFlagActiveMock: jest.MockedFunction<IsFlagActiveFn> = jest.fn();
+
+jest.mock("../../../functions/waffle", () => ({
+  isFlagActive: (runtimeData: RuntimeData | undefined, name: string) =>
+    isFlagActiveMock(runtimeData, name),
+}));
+
+jest.mock("../../../hooks/api/aliases", () => ({
+  isBlockingLevelOneTrackers: () => false,
+}));
+
+jest.mock("./images/calendar.svg", () => "calendar.svg");
+jest.mock("./images/email.svg", () => "email.svg");
+jest.mock(
+  "./../images/free-onboarding-horizontal-arrow.svg",
+  () => "arrow.svg",
+);
+
+jest.mock("../../../hooks/l10n", () => ({
+  useL10n: () => ({
+    getString: (id: string, _vars?: Record<string, unknown>) => id,
+    getAttributes: (_id: string) => ({}),
+    getNumberFormatter: () => (n: number) => String(n),
+  }),
+}));
+
+const matchText = (...variants: string[]) =>
+  new RegExp(
+    `^(?:${variants.map((v) => v.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})$`,
+    "i",
+  );
+
+jest.useFakeTimers();
+
+const baseMask: AliasData = {
+  full_address: "sample@relay.mozilla.com",
+  description: "Sample Label",
+  enabled: true,
+  block_list_emails: false,
+  num_blocked: 1234,
+  num_forwarded: 5678,
+  num_replied: 12,
+  num_level_one_trackers_blocked: 42,
+  created_at: "2024-01-15T10:00:00Z",
+} as unknown as AliasData;
+
+const baseUser: UserData = {
+  email: "user@example.com",
+} as unknown as UserData;
+
+const premiumProfile: ProfileData = {
+  has_premium: true,
+} as unknown as ProfileData;
+
+const freeProfile: ProfileData = {
+  has_premium: false,
+} as unknown as ProfileData;
+
+const runtimeData: RuntimeData = {} as unknown as RuntimeData;
+
+function renderMaskCard(override?: Partial<Props>) {
+  const onUpdate: Props["onUpdate"] = jest.fn();
+  const onDelete: Props["onDelete"] = jest.fn();
+  const onChangeOpen: Props["onChangeOpen"] = jest.fn();
+
+  const props: Props = {
+    mask: baseMask,
+    user: baseUser,
+    profile: premiumProfile,
+    onUpdate,
+    onDelete,
+    isOpen: false,
+    onChangeOpen,
+    showLabelEditor: true,
+    runtimeData,
+    placeholder: "Add a label",
+    isOnboarding: false,
+    children: <div data-testid="onboarding-children">child</div>,
+    copyAfterMaskGeneration: false,
+  };
+
+  const utils = render(<MaskCard {...{ ...props, ...override }} />);
+  return { ...utils, onUpdate, onDelete, onChangeOpen };
+}
+
+describe("MaskCard", () => {
+  test("copies address to clipboard and shows temporary confirmation", () => {
+    renderMaskCard();
+    const copyBtn = screen.getByTitle(
+      matchText("Click to copy", "profile-label-click-to-copy"),
+    );
+    fireEvent.click(copyBtn);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "sample@relay.mozilla.com",
+    );
+    expect(
+      screen.getByText(matchText("Copied!", "profile-label-copied")),
+    ).toHaveAttribute("aria-hidden", "false");
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(
+      screen.getByText(matchText("Copied!", "profile-label-copied")),
+    ).toHaveAttribute("aria-hidden", "true");
+  });
+
+  test("copyAfterMaskGeneration triggers copy on mount", () => {
+    renderMaskCard({ copyAfterMaskGeneration: true });
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "sample@relay.mozilla.com",
+    );
+  });
+
+  test("expand/collapse toggles via button and calls onChangeOpen", () => {
+    const { onChangeOpen } = renderMaskCard({ isOpen: false });
+    const expandBtn = screen.getByRole("button", {
+      name: /expand|profile-details-expand/i,
+    });
+    fireEvent.click(expandBtn);
+    expect(onChangeOpen).toHaveBeenCalledWith(true);
+  });
+
+  test("stats show blocked/forwarded and replies when premium; trackers when flag active", () => {
+    isFlagActiveMock.mockImplementation(
+      (_rd, name) => name === "tracker_removal",
+    );
+    renderMaskCard({
+      profile: premiumProfile,
+      mask: {
+        ...baseMask,
+        num_blocked: 1200,
+        num_forwarded: 3456,
+        num_replied: 78,
+        num_level_one_trackers_blocked: 1500,
+      } as AliasData,
+      isOpen: true,
+    });
+    expect(
+      screen.getByText(matchText("Blocked", "profile-label-blocked")),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1.2K")).toBeInTheDocument();
+    expect(
+      screen.getByText(matchText("Forwarded", "profile-label-forwarded")),
+    ).toBeInTheDocument();
+    expect(screen.getByText("3.5K")).toBeInTheDocument();
+    expect(
+      screen.getByText(matchText("Replies", "profile-label-replies")),
+    ).toBeInTheDocument();
+    expect(screen.getByText("78")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        matchText("Trackers removed", "profile-label-trackers-removed"),
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1.5K")).toBeInTheDocument();
+  });
+
+  test("replies are hidden for free users; promo option shows lock messaging and upgrade link", () => {
+    isFlagActiveMock.mockReturnValue(false);
+    renderMaskCard({
+      profile: freeProfile,
+      isOpen: true,
+    });
+    expect(
+      screen.queryByText(matchText("Replies", "profile-label-replies")),
+    ).not.toBeInTheDocument();
+    const promoOption = screen.getByText(
+      matchText("Promotions", "profile-promo-email-blocking-option-promotions"),
+    );
+    fireEvent.click(promoOption);
+    expect(
+      screen.getAllByText(
+        matchText(
+          "Promotionals (Premium)",
+          "profile-promo-email-blocking-description-promotionals-locked-label",
+        ),
+      )[0],
+    ).toBeInTheDocument();
+    const locks = screen.getAllByTestId("lock-icon");
+    expect(locks.length).toBeGreaterThan(0);
+    const upgrade = screen.getByRole("link", {
+      name: matchText("Upgrade", "banner-pack-upgrade-cta"),
+    });
+    expect(upgrade).toHaveAttribute("href", "/premium#pricing");
+  });
+
+  test("block level: selecting 'All' disables mask; 'Promotions' enables + sets block_list_emails=true; 'None' enables + sets block_list_emails=false", () => {
+    const { onUpdate } = renderMaskCard({
+      profile: premiumProfile,
+      isOpen: true,
+    });
+    fireEvent.click(
+      screen.getByText(
+        matchText("All", "profile-promo-email-blocking-option-all"),
+      ),
+    );
+    expect(onUpdate).toHaveBeenCalledWith({ enabled: false });
+    fireEvent.click(
+      screen.getByText(
+        matchText(
+          "Promotions",
+          "profile-promo-email-blocking-option-promotions",
+        ),
+      ),
+    );
+    expect(onUpdate).toHaveBeenCalledWith({
+      enabled: true,
+      block_list_emails: true,
+    });
+    fireEvent.click(
+      screen.getByText(
+        matchText("None", "profile-promo-email-blocking-option-none"),
+      ),
+    );
+    expect(onUpdate).toHaveBeenCalledWith({
+      enabled: true,
+      block_list_emails: false,
+    });
+  });
+
+  test("block level label reflects current state for all / promotions / none", () => {
+    const { rerender } = renderMaskCard({
+      isOpen: true,
+      mask: { ...baseMask, enabled: false },
+    });
+    expect(
+      screen.getByText(
+        matchText("Blocking all", "profile-promo-email-blocking-label-none-2"),
+      ),
+    ).toBeInTheDocument();
+    const noopUpdate: Props["onUpdate"] = jest.fn();
+    const noopDelete: Props["onDelete"] = jest.fn();
+    rerender(
+      <MaskCard
+        mask={{ ...baseMask, enabled: true, block_list_emails: true }}
+        user={baseUser}
+        profile={premiumProfile}
+        onUpdate={noopUpdate}
+        onDelete={noopDelete}
+        isOpen={true}
+        onChangeOpen={jest.fn() as Props["onChangeOpen"]}
+        showLabelEditor={true}
+        runtimeData={runtimeData}
+        placeholder="Add a label"
+        isOnboarding={false}
+        copyAfterMaskGeneration={false}
+      />,
+    );
+    expect(
+      screen.getByText(
+        matchText(
+          "Blocking promotionals",
+          "profile-promo-email-blocking-label-promotionals-2",
+        ),
+      ),
+    ).toBeInTheDocument();
+    rerender(
+      <MaskCard
+        mask={{ ...baseMask, enabled: true, block_list_emails: false }}
+        user={baseUser}
+        profile={premiumProfile}
+        onUpdate={noopUpdate}
+        onDelete={noopDelete}
+        isOpen={true}
+        onChangeOpen={jest.fn() as Props["onChangeOpen"]}
+        showLabelEditor={true}
+        runtimeData={runtimeData}
+        placeholder="Add a label"
+        isOnboarding={false}
+        copyAfterMaskGeneration={false}
+      />,
+    );
+    expect(
+      screen.getByText(
+        matchText(
+          "Forwarding all",
+          "profile-promo-email-blocking-label-forwarding-2",
+        ),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test("meta section shows created date and forwarding email", () => {
+    renderMaskCard({ isOpen: true });
+    expect(
+      screen.getByText(matchText("Created", "profile-label-created")),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/^Rendered\(2024-01-15T10:00:00Z\)$/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(matchText("Forward to", "profile-label-forward-emails")),
+    ).toBeInTheDocument();
+    expect(screen.getByText("user@example.com")).toBeInTheDocument();
+  });
+
+  test("deletion button variant is waffle-flag controlled", () => {
+    isFlagActiveMock.mockImplementation(
+      (_rd, name) => name === "custom_domain_management_redesign",
+    );
+    const { onDelete, rerender } = renderMaskCard({
+      isOnboarding: false,
+      isOpen: true,
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "alias-delete-permanent" }),
+    );
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    isFlagActiveMock.mockReturnValue(false);
+    const noopUpdate: Props["onUpdate"] = jest.fn();
+    rerender(
+      <MaskCard
+        mask={baseMask}
+        user={baseUser}
+        profile={premiumProfile}
+        onUpdate={noopUpdate}
+        onDelete={onDelete}
+        isOpen={true}
+        onChangeOpen={jest.fn() as Props["onChangeOpen"]}
+        showLabelEditor={true}
+        runtimeData={runtimeData}
+        placeholder="Add a label"
+        isOnboarding={false}
+        copyAfterMaskGeneration={false}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "alias-delete" }));
+    expect(onDelete).toHaveBeenCalledTimes(2);
+  });
+
+  test("label editor submits and calls onUpdate with new description", () => {
+    const { onUpdate } = renderMaskCard({ showLabelEditor: true });
+    fireEvent.click(screen.getByLabelText("submit-label"));
+    expect(onUpdate).toHaveBeenCalledWith({ description: "New Label" });
+  });
+
+  test("onboarding children render only when isOnboarding is true", () => {
+    renderMaskCard({ isOnboarding: false });
+    expect(screen.queryByTestId("onboarding-children")).not.toBeInTheDocument();
+    renderMaskCard({ isOnboarding: true, isOpen: true });
+    expect(screen.getByTestId("onboarding-children")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/tips/CustomAliasTip.test.tsx
+++ b/frontend/src/components/dashboard/tips/CustomAliasTip.test.tsx
@@ -1,0 +1,88 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { CustomAliasTip } from "./CustomAliasTip";
+import { getRuntimeConfig } from "../../../config";
+import { getLocale } from "../../../functions/getLocale";
+import { useL10n } from "../../../hooks/l10n";
+
+jest.mock("./CustomAliasTip.module.scss", () => ({}), { virtual: true });
+
+jest.mock("../../../config", () => ({
+  getRuntimeConfig: jest.fn(),
+}));
+
+jest.mock("../../../functions/getLocale", () => ({
+  getLocale: jest.fn(),
+}));
+
+jest.mock("../../../hooks/l10n", () => ({
+  useL10n: jest.fn(),
+}));
+
+describe("CustomAliasTip", () => {
+  const mockGetString = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useL10n as jest.Mock).mockReturnValue({
+      getString: mockGetString,
+    });
+
+    (getRuntimeConfig as jest.Mock).mockReturnValue({
+      mozmailDomain: "mozmail.com",
+    });
+
+    (getLocale as jest.Mock).mockReturnValue("en-US");
+
+    mockGetString.mockImplementation((id: string) => {
+      switch (id) {
+        case "tips-custom-alias-heading-2":
+          return "Custom Alias Heading";
+        case "tips-custom-alias-content-2":
+          return "Custom Alias Content";
+        default:
+          return id;
+      }
+    });
+  });
+
+  it("renders subdomain when provided", () => {
+    render(<CustomAliasTip subdomain="mydomain" />);
+    expect(screen.getByText(/@mydomain\.mozmail\.com/)).toBeInTheDocument();
+  });
+
+  it("does not render subdomain when not provided", () => {
+    render(<CustomAliasTip />);
+    expect(screen.queryByText(/@.*\.mozmail\.com/)).not.toBeInTheDocument();
+  });
+
+  it("renders heading and content from localization", () => {
+    render(<CustomAliasTip />);
+    expect(
+      screen.getByRole("heading", { name: "Custom Alias Heading" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Custom Alias Content")).toBeInTheDocument();
+  });
+
+  it("renders video only when locale is English", () => {
+    (getLocale as jest.Mock).mockReturnValue("en-US");
+    render(<CustomAliasTip />);
+
+    const video = screen.getByTestId("custom-alias-video") as HTMLVideoElement;
+    expect(video).toBeInTheDocument();
+    expect(video).toHaveAttribute("aria-hidden", "true");
+
+    expect(video).toHaveAttribute("autoplay");
+    expect(video).toHaveAttribute("loop");
+
+    expect(video).toHaveProperty("muted", true);
+  });
+
+  it("does not render video when locale is not English", () => {
+    (getLocale as jest.Mock).mockReturnValue("fr");
+    render(<CustomAliasTip />);
+
+    expect(screen.queryByTestId("custom-alias-video")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/tips/CustomAliasTip.tsx
+++ b/frontend/src/components/dashboard/tips/CustomAliasTip.tsx
@@ -29,6 +29,7 @@ export const CustomAliasTip = (props: CustomAliasTipProps) => {
         <video
           // This animation is redundant with the regular text accompanying it,
           // so screen readers should ignore it:
+          data-testid="custom-alias-video"
           aria-hidden={true}
           autoPlay={true}
           loop={true}

--- a/frontend/src/components/dashboard/tips/GenericTip.test.tsx
+++ b/frontend/src/components/dashboard/tips/GenericTip.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, within } from "@testing-library/react";
+import { GenericTip, GenericTipProps } from "./GenericTip";
+import { useL10n } from "../../../hooks/l10n";
+import { getLocale } from "../../../functions/getLocale";
+import React from "react";
+
+jest.mock("./GenericTip.module.scss", () => ({
+  "generic-tip": "generic-tip",
+  "still-alternative": "still-alternative",
+}));
+
+jest.mock("../../Image", () => {
+  const MockImage: React.FC<{
+    className?: string;
+    src: string | { src: string };
+    alt?: string;
+  }> = ({ className, src, alt }) => (
+    <img
+      data-testid="mock-image"
+      className={className}
+      src={typeof src === "string" ? src : src?.src}
+      alt={alt ?? ""}
+    />
+  );
+  return { __esModule: true, default: MockImage };
+});
+
+jest.mock("../../../hooks/l10n", () => ({
+  useL10n: jest.fn(),
+}));
+jest.mock("../../../functions/getLocale", () => ({
+  getLocale: jest.fn(),
+}));
+
+describe("GenericTip", () => {
+  const mockL10n = {};
+  const baseProps: GenericTipProps = {
+    title: "Test Tip Title",
+    content: <p>Some test tip content</p>,
+    videos: { "video/mp4": "video.mp4", "video/webm": "video.webm" },
+    image: {
+      src: "test-image.png",
+    } as unknown as import("next/image").StaticImageData,
+    alt: "Alt text",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useL10n as jest.Mock).mockReturnValue(mockL10n);
+    // default to a non-English locale
+    (getLocale as jest.Mock).mockReturnValue("fr");
+  });
+
+  it("renders title and content", () => {
+    render(<GenericTip {...baseProps} />);
+    expect(screen.getByText("Test Tip Title")).toBeInTheDocument();
+    expect(screen.getByText("Some test tip content")).toBeInTheDocument();
+  });
+
+  it("renders video and the still image when locale is English and videos provided", () => {
+    (getLocale as jest.Mock).mockReturnValue("en-US");
+    render(<GenericTip {...baseProps} />);
+    const video = screen.getByTitle("Alt text");
+    expect(video).toBeInTheDocument();
+    expect(video).toHaveAttribute("poster", "test-image.png");
+    const imgsByAlt = screen.getAllByRole("img", { name: "Alt text" });
+    const stillAlt = imgsByAlt.find((el) =>
+      el.classList.contains("still-alternative"),
+    );
+    expect(stillAlt).toBeTruthy();
+  });
+
+  it("falls back to an <img> inside <video> when image is a string", () => {
+    (getLocale as jest.Mock).mockReturnValue("en-US");
+    // @ts-expect-error: testing runtime-supported string image fallback
+    render(<GenericTip {...baseProps} image="fallback-image.png" />);
+    const video = screen.getByTitle("Alt text");
+    expect(video).toBeInTheDocument();
+    const imgInsideVideo = within(video).getByTestId("mock-image");
+    expect(imgInsideVideo).toHaveAttribute("src", "fallback-image.png");
+    const imgsByAlt = screen.getAllByRole("img", { name: "Alt text" });
+    const stillAlt = imgsByAlt.find((el) =>
+      el.classList.contains("still-alternative"),
+    );
+    expect(stillAlt).toBeTruthy();
+  });
+
+  it("does not render video when locale is not English", () => {
+    render(<GenericTip {...baseProps} />);
+    expect(screen.queryByTitle("Alt text")).not.toBeInTheDocument();
+  });
+
+  it("does not render video when videos prop is missing", () => {
+    (getLocale as jest.Mock).mockReturnValue("en-US");
+    render(<GenericTip {...baseProps} videos={undefined} />);
+    expect(screen.queryByTitle("Alt text")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/tips/Tips.test.tsx
+++ b/frontend/src/components/dashboard/tips/Tips.test.tsx
@@ -1,0 +1,238 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { Tips } from "./Tips";
+import type { ProfileData } from "../../../hooks/api/profile";
+import type { RuntimeData } from "../../../hooks/api/types";
+
+jest.mock("next/link", () => {
+  const Link = ({
+    href,
+    children,
+    title,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    title?: string;
+  }) => (
+    <a href={href} title={title}>
+      {children}
+    </a>
+  );
+  return Link;
+});
+
+jest.mock("react-intersection-observer", () => ({
+  useInView: () => [jest.fn(), true] as const,
+}));
+
+jest.mock("../../../hooks/l10n", () => ({
+  useL10n: () => ({
+    getString: (key: string, vars?: Record<string, unknown>) => {
+      if (key === "tips-header-title") return "Helpful tips";
+      if (key === "tips-footer-link-faq-label") return "FAQ";
+      if (key === "tips-footer-link-faq-tooltip") return "Read the FAQ";
+      if (key === "tips-footer-link-support-label") return "Support";
+      if (key === "tips-footer-link-support-tooltip") return "Open Support";
+      if (key === "tips-header-button-close-label") return "Minimize tips";
+      if (key === "tips-toast-button-expand-label") return "View";
+      if (key === "tips-custom-alias-heading-2")
+        return "Create a custom subdomain";
+      if (key === "tips-multi-replies-heading")
+        return "Reply to multiple senders";
+      if (key === "tips-multi-replies-content")
+        return "Use short codes to reply";
+      if (key === "tips-switcher-label")
+        return `Tip ${(vars?.nr as number) ?? 1}`;
+      return key;
+    },
+  }),
+}));
+
+const mockDismiss = jest.fn();
+jest.mock("../../../hooks/localDismissal", () => ({
+  useLocalDismissal: () => ({ isDismissed: false, dismiss: mockDismiss }),
+}));
+
+const mockGaEvent = jest.fn();
+jest.mock("../../../hooks/gaEvent", () => ({
+  useGaEvent: () => mockGaEvent,
+}));
+
+jest.mock("../../../hooks/gaViewPing", () => ({
+  useGaViewPing: () => () => {},
+}));
+
+jest.mock("../../../config", () => ({
+  getRuntimeConfig: () => ({ frontendOrigin: "http://relay.local" }),
+}));
+
+jest.mock("../../../functions/waffle", () => ({
+  isFlagActive: jest.fn(),
+}));
+import { isFlagActive } from "../../../functions/waffle";
+const isFlagActiveMock = isFlagActive as jest.MockedFunction<
+  typeof isFlagActive
+>;
+
+let relayData: unknown[] = [];
+jest.mock("../../../hooks/api/relayNumber", () => ({
+  useRelayNumber: (_: { disable: boolean }) => ({ data: relayData }),
+}));
+
+jest.mock("./GenericTip", () => ({
+  GenericTip: ({ title, content }: { title: string; content: string }) => (
+    <div>
+      <h3>{title}</h3>
+      <p>{content}</p>
+    </div>
+  ),
+}));
+
+jest.mock("./CustomAliasTip", () => ({
+  CustomAliasTip: ({ subdomain }: { subdomain?: string }) => (
+    <div>
+      {subdomain ? `Your subdomain: ${subdomain}` : "Create your subdomain"}
+    </div>
+  ),
+}));
+
+const baseProfile = (overrides: Partial<ProfileData> = {}): ProfileData =>
+  ({
+    id: 123,
+    has_phone: false,
+    has_premium: false,
+    subdomain: null,
+    ...overrides,
+  }) as unknown as ProfileData;
+
+const rd = {} as unknown as RuntimeData;
+
+describe("Tips", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDismiss.mockClear();
+    mockGaEvent.mockClear();
+    relayData = [];
+    isFlagActiveMock.mockReset();
+    isFlagActiveMock.mockReturnValue(false);
+  });
+
+  it("renders null when there are no eligible tips", () => {
+    render(<Tips profile={baseProfile()} runtimeData={rd} />);
+    expect(
+      screen.queryByRole("complementary", { name: "Helpful tips" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the Custom Alias tip for Premium users and shows footer links after expanding", async () => {
+    const user = userEvent.setup();
+    render(
+      <Tips
+        profile={baseProfile({ has_premium: true, subdomain: "me" })}
+        runtimeData={rd}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Helpful tips" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create a custom subdomain")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "View" }));
+    expect(screen.getByText("Your subdomain: me")).toBeInTheDocument();
+
+    const faq = screen.getByRole("link", { name: "FAQ" });
+    expect(faq).toHaveAttribute("href", "/faq");
+
+    const support = screen.getByRole("link", { name: "Support" });
+    expect(support).toHaveAttribute(
+      "href",
+      expect.stringContaining("http://relay.local"),
+    );
+  });
+
+  it("renders the multi-replies tip content after expanding when conditions are met", async () => {
+    const user = userEvent.setup();
+    isFlagActiveMock.mockImplementation((_, name) => name === "multi_replies");
+    relayData = [{}];
+    render(
+      <Tips profile={baseProfile({ has_phone: true })} runtimeData={rd} />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Helpful tips" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Reply to multiple senders")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "View" }));
+    expect(
+      screen.getByRole("heading", { name: "Reply to multiple senders" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Use short codes to reply")).toBeInTheDocument();
+  });
+
+  it("minimizes, dismisses tips, and shows teaser summary after closing", async () => {
+    const user = userEvent.setup();
+    render(
+      <Tips profile={baseProfile({ has_premium: true })} runtimeData={rd} />,
+    );
+
+    const close = screen.getByRole("button", { name: "Minimize tips" });
+    await user.click(close);
+
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
+    expect(mockGaEvent).toHaveBeenCalledWith({
+      category: "Tips",
+      action: "Collapse",
+      label: "tips-header",
+    });
+
+    expect(screen.getByText("Create a custom subdomain")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "View" })).toBeInTheDocument();
+  });
+
+  it("shows a tip switcher with multiple tips and can switch to the custom alias tip", async () => {
+    const user = userEvent.setup();
+    isFlagActiveMock.mockImplementation((_, name) => name === "multi_replies");
+    relayData = [{}];
+
+    render(
+      <Tips
+        profile={baseProfile({
+          has_premium: true,
+          has_phone: true,
+          subdomain: "me",
+        })}
+        runtimeData={rd}
+      />,
+    );
+
+    expect(screen.getByText("Reply to multiple senders")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "View" }));
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(2);
+
+    await user.click(tabs[1]);
+    expect(
+      screen.getByText(/Your subdomain: me|Create your subdomain/),
+    ).toBeInTheDocument();
+  });
+
+  it("fires GA when expanding from teaser", async () => {
+    const user = userEvent.setup();
+    render(
+      <Tips profile={baseProfile({ has_premium: true })} runtimeData={rd} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "View" }));
+
+    expect(mockGaEvent).toHaveBeenCalledWith({
+      category: "Tips",
+      action: "Expand (from teaser)",
+      label: "custom-subdomain",
+    });
+  });
+});

--- a/frontend/src/components/phones/dashboard/PhoneDashboard.test.tsx
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { PhoneDashboard } from "./PhoneDashboard";
+import {
+  mockedRuntimeData,
+  mockedProfiles,
+  mockedRelaynumbers,
+  mockedRealphones,
+  mockedInboundContacts,
+} from "frontend/src/apiMocks/mockData";
+import { toast } from "react-toastify";
+import { VerifiedPhone } from "frontend/src/hooks/api/realPhone";
+import * as l10nModule from "frontend/src/hooks/l10n";
+import { formatPhone } from "frontend/src/functions/formatPhone";
+import { useRelayNumber } from "frontend/src/hooks/api/relayNumber";
+import { useInboundContact } from "frontend/src/hooks/api/inboundContact";
+
+jest.mock("next/config", () => () => ({
+  publicRuntimeConfig: {
+    BASE_URL: "https://example.com",
+    API_URL: "https://api.example.com",
+  },
+}));
+
+beforeAll(() => {
+  class MockIntersectionObserver implements IntersectionObserver {
+    readonly root: Element | null = null;
+    readonly rootMargin: string = "";
+    readonly thresholds: ReadonlyArray<number> = [];
+
+    constructor() {}
+
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+  }
+
+  global.IntersectionObserver = MockIntersectionObserver;
+});
+
+jest.mock("frontend/src/hooks/api/relayNumber", () => ({
+  useRelayNumber: jest.fn(),
+}));
+
+jest.mock("frontend/src/hooks/api/inboundContact", () => ({
+  useInboundContact: jest.fn(),
+}));
+
+jest.mock("frontend/src/hooks/l10n", () => ({
+  useL10n: jest.fn(),
+}));
+
+jest.mock("react-toastify", () => ({
+  toast: jest.fn(),
+}));
+
+describe("PhoneDashboard", () => {
+  const mockRelayNumber = mockedRelaynumbers.full[0];
+  const mockPhone = mockedRealphones.full[0] as VerifiedPhone;
+  const mockProfile = mockedProfiles.full;
+  const mockInboundContacts = mockedInboundContacts.full;
+
+  const mockDismiss = jest.fn();
+  const mockRequestContactCard = jest.fn().mockResolvedValue({ ok: true });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (l10nModule.useL10n as jest.Mock).mockReturnValue({
+      getString: (key: string) => key,
+      bundles: [{ locales: ["en-US"] }],
+    });
+
+    (useRelayNumber as jest.Mock).mockReturnValue({
+      data: [mockRelayNumber],
+      setForwardingState: jest.fn(),
+    });
+
+    (useInboundContact as jest.Mock).mockReturnValue({
+      data: mockInboundContacts,
+    });
+  });
+
+  it("renders the dashboard with relay number and phone number", () => {
+    render(
+      <PhoneDashboard
+        profile={mockProfile}
+        runtimeData={mockedRuntimeData}
+        realPhone={mockPhone}
+        dismissal={{ resendSMS: { isDismissed: true, dismiss: mockDismiss } }}
+        onRequestContactCard={mockRequestContactCard}
+      />,
+    );
+
+    const formattedRelayNumber = formatPhone(mockRelayNumber.number, {
+      withCountryCode: true,
+    });
+
+    expect(screen.getByText(formattedRelayNumber)).toBeInTheDocument();
+    expect(
+      screen.getByText("phone-statistics-remaining-call-minutes"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("phone-statistics-calls-texts-forwarded"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows resend welcome SMS banner if not dismissed", () => {
+    render(
+      <PhoneDashboard
+        profile={mockProfile}
+        runtimeData={mockedRuntimeData}
+        realPhone={mockPhone}
+        dismissal={{ resendSMS: { isDismissed: false, dismiss: mockDismiss } }}
+        onRequestContactCard={mockRequestContactCard}
+      />,
+    );
+
+    expect(
+      screen.getByText("phone-banner-resend-welcome-sms-title"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("phone-banner-resend-welcome-sms-body"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("phone-banner-resend-welcome-sms-cta"),
+    ).toBeInTheDocument();
+  });
+
+  it("clicks resend SMS CTA and triggers toast and dismissal", async () => {
+    render(
+      <PhoneDashboard
+        profile={mockProfile}
+        runtimeData={mockedRuntimeData}
+        realPhone={mockPhone}
+        dismissal={{ resendSMS: { isDismissed: false, dismiss: mockDismiss } }}
+        onRequestContactCard={mockRequestContactCard}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("phone-banner-resend-welcome-sms-cta"));
+    await waitFor(() => expect(mockRequestContactCard).toHaveBeenCalled());
+    expect(mockDismiss).toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith(
+      "phone-banner-resend-welcome-sms-toast-msg",
+      { type: "success" },
+    );
+  });
+
+  it("toggles to the SendersPanelView when senders button is clicked", () => {
+    render(
+      <PhoneDashboard
+        profile={mockProfile}
+        runtimeData={mockedRuntimeData}
+        realPhone={mockPhone}
+        dismissal={{ resendSMS: { isDismissed: true, dismiss: mockDismiss } }}
+        onRequestContactCard={mockRequestContactCard}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("phone-dashboard-senders-header"));
+    expect(screen.getByTestId("senders-panel-view")).toBeInTheDocument();
+  });
+
+  it("copies relay number on click and shows copied message", async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn(),
+      },
+    });
+
+    render(
+      <PhoneDashboard
+        profile={mockProfile}
+        runtimeData={mockedRuntimeData}
+        realPhone={mockPhone}
+        dismissal={{ resendSMS: { isDismissed: true, dismiss: mockDismiss } }}
+        onRequestContactCard={mockRequestContactCard}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle("Copied"));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      mockRelayNumber.number.replace("+", ""),
+    );
+
+    expect(
+      await screen.findByText("phone-dashboard-number-copied"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/phones/dashboard/PhoneWelcomeView.test.tsx
+++ b/frontend/src/components/phones/dashboard/PhoneWelcomeView.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { PhoneWelcomeView } from "./PhoneWelcomeView";
+import { mockedProfiles } from "frontend/src/apiMocks/mockData";
+import * as l10nModule from "frontend/src/hooks/l10n";
+import { toast } from "react-toastify";
+import { LocalizationProvider, ReactLocalization } from "@fluent/react";
+import { FluentBundle } from "@fluent/bundle";
+
+jest.mock("frontend/src/hooks/l10n", () => ({
+  useL10n: jest.fn(),
+}));
+
+jest.mock("react-toastify", () => ({
+  toast: jest.fn(),
+}));
+
+const dismissMock = jest.fn();
+const resendDismissMock = jest.fn();
+
+const mockResponse = {
+  ok: true,
+  status: 200,
+  json: async () => ({}),
+} as Response;
+
+const requestContactCardMock = jest.fn(() => Promise.resolve(mockResponse));
+
+function createLocalizationBundle(): ReactLocalization {
+  const bundle = new FluentBundle("en-US");
+  bundle.hasMessage("placeholder-id");
+  return new ReactLocalization([bundle]);
+}
+
+describe("PhoneWelcomeView", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (l10nModule.useL10n as jest.Mock).mockReturnValue({
+      getString: (key: string) => key,
+      bundles: [{ locales: ["en-US"] }],
+    });
+  });
+
+  const renderView = (
+    overrides: Partial<Parameters<typeof PhoneWelcomeView>[0]> = {},
+  ) => {
+    const l10n = createLocalizationBundle();
+
+    render(
+      <LocalizationProvider l10n={l10n}>
+        <PhoneWelcomeView
+          dismissal={{
+            welcomeScreen: {
+              isDismissed: false,
+              dismiss: dismissMock,
+            },
+            resendSMS: {
+              isDismissed: false,
+              dismiss: resendDismissMock,
+            },
+          }}
+          onRequestContactCard={requestContactCardMock}
+          profile={mockedProfiles.full}
+          {...overrides}
+        />
+      </LocalizationProvider>,
+    );
+  };
+
+  it("renders welcome content: header, subheading, instructions, and continue button", () => {
+    renderView();
+
+    // Header + subheading
+    expect(screen.getByText("phone-masking-splash-header")).toBeInTheDocument();
+    expect(
+      screen.getByText("phone-masking-splash-subheading"),
+    ).toBeInTheDocument();
+
+    // Three instruction sections
+    expect(
+      screen.getByText("phone-masking-splash-save-contact-title"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("phone-masking-splash-replies-title"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("phone-masking-splash-blocking-title"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("phone-masking-splash-continue-btn"),
+    ).toBeInTheDocument();
+  });
+
+  it("dismisses welcome screen on continue button click", () => {
+    renderView();
+    fireEvent.click(screen.getByText("phone-masking-splash-continue-btn"));
+    expect(dismissMock).toHaveBeenCalled();
+  });
+
+  it("shows resend SMS button and calls contact card + toast", async () => {
+    renderView();
+    fireEvent.click(screen.getByText("phone-masking-splash-save-contact-cta"));
+
+    await waitFor(() => {
+      expect(requestContactCardMock).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        "phone-banner-resend-welcome-sms-toast-msg",
+        { type: "success" },
+      );
+    });
+
+    await waitFor(() => {
+      expect(resendDismissMock).toHaveBeenCalled();
+    });
+  });
+
+  it("does not show resend SMS button when already dismissed", () => {
+    renderView({
+      dismissal: {
+        welcomeScreen: {
+          isDismissed: false,
+          dismiss: dismissMock,
+        },
+        resendSMS: {
+          isDismissed: true,
+          dismiss: resendDismissMock,
+        },
+      },
+    });
+    expect(
+      screen.queryByText("phone-masking-splash-save-contact-cta"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/phones/dashboard/SendersPanelView.test.tsx
+++ b/frontend/src/components/phones/dashboard/SendersPanelView.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SendersPanelView } from "./SendersPanelView";
+import * as l10nModule from "frontend/src/hooks/l10n";
+import * as metricsModule from "frontend/src/hooks/metrics";
+import * as inboundContactModule from "frontend/src/hooks/api/inboundContact";
+import { FluentBundle } from "@fluent/bundle";
+import { ReactLocalization } from "@fluent/react";
+
+jest.mock("frontend/src/hooks/l10n", () => ({
+  useL10n: jest.fn(),
+}));
+
+jest.mock("frontend/src/hooks/metrics", () => ({
+  useMetrics: jest.fn(),
+}));
+
+jest.mock("frontend/src/hooks/api/inboundContact", () => ({
+  useInboundContact: jest.fn(),
+}));
+
+const mockBack = jest.fn();
+
+function mockL10n(): ReactLocalization {
+  const bundle = new FluentBundle("en-US");
+  return new ReactLocalization([bundle]);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  (l10nModule.useL10n as jest.Mock).mockReturnValue({
+    getString: (key: string) => key,
+    bundles: mockL10n().bundles,
+  });
+
+  (inboundContactModule.useInboundContact as jest.Mock).mockReturnValue({
+    data: [],
+    setForwardingState: jest.fn(),
+  });
+});
+
+describe("SendersPanelView", () => {
+  it("renders the empty senders panel", () => {
+    render(<SendersPanelView type="empty" back_btn={mockBack} />);
+    expect(
+      screen.getByAltText("Empty Senders Data Illustration"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("phone-dashboard-sender-empty-body"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders disabled panel with metrics link", () => {
+    (metricsModule.useMetrics as jest.Mock).mockReturnValue(true);
+
+    render(<SendersPanelView type="disabled" back_btn={mockBack} />);
+
+    expect(
+      screen.getByAltText("Disabled Senders Data Illustration"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("phone-dashboard-sender-disabled-body"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", {
+        name: "phone-dashboard-sender-disabled-update-settings",
+      }),
+    ).toHaveAttribute("href", "/accounts/settings/");
+  });
+
+  it("renders disabled panel without metrics link", () => {
+    (metricsModule.useMetrics as jest.Mock).mockReturnValue(false);
+
+    render(<SendersPanelView type="disabled" back_btn={mockBack} />);
+
+    expect(
+      screen.getByRole("link", {
+        name: "phone-dashboard-sender-disabled-update-settings",
+      }),
+    ).toHaveAttribute("href", "/accounts/settings");
+  });
+
+  it("renders sorted sender logs", () => {
+    (inboundContactModule.useInboundContact as jest.Mock).mockReturnValue({
+      data: [
+        {
+          id: "1",
+          inbound_number: "+1234567890",
+          last_inbound_date: "2025-07-01T10:00:00Z",
+          last_inbound_type: "text",
+          blocked: false,
+        },
+        {
+          id: "2",
+          inbound_number: "+1987654321",
+          last_inbound_date: "2025-07-01T09:00:00Z",
+          last_inbound_type: "call",
+          blocked: true,
+        },
+      ],
+      setForwardingState: jest.fn(),
+    });
+
+    render(<SendersPanelView type="primary" back_btn={mockBack} />);
+
+    // Match the component's exact formatting (spaces around the hyphen)
+    expect(screen.getByText("(234) 567 - 890")).toBeInTheDocument();
+    expect(screen.getByText("(987) 654 - 321")).toBeInTheDocument();
+
+    const buttons = screen.getAllByRole("button", { name: /Block|Unblock/ });
+    expect(buttons).toHaveLength(2);
+  });
+
+  it("calls back_btn when the back button is clicked", () => {
+    render(<SendersPanelView type="primary" back_btn={mockBack} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Back to Primary Dashboard" }),
+    );
+    expect(mockBack).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/phones/dashboard/SendersPanelView.tsx
+++ b/frontend/src/components/phones/dashboard/SendersPanelView.tsx
@@ -155,7 +155,11 @@ export const SendersPanelView = (props: Props) => {
   );
 
   return (
-    <div id="secondary-panel" className={styles["dashboard-card"]}>
+    <div
+      id="secondary-panel"
+      className={styles["dashboard-card"]}
+      data-testid="senders-panel-view"
+    >
       <div className={styles["dashboard-card-caller-sms-senders-header"]}>
         <span>
           <button

--- a/frontend/src/pages/accounts/account_inactive.page.test.tsx
+++ b/frontend/src/pages/accounts/account_inactive.page.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+
+jest.mock("../../components/layout/Layout", () => ({
+  Layout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="mock-layout">{children}</div>
+  ),
+}));
+
+jest.mock("../../hooks/l10n", () => ({
+  useL10n: () => ({
+    getString: (id: string) =>
+      id === "api-error-account-is-inactive" ? "Your account is inactive." : id,
+  }),
+}));
+
+import AccountInactive from "./account_inactive.page";
+
+describe("AccountInactive page", () => {
+  it("renders the inactive account error message", () => {
+    render(<AccountInactive />);
+    expect(screen.getByText("Your account is inactive.")).toBeInTheDocument();
+    expect(screen.getByTestId("mock-layout")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# [MPP-4293](https://mozilla-hub.atlassian.net/browse/MPP-4293) - Part Two

[Original PR](https://github.com/mozilla/fx-private-relay/pull/5761)

Test code coverage improved on the following: 
- phone components (dashboard)
- components dashboard
- pages accounts

# OLD COVERAGE
![Screenshot 2025-06-11 at 10 53 33 PM](https://github.com/user-attachments/assets/ba0d2b5b-8093-4069-9fbd-e594f04da9bc)


# NEW COVERAGE
- phone components (dashboard) --> 86.96%
- components dashboard --> 89.17%
- pages accounts --> 80.65%

[MPP-4293]: https://mozilla-hub.atlassian.net/browse/MPP-4293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ