### PR TITLE
MPP-4315: reroute "Contact us" and related support links to the new Relay form

### DIFF
--- a/frontend/src/pages/faq.page.tsx
+++ b/frontend/src/pages/faq.page.tsx
@@ -287,7 +287,7 @@ const Faq: NextPage = () => {
                 <Localized
                   id="faq-question-1-answer-b-2-html"
                   vars={{
-                    url: "https://addons.mozilla.org/firefox/addon/private-relay/",
+                    url: "https://support.mozilla.org/questions/new/relay/form",
                     attrs: "",
                   }}
                   elems={{


### PR DESCRIPTION
# This PR fixes [MPP-4315](https://mozilla-hub.atlassian.net/browse/MPP-4315)

# How to test
Check the following have the new support form link:
- “report this to us” link from the FAQ page

# Checklist (Definition of Done)

- [X] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [X] Customer Experience team has seen or waived a demo of functionality.
- [X] All acceptance criteria are met.
- [X] Jira ticket has been updated (if needed) to match changes made during the development process.
- [X] I've added or updated relevant docs in the docs/ directory
- [X] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [X] l10n changes have been submitted to the l10n repository, if any.


[MPP-4315]: https://mozilla-hub.atlassian.net/browse/MPP-4315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ