### PR TITLE
fix(twilio): Add error handling for erroring Twilio calls

### DIFF
--- a/phones/tests/models_tests.py
+++ b/phones/tests/models_tests.py
@@ -13,7 +13,7 @@ from django.core.exceptions import BadRequest, ValidationError
 import pytest
 from allauth.socialaccount.models import SocialAccount, SocialToken
 from model_bakery import baker
-from twilio.base.exceptions import TwilioRestException
+from twilio.base.exceptions import TwilioException, TwilioRestException
 
 from privaterelay.tests.utils import omit_markus_logs
 
@@ -677,6 +677,37 @@ def test_suggested_numbers(phone_user, real_phone_us, mock_twilio_client):
         call(contains="+1222*******", limit=10),
         call(limit=10),
     ]
+
+
+def test_suggested_numbers_hotfix_error_test(
+    phone_user, real_phone_us, mock_twilio_client
+):
+    # Special hotfix test case for error handling certain types of numbers, clean later
+    def _twilioCall(contains=None, limit=None):
+        if contains:
+            # Any prefix will raise an error, only the most general fetch succeeds
+            if contains == "+1***3334444":
+                raise TwilioRestException(500, "/url", "Service Error 500")
+            raise TwilioException("Unable to fetch page")
+        return [Mock() for i in range(5)]
+
+    mock_list = Mock(side_effect=_twilioCall)
+    mock_twilio_client.available_phone_numbers = Mock(
+        return_value=Mock(local=Mock(list=mock_list))
+    )
+
+    numbers = suggested_numbers(phone_user)
+    available_numbers_calls = mock_twilio_client.available_phone_numbers.call_args_list
+    assert available_numbers_calls == [call("US")]
+    assert mock_list.call_args_list == [
+        call(contains="+1222333****", limit=10),
+        call(contains="+122233***44", limit=10),
+        call(contains="+12223******", limit=10),
+        call(contains="+1***3334444", limit=10),
+        call(contains="+1222*******", limit=10),
+        call(limit=10),
+    ]
+    assert len(numbers) == 5
 
 
 def test_suggested_numbers_ca(phone_user, mock_twilio_client):


### PR DESCRIPTION
This is adding error handling to hotfix erroring "phone number availability" calls. We will still depend on the final, no prefix call succeeding, but in my testing that call continues to work fine.

Incident doc: https://docs.google.com/document/d/1TbMRN-f3l65o7GmzU4_eNidonLsRfsMorEopfOMh_18/edit?tab=t.0
This PR fixes MPP-4403.

How to test:

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
