### PR TITLE
Fix hydration errors

### DIFF
--- a/frontend/src/components/landing/PlanGrid.test.tsx
+++ b/frontend/src/components/landing/PlanGrid.test.tsx
@@ -11,6 +11,7 @@ import { isMegabundleAvailableInCountry } from "../../functions/getPlan";
 jest.mock("../../hooks/l10n");
 jest.mock("../../hooks/gaViewPing");
 jest.mock("../../hooks/gaEvent");
+jest.mock("../../hooks/hasRenderedClientSide");
 jest.mock("../../hooks/session");
 jest.mock("../../functions/trackPurchase");
 jest.mock("../../functions/cookies", () => ({ setCookie: jest.fn() }));

--- a/frontend/src/components/landing/PlanGrid.tsx
+++ b/frontend/src/components/landing/PlanGrid.tsx
@@ -41,6 +41,7 @@ import { useL10n } from "../../hooks/l10n";
 import { LinkButton } from "../Button";
 import { useIsLoggedIn } from "../../hooks/session";
 import { getLocale } from "../../functions/getLocale";
+import { useUtmApplier } from "../../hooks/utmApplier";
 
 export type Props = {
   runtimeData: RuntimeData;
@@ -74,6 +75,8 @@ export const PlanGrid = (props: Props) => {
   };
 
   const isLoggedIn = useIsLoggedIn();
+
+  const applyUtmParams = useUtmApplier();
 
   const formatter = new Intl.NumberFormat(getLocale(l10n), {
     style: "currency",
@@ -321,9 +324,11 @@ export const PlanGrid = (props: Props) => {
                     "monthly",
                     l10n,
                   ),
-                  subscribeLink: getPeriodicalPremiumSubscribeLink(
-                    props.runtimeData,
-                    "monthly",
+                  subscribeLink: applyUtmParams(
+                    getPeriodicalPremiumSubscribeLink(
+                      props.runtimeData,
+                      "monthly",
+                    ),
                   ),
                   gaViewPing: {
                     category: "Purchase monthly Premium button",
@@ -345,9 +350,11 @@ export const PlanGrid = (props: Props) => {
                     "yearly",
                     l10n,
                   ),
-                  subscribeLink: getPeriodicalPremiumSubscribeLink(
-                    props.runtimeData,
-                    "yearly",
+                  subscribeLink: applyUtmParams(
+                    getPeriodicalPremiumSubscribeLink(
+                      props.runtimeData,
+                      "yearly",
+                    ),
                   ),
                   gaViewPing: {
                     category: "Purchase yearly Premium button",
@@ -405,11 +412,7 @@ export const PlanGrid = (props: Props) => {
             </p>
             <LinkButton
               ref={freeButtonRef}
-              href={`${getRuntimeConfig().fxaLoginUrl}&auth_params=${
-                typeof window !== "undefined"
-                  ? encodeURIComponent(window.location.search.slice(1))
-                  : ""
-              }`}
+              href={applyUtmParams(getRuntimeConfig().fxaLoginUrl)}
               onClick={() => countSignIn("plan-grid-free-cta")}
               className={styles["pick-button"]}
               disabled={isLoggedIn === "logged-in"}

--- a/frontend/src/components/landing/PlanMatrix.tsx
+++ b/frontend/src/components/landing/PlanMatrix.tsx
@@ -31,6 +31,7 @@ import { Localized } from "../Localized";
 import { LinkButton } from "../Button";
 import { VisuallyHidden } from "../VisuallyHidden";
 import { useIsLoggedIn } from "../../hooks/session";
+import { useUtmApplier } from "../../hooks/utmApplier";
 
 type FeatureList = {
   "email-masks": number;
@@ -107,6 +108,8 @@ export const PlanMatrix = (props: Props) => {
 
   const isLoggedIn = useIsLoggedIn();
 
+  const applyUtmParams = useUtmApplier();
+
   const desktopView = (
     <table className={styles.desktop}>
       <thead>
@@ -167,11 +170,7 @@ export const PlanMatrix = (props: Props) => {
                 </span>
                 <LinkButton
                   ref={freeButtonDesktopRef}
-                  href={`${getRuntimeConfig().fxaLoginUrl}&auth_params=${
-                    typeof window !== "undefined"
-                      ? encodeURIComponent(window.location.search.slice(1))
-                      : ""
-                  }`}
+                  href={applyUtmParams(getRuntimeConfig().fxaLoginUrl)}
                   onClick={() => countSignIn("plan-matrix-free-cta-desktop")}
                   className={styles["primary-pick-button"]}
                   disabled={isLoggedIn === "logged-in"}
@@ -199,9 +198,11 @@ export const PlanMatrix = (props: Props) => {
                     "monthly",
                     l10n,
                   ),
-                  subscribeLink: getPeriodicalPremiumSubscribeLink(
-                    props.runtimeData,
-                    "monthly",
+                  subscribeLink: applyUtmParams(
+                    getPeriodicalPremiumSubscribeLink(
+                      props.runtimeData,
+                      "monthly",
+                    ),
                   ),
                   gaViewPing: {
                     category: "Purchase monthly Premium button",
@@ -218,9 +219,11 @@ export const PlanMatrix = (props: Props) => {
                     "yearly",
                     l10n,
                   ),
-                  subscribeLink: getPeriodicalPremiumSubscribeLink(
-                    props.runtimeData,
-                    "yearly",
+                  subscribeLink: applyUtmParams(
+                    getPeriodicalPremiumSubscribeLink(
+                      props.runtimeData,
+                      "yearly",
+                    ),
                   ),
                   gaViewPing: {
                     category: "Purchase yearly Premium button",
@@ -410,11 +413,7 @@ export const PlanMatrix = (props: Props) => {
               </span>
               <LinkButton
                 ref={freeButtonMobileRef}
-                href={`${getRuntimeConfig().fxaLoginUrl}&auth_params=${
-                  typeof window !== "undefined"
-                    ? encodeURIComponent(window.location.search.slice(1))
-                    : ""
-                }`}
+                href={applyUtmParams(getRuntimeConfig().fxaLoginUrl)}
                 onClick={() => countSignIn("plan-matrix-free-cta-mobile")}
                 className={styles["primary-pick-button"]}
               >
@@ -434,9 +433,11 @@ export const PlanMatrix = (props: Props) => {
                   "monthly",
                   l10n,
                 ),
-                subscribeLink: getPeriodicalPremiumSubscribeLink(
-                  props.runtimeData,
-                  "monthly",
+                subscribeLink: applyUtmParams(
+                  getPeriodicalPremiumSubscribeLink(
+                    props.runtimeData,
+                    "monthly",
+                  ),
                 ),
                 gaViewPing: {
                   category: "Purchase monthly Premium button",
@@ -453,9 +454,11 @@ export const PlanMatrix = (props: Props) => {
                   "yearly",
                   l10n,
                 ),
-                subscribeLink: getPeriodicalPremiumSubscribeLink(
-                  props.runtimeData,
-                  "yearly",
+                subscribeLink: applyUtmParams(
+                  getPeriodicalPremiumSubscribeLink(
+                    props.runtimeData,
+                    "yearly",
+                  ),
                 ),
                 gaViewPing: {
                   category: "Purchase yearly Premium button",

--- a/frontend/src/components/layout/navigation/SignInButton.tsx
+++ b/frontend/src/components/layout/navigation/SignInButton.tsx
@@ -4,6 +4,7 @@ import { setCookie } from "../../../functions/cookies";
 import { getLoginUrl, useFxaFlowTracker } from "../../../hooks/fxaFlowTracker";
 import { useGaEvent } from "../../../hooks/gaEvent";
 import { useL10n } from "../../../hooks/l10n";
+import { useUtmApplier } from "../../../hooks/utmApplier";
 
 export type Props = {
   className?: string;
@@ -16,9 +17,10 @@ export const SignInButton = (props: Props): React.JSX.Element => {
     label: "nav-profile-sign-in",
     entrypoint: "relay-sign-in-header",
   });
-  const signInUrl = getLoginUrl(
-    "relay-sign-in-header",
-    signInFxaFlowTracker.flowData,
+
+  const applyUtmParams = useUtmApplier();
+  const signInUrl = applyUtmParams(
+    getLoginUrl("relay-sign-in-header", signInFxaFlowTracker.flowData),
   );
   const gaEvent = useGaEvent();
 

--- a/frontend/src/components/layout/navigation/SignUpButton.tsx
+++ b/frontend/src/components/layout/navigation/SignUpButton.tsx
@@ -4,6 +4,7 @@ import { setCookie } from "../../../functions/cookies";
 import { useGaEvent } from "../../../hooks/gaEvent";
 import { getLoginUrl, useFxaFlowTracker } from "../../../hooks/fxaFlowTracker";
 import { useL10n } from "../../../hooks/l10n";
+import { useUtmApplier } from "../../../hooks/utmApplier";
 
 export type Props = {
   className: string;
@@ -15,9 +16,9 @@ export const SignUpButton = (props: Props): React.JSX.Element => {
     label: "nav-profile-sign-up",
     entrypoint: "relay-sign-up-header",
   });
-  const signUpUrl = getLoginUrl(
-    "relay-sign-up-header",
-    signUpFxaFlowTracker.flowData,
+  const applyUtmParams = useUtmApplier();
+  const signUpUrl = applyUtmParams(
+    getLoginUrl("relay-sign-up-header", signUpFxaFlowTracker.flowData),
   );
   const gaEvent = useGaEvent();
 

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -77,6 +77,7 @@ import { useL10n } from "../../../../hooks/l10n";
 import { VisuallyHidden } from "../../../VisuallyHidden";
 import { useOverlayBugWorkaround } from "../../../../hooks/overlayBugWorkaround";
 import { useGaViewPing } from "../../../../hooks/gaViewPing";
+import { useUtmApplier } from "../../../../hooks/utmApplier";
 
 export type WhatsNewEntry = {
   title: string;
@@ -342,11 +343,14 @@ export const WhatsNewMenu = (props: Props) => {
     entries.push(premiumInFinland);
   }
 
+  const applyUtmParams = useUtmApplier();
   // Check if yearlyPlanLink should be generated based on runtimeData and availability
   const yearlyPlanLink =
     props.runtimeData &&
     isPeriodicalPremiumAvailableInCountry(props.runtimeData)
-      ? getPeriodicalPremiumSubscribeLink(props.runtimeData, "yearly")
+      ? applyUtmParams(
+          getPeriodicalPremiumSubscribeLink(props.runtimeData, "yearly"),
+        )
       : undefined;
 
   const yearlyPlanRefWithCoupon = `${yearlyPlanLink}&coupon=HOLIDAY20&utm_source=relay.firefox.com&utm_medium=whatsnew-announcement&utm_campaign=relay-holiday-promo-2023`;

--- a/frontend/src/components/layout/topmessage/HolidayPromoBanner.tsx
+++ b/frontend/src/components/layout/topmessage/HolidayPromoBanner.tsx
@@ -11,6 +11,7 @@ import {
 import { ProfileData } from "../../../hooks/api/profile";
 import { useGaEvent } from "../../../hooks/gaEvent";
 import { useGaViewPing } from "../../../hooks/gaViewPing";
+import { useUtmApplier } from "../../../hooks/utmApplier";
 
 type Props = {
   isLoading: boolean;
@@ -23,8 +24,11 @@ export const HolidayPromoBanner = (props: Props) => {
   const gaEvent = useGaEvent();
   const router = useRouter();
   const coupon = "HOLIDAY20";
+  const applyUtmParams = useUtmApplier();
   const subscribeLink = isPeriodicalPremiumAvailableInCountry(props.runtimeData)
-    ? getPeriodicalPremiumSubscribeLink(props.runtimeData, "yearly")
+    ? applyUtmParams(
+        getPeriodicalPremiumSubscribeLink(props.runtimeData, "yearly"),
+      )
     : null;
   const todaysDate = new Date();
   const expiryDate = new Date("December 31, 2023");

--- a/frontend/src/functions/getPlan.ts
+++ b/frontend/src/functions/getPlan.ts
@@ -51,31 +51,10 @@ export const getPeriodicalPremiumSubscribeLink = (
 ) => {
   const plan = getPlan(runtimeData.PERIODICAL_PREMIUM_PLANS, billingPeriod);
 
-  const baseHref = plan.id
-    ? `${runtimeData.FXA_ORIGIN}/subscriptions/products/${runtimeData.PERIODICAL_PREMIUM_PRODUCT_ID}?plan=${plan.id}`
-    : (plan.url ?? "");
-
-  if (typeof window !== "undefined" && baseHref) {
-    const url = new URL(baseHref, window.location.origin);
-    const inbound = new URLSearchParams(window.location.search);
-
-    (
-      [
-        "utm_source",
-        "utm_campaign",
-        "utm_medium",
-        "utm_content",
-        "utm_term",
-      ] as const
-    ).forEach((k) => {
-      const v = inbound.get(k);
-      if (v && !url.searchParams.has(k)) url.searchParams.set(k, v);
-    });
-
-    return url.toString();
+  if (plan.id) {
+    return `${runtimeData.FXA_ORIGIN}/subscriptions/products/${runtimeData.PERIODICAL_PREMIUM_PRODUCT_ID}?plan=${plan.id}`;
   }
-
-  return baseHref;
+  return plan.url ?? "";
 };
 
 export const getPhonesPrice = (

--- a/frontend/src/hooks/__mocks__/hasRenderedClientSide.ts
+++ b/frontend/src/hooks/__mocks__/hasRenderedClientSide.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { useHasRenderedClientSide as ogUseHasRenderedClientSide } from "../hasRenderedClientSide";
+
+/**
+ * Mock that always returns `true`
+ *
+ * This allows tests to simply call
+ * `jest.mock("path/to/useHasRenderedClientSide")` to skip the loading phase
+ * followed by an automatic re-render, which would result in the error:
+ *
+ * > Warning: A suspended resource finished loading inside a test, but
+ * > the event was not wrapped in act(...).
+ */
+export const useHasRenderedClientSide: typeof ogUseHasRenderedClientSide = () =>
+  true;

--- a/frontend/src/hooks/api/runtimeData.ts
+++ b/frontend/src/hooks/api/runtimeData.ts
@@ -2,12 +2,14 @@ import { SWRResponse } from "swr";
 import { useApiV1 } from "./api";
 import { RuntimeData } from "./types";
 import { DEFAULT_RUNTIME_DATA } from "./runtimeData-default";
+import { useHasRenderedClientSide } from "../hasRenderedClientSide";
 
 /**
  * Fetch data from the back-end that wasn't known at build time (e.g. the user's country, or environment variables) using [SWR](https://swr.vercel.app).
  * Falls back to default runtime data values when API data is unavailable.
  */
 export function useRuntimeData() {
+  const hasRenderedClientside = useHasRenderedClientSide();
   const runtimeData: SWRResponse<RuntimeData, unknown> = useApiV1(
     "/runtime_data",
     {
@@ -17,10 +19,11 @@ export function useRuntimeData() {
     },
   );
 
-  const isClient = typeof window !== "undefined";
   // Return SWR response, but override the `data` with defaults if missing
   return {
     ...runtimeData,
-    data: runtimeData.data ?? (isClient ? DEFAULT_RUNTIME_DATA : undefined),
+    data:
+      runtimeData.data ??
+      (hasRenderedClientside ? DEFAULT_RUNTIME_DATA : undefined),
   };
 }

--- a/frontend/src/hooks/fxaFlowTracker.ts
+++ b/frontend/src/hooks/fxaFlowTracker.ts
@@ -98,22 +98,6 @@ export function getLoginUrl(entrypoint: string, flowData?: FlowData): string {
     );
   }
 
-  if (typeof window !== "undefined") {
-    const inbound = new URLSearchParams(window.location.search);
-    [
-      "utm_source",
-      "utm_campaign",
-      "utm_medium",
-      "utm_content",
-      "utm_term",
-    ].forEach((k) => {
-      const v = inbound.get(k);
-      if (v && !urlObject.searchParams.has(k)) {
-        urlObject.searchParams.append(k, v);
-      }
-    });
-  }
-
   const fullUrl = urlObject.href;
   // If the configured fxaLoginUrl was a relative URL,
   // the URL we return should be relative as well, rather than potentially

--- a/frontend/src/hooks/hasRenderedClientSide.ts
+++ b/frontend/src/hooks/hasRenderedClientSide.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Hook to help selectively opting out of static site generation
+ *
+ * Sometimes you want to adapt the appearance of a component based on specific
+ * characteristics of the user's in-browser environment. However, this can
+ * cause problems: we pre-render our components to static HTML before sending
+ * them to the user, and then React re-renders the components on the client-
+ * side, and matches the resulting HTML with the HTML that we already sent to
+ * the browser. If those two don't align, that can cause hydration errors; see
+ * https://nextjs.org/docs/messages/react-hydration-error?trk=public_post_comment-text
+ *
+ * To avoid this, you can use this hook to defer client-side adjustments until
+ * *after* hydration. That way, React knows how the adjustments are different
+ * from the initial render, and can apply just those changes.
+ *
+ * @returns Whether the component has already rendered client-side; if `true`,
+ *          subsequent renders are guaranteed to be on the client-side.
+ */
+export function useHasRenderedClientSide() {
+  const [hasRenderedClientSide, setHasRenderedClientSide] = useState(false);
+
+  useEffect(() => {
+    setHasRenderedClientSide(true);
+  }, []);
+
+  return hasRenderedClientSide;
+}

--- a/frontend/src/hooks/utmApplier.ts
+++ b/frontend/src/hooks/utmApplier.ts
@@ -1,0 +1,49 @@
+import { useHasRenderedClientSide } from "./hasRenderedClientSide";
+
+/**
+ * Hook to pass UTM parameters on to FxA
+ *
+ * To learn how people generally subscribe, we need to pass UTM parameters on
+ * to FxA. However, since we're pre-rendering the website at build-time, rather
+ * than dynamically when a user request comes in, we can't know the values of
+ * those parameters yet. And since the first client-side render has to produce
+ * the same HTML as the build-time render did (so React can properly attach
+ * event handlers and such), we can only add those parameters on the client
+ * side *after* that first render happens.
+ *
+ * This hook provides a function that takes care of that.
+ *
+ * (The reason it returns a function rather than just taking a URL as a parameter,
+ * is that hooks can't run conditionally, and the URL to update might not always be available.)
+ *
+ * @returns A function that takes a URL, and returns it (with the relevant UTM parameters appended on the client-side).
+ */
+export function useUtmApplier(): (url: string) => string {
+  const hasRenderedClientSide = useHasRenderedClientSide();
+
+  if (!hasRenderedClientSide) {
+    // We don't have access to the UTM parameters at the first (build-time)
+    // render, so just return the input URL:
+    return (url) => url;
+  }
+
+  return (inputUrl) => {
+    const url = new URL(inputUrl, window.location.origin);
+    const inbound = new URLSearchParams(window.location.search);
+
+    (
+      [
+        "utm_source",
+        "utm_campaign",
+        "utm_medium",
+        "utm_content",
+        "utm_term",
+      ] as const
+    ).forEach((k) => {
+      const v = inbound.get(k);
+      if (v && !url.searchParams.has(k)) url.searchParams.set(k, v);
+    });
+
+    return url.href;
+  };
+}

--- a/frontend/src/pages/accounts/settings.page.tsx
+++ b/frontend/src/pages/accounts/settings.page.tsx
@@ -30,6 +30,7 @@ import { useAddonData } from "../../hooks/addon";
 import { isFlagActive } from "../../functions/waffle";
 import { isPhonesAvailableInCountry } from "../../functions/getPlan";
 import { useL10n } from "../../hooks/l10n";
+import { useUtmApplier } from "../../hooks/utmApplier";
 
 const Settings: NextPage = () => {
   const runtimeData = useRuntimeData();
@@ -60,14 +61,9 @@ const Settings: NextPage = () => {
     countLabelCollectionDisabledWarningToggle();
   }, [labelCollectionEnabled]);
 
+  const applyUtmParams = useUtmApplier();
   if (!profileData.isValidating && profileData.error) {
-    const authParams =
-      typeof window !== "undefined"
-        ? encodeURIComponent(window.location.search.replace(/^\?/, ""))
-        : "";
-    document.location.assign(
-      `${getRuntimeConfig().fxaLoginUrl}&auth_params=${authParams}`,
-    );
+    document.location.assign(applyUtmParams(getRuntimeConfig().fxaLoginUrl));
   }
 
   if (!profileData.data || !runtimeData.data) {

--- a/frontend/src/pages/flags.page.tsx
+++ b/frontend/src/pages/flags.page.tsx
@@ -10,25 +10,21 @@ import { isFlagActive } from "../functions/waffle";
 import { apiFetch, useApiV1 } from "../hooks/api/api";
 import { BlockIcon, CheckIcon } from "../components/Icons";
 import { toast } from "react-toastify";
+import { useUtmApplier } from "../hooks/utmApplier";
 
 const Flags: NextPage = () => {
   const runtimeData = useRuntimeData();
   const flagData = useFlagData();
   const [actionInput, setActionInput] = useState("");
   const [flagInput, setFlagInput] = useState("");
+  const applyUtmParams = useUtmApplier();
 
   if (!runtimeData.data) {
     return null;
   }
 
   if (!isFlagActive(runtimeData.data, "manage_flags") || flagData.error) {
-    const authParams =
-      typeof window !== "undefined"
-        ? encodeURIComponent(window.location.search.replace(/^\?/, ""))
-        : "";
-    document.location.assign(
-      `${getRuntimeConfig().fxaLoginUrl}&auth_params=${authParams}`,
-    );
+    document.location.assign(applyUtmParams(getRuntimeConfig().fxaLoginUrl));
     return null;
   }
 

--- a/frontend/src/pages/phone.page.tsx
+++ b/frontend/src/pages/phone.page.tsx
@@ -16,6 +16,7 @@ import { useRouter } from "next/router";
 import { isPhonesAvailableInCountry } from "../functions/getPlan";
 import { PhoneWelcomeView } from "../components/phones/dashboard/PhoneWelcomeView";
 import { useLocalDismissal } from "../hooks/localDismissal";
+import { useUtmApplier } from "../hooks/utmApplier";
 
 const Phone: NextPage = () => {
   const runtimeData = useRuntimeData();
@@ -72,14 +73,9 @@ const Phone: NextPage = () => {
     }
   }, [isInOnboarding, relayNumberData]);
 
+  const applyUtmParams = useUtmApplier();
   if (!userData.isValidating && userData.error) {
-    const authParams =
-      typeof window !== "undefined"
-        ? encodeURIComponent(window.location.search.replace(/^\?/, ""))
-        : "";
-    document.location.assign(
-      `${getRuntimeConfig().fxaLoginUrl}&auth_params=${authParams}`,
-    );
+    document.location.assign(applyUtmParams(getRuntimeConfig().fxaLoginUrl));
   }
 
   if (!profile || !user || !relayNumberData.data || !runtimeData.data) {


### PR DESCRIPTION
We had a few places where we render different content depending on data from the runtime, causing the first render to be different from the prerender that happens in the build. This PR adds the `hasRenderedClientSide` hook from Monitor, and ensures that runtime-dependent customisations are only applied after that returns `true`.