### PR TITLE
fix: Report the invalid product key (MPP-4460)

### DIFF
--- a/privaterelay/sp3_plans.py
+++ b/privaterelay/sp3_plans.py
@@ -201,7 +201,7 @@ def get_subscription_url(plan: PlanType, period: PeriodStr) -> str:
     if settings.IN_PYTEST:
         valid_keys.extend(TEST_PRODUCT_KEYS)
     if product_key not in valid_keys:
-        raise ValueError("'{product_key}' is not a ProductKey")
+        raise ValueError(f"'{product_key}' is not a ProductKey")
     return f"{settings.SUBPLAT3_HOST}/{product_key}/{period}/landing"
 
 


### PR DESCRIPTION
This exception is tracked as [RELAY-1CN](https://mozilla.sentry.io/issues/6869092354/?referrer=jira_integration), and has occurred 200 times in the dev environment when fetching runtime data. This change will allow debugging which plan is incorrect.