### PR TITLE
chore: fix typos

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -284,7 +284,7 @@ Here is an index of the event categories and actions:
 [Email Masks, Get Domain Link]: #ctx-web-emails-link-get-domain "Details for the link 'Get your own domain with Premium'"
 [Email Masks, Get Firefox Banner]: #ctx-web-emails-banner-firefox "Details for the banner to download the Relay extension"
 [Email Masks, Mask Details]: #ctx-web-emails-detail "Details for the Email Masks dashboard, opening the details for a mask."
-[Email Masks, Maximize Banner]: #ctx-web-emails-banner-maximize "Details for the banner 'Introducting: Relay + VPN subscription plan'."
+[Email Masks, Maximize Banner]: #ctx-web-emails-banner-maximize "Details for the banner 'Introducing: Relay + VPN subscription plan'."
 [Email Masks, Unlimited Button]: #ctx-web-emails-button-unlimited "Details for the 'Get unlimited email masks' button."
 [Email Masks, Upgrade Corner Notification]: #ctx-web-emails-corner-upgrade "Details for the lower-right corner notification to upgrade to premium"
 [Free Onboarding]: #ctx-web-onboarding-free "Details for the free onboarding sequence"
@@ -1385,7 +1385,7 @@ survey is not covered by this document, but is processed in accordance with
 
 [<img src="./docs/img/website-survey-recruitment.png"
       width=380
-      alt="The intereview recruitment survey, with the text &quot;Want to help improve Firefox Relay? We'd love to hear what you think. Research participants receive a $50 gift card.&quot;"
+      alt="The interview recruitment survey, with the text &quot;Want to help improve Firefox Relay? We'd love to hear what you think. Research participants receive a $50 gift card.&quot;"
 />](./docs/img/website-survey-recruitment.png)
 
 The Google Analytics events:

--- a/api/authentication.py
+++ b/api/authentication.py
@@ -54,7 +54,7 @@ def introspect_token(token: str) -> dict[str, Any]:
 
 
 def get_fxa_uid_from_oauth_token(token: str, use_cache: bool = True) -> str:
-    # set a default cache_timeout, but this will be overriden to match
+    # set a default cache_timeout, but this will be overridden to match
     # the 'exp' time in the JWT returned by FxA
     cache_timeout = 60
     cache_key = get_cache_key(token)

--- a/api/schema.py
+++ b/api/schema.py
@@ -79,7 +79,7 @@ def sort_by_tag(endpoint: ENDPOINT) -> tuple[int, str, int]:
     """
     Sort paths by their tag, then name, then method.
 
-    The browseable APIs will sort by tag, but in the order returned by this sort key.
+    The browsable APIs will sort by tag, but in the order returned by this sort key.
     """
     drf_order = alpha_operation_sorter(endpoint)
     partial_path = endpoint[0].split("/")[3]

--- a/api/tests/privaterelay_views_tests.py
+++ b/api/tests/privaterelay_views_tests.py
@@ -293,7 +293,7 @@ class TermsAcceptedUserViewTest(TestCase):
         fxa_response = _setup_fxa_response(
             200, {"active": True, "sub": self.uid, "exp": exp_time}
         )
-        # setup fxa profile reponse
+        # setup fxa profile response
         profile_json = {
             "email": email,
             "amrValues": ["pwd", "email"],

--- a/api/views/privaterelay.py
+++ b/api/views/privaterelay.py
@@ -235,7 +235,7 @@ def _get_example_plan(
 @api_view()
 @permission_classes([AllowAny])
 def runtime_data(request):
-    """Get data needed to present the Relay dashboard to a vistor or user."""
+    """Get data needed to present the Relay dashboard to a visitor or user."""
     flags = get_waffle_flag_model().get_all()
     flag_values = [(f.name, f.is_active(request)) for f in flags]
     switches = Switch.get_all()

--- a/docs/adr/0003-decouple-welcome-email-from-new-user-flow.md
+++ b/docs/adr/0003-decouple-welcome-email-from-new-user-flow.md
@@ -60,7 +60,7 @@ Proceeded with **Option 3. Implement cron job to send welcome email** because it
 
 ### Option 3: Implement cron job to send welcome email
 
-Relay already has [many scheduled jobs](https://dashboard.heroku.com/apps/fx-private-relay/scheduler) setup to handle asynchronous work ranging from maintainig old data to renewing monthly phone limits for users.
+Relay already has [many scheduled jobs](https://dashboard.heroku.com/apps/fx-private-relay/scheduler) setup to handle asynchronous work ranging from maintaining old data to renewing monthly phone limits for users.
 
 - Good, because Relay can reuse code to send welcome email if or when we move to Option 1 using Redis Queue.
 - Good, because this option is inline with how we used scheduled jobs and is the lowest complexity to implement.

--- a/docs/api_auth.md
+++ b/docs/api_auth.md
@@ -68,7 +68,7 @@ sequenceDiagram
     Firefox->>Relay: POST /api/v1/terms-accepted-user Authorization: Token {token}
     Relay->>FXA: POST /v1/introspect {token}
     FXA->>Relay: 200 OK
-    Relay->>Relay: Create new user on DB if Fxa user DNE
+    Relay->>Relay: Create new user on DB if Fxa user does not exist
     Relay->>Firefox: 201 Created or 202 User already exists
     end
     rect rgba(255, 255, 153, .09)

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -53,7 +53,7 @@ What follows is a list of dependencies and how to check for potential breakage w
 
 For linters, type definitions, and non-Playwright testing-related packages, a
 successful CI run generally provides enough confidence that the upgrade is fine.
-That said, it can't harm to occassionally scan the results of the
+That said, it can't harm to occasionally scan the results of the
 `build_frontend` or `test_frontend` CI runs to see if any new warnings were
 added. If `jest-junit` is updated, you'll want to check that CircleCI can still
 see code coverage for the frontend.
@@ -94,7 +94,7 @@ workflow", and pick the `main` branch and the `stage` environment.
 These dependencies handle most of the dynamic UI elements in our frontend, such
 as the user menu and the app menu in the header, the modals when claiming a
 subdomain or creating a new custom mask, or the toggle that allows you to set a
-mask to block nothing, promotional emails, or everything. To verfy these
+mask to block nothing, promotional emails, or everything. To verify these
 updates, open the preview deployments and check that you can still interact with
 those using both a keyboard and a mouse.
 
@@ -102,7 +102,7 @@ those using both a keyboard and a mouse.
 
 [Fluent](https://projectfluent.org/) handles localisation, so verifying these
 involves setting your browser language to something other than English, and
-verifing that the website content indeed shows up in your chosen different
+verifying that the website content indeed shows up in your chosen different
 language.
 
 ### `next`

--- a/docs/end-to-end-local-email-dev.md
+++ b/docs/end-to-end-local-email-dev.md
@@ -12,7 +12,7 @@ sequenceDiagram
     AWS->>yourapp.ngrok.io: POST /emails/sns-inbound
     yourapp.ngrok.io->>127.0.0.1: POST /emails/sns-inbound
     127.0.0.1->>AWS: POST /SendRawEmail
-    AWS->>Reciving MTA: SMTP
+    AWS->>Receiving MTA: SMTP
 ```
 
 ## Requirements
@@ -388,7 +388,7 @@ sequenceDiagram
     Sending MTA->>AWS: SMTP
     Local app->>AWS: SQS fetch
     Local app->>AWS: POST /SendRawEmail
-    AWS->>Reciving MTA: SMTP
+    AWS->>Receiving MTA: SMTP
 ```
 
 To make this change:

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -216,7 +216,7 @@ An example:
       }
     }
 
-You can generate this URL yourself by pasing the following in your browser
+You can generate this URL yourself by passing the following in your browser
 console, changing the contents of `JSON.stringify()` with your desired values:
 
     { let url = new URL("http://localhost:3000/tracker-report"); url.hash = JSON.stringify({ sender: "email@example.com", received_at: Date.now(), trackers: { "ads.facebook.com": 1, "ads.googletagmanager.com": 2 } }); url.href }

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -160,7 +160,7 @@ After you push the tag to GitHub, you should also
 ## Release to Prod
 
 We leave the tag on [Stage][stage] for a week so that we (and especially QA)
-can check the tag on GCP infrastucture before we deploy it to production.
+can check the tag on GCP infrastructure before we deploy it to production.
 
 On Monday, after the Release Readiness Review:
 
@@ -289,7 +289,7 @@ GitHub, you should [make a pre-release on GitHub][github-new-release] for the
 new release tag.
 
 1. Choose the tag you just pushed (e.g., `2022.08.02.1`)
-2. Type the same tag name for the releae title (e.g., `2022.08.02.1`)
+2. Type the same tag name for the release title (e.g., `2022.08.02.1`)
 3. Click "Previous tag:" and choose the previous tag. (e.g., `2022.08.02`)
 4. Click the "Generate release notes" button!
 5. Check the pre-release box.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -383,7 +383,7 @@ flag, users can view new content and test buying a subscription.
 
 > [!NOTE]
 > Testing subscriptions in a new region requires setting the preferred language.
-> Change the browser language preference, `intl.accept_languagues` in `about:config`.
+> Change the browser language preference, `intl.accept_languages` in `about:config`.
 > Use a Mozilla account created with that language preference.
 >
 > Do not use a language-switcher extension. Many extensions are not allowed to run on the

--- a/e2e-tests/pages/dashboardPage.ts
+++ b/e2e-tests/pages/dashboardPage.ts
@@ -15,7 +15,7 @@ export class DashboardPage {
   readonly userMenuButton: Locator;
   readonly signOutButton: Locator;
   readonly signOutToastAlert: Locator;
-  readonly bottomUgradeBanner: Locator;
+  readonly bottomUpgradeBanner: Locator;
   readonly relayExtensionBanner: Locator;
   readonly dashBoardWithoutMasks: Locator;
   readonly dashBoardWithoutMasksEmail: Locator;
@@ -116,7 +116,7 @@ export class DashboardPage {
     this.closeCornerTips = page.locator(
       '//button[starts-with(@class, "Tips_close-button")]',
     );
-    this.bottomUgradeBanner = page.locator(
+    this.bottomUpgradeBanner = page.locator(
       '//div[starts-with(@class, "profile_bottom-banner-wrapper")]',
     );
     this.relayExtensionBanner = page.locator(

--- a/emails/management/commands/check_health.py
+++ b/emails/management/commands/check_health.py
@@ -1,7 +1,7 @@
 """
 Check that a healthcheck JSON file exists and is recent.
 
-A healthcheck file with JSON is loaded. If the timestamp (a string, formated
+A healthcheck file with JSON is loaded. If the timestamp (a string, formatted
 like Python's datetime.isoformat) is too far in the past, it exits with a
 non-zero exit code. This makes it suitable for Kubernetes liveness checks of
 processes without a webservice.

--- a/emails/tests/cleaners_tests.py
+++ b/emails/tests/cleaners_tests.py
@@ -312,7 +312,7 @@ Users:
 
 @pytest.mark.django_db
 def test_missing_profile_cleaner_with_users() -> None:
-    """MissingProfileCleaner works when data is consistant."""
+    """MissingProfileCleaner works when data is consistent."""
     setup_profile_mismatch_test_data()
 
     task = MissingProfileCleaner()

--- a/phones/tests/models_tests.py
+++ b/phones/tests/models_tests.py
@@ -784,7 +784,7 @@ def test_save_store_phone_log_true_doesnt_delete_data() -> None:
     assert inbound_contact
 
 
-def _setup_phone_user_for_last_engagment(phone_user):
+def _setup_phone_user_for_last_engagement(phone_user):
     add_verified_realphone_to_user(phone_user)
     relay_number = RelayNumber.objects.create(user=phone_user, number="+12223334444")
 
@@ -797,7 +797,7 @@ def test_relaynumber_save_updates_last_engagement(phone_user):
     """
     Test that updating specific RelayNumber fields triggers last_engagement update.
     """
-    relay_number, initial_last_engagement = _setup_phone_user_for_last_engagment(
+    relay_number, initial_last_engagement = _setup_phone_user_for_last_engagement(
         phone_user
     )
 
@@ -817,7 +817,7 @@ def test_relaynumber_save_no_update_when_other_fields_change(phone_user):
     """
     Test that updating fields NOT in the tracked list does NOT update last_engagement.
     """
-    relay_number, initial_last_engagement = _setup_phone_user_for_last_engagment(
+    relay_number, initial_last_engagement = _setup_phone_user_for_last_engagement(
         phone_user
     )
 
@@ -848,7 +848,7 @@ def test_multiple_relaynumber_updates_trigger_last_engagement_once(phone_user):
     """
     Test that multiple updates to a tracked field still updates last_engagement.
     """
-    relay_number, initial_last_engagement = _setup_phone_user_for_last_engagment(
+    relay_number, initial_last_engagement = _setup_phone_user_for_last_engagement(
         phone_user
     )
 

--- a/privaterelay/country_utils.py
+++ b/privaterelay/country_utils.py
@@ -145,7 +145,7 @@ _LANGUAGE_TAG_TO_COUNTRY_OVERRIDE = {
     # Would be Catalan in Valencian script -> France
     # Change to Valencian -> Spain
     ("ca", "VALENCIA"): "ES",
-    # Spanish in UN region 419 (Latin America and Carribean)
+    # Spanish in UN region 419 (Latin America and Caribbean)
     # Pick Mexico, which has highest number of Spanish speakers
     ("es", "419"): "MX",
     # Would be Galician (Greenland) -> Greenland
@@ -229,7 +229,7 @@ def guess_country_from_accept_lang(accept_lang: str) -> str:
     try:
         return _PRIMARY_LANGUAGE_TO_COUNTRY[lang]
     except KeyError:
-        raise AcceptLanguageError("Unknown langauge", accept_lang)
+        raise AcceptLanguageError("Unknown language", accept_lang)
 
 
 def _get_cc_from_lang(accept_lang: str) -> str:

--- a/privaterelay/fxa_utils.py
+++ b/privaterelay/fxa_utils.py
@@ -139,16 +139,16 @@ def get_phone_subscription_dates(social_account):
         return None, None, None
 
     date_subscribed_phone = start_date = end_date = None
-    product_w_phone_capabilites = [settings.PHONE_PROD_ID, settings.BUNDLE_PROD_ID]
+    product_w_phone_capabilities = [settings.PHONE_PROD_ID, settings.BUNDLE_PROD_ID]
     for sub in subscription_data.get("subscriptions", []):
         # Even if a user upgrade subscription e.g. from monthly to yearly
         # or from phone to VPN bundle use the last subscription subscription dates
-        # Later, when the subscription details only show one valid subsription
+        # Later, when the subscription details only show one valid subscription
         # this information can be updated
         subscription_created_timestamp = None
         subscription_start_timestamp = None
         subscription_end_timestamp = None
-        if sub.get("product_id") in product_w_phone_capabilites:
+        if sub.get("product_id") in product_w_phone_capabilities:
             subscription_created_timestamp = sub.get("created")
             subscription_start_timestamp = sub.get("current_period_start")
             subscription_end_timestamp = sub.get("current_period_end")

--- a/privaterelay/management/commands/cleanup_data.py
+++ b/privaterelay/management/commands/cleanup_data.py
@@ -229,7 +229,7 @@ class Command(BaseCommand):
             totals[2] += query_timer
             totals[3] += clean_timer
 
-            # Details are ommited on low verbosity
+            # Details are omitted on low verbosity
             if verbosity <= 1:
                 continue
 

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -151,7 +151,7 @@ API_DOCS_ENABLED = config("API_DOCS_ENABLED", False, cast=bool) or DEBUG
 _CSP_SCRIPT_INLINE = USE_SILK
 
 # When running locally, styles might get refreshed while the server is running, so their
-# hashes would get oudated. Hence, we just allow all of them.
+# hashes would get outdated. Hence, we just allow all of them.
 _CSP_STYLE_INLINE = API_DOCS_ENABLED or RELAY_CHANNEL == "local"
 
 if API_DOCS_ENABLED:

--- a/privaterelay/tests/mgmt_sync_phone_related_dates_on_profile_tests.py
+++ b/privaterelay/tests/mgmt_sync_phone_related_dates_on_profile_tests.py
@@ -45,7 +45,7 @@ def test_no_accounts_with_phones(db: None) -> None:
 @pytest.fixture
 def patch_datetime_now() -> Iterator[datetime]:
     """
-    Selectively patch datatime.now() for emails models
+    Selectively patch datetime.now() for emails models
 
     https://docs.python.org/3/library/unittest.mock-examples.html#partial-mocking
     """

--- a/privaterelay/tests/mgmt_update_phone_remaining_stats_tests.py
+++ b/privaterelay/tests/mgmt_update_phone_remaining_stats_tests.py
@@ -46,7 +46,7 @@ def test_no_accounts_with_phones(db):
 @pytest.fixture
 def patch_datetime_now():
     """
-    Selectively patch datatime.now() for emails models
+    Selectively patch datetime.now() for emails models
 
     https://docs.python.org/3/library/unittest.mock-examples.html#partial-mocking
     """

--- a/privaterelay/tests/model_tests.py
+++ b/privaterelay/tests/model_tests.py
@@ -693,7 +693,7 @@ class ProfileUpdateAbuseMetricTest(ProfileTestCase):
         self.mocked_abuse_info = patcher_logger.start()
         self.addCleanup(patcher_logger.stop)
 
-        # Selectively patch datatime.now() for emails models
+        # Selectively patch datetime.now() for emails models
         # https://docs.python.org/3/library/unittest.mock-examples.html#partial-mocking
         patcher = patch("privaterelay.models.datetime")
         mocked_datetime = patcher.start()


### PR DESCRIPTION
Use [typos](https://github.com/crate-ci/typos) to fix some typos in comments and variable names. 

I avoided fixing typos in the frontend, like `mockReactIntersectionObsever` (should be `mockReactIntersectionObserver`). I can open those in a new PR if desired.