### PR TITLE
build(mozcloud): enable more MozCloud deployments

### DIFF
--- a/.github/workflows/build-and-push-to-gar.yml
+++ b/.github/workflows/build-and-push-to-gar.yml
@@ -1,13 +1,15 @@
 name: Push container image to MozCloud GAR
 on:
-  pull_request: {}
-  push:
-    branches: [ main ]
-    tags: ['*']
+  workflow_call:
+    inputs:
+      image_tag_metadata:
+        required: false
+        description: Optional metadata to append to image tag
+        type: string
 
 jobs:
   build-and-push:
-    name: Build and push
+    name: Build and push Docker image
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -51,6 +53,7 @@ jobs:
             GIT_SHA=${{ github.sha }}
             GIT_TAG=${{ env.GIT_TAG }}
           dockerfile_path: "./Dockerfile"
+          image_tag_metadata: ${{ inputs.image_tag_metadata }}
       - name: Push Container Image
         uses: mozilla-it/deploy-actions/docker-push@v5.2.0
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/deploy-mozcloud.yml
+++ b/.github/workflows/deploy-mozcloud.yml
@@ -1,0 +1,26 @@
+name: Deploy to MozCloud environment
+on:
+  push:
+    branches: [ main ]
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        default: dev
+        type: string
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment to deploy
+        required: true
+        default: stage
+        type: choice
+        options:
+          - dev
+          - stage
+          - prod
+jobs:
+  build-and-deploy-dev:
+    uses: ./.github/workflows/build-and-push-to-gar.yml
+    with:
+      image_tag_metadata: ${{ inputs.environment }}


### PR DESCRIPTION
This PR fixes MPP-4458. See [this PR](https://github.com/mozilla/global-platform-admin/pull/4525) for corresponding work to make sure Argo pulls the images correctly.

Changes:
- Convert `build-and-push-to-gar.yml` into reusable workflow
- Deploy to `dev` on push to `main`
- Deploy to any environment via dispatch
- Updated `docs/` to reflect new deployment strategy.

Todo:
- [x] Add Slack notifications for deploys

How to test:

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

