### PR TITLE
fix: Keep querystring when redirecting for slash (MPP-3448)

### DIFF
--- a/privaterelay/middleware.py
+++ b/privaterelay/middleware.py
@@ -4,6 +4,7 @@ import re
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime
+from urllib.parse import urlencode, urlsplit, urlunsplit
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
@@ -199,6 +200,44 @@ class RelayStaticFilesMiddleware(WhiteNoiseMiddleware):
         else:
             static_file = self.files.get(path_info)
         return static_file is not None
+
+    PRESERVE_QS_KEYS = set(
+        (
+            "utm_source",
+            "utm_campaign",
+            "utm_medium",
+            "utm_content",
+            "utm_term",
+        )
+    )
+
+    @staticmethod
+    def serve(static_file, request):
+        """Preserve some query params when redirecting."""
+        resp = WhiteNoiseMiddleware.serve(static_file, request)
+        if (
+            resp.status_code == 302
+            and (redirect_url := resp["location"])
+            and (request_qs_params := request.GET)
+            and (
+                response_qs_params := {
+                    key: val
+                    for key, val in request_qs_params.items()
+                    if key in RelayStaticFilesMiddleware.PRESERVE_QS_KEYS
+                }
+            )
+        ):
+            redirect_url_parts = urlsplit(redirect_url)
+            new_redirect_parts = (
+                redirect_url_parts.scheme,
+                redirect_url_parts.netloc,
+                redirect_url_parts.path,
+                urlencode(response_qs_params),
+                redirect_url_parts.fragment,
+            )
+            new_redirect_url = urlunsplit(new_redirect_parts)
+            resp["Location"] = new_redirect_url
+        return resp
 
 
 class GleanApiAccessMiddleware:


### PR DESCRIPTION
When [WhiteNoise](https://whitenoise.readthedocs.io/en/latest/) sees a URL like `/accounts/profile`, it recognizes it as a static file (`accounts/profile/index.html`), and redirects to `/accounts/profile/` with a trailing slash. This change adds the UTM parameters to the redirect URL. This will help when a campaign URL has the URL version without a slash.

## Testing

With this branch:

* `curl -I "http://127.0.0.1:8000/accounts/profile` has header `Location: profile/` (existing behavior)
* `curl -I "http://127.0.0.1:8000/accounts/profile?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=products"` has header `Location: profile/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=products` (fixed behavior)
* `curl -I "http://127.0.0.1:8000/accounts/profile?utm_source=www.mozilla.org&other=123abc"` has header `Location: profile/?utm_source=www.mozilla.org` (unknown headers are not retained)
