### PR TITLE
MPP-4184: test(premium-sub): increasing frontend test coverage

### DIFF
--- a/frontend/__mocks__/components/IconsMock.tsx
+++ b/frontend/__mocks__/components/IconsMock.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+const Svg = (props: React.SVGProps<SVGSVGElement> & { alt?: string }) => {
+  const ariaLabel = props["aria-label"] || props.alt;
+  const { alt, ...svgProps } = props;
+  return (
+    <svg data-testid="svg-icon" {...svgProps} aria-label={ariaLabel}>
+      {ariaLabel && <title>{ariaLabel}</title>}
+    </svg>
+  );
+};
+
+export const MaskIcon = Svg;
+export const PhoneIcon = Svg;
+export const VpnIcon = Svg;
+
+export const ChevronLeftIcon = Svg;
+export const ChevronRightIcon = Svg;
+export const QuotationIcon = Svg;
+
+export const StarIcon = Svg;

--- a/frontend/__mocks__/components/ImageMock.tsx
+++ b/frontend/__mocks__/components/ImageMock.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+type ImgSrc = { src: string } | string;
+type ImageProps = { alt?: string; src: ImgSrc; className?: string };
+
+const ImageMock: React.FC<ImageProps> = ({ alt, src, className }) => {
+  const resolved = typeof src === "string" ? src : src.src;
+  return (
+    <img
+      alt={alt ?? ""}
+      src={resolved}
+      className={className}
+      data-testid="mocked-image"
+    />
+  );
+};
+
+export default ImageMock;

--- a/frontend/__mocks__/components/landingImages.mocks.ts
+++ b/frontend/__mocks__/components/landingImages.mocks.ts
@@ -1,0 +1,102 @@
+// BundleBanner
+jest.mock(
+  "../../src/components/landing/images/bundle-banner-woman-400w.png",
+  () => ({ __esModule: true, default: "/img400.png" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/bundle-banner-woman-768w.png",
+  () => ({ __esModule: true, default: "/img768.png" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/bundle-float-1.svg",
+  () => ({ __esModule: true, default: "/float1.svg" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/bundle-float-2.svg",
+  () => ({ __esModule: true, default: "/float2.svg" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/bundle-float-3.svg",
+  () => ({ __esModule: true, default: "/float3.svg" }),
+  { virtual: true },
+);
+
+// HighlightedFeatures
+jest.mock(
+  "../../src/components/landing/images/highlighted-features/features-unlimited-email-masks.svg",
+  () => ({ __esModule: true, default: "/unlimited.svg" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/highlighted-features/features-instantly-masks-on-the-go.svg",
+  () => ({ __esModule: true, default: "/on-the-go.svg" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/highlighted-features/features-reply-to-emails-anon.svg",
+  () => ({ __esModule: true, default: "/reply.svg" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/highlighted-features/features-block-promotional-emails.svg",
+  () => ({ __esModule: true, default: "/block.svg" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/highlighted-features/features-remove-email-trackers.svg",
+  () => ({ __esModule: true, default: "/remove.svg" }),
+  { virtual: true },
+);
+
+// DemoPhone
+jest.mock(
+  "../../src/components/landing/images/hero-image-bg.svg",
+  () => ({ __esModule: true, default: "/bg.svg" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/hero-image-premium.svg",
+  () => ({ __esModule: true, default: "/premium.svg" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/hero-image-premium-fr.svg",
+  () => ({ __esModule: true, default: "/premium-fr.svg" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/hero-image-premium-de.svg",
+  () => ({ __esModule: true, default: "/premium-de.svg" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/hero-image-nopremium.svg",
+  () => ({ __esModule: true, default: "/nopremium.svg" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/hero-image-fg.svg",
+  () => ({ __esModule: true, default: "/fg.svg" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/hero-image-fg-de.svg",
+  () => ({ __esModule: true, default: "/fg-de.svg" }),
+  { virtual: true },
+);
+jest.mock(
+  "../../src/components/landing/images/hero-image-fg-fr.svg",
+  () => ({ __esModule: true, default: "/fg-fr.svg" }),
+  { virtual: true },
+);
+
+// Reviews
+jest.mock(
+  "../../src/components/landing/images/fx-logo.svg",
+  () => ({ __esModule: true, default: "/fx-logo.svg" }),
+  { virtual: true },
+);

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,4 +1,158 @@
+import React from "react";
 import "@testing-library/jest-dom";
 import { toHaveNoViolations } from "jest-axe";
+import "./__mocks__/components/landingImages.mocks";
+
+import { mockGetLocaleModule } from "./__mocks__/functions/getLocale";
+import { mockUseL10nModule } from "./__mocks__/hooks/l10n";
+
+if (!("IntersectionObserver" in global)) {
+  class MockIntersectionObserver {
+    readonly root: Element | null = null;
+    readonly rootMargin: string = "0px";
+    readonly thresholds: ReadonlyArray<number> = [0];
+
+    constructor(
+      _cb: IntersectionObserverCallback,
+      _options?: IntersectionObserverInit,
+    ) {}
+
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+  }
+
+  // @ts-expect-error attach to both
+  global.IntersectionObserver = MockIntersectionObserver;
+  if (typeof window !== "undefined") {
+    window.IntersectionObserver = MockIntersectionObserver;
+  }
+}
+
+jest.mock("./src/components/Image", () => ({
+  __esModule: true,
+  default: require("./__mocks__/components/ImageMock").default,
+}));
+
+jest.mock(require.resolve("./src/components/Icons"), () => {
+  const Svg = (props: React.SVGProps<SVGSVGElement> & { alt?: string }) => {
+    const ariaLabel = props["aria-label"] || props.alt;
+    const { alt, ...svgProps } = props;
+    return React.createElement(
+      "svg",
+      {
+        "data-testid": "svg-icon",
+        "aria-label": ariaLabel,
+        ...svgProps,
+      },
+      ariaLabel ? React.createElement("title", {}, ariaLabel) : null,
+    );
+  };
+
+  const moduleObj = new Proxy({ __esModule: true } as Record<string, any>, {
+    get: (_target, _prop) => Svg,
+  });
+
+  moduleObj.default = new Proxy({}, { get: () => Svg });
+
+  return moduleObj;
+});
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  var gaEventMock: jest.Mock<any, any>;
+  var getLocaleMock: jest.Mock<string, unknown[]>;
+  var useL10nImpl: () => ReturnType<typeof mockUseL10nModule.useL10n>;
+}
+
+beforeEach(() => {
+  global.gaEventMock = jest.fn();
+
+  global.getLocaleMock = mockGetLocaleModule.getLocale as unknown as jest.Mock;
+  global.getLocaleMock.mockReturnValue("en-GB");
+
+  global.useL10nImpl = mockUseL10nModule.useL10n;
+});
+
+jest.mock(require.resolve("./src/hooks/gaEvent"), () => ({
+  __esModule: true,
+  useGaEvent: () => global.gaEventMock,
+}));
+
+jest.mock(require.resolve("./src/hooks/gaViewPing"), () => ({
+  __esModule: true,
+  useGaViewPing: () => React.createRef<HTMLAnchorElement>(),
+}));
+
+jest.mock(require.resolve("./src/functions/getLocale"), () => ({
+  __esModule: true,
+  getLocale: (...args: unknown[]) => global.getLocaleMock(...args),
+}));
+
+jest.mock(require.resolve("./src/hooks/l10n"), () => ({
+  __esModule: true,
+  useL10n: () => global.useL10nImpl(),
+}));
+
+// Next.js router mock
+jest.mock(
+  "next/router",
+  () => require("./__mocks__/modules/next__router").mockNextRouter,
+);
+
+// Next.js Link component mock
+jest.mock("next/link", () => {
+  return {
+    __esModule: true,
+    default: ({ href, children, ...props }: any) =>
+      React.createElement("a", { href, ...props }, children),
+  };
+});
+
+// Google Analytics mock
+jest.mock(
+  "react-ga",
+  () => require("./__mocks__/modules/react-ga").mockReactGa,
+);
+
+// Localized component mock
+jest.mock(
+  require.resolve("./src/components/Localized"),
+  () => require("./__mocks__/components/Localized").mockLocalizedModule,
+);
+
+// Config module mock
+jest.mock(
+  require.resolve("./src/config"),
+  () => require("./__mocks__/configMock").mockConfigModule,
+);
+
+// FxA Flow Tracker mock
+jest.mock(
+  require.resolve("./src/hooks/fxaFlowTracker"),
+  () => require("./__mocks__/hooks/fxaFlowTracker").mockUseFxaFlowTrackerModule,
+);
+
+// React Intersection Observer mock
+jest.mock(
+  "react-intersection-observer",
+  () =>
+    require("./__mocks__/modules/react-intersection-observer")
+      .mockReactIntersectionObsever,
+);
+
+// React Toastify mock
+jest.mock("react-toastify", () => ({
+  toast: jest.fn(),
+  ToastContainer: () => null,
+}));
+
+// Waffle flags mock
+jest.mock(require.resolve("./src/functions/waffle"), () =>
+  require("./__mocks__/functions/waffle"),
+);
 
 expect.extend(toHaveNoViolations);

--- a/frontend/src/components/Banner.test.tsx
+++ b/frontend/src/components/Banner.test.tsx
@@ -1,12 +1,7 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Image from "../components/Image";
 import FirefoxLogo from "./dashboard/images/fx-logo.svg";
-
-jest.mock("../hooks/l10n.ts", () => mockUseL10nModule);
-
-import { mockUseL10nModule } from "../../__mocks__/hooks/l10n";
 
 import { Banner } from "./Banner";
 

--- a/frontend/src/components/GoogleAnalyticsWorkaround.test.tsx
+++ b/frontend/src/components/GoogleAnalyticsWorkaround.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  GoogleAnalyticsWorkaround,
+  sendGAEvent,
+} from "./GoogleAnalyticsWorkaround";
+
+// Mock Next.js Script component
+jest.mock("next/script", () => {
+  return function Script(props: {
+    id: string;
+    dangerouslySetInnerHTML?: { __html: string };
+    src?: string;
+    nonce?: string;
+  }) {
+    if (props.dangerouslySetInnerHTML) {
+      return (
+        // eslint-disable-next-line @next/next/no-sync-scripts
+        <script
+          id={props.id}
+          data-testid={props.id}
+          data-nonce={props.nonce}
+          dangerouslySetInnerHTML={props.dangerouslySetInnerHTML}
+        />
+      );
+    }
+    return (
+      // eslint-disable-next-line @next/next/no-sync-scripts
+      <script
+        id={props.id}
+        data-testid={props.id}
+        src={props.src}
+        data-nonce={props.nonce}
+      />
+    );
+  };
+});
+
+describe("GoogleAnalyticsWorkaround", () => {
+  let performanceMarkSpy: jest.SpyInstance | undefined;
+
+  beforeEach(() => {
+    // Mock performance.mark if it doesn't exist
+    if (typeof performance.mark !== "function") {
+      performance.mark = jest.fn();
+    }
+    performanceMarkSpy = jest.spyOn(performance, "mark");
+  });
+
+  afterEach(() => {
+    performanceMarkSpy?.mockRestore();
+  });
+
+  it("renders both GA scripts with the provided gaId", () => {
+    render(<GoogleAnalyticsWorkaround gaId="G-TEST123" />);
+
+    const initScript = screen.getByTestId("_next-ga-init");
+    const mainScript = screen.getByTestId("_next-ga");
+
+    expect(initScript).toBeInTheDocument();
+    expect(mainScript).toBeInTheDocument();
+    expect(mainScript).toHaveAttribute(
+      "src",
+      "https://www.googletagmanager.com/gtag/js?id=G-TEST123",
+    );
+  });
+
+  it("uses default dataLayer name when not specified", () => {
+    render(<GoogleAnalyticsWorkaround gaId="G-TEST123" />);
+
+    const initScript = screen.getByTestId("_next-ga-init");
+    const scriptContent = initScript.innerHTML;
+
+    expect(scriptContent).toContain("window['dataLayer']");
+  });
+
+  it("uses custom dataLayer name when specified", () => {
+    render(
+      <GoogleAnalyticsWorkaround
+        gaId="G-TEST123"
+        dataLayerName="customLayer"
+      />,
+    );
+
+    const initScript = screen.getByTestId("_next-ga-init");
+    const scriptContent = initScript.innerHTML;
+
+    expect(scriptContent).toContain("window['customLayer']");
+  });
+
+  it("passes nonce to both scripts when provided", () => {
+    render(
+      <GoogleAnalyticsWorkaround gaId="G-TEST123" nonce="test-nonce-123" />,
+    );
+
+    const initScript = screen.getByTestId("_next-ga-init");
+    const mainScript = screen.getByTestId("_next-ga");
+
+    expect(initScript).toHaveAttribute("data-nonce", "test-nonce-123");
+    expect(mainScript).toHaveAttribute("data-nonce", "test-nonce-123");
+  });
+
+  it("sets debug_mode to undefined by default", () => {
+    render(<GoogleAnalyticsWorkaround gaId="G-TEST123" />);
+
+    const initScript = screen.getByTestId("_next-ga-init");
+    const scriptContent = initScript.innerHTML;
+
+    expect(scriptContent).toContain("'debug_mode': undefined");
+  });
+
+  it("sets debug_mode to true when debugMode prop is true", () => {
+    render(<GoogleAnalyticsWorkaround gaId="G-TEST123" debugMode={true} />);
+
+    const initScript = screen.getByTestId("_next-ga-init");
+    const scriptContent = initScript.innerHTML;
+
+    expect(scriptContent).toContain("'debug_mode': true");
+  });
+
+  it("calls performance.mark with correct feature usage", () => {
+    render(<GoogleAnalyticsWorkaround gaId="G-TEST123" />);
+
+    expect(performanceMarkSpy).toHaveBeenCalledWith("mark_feature_usage", {
+      detail: {
+        feature: "next-third-parties-ga",
+      },
+    });
+  });
+
+  it("does not crash when performance.mark is not available", () => {
+    // Clear the spy and remove performance.mark temporarily
+    performanceMarkSpy?.mockRestore();
+    const originalMark = performance.mark;
+    // @ts-expect-error Testing missing API
+    delete performance.mark;
+
+    // Should not throw an error
+    expect(() => {
+      render(<GoogleAnalyticsWorkaround gaId="G-TEST123" />);
+    }).not.toThrow();
+
+    // Restore
+    performance.mark = originalMark;
+    performanceMarkSpy = jest.spyOn(performance, "mark");
+  });
+
+  it("includes gtag configuration with the provided gaId", () => {
+    render(<GoogleAnalyticsWorkaround gaId="G-CUSTOM456" />);
+
+    const initScript = screen.getByTestId("_next-ga-init");
+    const scriptContent = initScript.innerHTML;
+
+    expect(scriptContent).toContain("gtag('config', 'G-CUSTOM456'");
+  });
+});
+
+describe("sendGAEvent", () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("returns early in test environment without calling gtag", () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "test";
+
+    sendGAEvent("event", "test_event", { test: "data" });
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    process.env.NODE_ENV = originalEnv;
+  });
+});

--- a/frontend/src/components/GoogleAnalyticsWorkaround.tsx
+++ b/frontend/src/components/GoogleAnalyticsWorkaround.tsx
@@ -29,9 +29,6 @@ import { GAParams } from "@next/third-parties/dist/types/google";
 import Script, { ScriptProps } from "next/script";
 import { useEffect } from "react";
 
-// We don't send Analytics events in tests:
-/* c8 ignore start */
-
 let currDataLayerName: string | undefined = undefined;
 
 /**
@@ -105,4 +102,3 @@ export const sendGAEvent = (type: "event", eventName: string, args: object) => {
     );
   }
 };
-/* c8 ignore stop */

--- a/frontend/src/components/Icons.test.tsx
+++ b/frontend/src/components/Icons.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+
+// Import the actual Icons module, not the mock
+const IconsModule = jest.requireActual("./Icons");
+const InfoIcon = IconsModule.InfoIcon;
+const WarningFilledIcon = IconsModule.WarningFilledIcon;
+const ArrowDownIcon = IconsModule.ArrowDownIcon;
+const CheckIcon = IconsModule.CheckIcon;
+const CloseIcon = IconsModule.CloseIcon;
+const CopyIcon = IconsModule.CopyIcon;
+
+describe("Icons", () => {
+  describe("InfoIcon", () => {
+    it("renders with alt text", () => {
+      render(<InfoIcon alt="Information" />);
+      const icon = screen.getByRole("img", { name: "Information" });
+      expect(icon).toBeInTheDocument();
+    });
+
+    it("is hidden from screen readers when alt is empty", () => {
+      const { container } = render(<InfoIcon alt="" />);
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      const svg = container.querySelector("svg");
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("has proper viewBox and dimensions", () => {
+      const { container } = render(<InfoIcon alt="Info" />);
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      const svg = container.querySelector("svg");
+      expect(svg).toHaveAttribute("viewBox", "0 0 28 28");
+      expect(svg).toHaveAttribute("width", "28");
+      expect(svg).toHaveAttribute("height", "28");
+    });
+  });
+
+  describe("WarningFilledIcon", () => {
+    it("renders with alt text", () => {
+      render(<WarningFilledIcon alt="Warning" />);
+      const icon = screen.getByRole("img", { name: "Warning" });
+      expect(icon).toBeInTheDocument();
+    });
+
+    it("is hidden from screen readers when alt is empty", () => {
+      const { container } = render(<WarningFilledIcon alt="" />);
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      const svg = container.querySelector("svg");
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+
+  describe("ArrowDownIcon", () => {
+    it("renders with alt text", () => {
+      render(<ArrowDownIcon alt="Expand" />);
+      const icon = screen.getByRole("img", { name: "Expand" });
+      expect(icon).toBeInTheDocument();
+    });
+  });
+
+  describe("CheckIcon", () => {
+    it("renders with alt text", () => {
+      render(<CheckIcon alt="Success" />);
+      const icon = screen.getByRole("img", { name: "Success" });
+      expect(icon).toBeInTheDocument();
+    });
+  });
+
+  describe("CloseIcon", () => {
+    it("renders with alt text", () => {
+      render(<CloseIcon alt="Close" />);
+      const icon = screen.getByRole("img", { name: "Close" });
+      expect(icon).toBeInTheDocument();
+    });
+  });
+
+  describe("CopyIcon", () => {
+    it("renders with alt text", () => {
+      render(<CopyIcon alt="Copy" />);
+      const icon = screen.getByRole("img", { name: "Copy" });
+      expect(icon).toBeInTheDocument();
+    });
+  });
+
+  describe("Icon accessibility", () => {
+    it("all icons include title element for accessibility", () => {
+      const { container: infoContainer } = render(<InfoIcon alt="Info" />);
+      const { container: warningContainer } = render(
+        <WarningFilledIcon alt="Warning" />,
+      );
+
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      const infoTitle = infoContainer.querySelector("title");
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      const warningTitle = warningContainer.querySelector("title");
+
+      expect(infoTitle).toHaveTextContent("Info");
+      expect(warningTitle).toHaveTextContent("Warning");
+    });
+
+    it("passes custom props to svg element", () => {
+      const { container } = render(
+        <InfoIcon
+          alt="Info"
+          data-testid="custom-icon"
+          className="custom-class"
+        />,
+      );
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      const svg = container.querySelector("svg");
+
+      expect(svg).toHaveAttribute("data-testid", "custom-icon");
+      // Check if className baseVal contains the custom class
+      expect(svg?.getAttribute("class")).toContain("custom-class");
+    });
+  });
+});

--- a/frontend/src/components/Image.test.tsx
+++ b/frontend/src/components/Image.test.tsx
@@ -1,0 +1,128 @@
+import { render } from "@testing-library/react";
+
+// Import the actual Image module
+const ImageModule = jest.requireActual("./Image");
+const Image = ImageModule.default;
+
+// Mock next/image's getImageProps to return predictable props
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: jest.fn(),
+  getImageProps: jest.fn((props) => {
+    // Simulate what Next.js does - it might add inline styles
+    const { alt, src, width, height, ...rest } = props;
+    return {
+      props: {
+        src,
+        alt,
+        width,
+        height,
+        style: props.mockStyle || { color: "transparent" }, // Default to the transparent style
+        className: props.mockClassName || "",
+        ...rest,
+      },
+    };
+  }),
+}));
+
+describe("Image", () => {
+  it("renders an img element with basic props", () => {
+    const { container } = render(
+      <Image src="/test.png" alt="Test image" width={100} height={100} />,
+    );
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const img = container.querySelector("img");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "/test.png");
+    expect(img).toHaveAttribute("alt", "Test image");
+  });
+
+  it("converts color:transparent inline style to CSS class", () => {
+    const { container } = render(
+      <Image
+        src="/test.png"
+        alt="Test"
+        width={100}
+        height={100}
+        // @ts-expect-error - mockStyle is for testing
+        mockStyle={{ color: "transparent" }}
+      />,
+    );
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const img = container.querySelector("img");
+    expect(img?.className).toContain("transparent");
+  });
+
+  it("preserves existing className when adding transparent class", () => {
+    const { container } = render(
+      <Image
+        src="/test.png"
+        alt="Test"
+        width={100}
+        height={100}
+        // @ts-expect-error - mockClassName is for testing
+        mockClassName="existing-class"
+        // @ts-expect-error - mockStyle is for testing
+        mockStyle={{ color: "transparent" }}
+      />,
+    );
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const img = container.querySelector("img");
+    expect(img?.className).toContain("existing-class");
+    expect(img?.className).toContain("transparent");
+  });
+
+  it("does not add inline style attribute when converting to class", () => {
+    const { container } = render(
+      <Image
+        src="/test.png"
+        alt="Test"
+        width={100}
+        height={100}
+        // @ts-expect-error - mockStyle is for testing
+        mockStyle={{ color: "transparent" }}
+      />,
+    );
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const img = container.querySelector("img");
+    expect(img).not.toHaveAttribute("style");
+  });
+
+  it("renders without className when no style and no existing className", () => {
+    const { container } = render(
+      <Image
+        src="/test.png"
+        alt="Test"
+        width={100}
+        height={100}
+        // @ts-expect-error - mockStyle is for testing
+        mockStyle={{}}
+        // @ts-expect-error - mockClassName is for testing
+        mockClassName=""
+      />,
+    );
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const img = container.querySelector("img");
+    expect(img).not.toHaveAttribute("class");
+  });
+
+  it("preserves alt text correctly", () => {
+    const { container } = render(
+      <Image
+        src="/test.png"
+        alt="Descriptive alt text"
+        width={100}
+        height={100}
+      />,
+    );
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const img = container.querySelector("img");
+    expect(img).toHaveAttribute("alt", "Descriptive alt text");
+  });
+});

--- a/frontend/src/components/dashboard/CornerNotification.test.tsx
+++ b/frontend/src/components/dashboard/CornerNotification.test.tsx
@@ -7,9 +7,7 @@ import {
   mockedProfiles,
   mockedRelayaddresses,
 } from "frontend/__mocks__/api/mockData";
-import { useL10n } from "frontend/src/hooks/l10n";
 import { useLocalDismissal } from "frontend/src/hooks/localDismissal";
-import { useGaEvent } from "frontend/src/hooks/gaEvent";
 
 jest.mock("frontend/src/functions/waffle", () => {
   const { mockIsFlagActive } = jest.requireActual(
@@ -23,17 +21,8 @@ import {
   resetFlags,
 } from "frontend/__mocks__/functions/flags";
 
-jest.mock("frontend/src/hooks/l10n", () => ({
-  useL10n: jest.fn(),
-}));
 jest.mock("frontend/src/hooks/localDismissal", () => ({
   useLocalDismissal: jest.fn(),
-}));
-jest.mock("frontend/src/hooks/gaEvent", () => ({
-  useGaEvent: jest.fn(),
-}));
-jest.mock("frontend/src/hooks/gaViewPing", () => ({
-  useGaViewPing: jest.fn(() => React.createRef()),
 }));
 
 beforeAll(() => {
@@ -73,12 +62,11 @@ describe("CornerNotification", () => {
     mockIsFlagActive.mockReset();
     mockIsFlagActive.mockImplementation(() => true);
 
-    (useL10n as jest.Mock).mockReturnValue(mockL10n);
+    global.useL10nImpl = () => mockL10n;
     (useLocalDismissal as jest.Mock).mockReturnValue({
       isDismissed: false,
       dismiss: mockDismiss,
     });
-    (useGaEvent as jest.Mock).mockReturnValue(jest.fn());
     mockL10n.getString.mockClear();
   });
 
@@ -153,7 +141,7 @@ describe("CornerNotification", () => {
   it("fires GA event when CTA is clicked", async () => {
     const user = userEvent.setup();
     const mockGaEvent = jest.fn();
-    (useGaEvent as jest.Mock).mockReturnValue(mockGaEvent);
+    global.gaEventMock = mockGaEvent;
     render(<CornerNotification {...defaultProps} />);
     const cta = screen.getByRole("link", {
       name: "upsell-banner-4-masks-us-cta",

--- a/frontend/src/components/dashboard/EmailForwardingModal.test.tsx
+++ b/frontend/src/components/dashboard/EmailForwardingModal.test.tsx
@@ -1,18 +1,10 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { EmailForwardingModal, Props } from "./EmailForwardingModal";
-import { useL10n } from "../../hooks/l10n";
 import { aliasEmailTest } from "../../hooks/api/aliases";
-import { useGaEvent } from "../../hooks/gaEvent";
 
-jest.mock("../../hooks/l10n", () => ({
-  useL10n: jest.fn(),
-}));
 jest.mock("../../hooks/api/aliases", () => ({
   aliasEmailTest: jest.fn(),
-}));
-jest.mock("../../hooks/gaEvent", () => ({
-  useGaEvent: jest.fn(),
 }));
 
 const mockGetString = jest.fn((id) => id);
@@ -28,8 +20,8 @@ const defaultProps: Props = {
 
 describe("EmailForwardingModal", () => {
   beforeEach(() => {
-    (useL10n as jest.Mock).mockReturnValue({ getString: mockGetString });
-    (useGaEvent as jest.Mock).mockReturnValue(mockGaEvent);
+    global.useL10nImpl = () => ({ getString: mockGetString });
+    global.gaEventMock = mockGaEvent;
     jest.clearAllMocks();
   });
 

--- a/frontend/src/components/dashboard/FreeOnboarding.test.tsx
+++ b/frontend/src/components/dashboard/FreeOnboarding.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FreeOnboarding, Props } from "./FreeOnboarding";
-import { useL10n } from "../../hooks/l10n";
 import { RandomAliasData, AliasData } from "../../hooks/api/aliases";
 import { ProfileData } from "../../hooks/api/profile";
 import { UserData } from "../../hooks/api/user";
@@ -10,18 +9,6 @@ jest.mock("next/config", () => () => ({
   publicRuntimeConfig: {
     maxOnboardingAvailable: 3,
   },
-}));
-
-jest.mock("../../hooks/l10n", () => ({
-  useL10n: jest.fn(),
-}));
-
-jest.mock("../../hooks/gaEvent", () => ({
-  useGaEvent: jest.fn(() => jest.fn()),
-}));
-
-jest.mock("../../hooks/gaViewPing", () => ({
-  useGaViewPing: jest.fn(() => null),
 }));
 
 jest.mock("../../functions/userAgent", () => ({
@@ -54,10 +41,6 @@ const mockAlias: AliasData = {
 } as RandomAliasData;
 
 const mockL10nGetString = jest.fn((key) => key);
-(useL10n as jest.Mock).mockReturnValue({
-  getString: mockL10nGetString,
-  bundles: [{ locales: ["en"] }],
-});
 
 const baseProps: Props = {
   profile: {
@@ -80,6 +63,10 @@ const baseProps: Props = {
 describe("FreeOnboarding", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    global.useL10nImpl = () => ({
+      getString: mockL10nGetString,
+      bundles: [{ locales: ["en"] }],
+    });
   });
 
   it("renders Step 1 and handles mask creation", async () => {

--- a/frontend/src/components/dashboard/Onboarding.test.tsx
+++ b/frontend/src/components/dashboard/Onboarding.test.tsx
@@ -2,21 +2,6 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Props } from "./Onboarding";
 import type { AliasData } from "../../hooks/api/aliases";
-
-jest.mock("../Image", () => ({
-  __esModule: true,
-  default: ({ src, alt }: { src: string; alt: string }) => (
-    <img src={src} alt={alt} data-testid="mocked-image" />
-  ),
-}));
-
-jest.mock("../../hooks/l10n", () => {
-  const { mockUseL10nModule } = jest.requireActual(
-    "../../../__mocks__/hooks/l10n",
-  );
-  return mockUseL10nModule;
-});
-
 import { Onboarding } from "./Onboarding";
 
 describe("Onboarding", () => {

--- a/frontend/src/components/dashboard/PremiumOnboarding.test.tsx
+++ b/frontend/src/components/dashboard/PremiumOnboarding.test.tsx
@@ -2,18 +2,10 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PremiumOnboarding } from "./PremiumOnboarding";
 import { mockedProfiles } from "../../../__mocks__/api/mockData";
-import { useL10n } from "../../hooks/l10n";
 import { supportsFirefoxExtension } from "../../functions/userAgent";
 import { useMinViewportWidth } from "../../hooks/mediaQuery";
 import { renderWithProviders } from "frontend/__mocks__/modules/renderWithProviders";
 
-jest.mock("../../hooks/l10n");
-jest.mock("../../hooks/gaViewPing", () => ({
-  useGaViewPing: () => undefined,
-}));
-jest.mock("../../hooks/gaEvent", () => ({
-  useGaEvent: () => jest.fn(),
-}));
 jest.mock("../../functions/userAgent");
 jest.mock("../../hooks/mediaQuery");
 jest.mock("../../config", () => ({
@@ -26,7 +18,7 @@ describe("PremiumOnboarding", () => {
   const mockL10nGetString = jest.fn((id: string) => id);
 
   beforeEach(() => {
-    (useL10n as jest.Mock).mockReturnValue({
+    global.useL10nImpl = () => ({
       getString: mockL10nGetString,
     });
 

--- a/frontend/src/components/dashboard/SubdomainPicker.test.tsx
+++ b/frontend/src/components/dashboard/SubdomainPicker.test.tsx
@@ -1,14 +1,9 @@
 import { render, screen, act } from "@testing-library/react";
 import { SubdomainPicker } from "./SubdomainPicker";
 import { mockedProfiles } from "../../../__mocks__/api/mockData";
-import { useL10n } from "../../hooks/l10n";
 import { getRuntimeConfig } from "../../config";
 import { SubdomainSearchForm } from "./subdomain/SearchForm";
 import { SubdomainConfirmationModal } from "./subdomain/ConfirmationModal";
-
-jest.mock("../../hooks/l10n", () => ({
-  useL10n: jest.fn(),
-}));
 
 jest.mock("../../hooks/flaggedAnchorLinks", () => ({
   useFlaggedAnchorLinks: jest.fn(),
@@ -37,7 +32,7 @@ describe("SubdomainPicker", () => {
   };
 
   beforeEach(() => {
-    (useL10n as jest.Mock).mockReturnValue(mockL10nStrings);
+    global.useL10nImpl = () => mockL10nStrings;
     (getRuntimeConfig as jest.Mock).mockReturnValue({
       mozmailDomain: "mozmail.com",
     });

--- a/frontend/src/components/dashboard/aliases/BlockLevelSlider.test.tsx
+++ b/frontend/src/components/dashboard/aliases/BlockLevelSlider.test.tsx
@@ -4,32 +4,6 @@ import React from "react";
 import { BlockLevelSlider, type BlockLevel } from "./BlockLevelSlider";
 import type { AliasData, RandomAliasData } from "../../../hooks/api/aliases";
 
-jest.mock("next/link", () => {
-  const MockLink = ({
-    href,
-    children,
-    ...rest
-  }: { href: string; children: React.ReactNode } & Omit<
-    React.AnchorHTMLAttributes<HTMLAnchorElement>,
-    "href"
-  >) => (
-    <a href={href} {...rest}>
-      {children}
-    </a>
-  );
-  MockLink.displayName = "MockLink";
-  return { __esModule: true, default: MockLink };
-});
-
-jest.mock("../../Image", () => {
-  const MockImage = ({
-    alt = "",
-    ...rest
-  }: React.ImgHTMLAttributes<HTMLImageElement>) => <img alt={alt} {...rest} />;
-  MockImage.displayName = "MockImage";
-  return { __esModule: true, default: MockImage };
-});
-
 jest.mock("./BlockLevelSlider.module.scss", () => {
   const styles = new Proxy({} as Record<string, string>, {
     get: (_t, p: string) => p,
@@ -42,14 +16,6 @@ const gaSpy = jest.fn();
 jest.mock("../../../hooks/gaEvent", () => ({
   useGaEvent: () => gaSpy,
 }));
-
-// Centralized l10n mock
-jest.mock("../../../hooks/l10n", () => {
-  const { mockUseL10nModule } = jest.requireActual(
-    "../../../../__mocks__/hooks/l10n",
-  );
-  return mockUseL10nModule;
-});
 
 function makeRandomAlias(
   overrides: Partial<RandomAliasData> = {},

--- a/frontend/src/components/dashboard/aliases/CategoryFilter.tsx
+++ b/frontend/src/components/dashboard/aliases/CategoryFilter.tsx
@@ -80,6 +80,7 @@ export const CategoryFilter = (props: Props) => {
         {...buttonProps}
         ref={triggerRef}
         title={l10n.getString("profile-filter-category-button-tooltip")}
+        aria-label={l10n.getString("profile-filter-category-button-tooltip")}
         className={styles["filter-button"]}
       >
         <FilterIcon

--- a/frontend/src/components/dashboard/aliases/CustomAddressGenerationModal.test.tsx
+++ b/frontend/src/components/dashboard/aliases/CustomAddressGenerationModal.test.tsx
@@ -10,24 +10,6 @@ import type { AliasData } from "../../../hooks/api/aliases";
 
 const TEST_SUBDOMAIN = "demo";
 
-jest.mock("next/link", () => ({
-  __esModule: true,
-  default: ({
-    href,
-    children,
-  }: {
-    href: string;
-    children: React.ReactNode;
-  }) => <a href={href}>{children}</a>,
-}));
-
-jest.mock("../../../hooks/l10n", () => {
-  const { mockUseL10nModule } = jest.requireActual(
-    "../../../../__mocks__/hooks/l10n",
-  );
-  return mockUseL10nModule;
-});
-
 const mockUseProfiles = jest.fn();
 jest.mock("../../../hooks/api/profile", () => ({
   useProfiles: () => mockUseProfiles(),

--- a/frontend/src/components/dashboard/tips/CustomAliasTip.test.tsx
+++ b/frontend/src/components/dashboard/tips/CustomAliasTip.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from "@testing-library/react";
 import { CustomAliasTip } from "./CustomAliasTip";
 import { getRuntimeConfig } from "../../../config";
 import { getLocale } from "../../../functions/getLocale";
-import { useL10n } from "../../../hooks/l10n";
 
 jest.mock("./CustomAliasTip.module.scss", () => ({}), { virtual: true });
 
@@ -15,17 +14,13 @@ jest.mock("../../../functions/getLocale", () => ({
   getLocale: jest.fn(),
 }));
 
-jest.mock("../../../hooks/l10n", () => ({
-  useL10n: jest.fn(),
-}));
-
 describe("CustomAliasTip", () => {
   const mockGetString = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (useL10n as jest.Mock).mockReturnValue({
+    global.useL10nImpl = () => ({
       getString: mockGetString,
     });
 

--- a/frontend/src/components/dashboard/tips/GenericTip.test.tsx
+++ b/frontend/src/components/dashboard/tips/GenericTip.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
 import { GenericTip, GenericTipProps } from "./GenericTip";
-import { useL10n } from "../../../hooks/l10n";
 import { getLocale } from "../../../functions/getLocale";
 import React from "react";
 
@@ -25,9 +24,6 @@ jest.mock("../../Image", () => {
   return { __esModule: true, default: MockImage };
 });
 
-jest.mock("../../../hooks/l10n", () => ({
-  useL10n: jest.fn(),
-}));
 jest.mock("../../../functions/getLocale", () => ({
   getLocale: jest.fn(),
 }));
@@ -46,7 +42,7 @@ describe("GenericTip", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (useL10n as jest.Mock).mockReturnValue(mockL10n);
+    global.useL10nImpl = () => mockL10n;
     // default to a non-English locale
     (getLocale as jest.Mock).mockReturnValue("fr");
   });

--- a/frontend/src/components/landing/BundleBanner.test.tsx
+++ b/frontend/src/components/landing/BundleBanner.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { BundleBanner } from "./BundleBanner";
+import { type RuntimeData } from "../../hooks/api/types";
+
+jest.mock(
+  "./BundleBanner.module.scss",
+  () => new Proxy({}, { get: (_: unknown, p: PropertyKey) => String(p) }),
+);
+
+jest.mock("../Localized", () => {
+  const React = jest.requireActual("react");
+  const Localized = ({
+    id,
+    children,
+  }: {
+    id: string;
+    children?: React.ReactNode;
+  }) => (
+    <span>
+      {`l10n string: [${id}], with vars: {}`}
+      {children}
+    </span>
+  );
+  (Localized as React.FC).displayName = "Localized";
+  return { __esModule: true, default: Localized, Localized };
+});
+
+const getBundlePriceMock = jest.fn();
+const getBundleSubscribeLinkMock = jest.fn();
+const isBundleAvailableInCountryMock = jest.fn();
+
+jest.mock("../../functions/getPlan", () => ({
+  __esModule: true,
+  getBundlePrice: (...args: unknown[]) => getBundlePriceMock(...args),
+  getBundleSubscribeLink: (...args: unknown[]) =>
+    getBundleSubscribeLinkMock(...args),
+  isBundleAvailableInCountry: (...args: unknown[]) =>
+    isBundleAvailableInCountryMock(...args),
+}));
+
+const trackPlanPurchaseStartMock = jest.fn();
+jest.mock("../../functions/trackPurchase", () => ({
+  __esModule: true,
+  trackPlanPurchaseStart: (...args: unknown[]) =>
+    trackPlanPurchaseStartMock(...args),
+}));
+
+function setup(runtimeData?: RuntimeData) {
+  const user = userEvent.setup();
+  const utils = render(
+    <BundleBanner
+      runtimeData={runtimeData ?? ({} as unknown as RuntimeData)}
+    />,
+  );
+  return { user, ...utils };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.useL10nImpl = () => ({
+    getString: (id: string, vars?: Record<string, unknown>) =>
+      `l10n string: [${id}], with vars: ${JSON.stringify(vars ?? {})}`,
+    getFragment: () => "",
+    bundles: [{ locales: ["en-GB"] }],
+  });
+  global.gaEventMock = jest.fn();
+});
+
+describe("BundleBanner", () => {
+  it("does not render the purchase section when bundle is unavailable", () => {
+    isBundleAvailableInCountryMock.mockReturnValue(false);
+    setup();
+    expect(
+      screen.queryByRole("link", {
+        name: "l10n string: [bundle-banner-cta], with vars: {}",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders header with price and CTA when bundle is available", () => {
+    isBundleAvailableInCountryMock.mockReturnValue(true);
+    getBundlePriceMock.mockReturnValue("$9.99");
+    getBundleSubscribeLinkMock.mockReturnValue("https://example.com/subscribe");
+    setup();
+
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /l10n string: \[bundle-banner-header-2], with vars:/,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/"monthly_price":"\$9\.99"/)).toBeInTheDocument();
+
+    const cta = screen.getByRole("link", {
+      name: "l10n string: [bundle-banner-cta], with vars: {}",
+    });
+    expect(cta).toHaveAttribute("href", "https://example.com/subscribe");
+  });
+
+  it("tracks purchase start on CTA click with expected args", async () => {
+    isBundleAvailableInCountryMock.mockReturnValue(true);
+    getBundlePriceMock.mockReturnValue("$9.99");
+    getBundleSubscribeLinkMock.mockReturnValue("https://example.com/subscribe");
+    const { user } = setup();
+
+    const cta = screen.getByRole("link", {
+      name: "l10n string: [bundle-banner-cta], with vars: {}",
+    });
+    await user.click(cta);
+
+    expect(trackPlanPurchaseStartMock).toHaveBeenCalledTimes(1);
+    const [gaFnArg, planArg, optsArg] =
+      trackPlanPurchaseStartMock.mock.calls[0];
+    expect(gaFnArg).toBe(global.gaEventMock);
+    expect(planArg).toEqual({ plan: "bundle" });
+    expect(optsArg).toEqual({ label: "bundle-banner-upgrade-promo" });
+  });
+
+  it("renders floating features and product list", () => {
+    isBundleAvailableInCountryMock.mockReturnValue(true);
+    getBundlePriceMock.mockReturnValue("$9.99");
+    getBundleSubscribeLinkMock.mockReturnValue("https://example.com/subscribe");
+    setup();
+
+    expect(screen.getAllByTestId("svg-icon").length).toBeGreaterThanOrEqual(3);
+    expect(
+      screen.getByText(
+        "l10n string: [bundle-banner-money-back-guarantee], with vars: {}",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/landing/DemoPhone.test.tsx
+++ b/frontend/src/components/landing/DemoPhone.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { DemoPhone } from "./DemoPhone";
+
+jest.mock(
+  "./DemoPhone.module.scss",
+  () => new Proxy({}, { get: (_: unknown, p: PropertyKey) => String(p) }),
+);
+
+// Image imports are mocked globally in __mocks__/components/landingImages.mocks.ts
+// The mocked values are:
+// - background: "/bg.svg"
+// - premium (en): "/premium.svg"
+// - premium (fr): "/premium-fr.svg"
+// - premium (de): "/premium-de.svg"
+// - nopremium: "/nopremium.svg"
+// - foreground (en): "/fg.svg"
+// - foreground (de): "/fg-de.svg"
+// - foreground (fr): "/fg-fr.svg"
+
+function setup({ premium, locale }: { premium?: boolean; locale: string }) {
+  getLocaleMock.mockReturnValue(locale);
+  render(<DemoPhone premium={premium} />);
+  const allImages = screen.getAllByTestId("mocked-image") as HTMLImageElement[];
+  return { allImages };
+}
+
+describe("DemoPhone", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("always renders the background image", () => {
+    const { allImages } = setup({ locale: "en-US", premium: true });
+    expect(allImages).toHaveLength(3);
+    expect(allImages[0]).toHaveAttribute("src", "/bg.svg");
+  });
+
+  it("uses French premium screenshot and French foreground for fr-FR locale", () => {
+    const { allImages } = setup({ locale: "fr-FR", premium: true });
+    expect(allImages).toHaveLength(3);
+    expect(allImages[0]).toHaveAttribute("src", "/bg.svg");
+    expect(allImages[1]).toHaveAttribute("src", "/premium-fr.svg");
+    expect(allImages[2]).toHaveAttribute("src", "/fg-fr.svg");
+  });
+
+  it("uses German premium screenshot and German foreground for de-DE locale", () => {
+    const { allImages } = setup({ locale: "de-DE", premium: true });
+    expect(allImages).toHaveLength(3);
+    expect(allImages[0]).toHaveAttribute("src", "/bg.svg");
+    expect(allImages[1]).toHaveAttribute("src", "/premium-de.svg");
+    expect(allImages[2]).toHaveAttribute("src", "/fg-de.svg");
+  });
+
+  it("uses English premium screenshot and English foreground for en-US locale", () => {
+    const { allImages } = setup({ locale: "en-US", premium: true });
+    expect(allImages).toHaveLength(3);
+    expect(allImages[0]).toHaveAttribute("src", "/bg.svg");
+    expect(allImages[1]).toHaveAttribute("src", "/premium.svg");
+    expect(allImages[2]).toHaveAttribute("src", "/fg.svg");
+  });
+
+  it("uses no-premium screenshot and English foreground when premium is not available", () => {
+    const { allImages } = setup({ locale: "en-US", premium: false });
+    expect(allImages).toHaveLength(3);
+    expect(allImages[0]).toHaveAttribute("src", "/bg.svg");
+    expect(allImages[1]).toHaveAttribute("src", "/nopremium.svg");
+    expect(allImages[2]).toHaveAttribute("src", "/fg.svg");
+  });
+
+  it("falls back to English images for unsupported locales", () => {
+    const { allImages } = setup({ locale: "es-ES", premium: true });
+    expect(allImages).toHaveLength(3);
+    expect(allImages[0]).toHaveAttribute("src", "/bg.svg");
+    expect(allImages[1]).toHaveAttribute("src", "/premium.svg");
+    expect(allImages[2]).toHaveAttribute("src", "/fg.svg");
+  });
+});

--- a/frontend/src/components/landing/FaqAccordion.test.tsx
+++ b/frontend/src/components/landing/FaqAccordion.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { FaqAccordionItem } from "./FaqAccordion";
+
+jest.mock("./FaqAccordion.module.scss", () => ({
+  __esModule: true,
+  default: new Proxy({}, { get: (_: unknown, p: PropertyKey) => String(p) }),
+}));
+
+function setup(ui: React.ReactElement) {
+  const user = userEvent.setup();
+  const utils = render(ui);
+  return { user, ...utils };
+}
+
+const entries = [
+  { q: "Question 1", a: <span>Answer 1</span> },
+  { q: "Question 2", a: <span>Answer 2</span> },
+  { q: "Question 3", a: <span>Answer 3</span> },
+];
+
+describe("FaqAccordionItem", () => {
+  it("renders all entries", () => {
+    setup(<FaqAccordionItem entries={entries} />);
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(3);
+    expect(screen.getByText("Answer 1")).toBeInTheDocument();
+    expect(screen.getByText("Answer 2")).toBeInTheDocument();
+    expect(screen.getByText("Answer 3")).toBeInTheDocument();
+    expect(screen.getAllByTestId("svg-icon")).toHaveLength(3);
+  });
+
+  it("focuses the first item by default when autoFocus is enabled", () => {
+    setup(<FaqAccordionItem entries={entries} autoFocus />);
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0]).toHaveFocus();
+  });
+
+  it("respects defaultExpandedIndex for initial focus when autoFocus is enabled", () => {
+    setup(
+      <FaqAccordionItem entries={entries} autoFocus defaultExpandedIndex={1} />,
+    );
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[1]).toHaveFocus();
+  });
+
+  it("moves focus to the clicked item when autoFocus is enabled", async () => {
+    const { user } = setup(<FaqAccordionItem entries={entries} autoFocus />);
+    const buttons = screen.getAllByRole("button");
+    await user.click(buttons[2]);
+    expect(buttons[2]).toHaveFocus();
+    await user.click(buttons[1]);
+    expect(buttons[1]).toHaveFocus();
+  });
+});

--- a/frontend/src/components/landing/HighlightedFeatures.test.tsx
+++ b/frontend/src/components/landing/HighlightedFeatures.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { HighlightedFeatures } from "./HighlightedFeatures";
+
+jest.mock("./HighlightedFeatures.module.scss", () => ({
+  __esModule: true,
+  default: new Proxy({}, { get: (_: unknown, p: PropertyKey) => String(p) }),
+}));
+
+describe("HighlightedFeatures", () => {
+  it("renders section titles and CTA", () => {
+    render(<HighlightedFeatures />);
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: "l10n string: [highlighted-features-section-title], with vars: {}",
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: "l10n string: [highlighted-features-section-bottom-title], with vars: {}",
+      }),
+    ).toBeInTheDocument();
+
+    const cta = screen.getByRole("link", {
+      name: "l10n string: [highlighted-features-section-bottom-cta], with vars: {}",
+    });
+    expect(cta).toHaveAttribute("href", "#pricing");
+  });
+
+  it("renders all highlighted items with headline and body", () => {
+    render(<HighlightedFeatures />);
+    const names = [
+      "unlimited-masks",
+      "masks-on-the-go",
+      "replying",
+      "block-promotions",
+      "remove-trackers",
+    ];
+
+    for (const n of names) {
+      expect(
+        screen.getByText(
+          `l10n string: [highlighted-features-section-${n}-headline], with vars: {}`,
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          `l10n string: [highlighted-features-section-${n}-body], with vars: {"mask_limit":"5","mozmail":"mozmail.com"}`,
+        ),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("renders five feature images", () => {
+    render(<HighlightedFeatures />);
+    const imgs = screen.getAllByAltText("");
+    expect(imgs).toHaveLength(5);
+  });
+});

--- a/frontend/src/components/landing/MegabundleBanner.test.tsx
+++ b/frontend/src/components/landing/MegabundleBanner.test.tsx
@@ -2,20 +2,12 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MegabundleBanner } from "./MegaBundleBanner";
 import { trackPlanPurchaseStart } from "../../functions/trackPurchase";
-import { useGaEvent } from "../../hooks/gaEvent";
-import { useL10n } from "../../hooks/l10n";
-import { useGaViewPing } from "../../hooks/gaViewPing";
 import type { RuntimeDataWithBundleAvailable } from "../../functions/getPlan";
 
 // Mock icons
 jest.mock("./images/vpn-icon.svg", () => ({ src: "vpn-icon.svg" }));
 jest.mock("./images/relay-icon.svg", () => ({ src: "relay-icon.svg" }));
 jest.mock("./images/monitor-icon.svg", () => ({ src: "monitor-icon.svg" }));
-
-// Mock hooks
-jest.mock("../../hooks/l10n");
-jest.mock("../../hooks/gaViewPing");
-jest.mock("../../hooks/gaEvent");
 
 // Mock functions
 jest.mock("../../functions/getPlan", () => ({
@@ -90,10 +82,6 @@ describe("MegabundleBanner", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-
-    (useL10n as jest.Mock).mockReturnValue({ getString: getStringMock });
-    (useGaViewPing as jest.Mock).mockReturnValue({ current: null });
-    (useGaEvent as jest.Mock).mockReturnValue(jest.fn());
 
     getStringMock.mockImplementation((key: string, vars?: string) => {
       if (vars) return `${key} ${JSON.stringify(vars)}`;

--- a/frontend/src/components/landing/PlanGrid.test.tsx
+++ b/frontend/src/components/landing/PlanGrid.test.tsx
@@ -1,16 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PlanGrid } from "./PlanGrid";
-import { useL10n } from "../../hooks/l10n";
 import { useIsLoggedIn } from "../../hooks/session";
-import { useGaViewPing } from "../../hooks/gaViewPing";
-import { useGaEvent } from "../../hooks/gaEvent";
 import { RuntimeData } from "../../hooks/api/types";
 
-// Mock hooks and utilities
-jest.mock("../../hooks/l10n");
-jest.mock("../../hooks/gaViewPing");
-jest.mock("../../hooks/gaEvent");
 jest.mock("../../hooks/hasRenderedClientSide");
 jest.mock("../../hooks/session");
 jest.mock("../../functions/trackPurchase");
@@ -53,9 +46,7 @@ const mockRuntimeData: RuntimeData = mockedRuntimeData;
 describe("PlanGrid", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (useL10n as jest.Mock).mockReturnValue(l10nMock);
-    (useGaViewPing as jest.Mock).mockReturnValue({ current: null });
-    (useGaEvent as jest.Mock).mockReturnValue(jest.fn());
+    global.useL10nImpl = () => l10nMock;
   });
 
   describe("basic rendering", () => {

--- a/frontend/src/components/landing/PlanMatrix.test.tsx
+++ b/frontend/src/components/landing/PlanMatrix.test.tsx
@@ -1,7 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
+import { renderWithProviders as render } from "../../../__mocks__/modules/renderWithProviders";
 
-import { mockLocalizedModule } from "../../../__mocks__/components/Localized";
-import { mockConfigModule } from "../../../__mocks__/configMock";
 import { setMockProfileData } from "../../../__mocks__/hooks/api/profile";
 import {
   setMockRuntimeDataOnce,
@@ -9,19 +8,6 @@ import {
   getMockRuntimeDataWithBundle,
   getMockRuntimeDataWithoutPremium,
 } from "../../../__mocks__/hooks/api/runtimeData";
-import { mockUseFxaFlowTrackerModule } from "../../../__mocks__/hooks/fxaFlowTracker";
-import { mockUseL10nModule } from "../../../__mocks__/hooks/l10n";
-import { mockNextRouter } from "../../../__mocks__/modules/next__router";
-import { mockReactGa } from "../../../__mocks__/modules/react-ga";
-
-jest.mock("next/router", () => mockNextRouter);
-jest.mock("react-ga", () => mockReactGa);
-jest.mock("../../config.ts", () => mockConfigModule);
-jest.mock("../../hooks/gaViewPing.ts");
-jest.mock("../../hooks/gaEvent.ts");
-jest.mock("../../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
-jest.mock("../../hooks/l10n.ts", () => mockUseL10nModule);
-jest.mock("../../components/Localized.tsx", () => mockLocalizedModule);
 
 import { PlanMatrix } from "./PlanMatrix";
 

--- a/frontend/src/components/landing/Reviews.test.tsx
+++ b/frontend/src/components/landing/Reviews.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { Reviews } from "./Reviews";
+
+jest.mock("./Reviews.module.scss", () => ({
+  __esModule: true,
+  default: new Proxy({}, { get: (_: unknown, p: PropertyKey) => String(p) }),
+}));
+
+jest.mock("react-aria", () => ({
+  useButton: (opts: { onPress?: () => void }) => ({
+    buttonProps: { onClick: opts.onPress },
+  }),
+}));
+
+function setup(locale = "en-US") {
+  global.getLocaleMock.mockReturnValue(locale);
+  const user = userEvent.setup();
+  render(<Reviews />);
+  return { user };
+}
+
+describe("Reviews", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders Firefox logo block and aggregate rating info", () => {
+    setup();
+    const logoImg = screen.getAllByAltText("")[0] as HTMLImageElement;
+    expect(logoImg).toBeInTheDocument();
+    expect(logoImg.src).toContain("/fx-logo.svg");
+
+    expect(
+      screen.getByText(
+        "l10n string: [landing-reviews-logo-title], with vars: {}",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("l10n string: [landing-reviews-add-ons], with vars: {}"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("4.1")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'l10n string: [landing-reviews-rating], with vars: {"review_count":"1,259"}',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows aggregate stars (relaxed assertion)", () => {
+    setup();
+    const allIcons = screen.getAllByTestId("svg-icon");
+    expect(allIcons.length).toBeGreaterThanOrEqual(5);
+    expect(screen.getByText("4.1")).toBeInTheDocument();
+  });
+
+  it("initially shows first user review details and stars", () => {
+    setup();
+    expect(screen.getByText("Jon")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "l10n string: [landing-reviews-details-source], with vars: {}",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getAllByTestId("svg-icon").length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("navigates to the last review on previous button (desktop controls)", async () => {
+    const { user } = setup();
+    const prevBtn = screen.getAllByRole("button", {
+      name: "l10n string: [landing-reviews-show-previous-button], with vars: {}",
+    })[0];
+
+    await user.click(prevBtn);
+
+    expect(
+      screen.getByText((content) =>
+        content.startsWith("l10n string: [landing-review-anonymous-user]"),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("navigates back to the first review on next button (desktop controls)", async () => {
+    const { user } = setup();
+    const prevBtn = screen.getAllByRole("button", {
+      name: "l10n string: [landing-reviews-show-previous-button], with vars: {}",
+    })[0];
+    await user.click(prevBtn);
+
+    const nextBtn = screen.getAllByRole("button", {
+      name: "l10n string: [landing-reviews-show-next-button], with vars: {}",
+    })[0];
+    await user.click(nextBtn);
+
+    expect(screen.getByText("Jon")).toBeInTheDocument();
+  });
+
+  it("mobile controls also navigate between reviews", async () => {
+    const { user } = setup();
+    const mobilePrev = screen.getAllByRole("button", {
+      name: "l10n string: [landing-reviews-show-previous-button], with vars: {}",
+    })[1];
+    await user.click(mobilePrev);
+
+    const anonName = screen.getByText((content) =>
+      content.startsWith("l10n string: [landing-review-anonymous-user]"),
+    );
+    expect(anonName).toBeInTheDocument();
+
+    const mobileNext = screen.getAllByRole("button", {
+      name: "l10n string: [landing-reviews-show-next-button], with vars: {}",
+    })[1];
+    await user.click(mobileNext);
+
+    expect(screen.getByText("Jon")).toBeInTheDocument();
+  });
+
+  it("formats the aggregate rating number using the locale from getLocale", () => {
+    setup("de-DE");
+    expect(screen.getByText("4,1")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/navigation/Navigation.test.tsx
+++ b/frontend/src/components/layout/navigation/Navigation.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import { mockConfigModule } from "../../../../__mocks__/configMock";
 import { setMockProfileData } from "../../../../__mocks__/hooks/api/profile";
 import {
   getMockRuntimeDataWithPeriodicalPremium,
@@ -7,21 +6,8 @@ import {
   setMockRuntimeData,
 } from "../../../../__mocks__/hooks/api/runtimeData";
 import { setMockUserData } from "../../../../__mocks__/hooks/api/user";
-import { mockUseFxaFlowTrackerModule } from "../../../../__mocks__/hooks/fxaFlowTracker";
-import { mockUseL10nModule } from "../../../../__mocks__/hooks/l10n";
-import { mockNextRouter } from "../../../../__mocks__/modules/next__router";
-import { mockReactIntersectionObsever } from "../../../../__mocks__/modules/react-intersection-observer";
 
 import { Navigation } from "./Navigation";
-
-jest.mock("next/router", () => mockNextRouter);
-jest.mock("react-intersection-observer", () => mockReactIntersectionObsever);
-jest.mock(
-  "../../../hooks/fxaFlowTracker.ts",
-  () => mockUseFxaFlowTrackerModule,
-);
-jest.mock("../../../hooks/l10n.ts", () => mockUseL10nModule);
-jest.mock("../../../config.ts", () => mockConfigModule);
 
 setMockRuntimeData();
 setMockProfileData();

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.test.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewDashboard.test.tsx
@@ -16,6 +16,12 @@ jest.mock(
   () => mockUseGoogleAnalyticsModule,
 );
 jest.mock("../../../../hooks/l10n.ts", () => mockUseL10nModule);
+jest.mock("../../../../hooks/gaEvent.ts", () => ({
+  useGaEvent: () => {
+    const googleAnalytics = mockUseGoogleAnalyticsModule.useGoogleAnalytics();
+    return googleAnalytics ? global.gaEventMock : jest.fn();
+  },
+}));
 
 function getMockEntry(
   id: number,
@@ -233,6 +239,8 @@ describe.each([true, false])(
   "The 'What's new' dashboard metrics, with googleAnalytics=%s",
   (googleAnalyticsAvailable) => {
     beforeEach(() => {
+      jest.clearAllMocks();
+      global.gaEventMock = jest.fn();
       mockUseGoogleAnalyticsModule.useGoogleAnalytics.mockReturnValue(
         googleAnalyticsAvailable,
       );
@@ -258,19 +266,19 @@ describe.each([true, false])(
       await userEvent.click(tabs[0]);
 
       if (googleAnalyticsAvailable) {
-        expect(mockReactGa.event).toHaveBeenCalledTimes(2);
-        expect(mockReactGa.event).toHaveBeenCalledWith({
+        expect(global.gaEventMock).toHaveBeenCalledTimes(2);
+        expect(global.gaEventMock).toHaveBeenCalledWith({
           category: "News",
           action: "Switch to 'History' tab",
           label: "news-dashboard",
         });
-        expect(mockReactGa.event).toHaveBeenCalledWith({
+        expect(global.gaEventMock).toHaveBeenCalledWith({
           category: "News",
           action: "Switch to 'News' tab",
           label: "news-dashboard",
         });
       } else {
-        expect(mockReactGa.event).not.toHaveBeenCalled();
+        expect(global.gaEventMock).not.toHaveBeenCalled();
       }
     });
 
@@ -294,14 +302,14 @@ describe.each([true, false])(
       await userEvent.click(menuItems[1]);
 
       if (googleAnalyticsAvailable) {
-        expect(mockReactGa.event).toHaveBeenCalledTimes(1);
-        expect(mockReactGa.event).toHaveBeenCalledWith({
+        expect(global.gaEventMock).toHaveBeenCalledTimes(1);
+        expect(global.gaEventMock).toHaveBeenCalledWith({
           category: "News",
           action: "Open entry",
           label: allEntries[1].title,
         });
       } else {
-        expect(mockReactGa.event).not.toHaveBeenCalled();
+        expect(global.gaEventMock).not.toHaveBeenCalled();
       }
     });
 
@@ -330,14 +338,14 @@ describe.each([true, false])(
       await userEvent.click(goBackButton);
 
       if (googleAnalyticsAvailable) {
-        expect(mockReactGa.event).toHaveBeenCalledTimes(2);
-        expect(mockReactGa.event).toHaveBeenCalledWith({
+        expect(global.gaEventMock).toHaveBeenCalledTimes(2);
+        expect(global.gaEventMock).toHaveBeenCalledWith({
           category: "News",
           action: "Close entry",
           label: allEntries[1].title,
         });
       } else {
-        expect(mockReactGa.event).not.toHaveBeenCalled();
+        expect(global.gaEventMock).not.toHaveBeenCalled();
       }
     });
 
@@ -363,15 +371,15 @@ describe.each([true, false])(
       await userEvent.click(clearAllButton);
 
       if (googleAnalyticsAvailable) {
-        expect(mockReactGa.event).toHaveBeenCalledTimes(1);
-        expect(mockReactGa.event).toHaveBeenCalledWith({
+        expect(global.gaEventMock).toHaveBeenCalledTimes(1);
+        expect(global.gaEventMock).toHaveBeenCalledWith({
           category: "News",
           action: "Clear all",
           label: "news-dashboard",
           value: newEntries.length,
         });
       } else {
-        expect(mockReactGa.event).not.toHaveBeenCalled();
+        expect(global.gaEventMock).not.toHaveBeenCalled();
       }
     });
   },

--- a/frontend/src/components/phones/dashboard/PhoneDashboard.test.tsx
+++ b/frontend/src/components/phones/dashboard/PhoneDashboard.test.tsx
@@ -10,7 +10,6 @@ import {
 } from "frontend/__mocks__/api/mockData";
 import { toast } from "react-toastify";
 import { VerifiedPhone } from "frontend/src/hooks/api/realPhone";
-import * as l10nModule from "frontend/src/hooks/l10n";
 import { formatPhone } from "frontend/src/functions/formatPhone";
 import { useRelayNumber } from "frontend/src/hooks/api/relayNumber";
 import { useInboundContact } from "frontend/src/hooks/api/inboundContact";
@@ -19,13 +18,6 @@ import type {
   NavigatorClipboard,
   ClipboardWrite,
 } from "frontend/__mocks__/components/clipboard";
-
-jest.mock("next/config", () => () => ({
-  publicRuntimeConfig: {
-    BASE_URL: "https://example.com",
-    API_URL: "https://api.example.com",
-  },
-}));
 
 beforeAll(() => {
   class MockIntersectionObserver implements IntersectionObserver {
@@ -43,16 +35,19 @@ beforeAll(() => {
   global.IntersectionObserver = MockIntersectionObserver;
 });
 
+jest.mock("next/config", () => () => ({
+  publicRuntimeConfig: {
+    BASE_URL: "https://example.com",
+    API_URL: "https://api.example.com",
+  },
+}));
+
 jest.mock("frontend/src/hooks/api/relayNumber", () => ({
   useRelayNumber: jest.fn(),
 }));
 
 jest.mock("frontend/src/hooks/api/inboundContact", () => ({
   useInboundContact: jest.fn(),
-}));
-
-jest.mock("frontend/src/hooks/l10n", () => ({
-  useL10n: jest.fn(),
 }));
 
 jest.mock("react-toastify", () => ({
@@ -71,7 +66,7 @@ describe("PhoneDashboard", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (l10nModule.useL10n as jest.Mock).mockReturnValue({
+    global.useL10nImpl = () => ({
       getString: (key: string) => key,
       bundles: [{ locales: ["en-US"] }],
     });

--- a/frontend/src/components/phones/dashboard/PhoneWelcomeView.test.tsx
+++ b/frontend/src/components/phones/dashboard/PhoneWelcomeView.test.tsx
@@ -3,13 +3,8 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PhoneWelcomeView } from "./PhoneWelcomeView";
 import { mockedProfiles } from "frontend/__mocks__/api/mockData";
-import * as l10nModule from "frontend/src/hooks/l10n";
 import { toast } from "react-toastify";
 import { renderWithProviders } from "frontend/__mocks__/modules/renderWithProviders";
-
-jest.mock("frontend/src/hooks/l10n", () => ({
-  useL10n: jest.fn(),
-}));
 
 jest.mock("react-toastify", () => ({
   toast: jest.fn(),
@@ -30,7 +25,7 @@ describe("PhoneWelcomeView", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (l10nModule.useL10n as jest.Mock).mockReturnValue({
+    global.useL10nImpl = () => ({
       getString: (key: string) => key,
       bundles: [{ locales: ["en-US"] }],
     });

--- a/frontend/src/components/phones/dashboard/SendersPanelView.test.tsx
+++ b/frontend/src/components/phones/dashboard/SendersPanelView.test.tsx
@@ -1,15 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SendersPanelView } from "./SendersPanelView";
-import * as l10nModule from "frontend/src/hooks/l10n";
 import * as metricsModule from "frontend/src/hooks/metrics";
 import * as inboundContactModule from "frontend/src/hooks/api/inboundContact";
 import { FluentBundle } from "@fluent/bundle";
 import { ReactLocalization } from "@fluent/react";
-
-jest.mock("frontend/src/hooks/l10n", () => ({
-  useL10n: jest.fn(),
-}));
 
 jest.mock("frontend/src/hooks/metrics", () => ({
   useMetrics: jest.fn(),
@@ -29,7 +24,7 @@ function mockL10n(): ReactLocalization {
 beforeEach(() => {
   jest.clearAllMocks();
 
-  (l10nModule.useL10n as jest.Mock).mockReturnValue({
+  global.useL10nImpl = () => ({
     getString: (key: string) => key,
     bundles: mockL10n().bundles,
   });
@@ -79,7 +74,7 @@ describe("SendersPanelView", () => {
       screen.getByRole("link", {
         name: "phone-dashboard-sender-disabled-update-settings",
       }),
-    ).toHaveAttribute("href", "/accounts/settings");
+    ).toHaveAttribute("href", "/accounts/settings/");
   });
 
   it("renders sorted sender logs", () => {

--- a/frontend/src/components/phones/onboarding/PhoneOnboarding.test.tsx
+++ b/frontend/src/components/phones/onboarding/PhoneOnboarding.test.tsx
@@ -7,13 +7,11 @@ import {
   mockedRealphones,
 } from "frontend/__mocks__/api/mockData";
 import { RuntimeDataWithPhonesAvailable } from "../../../functions/getPlan";
-import { useL10n } from "../../../hooks/l10n";
 
-// Mocks
-jest.mock("../../../hooks/l10n");
 jest.mock("../../../hooks/api/realPhone");
 
-const mockUseRealPhonesData = realPhoneHook.useRealPhonesData as jest.Mock;
+const mockUseRealPhonesData =
+  realPhoneHook.useRealPhonesData as unknown as jest.Mock;
 
 const l10nMock = {
   bundles: [{ locales: ["en"] }],
@@ -37,7 +35,7 @@ const renderComponent = (profileKey: keyof typeof mockedProfiles) =>
 describe("PhoneOnboarding", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (useL10n as jest.Mock).mockReturnValue(l10nMock);
+    global.useL10nImpl = () => l10nMock;
   });
 
   it("renders nothing if realPhoneData is undefined", () => {

--- a/frontend/src/components/phones/onboarding/RelayNumberConfirmationModal.test.tsx
+++ b/frontend/src/components/phones/onboarding/RelayNumberConfirmationModal.test.tsx
@@ -2,12 +2,7 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { RelayNumberConfirmationModal } from "../onboarding/RelayNumberConfirmationModal";
-import { useL10n } from "../../../hooks/l10n";
 import { renderWithProviders } from "frontend/__mocks__/modules/renderWithProviders";
-
-jest.mock("../../../hooks/l10n", () => ({
-  useL10n: jest.fn(),
-}));
 
 jest.mock("react-aria", () => {
   const original = jest.requireActual("react-aria");
@@ -25,7 +20,7 @@ describe("RelayNumberConfirmationModal", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (useL10n as jest.Mock).mockReturnValue({
+    global.useL10nImpl = () => ({
       getString: (key: string) => `translated(${key})`,
     });
   });

--- a/frontend/src/components/phones/onboarding/RelayNumberPicker.test.tsx
+++ b/frontend/src/components/phones/onboarding/RelayNumberPicker.test.tsx
@@ -1,14 +1,9 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { RelayNumberPicker } from "../onboarding/RelayNumberPicker";
-import { useL10n } from "../../../hooks/l10n";
 import * as relayNumberHooks from "../../../hooks/api/relayNumber";
 import { formatPhone } from "../../../functions/formatPhone";
 import { renderWithProviders } from "frontend/__mocks__/modules/renderWithProviders";
-
-jest.mock("../../../hooks/l10n", () => ({
-  useL10n: jest.fn(),
-}));
 
 jest.mock("../../../hooks/api/relayNumber", () => ({
   useRelayNumber: jest.fn(),
@@ -23,7 +18,7 @@ describe("RelayNumberPicker", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (useL10n as jest.Mock).mockReturnValue({
+    global.useL10nImpl = () => ({
       getString: (key: string) => `translated(${key})`,
     });
 

--- a/frontend/src/components/waitlist/CountryPicker.test.tsx
+++ b/frontend/src/components/waitlist/CountryPicker.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { CountryPicker } from "./CountryPicker";
+
+jest.mock(
+  "cldr-localenames-modern/main/it/territories.json",
+  () => ({
+    __esModule: true,
+    default: undefined,
+    main: {
+      it: {
+        localeDisplayNames: {
+          territories: {
+            IT: "Italia",
+            FR: "Francia",
+            "150": "Europa",
+          },
+        },
+      },
+    },
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  "cldr-localenames-modern/main/nl/territories.json",
+  () => ({
+    __esModule: true,
+    default: undefined,
+    main: {
+      nl: {
+        localeDisplayNames: {
+          territories: {
+            NL: "Nederland",
+            BE: "België",
+            "001": "Wereld",
+          },
+        },
+      },
+    },
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  "cldr-localenames-modern/main/en/territories.json",
+  () => ({
+    __esModule: true,
+    default: undefined,
+    main: {
+      en: {
+        localeDisplayNames: {
+          territories: {
+            US: "United States",
+            CA: "Canada",
+            "001": "World",
+          },
+        },
+      },
+    },
+  }),
+  { virtual: true },
+);
+
+function setup(props?: React.ComponentProps<typeof CountryPicker>) {
+  const user = userEvent.setup();
+  const utils = render(
+    <CountryPicker data-testid="country-picker" {...props} />,
+  );
+  return { user, ...utils };
+}
+
+describe("CountryPicker", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("renders countries for a locale that exists exactly (no fallback) — 'it'", async () => {
+    getLocaleMock.mockReturnValue("it");
+
+    setup();
+
+    const optionItalia = await screen.findByRole("option", { name: "Italia" });
+    const optionFrancia = screen.getByRole("option", { name: "Francia" });
+
+    expect(optionItalia).toBeInTheDocument();
+    expect(optionFrancia).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("option", { name: "Europa" }),
+    ).not.toBeInTheDocument();
+
+    const allOptions = screen.getAllByRole("option").map((o) => o.textContent);
+    expect(allOptions).toEqual(["Francia", "Italia"]);
+  });
+
+  it("falls back from 'nl-NL' to truncated 'nl' when full locale is missing", async () => {
+    getLocaleMock.mockReturnValue("nl-NL");
+
+    setup();
+
+    const optionBE = await screen.findByRole("option", { name: "België" });
+    const optionNL = screen.getByRole("option", { name: "Nederland" });
+    expect(optionBE).toBeInTheDocument();
+    expect(optionNL).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("option", { name: "Wereld" }),
+    ).not.toBeInTheDocument();
+
+    const allOptions = screen.getAllByRole("option").map((o) => o.textContent);
+    expect(allOptions).toEqual(["België", "Nederland"]);
+  });
+
+  it("falls back to English when both exact and truncated locale imports fail", async () => {
+    getLocaleMock.mockReturnValue("xx-XX");
+
+    setup();
+
+    const optionUS = await screen.findByRole("option", {
+      name: "United States",
+    });
+    const optionCA = screen.getByRole("option", { name: "Canada" });
+    expect(optionUS).toBeInTheDocument();
+    expect(optionCA).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("option", { name: "World" }),
+    ).not.toBeInTheDocument();
+
+    const allOptions = screen.getAllByRole("option").map((o) => o.textContent);
+    expect(allOptions).toEqual(["Canada", "United States"]);
+  });
+
+  it("spreads props to the underlying <select> and fires onChange", async () => {
+    getLocaleMock.mockReturnValue("en");
+
+    const handleChange = jest.fn((e) => e && e.target && e.target.value);
+
+    const { user } = setup({
+      name: "country",
+      defaultValue: "CA",
+      onChange: handleChange,
+      "aria-label": "Country",
+    });
+
+    await screen.findByRole("option", { name: "United States" });
+    const select = screen.getByTestId("country-picker");
+
+    expect(select).toHaveAttribute("name", "country");
+    expect(select).toHaveAttribute("aria-label", "Country");
+    expect((select as HTMLSelectElement).value).toBe("CA");
+
+    await user.selectOptions(select, "US");
+    expect(handleChange).toHaveBeenCalled();
+    expect((select as HTMLSelectElement).value).toBe("US");
+  });
+});

--- a/frontend/src/components/waitlist/LocalePicker.test.tsx
+++ b/frontend/src/components/waitlist/LocalePicker.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { LocalePicker } from "./LocalePicker";
+
+jest.mock(
+  "cldr-localenames-modern/main/it/languages.json",
+  () => ({
+    __esModule: true,
+    default: undefined,
+    main: {
+      it: {
+        localeDisplayNames: {
+          languages: {
+            it: "italiano",
+            en: "inglese",
+            fr: "francese",
+            zh: "cinese",
+          },
+        },
+      },
+    },
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  "cldr-localenames-modern/main/nl/languages.json",
+  () => ({
+    __esModule: true,
+    default: undefined,
+    main: {
+      nl: {
+        localeDisplayNames: {
+          languages: {
+            nl: "Nederlands",
+            en: "Engels",
+            fr: "Frans",
+          },
+        },
+      },
+    },
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  "cldr-localenames-modern/main/en/languages.json",
+  () => ({
+    __esModule: true,
+    default: undefined,
+    main: {
+      en: {
+        localeDisplayNames: {
+          languages: {
+            en: "English",
+            de: "German",
+            es: "Spanish",
+          },
+        },
+      },
+    },
+  }),
+  { virtual: true },
+);
+
+function setup(props?: React.ComponentProps<typeof LocalePicker>) {
+  const user = userEvent.setup();
+  const utils = render(
+    <LocalePicker
+      data-testid="locale-picker"
+      supportedLocales={[]}
+      {...props}
+    />,
+  );
+  return { user, ...utils };
+}
+
+describe("LocalePicker", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("renders languages for an exact locale 'it'", async () => {
+    getLocaleMock.mockReturnValue("it");
+    setup({ supportedLocales: ["fr", "en", "it"] });
+    await screen.findByRole("option", { name: "francese" });
+    const options = screen.getAllByRole("option").map((o) => o.textContent);
+    expect(options).toEqual(["francese", "inglese", "italiano"]);
+  });
+
+  it("falls back from 'nl-NL' to truncated 'nl'", async () => {
+    getLocaleMock.mockReturnValue("nl-NL");
+    setup({ supportedLocales: ["nl", "fr", "en"] });
+    await screen.findByRole("option", { name: "Frans" });
+    const options = screen.getAllByRole("option").map((o) => o.textContent);
+    expect(options).toEqual(["Engels", "Frans", "Nederlands"]);
+  });
+
+  it("falls back to English when exact and truncated locales fail", async () => {
+    getLocaleMock.mockReturnValue("xx-XX");
+    setup({ supportedLocales: ["de", "es", "en"] });
+    await screen.findByRole("option", { name: "English" });
+    const options = screen.getAllByRole("option").map((o) => o.textContent);
+    expect(options).toEqual(["English", "German", "Spanish"]);
+  });
+
+  it("spreads props to the select and handles change", async () => {
+    getLocaleMock.mockReturnValue("en");
+    const handleChange = jest.fn((e) => e && e.target && e.target.value);
+    const { user } = setup({
+      supportedLocales: ["de", "en"],
+      name: "locale",
+      defaultValue: "de",
+      onChange: handleChange,
+      "aria-label": "Locale",
+    });
+    await screen.findByRole("option", { name: "English" });
+    const select = screen.getByTestId("locale-picker");
+    expect(select).toHaveAttribute("name", "locale");
+    expect(select).toHaveAttribute("aria-label", "Locale");
+    await user.selectOptions(select, "de");
+    await user.selectOptions(select, "en");
+    expect(handleChange).toHaveBeenCalled();
+    expect((select as HTMLSelectElement).value).toBe("en");
+  });
+});

--- a/frontend/src/components/waitlist/WaitlistPage.test.tsx
+++ b/frontend/src/components/waitlist/WaitlistPage.test.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { act, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
+import "@testing-library/jest-dom";
 import { type Props as CountryPickerProps } from "./CountryPicker";
 import { type Props as LocalePickerProps } from "./LocalePicker";
 import { mockNextRouter } from "../../../__mocks__/modules/next__router";
@@ -10,27 +11,38 @@ import { setMockRuntimeData } from "../../../__mocks__/hooks/api/runtimeData";
 import { setMockUserData } from "../../../__mocks__/hooks/api/user";
 import { setMockProfileData } from "../../../__mocks__/hooks/api/profile";
 import { mockUseFxaFlowTrackerModule } from "../../../__mocks__/hooks/fxaFlowTracker";
-import { mockUseL10nModule } from "../../../__mocks__/hooks/l10n";
-import { mockLocalizedModule } from "../../../__mocks__/components/Localized";
-
 import { WaitlistPage } from "./WaitlistPage";
+import { toast as toastFn } from "react-toastify";
+
+jest.mock("../layout/Layout", () => ({
+  Layout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("react-toastify", () => ({ toast: jest.fn() }));
+
+const toastMock = toastFn as unknown as jest.Mock;
 
 jest.mock("next/router", () => mockNextRouter);
 jest.mock("../../config.ts", () => mockConfigModule);
-jest.mock("../../hooks/gaViewPing.ts");
 jest.mock("../../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
-jest.mock("../../hooks/l10n.ts", () => mockUseL10nModule);
-jest.mock("../Localized.tsx", () => mockLocalizedModule);
-jest.mock("../waitlist/CountryPicker.tsx", () => ({
+
+jest.mock("./CountryPicker.tsx", () => ({
   // We're mocking out the country picker because it dynamically imports the
   // list of available countries, which would mean the test would have to mock
   // out that import's Promise and wait for that to resolve, distracting from
   // the actual test code.
   // Since it's otherwise just a `<select>` element, we can just mock it out by
   // an empty <select>.
-  CountryPicker: (props: CountryPickerProps) => <select {...props} />,
+  CountryPicker: (props: CountryPickerProps) => (
+    <select {...props}>
+      <option value="US">United States</option>
+      <option value="CA">Canada</option>
+      <option value="DE">Germany</option>
+      <option value="FR">France</option>
+    </select>
+  ),
 }));
-jest.mock("../../components/waitlist/LocalePicker.tsx", () => ({
+jest.mock("./LocalePicker.tsx", () => ({
   // We're mocking out the locale picker because it dynamically imports the
   // list of available countries, which would mean the test would have to mock
   // out that import's Promise and wait for that to resolve, distracting from
@@ -38,11 +50,26 @@ jest.mock("../../components/waitlist/LocalePicker.tsx", () => ({
   // Since it's otherwise just a `<select>` element, we can just mock it out by
   // an empty <select>.
   LocalePicker: (allProps: LocalePickerProps) => {
-    const props: Partial<LocalePickerProps> = {
-      ...allProps,
-    };
-    delete props.supportedLocales;
-    return <select {...props} />;
+    const { supportedLocales, ...rest } = allProps;
+    const current =
+      typeof rest.value === "string"
+        ? rest.value
+        : Array.isArray(rest.value) && typeof rest.value[0] === "string"
+          ? rest.value[0]
+          : "en";
+    const list =
+      supportedLocales && supportedLocales.length > 0
+        ? supportedLocales
+        : [current];
+    return (
+      <select {...(rest as Omit<LocalePickerProps, "supportedLocales">)}>
+        {list.map((loc) => (
+          <option key={loc} value={loc}>
+            {loc}
+          </option>
+        ))}
+      </select>
+    );
   },
 }));
 
@@ -52,8 +79,55 @@ setMockProfileData();
 
 global.fetch = jest.fn();
 
+type SetupOptions = {
+  runtimeData?: Record<string, unknown>;
+  props?: Partial<React.ComponentProps<typeof WaitlistPage>>;
+};
+
+function setup(options: SetupOptions = {}) {
+  if (options.runtimeData) {
+    setMockRuntimeData(options.runtimeData);
+  }
+
+  const defaultProps: React.ComponentProps<typeof WaitlistPage> = {
+    headline: "h",
+    lead: "l",
+    legalese: <>x</>,
+    newsletterId: "n",
+    supportedLocales: ["en"],
+  };
+
+  const props = { ...defaultProps, ...options.props };
+  const view = render(<WaitlistPage {...props} />);
+
+  return {
+    ...view,
+    getEmailInput: () =>
+      screen.getByLabelText(
+        "l10n string: [waitlist-control-email-label], with vars: {}",
+      ),
+    getSubmitButton: () =>
+      screen.getByRole("button", {
+        name: "l10n string: [waitlist-submit-label-2], with vars: {}",
+      }),
+    getCountrySelect: () =>
+      screen.getByLabelText(
+        "l10n string: [waitlist-control-country-label-2], with vars: {}",
+      ) as HTMLSelectElement,
+    getLocaleSelect: () =>
+      screen.getByLabelText(
+        "l10n string: [waitlist-control-locale-label], with vars: {}",
+      ) as HTMLSelectElement,
+  };
+}
+
 beforeEach(() => {
   (global.fetch as jest.Mock).mockClear();
+  toastMock.mockClear();
+});
+
+afterEach(() => {
+  setMockRuntimeData(); // Reset to defaults
 });
 
 describe("The waitlist", () => {
@@ -68,83 +142,203 @@ describe("The waitlist", () => {
           supportedLocales={["en"]}
         />,
       );
-
-      let results;
-      await act(async () => {
-        results = await axe(baseElement);
-      });
-
+      const results = await axe(baseElement);
       expect(results).toHaveNoViolations();
-    }, 10000); // axe runs a suite of tests that can exceed the default 5s timeout, so we set it to 10s
+    }, 10000);
   });
 
-  // Disabled since the upgrade to Jest 28; for some reason, the waitlist form's
-  // `onSubmit` callback no longer gets called. For more information, see
-  // https://github.com/mozilla/fx-private-relay/pull/2211#issuecomment-1188884809
-  it.skip("sends the user's email to Basket", async () => {
-    render(
-      <WaitlistPage
-        headline="Arbitrary headline"
-        lead="Arbitrary lead text"
-        legalese={<>Arbitrary legalese footer.</>}
-        newsletterId="arbitrary-newsletter-id"
-        supportedLocales={["en"]}
-      />,
-    );
-
-    const emailInput = screen.getByLabelText(
-      "l10n string: [waitlist-control-email-label], with vars: {}",
-    );
-    await userEvent.clear(emailInput);
-    await userEvent.type(emailInput, "some_email@example.com");
-
-    const submitButton = screen.getByRole("button", {
-      name: "l10n string: [waitlist-submit-label], with vars: {}",
+  it("sends the user's email to Basket", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: "ok" }),
     });
-    await userEvent.click(submitButton);
+
+    const { getEmailInput, getSubmitButton } = setup();
+
+    await userEvent.clear(getEmailInput());
+    await userEvent.type(getEmailInput(), "some_email@example.com");
+    await userEvent.click(getSubmitButton());
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({ body: expect.any(String) }),
     );
-    const requestBody = (global.fetch as jest.Mock).mock.calls[0][1].body;
+    const requestBody = (global.fetch as jest.Mock).mock.calls[0][1]
+      .body as string;
     const params = new URLSearchParams(requestBody);
     expect(params.get("email")).toBe("some_email@example.com");
   });
 
-  // Disabled since the upgrade to Jest 28; for some reason, the waitlist form's
-  // `onSubmit` callback no longer gets called. For more information, see
-  // https://github.com/mozilla/fx-private-relay/pull/2211#issuecomment-1188884809
-  it.skip("uses the Basket URL set by the back-end", async () => {
-    setMockRuntimeData({ BASKET_ORIGIN: "https://some-basket-url.com" });
-    render(
-      <WaitlistPage
-        headline="Arbitrary headline"
-        lead="Arbitrary lead text"
-        legalese={<>Arbitrary legalese footer.</>}
-        newsletterId="arbitrary-newsletter-id"
-        supportedLocales={["en"]}
-      />,
-    );
-
-    const emailInput = screen.getByLabelText(
-      "l10n string: [waitlist-control-email-label], with vars: {}",
-    );
-    await userEvent.clear(emailInput);
-    await userEvent.type(emailInput, "arbitrary_email@example.com");
-
-    const submitButton = screen.getByRole("button", {
-      name: "l10n string: [waitlist-submit-label], with vars: {}",
+  it("uses the Basket URL set by the back-end", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: "ok" }),
     });
-    await userEvent.click(submitButton);
+
+    const { getEmailInput, getSubmitButton } = setup({
+      runtimeData: { BASKET_ORIGIN: "https://some-basket-url.com" },
+    });
+
+    await userEvent.clear(getEmailInput());
+    await userEvent.type(getEmailInput(), "arbitrary_email@example.com");
+    await userEvent.click(getSubmitButton());
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith(
       "https://some-basket-url.com/news/subscribe/",
       expect.anything(),
     );
-    // Restore the original runtime data mocks:
-    setMockRuntimeData();
+  });
+
+  it("prefers detected country from runtimeData for CountryPicker default", () => {
+    const { getCountrySelect } = setup({
+      runtimeData: {
+        PERIODICAL_PREMIUM_PLANS: { country_code: "ca" },
+      } as unknown as Record<string, unknown>,
+    });
+    expect(getCountrySelect().value).toBe("CA");
+  });
+
+  it("matches locale from navigator.language when supported", async () => {
+    const original = Object.getOwnPropertyDescriptor(
+      window.navigator,
+      "language",
+    );
+    Object.defineProperty(window.navigator, "language", {
+      value: "fr-FR",
+      configurable: true,
+    });
+
+    const { getLocaleSelect } = setup({
+      props: { supportedLocales: ["en", "fr", "de"] },
+    });
+
+    expect(getLocaleSelect().value).toBe("fr");
+
+    if (original) Object.defineProperty(window.navigator, "language", original);
+  });
+
+  it("falls back to en when navigator.language is unsupported", () => {
+    const original = Object.getOwnPropertyDescriptor(
+      window.navigator,
+      "language",
+    );
+    Object.defineProperty(window.navigator, "language", {
+      value: "sv-SE",
+      configurable: true,
+    });
+
+    const { getLocaleSelect } = setup({
+      props: { supportedLocales: ["en", "fr"] },
+    });
+
+    expect(getLocaleSelect().value).toBe("en");
+
+    if (original) Object.defineProperty(window.navigator, "language", original);
+  });
+
+  it("updates controlled selects for country and locale before submit", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: "ok" }),
+    });
+
+    const {
+      getEmailInput,
+      getCountrySelect,
+      getLocaleSelect,
+      getSubmitButton,
+    } = setup({
+      props: { supportedLocales: ["en", "de"] },
+    });
+
+    await userEvent.clear(getEmailInput());
+    await userEvent.type(getEmailInput(), "e@example.com");
+    await userEvent.selectOptions(getCountrySelect(), "DE");
+    await userEvent.selectOptions(getLocaleSelect(), "de");
+    await userEvent.click(getSubmitButton());
+
+    const body = (global.fetch as jest.Mock).mock.calls[0][1].body as string;
+    const params = new URLSearchParams(body);
+    expect(params.get("relay_country")).toBe("DE");
+    expect(params.get("lang")).toBe("de");
+  });
+
+  it("passes detected country and newsletter id into the request body", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: "ok" }),
+    });
+
+    const { getEmailInput, getSubmitButton } = setup({
+      runtimeData: {
+        BASKET_ORIGIN: "https://basket.mozilla.org",
+        PERIODICAL_PREMIUM_PLANS: { country_code: "us" },
+      } as unknown as Record<string, unknown>,
+      props: { newsletterId: "newsletter-123" },
+    });
+
+    await userEvent.clear(getEmailInput());
+    await userEvent.type(getEmailInput(), "a@b.co");
+    await userEvent.click(getSubmitButton());
+
+    const body = (global.fetch as jest.Mock).mock.calls[0][1].body as string;
+    const params = new URLSearchParams(body);
+    expect(params.get("country")).toBe("US");
+    expect(params.get("newsletters")).toBe("newsletter-123");
+    expect(params.get("format")).toBe("html");
+    expect(params.get("source_url")).toContain(document.location.origin);
+  });
+
+  it("shows success toast when response ok with status ok", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: "ok" }),
+    });
+
+    const { getEmailInput, getSubmitButton } = setup();
+
+    await userEvent.clear(getEmailInput());
+    await userEvent.type(getEmailInput(), "ok@example.com");
+    await userEvent.click(getSubmitButton());
+
+    expect(toastMock).toHaveBeenCalledWith(
+      "l10n string: [waitlist-subscribe-success], with vars: {}",
+      expect.objectContaining({ type: "success" }),
+    );
+  });
+
+  it("shows unknown error toast when response not ok or status not ok", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: "error", code: 400, desc: "x" }),
+    });
+
+    const { getEmailInput, getSubmitButton } = setup();
+
+    await userEvent.clear(getEmailInput());
+    await userEvent.type(getEmailInput(), "bad@example.com");
+    await userEvent.click(getSubmitButton());
+
+    expect(toastMock).toHaveBeenCalledWith(
+      "l10n string: [waitlist-subscribe-error-unknown], with vars: {}",
+      expect.objectContaining({ type: "error" }),
+    );
+  });
+
+  it("shows connection error toast when fetch rejects", async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("net"));
+
+    const { getEmailInput, getSubmitButton } = setup();
+
+    await userEvent.clear(getEmailInput());
+    await userEvent.type(getEmailInput(), "err@example.com");
+    await userEvent.click(getSubmitButton());
+
+    expect(toastMock).toHaveBeenCalledWith(
+      "l10n string: [waitlist-subscribe-error-connection], with vars: {}",
+      expect.objectContaining({ type: "error" }),
+    );
   });
 });

--- a/frontend/src/config.test.ts
+++ b/frontend/src/config.test.ts
@@ -1,0 +1,78 @@
+import { getRuntimeConfig } from "./config";
+
+describe("config", () => {
+  describe("getRuntimeConfig", () => {
+    it("returns publicRuntimeConfig from next/config", () => {
+      const result = getRuntimeConfig();
+
+      // Verify the result has the expected structure and required fields
+      expect(result).toHaveProperty("backendOrigin");
+      expect(result).toHaveProperty("frontendOrigin");
+      expect(result).toHaveProperty("fxaLoginUrl");
+      expect(result).toHaveProperty("fxaLogoutUrl");
+      expect(result).toHaveProperty("supportUrl");
+      expect(result).toHaveProperty("emailSizeLimitNumber");
+      expect(result).toHaveProperty("emailSizeLimitUnit");
+      expect(result).toHaveProperty("maxFreeAliases");
+      expect(result).toHaveProperty("mozmailDomain");
+      expect(result).toHaveProperty("googleAnalyticsId");
+      expect(result).toHaveProperty("maxOnboardingAvailable");
+      expect(result).toHaveProperty("maxOnboardingFreeAvailable");
+      expect(result).toHaveProperty("featureFlags");
+
+      // Verify feature flags structure
+      expect(result.featureFlags).toHaveProperty("tips");
+      expect(result.featureFlags).toHaveProperty("generateCustomAliasMenu");
+      expect(result.featureFlags).toHaveProperty(
+        "generateCustomAliasSubdomain",
+      );
+      expect(result.featureFlags).toHaveProperty("interviewRecruitment");
+      expect(result.featureFlags).toHaveProperty("csatSurvey");
+
+      // Verify types
+      expect(typeof result.backendOrigin).toBe("string");
+      expect(typeof result.maxFreeAliases).toBe("number");
+      expect(result.mozmailDomain).toBe("mozmail.com");
+    });
+
+    it("returns consistent config on multiple calls", () => {
+      const firstCall = getRuntimeConfig();
+      const secondCall = getRuntimeConfig();
+
+      expect(firstCall).toEqual(secondCall);
+    });
+
+    it("returns all URL fields as strings", () => {
+      const result = getRuntimeConfig();
+
+      expect(typeof result.backendOrigin).toBe("string");
+      expect(typeof result.frontendOrigin).toBe("string");
+      expect(typeof result.fxaLoginUrl).toBe("string");
+      expect(typeof result.fxaLogoutUrl).toBe("string");
+      expect(typeof result.supportUrl).toBe("string");
+    });
+
+    it("returns all numeric fields as numbers", () => {
+      const result = getRuntimeConfig();
+
+      expect(typeof result.emailSizeLimitNumber).toBe("number");
+      expect(typeof result.maxFreeAliases).toBe("number");
+      expect(typeof result.maxOnboardingAvailable).toBe("number");
+      expect(typeof result.maxOnboardingFreeAvailable).toBe("number");
+    });
+
+    it("returns feature flags as booleans", () => {
+      const result = getRuntimeConfig();
+
+      expect(typeof result.featureFlags.tips).toBe("boolean");
+      expect(typeof result.featureFlags.generateCustomAliasMenu).toBe(
+        "boolean",
+      );
+      expect(typeof result.featureFlags.generateCustomAliasSubdomain).toBe(
+        "boolean",
+      );
+      expect(typeof result.featureFlags.interviewRecruitment).toBe("boolean");
+      expect(typeof result.featureFlags.csatSurvey).toBe("boolean");
+    });
+  });
+});

--- a/frontend/src/functions/cookies.test.ts
+++ b/frontend/src/functions/cookies.test.ts
@@ -1,0 +1,77 @@
+import { getCookie, setCookie, clearCookie, getCsrfToken } from "./cookies";
+
+describe("cookies", () => {
+  beforeEach(() => {
+    // Clear all cookies before each test
+    document.cookie.split(";").forEach((cookie) => {
+      const name = cookie.split("=")[0].trim();
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+    });
+  });
+
+  describe("getCookie", () => {
+    it("returns undefined when cookie does not exist", () => {
+      expect(getCookie("nonexistent")).toBeUndefined();
+    });
+
+    it("returns the cookie value when cookie exists", () => {
+      document.cookie = "testcookie=testvalue; path=/";
+      expect(getCookie("testcookie")).toBe("testvalue");
+    });
+
+    it("returns the correct cookie when multiple cookies exist", () => {
+      document.cookie = "cookie1=value1; path=/";
+      document.cookie = "cookie2=value2; path=/";
+      expect(getCookie("cookie2")).toBe("value2");
+    });
+
+    it("handles cookies with spaces in the cookie string", () => {
+      document.cookie = "test=value; path=/";
+      expect(getCookie("test")).toBe("value");
+    });
+  });
+
+  describe("setCookie", () => {
+    it("sets a cookie without maxAge", () => {
+      setCookie("newcookie", "newvalue");
+      expect(document.cookie).toContain("newcookie=newvalue");
+    });
+
+    it("sets a cookie with maxAge", () => {
+      setCookie("timecookie", "timevalue", { maxAgeInSeconds: 3600 });
+      expect(document.cookie).toContain("timecookie=timevalue");
+    });
+
+    it("overwrites existing cookie value", () => {
+      setCookie("overwrite", "original");
+      setCookie("overwrite", "updated");
+      expect(getCookie("overwrite")).toBe("updated");
+    });
+  });
+
+  describe("clearCookie", () => {
+    it("clears an existing cookie", () => {
+      document.cookie = "toclear=value; path=/";
+      expect(getCookie("toclear")).toBe("value");
+
+      clearCookie("toclear");
+
+      // Cookie should be cleared (maxAge set to 0)
+      // Note: In jsdom, the cookie might still appear but with expired max-age
+      const afterClear = getCookie("toclear");
+      // After clearing, cookie should either be undefined or empty
+      expect(afterClear === undefined || afterClear === "").toBe(true);
+    });
+  });
+
+  describe("getCsrfToken", () => {
+    it("returns undefined when csrftoken cookie does not exist", () => {
+      expect(getCsrfToken()).toBeUndefined();
+    });
+
+    it("returns the csrftoken value when it exists", () => {
+      document.cookie = "csrftoken=abc123; path=/";
+      expect(getCsrfToken()).toBe("abc123");
+    });
+  });
+});

--- a/frontend/src/functions/getPlan.test.ts
+++ b/frontend/src/functions/getPlan.test.ts
@@ -176,12 +176,9 @@ describe("Megabundle Tests", () => {
       mockL10n,
     );
 
-    const expected = new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency,
-    }).format(price);
-
-    expect(formatted).toBe(expected);
+    // Currency formatting can vary by environment (e.g., "$8.25" vs "US$8.25")
+    expect(formatted).toMatch(/\$8\.25/);
+    expect(formatted).toContain("8.25");
   });
 
   it("getMegabundleYearlyPrice should return formatted yearly price", () => {
@@ -196,12 +193,9 @@ describe("Megabundle Tests", () => {
       mockL10n,
     );
 
-    const expected = new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency,
-    }).format(price * 12);
-
-    expect(formatted).toBe(expected);
+    // Currency formatting can vary by environment (e.g., "$99.00" vs "US$99.00")
+    expect(formatted).toMatch(/\$99\.00/);
+    expect(formatted).toContain("99.00");
   });
 
   it("getBundleDiscountPercentage should return discount percentage as number", () => {
@@ -255,12 +249,9 @@ describe("Price Formatting Tests", () => {
       mockL10n,
     );
 
-    expect(result).toBe(
-      new Intl.NumberFormat("en-US", {
-        style: "currency",
-        currency: "USD",
-      }).format(2.5),
-    );
+    // Currency formatting can vary by environment
+    expect(result).toMatch(/\$2\.50/);
+    expect(result).toContain("2.50");
   });
 
   it("getBundlePrice should return formatted price", () => {

--- a/frontend/src/functions/makeToast.test.ts
+++ b/frontend/src/functions/makeToast.test.ts
@@ -1,0 +1,99 @@
+import { toast } from "react-toastify";
+import { makeToast } from "./makeToast";
+
+// Mock react-toastify
+jest.mock("react-toastify", () => ({
+  toast: {
+    success: jest.fn(),
+  },
+}));
+
+// Mock cookies module
+jest.mock("./cookies", () => ({
+  getCookie: jest.fn(),
+  clearCookie: jest.fn(),
+  setCookie: jest.fn(),
+}));
+
+const mockGetCookie = jest.requireMock("./cookies").getCookie;
+const mockClearCookie = jest.requireMock("./cookies").clearCookie;
+
+describe("makeToast", () => {
+  const mockL10n = {
+    getString: jest.fn((key: string, vars?: Record<string, unknown>) => {
+      if (vars) {
+        return `l10n string: [${key}], with vars: ${JSON.stringify(vars)}`;
+      }
+      return `l10n string: [${key}], with vars: {}`;
+    }),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not show toast when no cookies are set", () => {
+    mockGetCookie.mockReturnValue(undefined);
+
+    makeToast(mockL10n as never);
+
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("shows sign-out success toast when user-sign-out cookie exists", () => {
+    mockGetCookie.mockImplementation((name: string) => {
+      if (name === "user-sign-out") return "true";
+      return undefined;
+    });
+
+    makeToast(mockL10n as never);
+
+    expect(mockClearCookie).toHaveBeenCalledWith("user-sign-out");
+    expect(toast.success).toHaveBeenCalledWith(
+      "l10n string: [success-signed-out-message], with vars: {}",
+    );
+  });
+
+  it("shows sign-in success toast when user-sign-in cookie exists and user data is provided", () => {
+    mockGetCookie.mockImplementation((name: string) => {
+      if (name === "user-sign-in") return "true";
+      return undefined;
+    });
+
+    const userData = { email: "test@example.com" };
+    makeToast(mockL10n as never, userData as never);
+
+    expect(mockClearCookie).toHaveBeenCalledWith("user-sign-in");
+    expect(toast.success).toHaveBeenCalledWith(
+      'l10n string: [success-signed-in-message], with vars: {"username":"test@example.com"}',
+    );
+  });
+
+  it("does not show sign-in toast when cookie exists but user data is undefined", () => {
+    mockGetCookie.mockImplementation((name: string) => {
+      if (name === "user-sign-in") return "true";
+      return undefined;
+    });
+
+    makeToast(mockL10n as never, undefined);
+
+    expect(mockClearCookie).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("prioritizes sign-out toast over sign-in when both cookies exist", () => {
+    mockGetCookie.mockReturnValue("true");
+
+    const userData = { email: "test@example.com" };
+    makeToast(mockL10n as never, userData as never);
+
+    expect(mockClearCookie).toHaveBeenCalledWith("user-sign-out");
+    expect(mockL10n.getString).toHaveBeenCalledWith(
+      "success-signed-out-message",
+    );
+    expect(mockL10n.getString).not.toHaveBeenCalledWith(
+      "success-signed-in-message",
+      expect.anything(),
+    );
+  });
+});

--- a/frontend/src/hooks/fxaFlowTracker.test.ts
+++ b/frontend/src/hooks/fxaFlowTracker.test.ts
@@ -1,7 +1,9 @@
 import { mockConfigModule } from "../../__mocks__/configMock";
-import { getLoginUrl } from "./fxaFlowTracker";
 
-jest.mock("../config.ts", () => mockConfigModule);
+// This test needs to test the real implementation, so unmock it
+jest.unmock("./fxaFlowTracker");
+
+import { getLoginUrl } from "./fxaFlowTracker";
 
 const mockFlowBeginTime = new Date("1990-11-12T13:37:42.000Z").getTime();
 

--- a/frontend/src/hooks/googleAnalytics.test.ts
+++ b/frontend/src/hooks/googleAnalytics.test.ts
@@ -1,0 +1,85 @@
+import { renderHook } from "@testing-library/react";
+import { useGoogleAnalytics, initGoogleAnalytics } from "./googleAnalytics";
+import ReactGa from "react-ga";
+
+// Extend the global react-ga mock to include initialize and set
+const mockInitialize = jest.fn();
+const mockSet = jest.fn();
+const mockEvent = jest.fn();
+
+(ReactGa as unknown as Record<string, jest.Mock>).initialize = mockInitialize;
+(ReactGa as unknown as Record<string, jest.Mock>).set = mockSet;
+(ReactGa as unknown as Record<string, jest.Mock>).event = mockEvent;
+
+describe("googleAnalytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInitialize.mockClear();
+    mockSet.mockClear();
+    mockEvent.mockClear();
+
+    // Clear document.cookie
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "",
+    });
+  });
+
+  describe("useGoogleAnalytics", () => {
+    it("returns false initially when GA is not initialized", () => {
+      const { result } = renderHook(() => useGoogleAnalytics());
+      expect(result.current).toBe(false);
+    });
+  });
+
+  describe("initGoogleAnalytics", () => {
+    it("initializes ReactGa with correct configuration", () => {
+      initGoogleAnalytics();
+
+      expect(mockInitialize).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          titleCase: false,
+        }),
+      );
+    });
+
+    it("sets anonymizeIp and transport options", () => {
+      initGoogleAnalytics();
+
+      expect(mockSet).toHaveBeenCalledWith({
+        anonymizeIp: true,
+        transport: "beacon",
+      });
+    });
+
+    it("processes server_ga_event cookies", () => {
+      Object.defineProperty(document, "cookie", {
+        writable: true,
+        value: "server_ga_event:test_event",
+      });
+
+      initGoogleAnalytics();
+
+      // Just verify it doesn't throw errors when processing cookies
+      expect(mockInitialize).toHaveBeenCalled();
+      expect(mockSet).toHaveBeenCalled();
+    });
+
+    it("enables debug mode when NEXT_PUBLIC_DEBUG is true", () => {
+      const originalEnv = process.env.NEXT_PUBLIC_DEBUG;
+      process.env.NEXT_PUBLIC_DEBUG = "true";
+
+      initGoogleAnalytics();
+
+      expect(mockInitialize).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          debug: true,
+        }),
+      );
+
+      process.env.NEXT_PUBLIC_DEBUG = originalEnv;
+    });
+  });
+});

--- a/frontend/src/pages/accounts/account_inactive.page.test.tsx
+++ b/frontend/src/pages/accounts/account_inactive.page.test.tsx
@@ -1,13 +1,10 @@
 import { render, screen } from "@testing-library/react";
-import { mockUseL10nModule } from "../../../__mocks__/hooks/l10n";
 
 jest.mock("../../components/layout/Layout", () => ({
   Layout: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="mock-layout">{children}</div>
   ),
 }));
-
-jest.mock("../../hooks/l10n", () => mockUseL10nModule);
 
 import AccountInactive from "./account_inactive.page";
 

--- a/frontend/src/pages/faq.test.tsx
+++ b/frontend/src/pages/faq.test.tsx
@@ -1,7 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
-import { mockLocalizedModule } from "../../__mocks__/components/Localized";
-import { mockConfigModule } from "../../__mocks__/configMock";
 import { setMockProfileData } from "../../__mocks__/hooks/api/profile";
 import {
   getMockRuntimeDataWithoutPremium,
@@ -9,20 +7,8 @@ import {
   setMockRuntimeData,
   setMockRuntimeDataOnce,
 } from "../../__mocks__/hooks/api/runtimeData";
-import { mockUseFxaFlowTrackerModule } from "../../__mocks__/hooks/fxaFlowTracker";
-import { mockUseL10nModule } from "../../__mocks__/hooks/l10n";
-import { mockNextRouter } from "../../__mocks__/modules/next__router";
-import { mockReactGa } from "../../__mocks__/modules/react-ga";
 
 import Faq from "./faq.page";
-
-jest.mock("next/router", () => mockNextRouter);
-jest.mock("react-ga", () => mockReactGa);
-jest.mock("../config.ts", () => mockConfigModule);
-jest.mock("../hooks/gaViewPing.ts");
-jest.mock("../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
-jest.mock("../hooks/l10n.ts", () => mockUseL10nModule);
-jest.mock("../components/Localized.tsx", () => mockLocalizedModule);
 
 setMockRuntimeData();
 setMockProfileData(null);

--- a/frontend/src/pages/index.test.tsx
+++ b/frontend/src/pages/index.test.tsx
@@ -1,27 +1,13 @@
 import { act, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
-import { mockLocalizedModule } from "../../__mocks__/components/Localized";
-import { mockConfigModule } from "../../__mocks__/configMock";
 import { setMockProfileData } from "../../__mocks__/hooks/api/profile";
 import {
   getMockRuntimeDataWithPhones,
   setMockRuntimeData,
   getMockRuntimeDataWithMegabundle,
 } from "../../__mocks__/hooks/api/runtimeData";
-import { mockUseFxaFlowTrackerModule } from "../../__mocks__/hooks/fxaFlowTracker";
-import { mockUseL10nModule } from "../../__mocks__/hooks/l10n";
-import { mockNextRouter } from "../../__mocks__/modules/next__router";
-import { mockReactGa } from "../../__mocks__/modules/react-ga";
 
 import Home from "./index.page";
-
-jest.mock("next/router", () => mockNextRouter);
-jest.mock("react-ga", () => mockReactGa);
-jest.mock("../config.ts", () => mockConfigModule);
-jest.mock("../hooks/gaViewPing.ts");
-jest.mock("../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
-jest.mock("../hooks/l10n.ts", () => mockUseL10nModule);
-jest.mock("../components/Localized.tsx", () => mockLocalizedModule);
 
 jest.mock("../functions/getPlan", () =>
   jest.requireActual("../../__mocks__/functions/getPlan"),

--- a/frontend/src/pages/phone.test.tsx
+++ b/frontend/src/pages/phone.test.tsx
@@ -1,7 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
-import { mockLocalizedModule } from "../../__mocks__/components/Localized";
-import { mockConfigModule } from "../../__mocks__/configMock";
 import { setMockInboundContactData } from "../../__mocks__/hooks/api/inboundContact";
 import {
   setMockProfileData,
@@ -22,18 +20,8 @@ import {
   setMockRuntimeDataOnce,
 } from "../../__mocks__/hooks/api/runtimeData";
 import { setMockUserData } from "../../__mocks__/hooks/api/user";
-import { mockUseL10nModule } from "../../__mocks__/hooks/l10n";
-import { mockNextRouter } from "../../__mocks__/modules/next__router";
-import { mockReactGa } from "../../__mocks__/modules/react-ga";
 
 import PhoneDashboard from "./phone.page";
-
-jest.mock("next/router", () => mockNextRouter);
-jest.mock("react-ga", () => mockReactGa);
-jest.mock("../config.ts", () => mockConfigModule);
-jest.mock("../hooks/gaViewPing.ts");
-jest.mock("../hooks/l10n.ts", () => mockUseL10nModule);
-jest.mock("../components/Localized.tsx", () => mockLocalizedModule);
 
 setMockProfileData();
 setMockUserData();

--- a/frontend/src/pages/phone/waitlist.page.test.tsx
+++ b/frontend/src/pages/phone/waitlist.page.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import PhoneWaitlist from "../../../src/pages/phone/waitlist.page";
-import { useL10n } from "../../../src/hooks/l10n";
 import { WaitlistPage } from "../../../src/components/waitlist/WaitlistPage";
 
 jest.mock("../../../src/components/Localized", () => {
@@ -10,7 +9,6 @@ jest.mock("../../../src/components/Localized", () => {
   return mockLocalizedModule;
 });
 
-jest.mock("../../../src/hooks/l10n");
 jest.mock("../../../src/components/waitlist/WaitlistPage", () => ({
   WaitlistPage: jest.fn(() => <div data-testid="mock-waitlist-page" />),
 }));
@@ -21,7 +19,7 @@ describe("PhoneWaitlist page", () => {
   const mockGetString = jest.fn();
 
   beforeEach(() => {
-    (useL10n as jest.Mock).mockReturnValue({
+    global.useL10nImpl = () => ({
       getString: mockGetString,
     });
 

--- a/frontend/src/pages/premium.test.tsx
+++ b/frontend/src/pages/premium.test.tsx
@@ -1,7 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
-import { mockLocalizedModule } from "../../__mocks__/components/Localized";
-import { mockConfigModule } from "../../__mocks__/configMock";
 import { setMockProfileData } from "../../__mocks__/hooks/api/profile";
 import {
   getMockRuntimeDataWithMegabundle,
@@ -10,19 +8,6 @@ import {
   getMockRuntimeDataWithPhones,
   setMockRuntimeData,
 } from "../../__mocks__/hooks/api/runtimeData";
-import { mockUseFxaFlowTrackerModule } from "../../__mocks__/hooks/fxaFlowTracker";
-import { mockUseL10nModule } from "../../__mocks__/hooks/l10n";
-import { mockNextRouter } from "../../__mocks__/modules/next__router";
-import { mockReactGa } from "../../__mocks__/modules/react-ga";
-
-jest.mock("next/router", () => mockNextRouter);
-jest.mock("react-ga", () => mockReactGa);
-jest.mock("../config.ts", () => mockConfigModule);
-jest.mock("../hooks/gaViewPing.ts");
-jest.mock("../hooks/gaEvent.ts");
-jest.mock("../hooks/fxaFlowTracker.ts", () => mockUseFxaFlowTrackerModule);
-jest.mock("../hooks/l10n.ts", () => mockUseL10nModule);
-jest.mock("../components/Localized.tsx", () => mockLocalizedModule);
 
 jest.mock("../functions/getPlan", () =>
   jest.requireActual("../../__mocks__/functions/getPlan"),

--- a/frontend/src/pages/premium/waitlist.page.test.tsx
+++ b/frontend/src/pages/premium/waitlist.page.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import PremiumWaitlist from "../../../src/pages/premium/waitlist.page";
-import { useL10n } from "../../../src/hooks/l10n";
 import { WaitlistPage } from "../../../src/components/waitlist/WaitlistPage";
 
 jest.mock("../../../src/components/Localized", () => {
@@ -10,7 +9,6 @@ jest.mock("../../../src/components/Localized", () => {
   return mockLocalizedModule;
 });
 
-jest.mock("../../../src/hooks/l10n");
 jest.mock("../../../src/components/waitlist/WaitlistPage", () => ({
   WaitlistPage: jest.fn(() => <div data-testid="mock-waitlist-page" />),
 }));
@@ -21,7 +19,7 @@ describe("PremiumWaitlist page", () => {
   const mockGetString = jest.fn();
 
   beforeEach(() => {
-    (useL10n as jest.Mock).mockReturnValue({
+    global.useL10nImpl = () => ({
       getString: mockGetString,
     });
 

--- a/frontend/src/pages/vpn-relay/waitlist.page.test.tsx
+++ b/frontend/src/pages/vpn-relay/waitlist.page.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import BundleWaitlist from "../../../src/pages/vpn-relay/waitlist.page";
-import { useL10n } from "../../../src/hooks/l10n";
 import { WaitlistPage } from "../../../src/components/waitlist/WaitlistPage";
 
 jest.mock("../../../src/components/Localized", () => {
@@ -10,7 +9,6 @@ jest.mock("../../../src/components/Localized", () => {
   return mockLocalizedModule;
 });
 
-jest.mock("../../../src/hooks/l10n");
 jest.mock("../../../src/components/waitlist/WaitlistPage", () => ({
   WaitlistPage: jest.fn(() => <div data-testid="mock-waitlist-page" />),
 }));
@@ -21,7 +19,7 @@ describe("BundleWaitlist page", () => {
   const mockGetString = jest.fn();
 
   beforeEach(() => {
-    (useL10n as jest.Mock).mockReturnValue({
+    global.useL10nImpl = () => ({
       getString: mockGetString,
     });
 
@@ -30,7 +28,7 @@ describe("BundleWaitlist page", () => {
         "waitlist-heading-bundle": "Bundle up with VPN and Relay",
         "waitlist-lead-bundle": "Get notified when our privacy bundle is ready",
         "waitlist-privacy-policy-use-bundle":
-          "We’ll only use your info for bundle updates.",
+          "We'll only use your info for bundle updates.",
       };
       return strings[id] ?? id;
     });
@@ -65,7 +63,9 @@ describe("BundleWaitlist page", () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText("We’ll only use your info for bundle updates."),
+      screen.getByText((content) =>
+        content.includes("We'll only use your info for bundle updates"),
+      ),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# [MPP-4184](https://mozilla-hub.atlassian.net/browse/MPP-4184) & [MPP-4185](https://mozilla-hub.atlassian.net/browse/MPP-4185)

Test code coverage improved on the following: 
- premium waitlist page
- waitlist components
- landing page components 
- settings page 
- banner components

# OLD COVERAGE
<img width="769" height="141" alt="Screenshot 2025-11-02 at 10 55 35 PM" src="https://github.com/user-attachments/assets/644fa8e2-ea0b-4b6a-bb01-3c339b80b7fd" />
<img width="715" height="97" alt="Screenshot 2025-11-29 at 3 58 40 PM" src="https://github.com/user-attachments/assets/08bca3dc-3b1c-4642-9b61-872fc5f4e8d5" />

# NEW COVERAGE
- premium waitlist page --> 100% (from previous PR)
- waitlist components --> 89.63%
- landing page components -->  92.38%
- settings page --> 90.38%
- banner components --> 85.51%

[MPP-4184]: https://mozilla-hub.atlassian.net/browse/MPP-4184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MPP-4185]: https://mozilla-hub.atlassian.net/browse/MPP-4185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ