### PR TITLE
MPP-4393 - fix(circleci): run unit tests against postgres17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -663,7 +663,7 @@ workflows:
           command: pytest
           matrix:
             parameters:
-              postgres_version: ["15.5", "16.1"]
+              postgres_version: ["17.5"]
           executor: python_with_postgres
           test_results_filename: "pytest-postgres-<< matrix.postgres_version >>.xml"
           filters: *default_filters


### PR DESCRIPTION
This PR fixes MPP-4393. We are updating the additional postgres test matrix to run against the Postgres version we will be updating to, rather than 15/16.

How to test:
<img width="573" height="124" alt="Screenshot 2025-09-11 at 11 09 16 AM" src="https://github.com/user-attachments/assets/3714d8f2-8517-47a5-8806-d12b628a70d5" />

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
