### PR TITLE
fix(relay): Identify GCPv2 dev vs heroku (MPP-4425)

### DIFF
--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -24,7 +24,7 @@ from emails.utils import (
 
 
 class GetEmailDomainFromSettingsTest(TestCase):
-    @override_settings(RELAY_CHANNEL="dev", SITE_ORIGIN="https://test.com")
+    @override_settings(RELAY_CHANNEL="heroku", SITE_ORIGIN="https://test.com")
     def test_get_email_domain_from_settings_on_dev(self) -> None:
         email_domain = get_email_domain_from_settings()
         assert "mail.test.com" == email_domain

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -150,7 +150,7 @@ def get_email_domain_from_settings() -> str:
     email_network_locality = str(urlparse(settings.SITE_ORIGIN).netloc)
     # on dev server we need to add "mail" prefix
     # because we can’t publish MX records on Heroku
-    if settings.RELAY_CHANNEL == "dev":
+    if settings.RELAY_CHANNEL == "heroku":
         email_network_locality = f"mail.{email_network_locality}"
     return email_network_locality
 

--- a/privaterelay/apps.py
+++ b/privaterelay/apps.py
@@ -58,10 +58,10 @@ def configure_google_profiler() -> None:
 def get_profiler_startup_data() -> tuple[str | None, str | None]:
     from .utils import get_version_info
 
-    if settings.RELAY_CHANNEL not in ("dev", "stage", "prod"):
+    if settings.RELAY_CHANNEL not in ("dev", "stage", "prod", "heroku"):
         return (None, None)
 
-    if settings.RELAY_CHANNEL in ("dev", "stage"):
+    if settings.RELAY_CHANNEL in ("dev", "stage", "heroku"):
         service = f"fxprivaterelay-{settings.RELAY_CHANNEL}"
     if settings.RELAY_CHANNEL == "prod":
         service = "fxprivaterelay"

--- a/privaterelay/types.py
+++ b/privaterelay/types.py
@@ -4,7 +4,7 @@ from typing import Literal, TypedDict
 
 from csp.constants import Nonce
 
-RELAY_CHANNEL_NAME = Literal["local", "dev", "stage", "prod"]
+RELAY_CHANNEL_NAME = Literal["local", "dev", "stage", "prod", "heroku"]
 
 # django-csp 4.0: types for CONTENT_SECURITY_POLICY in settings.py
 


### PR DESCRIPTION
Currently:
* https://relay-dev.allizom.org (dev in GCPv2) has `RELAY_CHANNEL="local"`
* https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net (Heroku) has `RELAY_CHANNEL="dev"`

After this PR:
* https://relay-dev.allizom.org will have `RELAY_CHANNEL="dev"`
* https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net will have `RELAY_CHANNEL="heroku"`
