### PR TITLE
fix(gha): fix workflow_dispatch conditions for MozCloud deploys

### DIFF
--- a/.github/workflows/deploy-mozcloud.yml
+++ b/.github/workflows/deploy-mozcloud.yml
@@ -1,7 +1,8 @@
 name: Deploy to MozCloud environment
 on:
   push:
-    branches: [ main ]
+    branches: [ '**' ]
+    tags: ['*']
   workflow_call:
     inputs:
       environment:
@@ -22,5 +23,10 @@ on:
 jobs:
   build-and-deploy-dev:
     uses: ./.github/workflows/build-and-push-to-gar.yml
+    # Allow this to run when a push to main happens
+    # or we call the dispatch
+    if: >
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'workflow_dispatch'
     with:
       image_tag_metadata: ${{ inputs.environment }}


### PR DESCRIPTION
This is a fix to the [earlier dispatch PR](https://github.com/mozilla/fx-private-relay/pull/5991) that will allow us to actually run the `workflow_dispatch` from branches other than `main`.

This is the current behavior:
<img width="413" height="316" alt="Screenshot 2025-10-27 at 11 16 59 AM" src="https://github.com/user-attachments/assets/60cbc376-dd05-445f-8678-09fd982839ad" />

Instead we want to be able to run this from any tag/branch.


How to test:

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
