### PR TITLE
fix(tests): update e2e test targeting for subscription plans

### DIFF
--- a/e2e-tests/pages/subscriptionPaymentPage.ts
+++ b/e2e-tests/pages/subscriptionPaymentPage.ts
@@ -16,7 +16,6 @@ export class SubscriptionPaymentPage {
   readonly subscription3Title: Locator;
   readonly subscriptionType: Locator;
   readonly planDetails: Locator;
-  readonly planDetails3: Locator;
   readonly planType: Locator;
   readonly planType3: Locator;
 
@@ -44,17 +43,12 @@ export class SubscriptionPaymentPage {
       '[data-testid="subscription-create-title"]',
     );
     this.subscription3Title = page.locator("#subscription-heading");
-    this.planDetails = page.locator("#plan-details-product");
-    this.planDetails3 = page.locator("#product-details-heading");
+    this.planDetails = page.locator("#product-details-heading");
     this.planType = page.locator(".plan-details-description");
     // this is ugly but someone repeated the datatest-id="total-price" in the component
     this.planType3 = page.locator(
       ".overflow-hidden.text-ellipsis.text-lg.whitespace-nowrap",
     );
-  }
-
-  private isVersion3(): boolean {
-    return this.page.url().includes("payments-next");
   }
 
   async getSubscriptionTitleText(): Promise<string> {
@@ -68,10 +62,7 @@ export class SubscriptionPaymentPage {
   }
 
   async getPlanDetailsText(): Promise<string> {
-    const text = this.isVersion3()
-      ? await this.planDetails3.textContent()
-      : await this.planDetails.textContent();
-
+    const text = await this.planDetails.textContent();
     if (!text) {
       throw new Error("Get Plan title text not found.");
     }


### PR DESCRIPTION
This PR fixes MPP-4417.

Testing output of previously failing tests:
```
  ✓   3 ….spec.ts:99:7 › Subscription flows with PlanGrid @health_check › Verify that the yearly "Relay Premium" plan works correctly, C1818792 (5.9s)
  ✓   4 …pec.ts:117:7 › Subscription flows with PlanGrid @health_check › Verify that the monthly "Relay Premium" plan works correctly, C1818792 (4.0s)
  ✓   5 …:135:7 › Subscription flows with PlanGrid @health_check › Verify that the yearly "Relay + Phone" bundle plan works correctly, C1818792 (4.7s)
  ✓   6 …149:7 › Subscription flows with PlanGrid @health_check › Verify that the monthly "Relay + Phone" bundle plan works correctly, C1818792 (4.0s)
  ✓   7 …relay-e2e.spec.ts:163:7 › Subscription flows with PlanGrid @health_check › Verify that the "Megabundle" plan works correctly, C1818792 (5.2s)
```

How to test:

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
