### PR TITLE
MPP-4453: hide Firefox extension banner when already using Firefox on mobile

### DIFF
--- a/frontend/src/components/dashboard/ProfileBanners.tsx
+++ b/frontend/src/components/dashboard/ProfileBanners.tsx
@@ -64,7 +64,7 @@ export const ProfileBanners = (props: Props) => {
 
   // Don't show the "Get Firefox" banner if we have an extension available,
   // to avoid banner overload:
-  if (!isUsingFirefox() || !isLargeScreen) {
+  if (!isUsingFirefox()) {
     banners.push(<NoFirefoxBanner key="firefox-banner" />);
   }
 


### PR DESCRIPTION
# This PR fixes [MPP-4453](https://mozilla-hub.atlassian.net/browse/MPP-4453)

# How to test:
- using Firefox browser, change settings to mobile and notice banner is no longer there 

# Screenshots 
## Before 
<img width="531" height="1051" alt="Screenshot 2025-10-30 at 7 45 04 AM" src="https://github.com/user-attachments/assets/eedebb51-3402-47d3-8928-80dcd88dbde8" />

## After 
<img width="505" height="1024" alt="Screenshot 2025-10-30 at 7 42 11 AM" src="https://github.com/user-attachments/assets/a9ee5598-bd92-4a9a-b27c-012d0516bd96" />

- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

[MPP-4453]: https://mozilla-hub.atlassian.net/browse/MPP-4453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ