### PR TITLE
task: Add more context for FxA event issues (MPP-4460)

### DIFF
--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -574,6 +574,12 @@ def test_fxa_rp_events_delete_user(
     assert DeletedAddress.objects.filter(address_hash=da_address_hash).exists()
 
 
+def test_fxa_rp_events_no_auth_header(client: Client) -> None:
+    response = client.get("/fxa-rp-events")
+    assert response.status_code == 401
+    assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
 def test_version_view(client: Client, version_json_path: Path) -> None:
     version_info = {
         "commit": "a_commit_hash",


### PR DESCRIPTION
This PR adds more context to sentry exceptions around the FxA relying party endpoint and other FxA profile updates:

* Include the body and parsed JWT token for FxA relying party events. This will help with handling of new events and identifying problematic FxA accounts.
* Create Sentry issue for new FxA events. This will help us discover when FxA is sending new events.
* Include calling arguments for FxA profile updates. This will help in the case when a user requests a profile refresh, rather than the refresh being triggered by an FxA event
* When the FxA profile request returns a non-JSON response, create a sentry issue including the status code and body. This will help determine what we should do for these non-JSON responses.