### PR TITLE
fix(ci): Fix version.json generation

### DIFF
--- a/.github/workflows/build-and-push-to-gar.yml
+++ b/.github/workflows/build-and-push-to-gar.yml
@@ -53,7 +53,7 @@ jobs:
           dockerfile_path: "./Dockerfile"
       - name: Push Container Image
         uses: mozilla-it/deploy-actions/docker-push@v5.1.0
-        if: ${{ github.event_name != 'pull_request' || github.ref_name == '5963/merge' }}
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           image_tags: ${{ steps.build.outputs.image_tags }}
           project_id: ${{ vars.GCP_MOZCLOUD_PROJECT_ID_PROD }}


### PR DESCRIPTION
The generated `version.json` for a non-tag release is invalid JSON, and doesn't include the build reference:

```
{"commit":"e7777ba5853d9b5b9f425757a865e7649cf0024c","version":"""","source":"https://github.com/mozilla/fx-private-relay","build":"https://github.com/mozilla/fx-private-relay/actions/runs/unknown"}
```

This includes two fixes:

* Change the env setting from `GIT_TAG=""`, setting it to a string of two quotes, to `GIT_TAG=`, an unquoted empty string. This will ensure `printf` doesn't include the quotes.
* ~Remove the `env.` prefixes~ switch to `github.` prefixes from the [github context](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context)