### PR TITLE
fix(deploy): Properly set defaults for dev deploy from push

### DIFF
--- a/.github/workflows/build-and-push-to-gar.yml
+++ b/.github/workflows/build-and-push-to-gar.yml
@@ -3,8 +3,9 @@ on:
   workflow_call:
     inputs:
       image_tag_metadata:
-        required: false
-        description: Optional metadata to append to image tag
+        required: true
+        description: Metadata to append to image tag to set the environment
+        default: dev
         type: string
 
 jobs:

--- a/.github/workflows/deploy-mozcloud.yml
+++ b/.github/workflows/deploy-mozcloud.yml
@@ -3,12 +3,6 @@ on:
   push:
     branches: [ '**' ]
     tags: ['*']
-  workflow_call:
-    inputs:
-      environment:
-        required: true
-        default: dev
-        type: string
   workflow_dispatch:
     inputs:
       environment:
@@ -29,4 +23,4 @@ jobs:
       github.ref == 'refs/heads/main' ||
       github.event_name == 'workflow_dispatch'
     with:
-      image_tag_metadata: ${{ inputs.environment }}
+      image_tag_metadata: ${{ inputs.environment || 'dev' }}


### PR DESCRIPTION
This PR fixes an issue with `--dev` not being properly added to the container image tag when we push to `main`.
<img width="565" height="29" alt="Screenshot 2025-10-27 at 3 51 27 PM" src="https://github.com/user-attachments/assets/20d53e1d-a0d5-4961-a787-b2cee6007aa2" />

I misunderstood how the `workflow_call` option is used. It doesn't need to be part of the "Deploy to MozCloud" action, the `job.uses` will be enough to run the `build-and-push-to-gar`, and we can set the default in there for the case where we haven't manually specified the environment during a `workflow_dispatch`.

I ran a temporary test by having the logic check this branch instead of `main`. Tagging now works properly:
<img width="459" height="117" alt="Screenshot 2025-10-27 at 4 17 45 PM" src="https://github.com/user-attachments/assets/ee0455db-7f21-49d2-be01-30e84ee2142c" />


How to test:

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).