### PR TITLE
fix MPP-4486 - fix(l10n-sync): create PRs instead of direct commits

### DIFF
--- a/.github/workflows/l10n-sync.yml
+++ b/.github/workflows/l10n-sync.yml
@@ -19,10 +19,52 @@ jobs:
         run: |
           git submodule update --init --recursive
           git submodule update --recursive --remote
-      - name: Commit
+
+      - name: Check for changes
+        id: check_changes
         run: |
-          git config user.email "actions@github.com"
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.has_changes == 'true'
+        id: create_pr
+        run: |
+          # Configure git
           git config user.name "GitHub Actions — l10n sync"
+          git config user.email "actions@github.com"
+          
+          # Create a new branch
+          BRANCH_NAME="automated-l10n-sync-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH_NAME"
+          
+          # Commit changes
           git add --all
-          git commit --message="Merge in latest l10n strings" || echo "No changes to commit"
-          git push
+          git commit -m "Merge in latest l10n strings"
+          
+          # Push branch
+          git push origin "$BRANCH_NAME"
+          
+          # Create PR using gh CLI
+          PR_URL=$(gh pr create \
+            --title "chore: Merge in latest l10n strings" \
+            --body "Automated pull request to sync the latest localization strings from the l10n repository."
+            --base main \
+            --head "$BRANCH_NAME")
+          
+          # Extract PR number from URL
+          PR_NUMBER=$(echo "$PR_URL" | grep -oP '\d+$')
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.L10N_UPDATE_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.check_changes.outputs.has_changes == 'true' && steps.create_pr.outputs.pr_number
+        run: gh pr merge ${{ steps.create_pr.outputs.pr_number }} --auto --merge
+        env:
+          GH_TOKEN: ${{ secrets.L10N_UPDATE_TOKEN }}
+


### PR DESCRIPTION
Update l10n-sync workflow to create pull requests instead of committing directly to main, with auto-merge enabled for automated l10n updates.

This PR fixes #MPP-4486.

How to test:
The workflow already ran successfully on this branch here: https://github.com/mozilla/fx-private-relay/actions/runs/19179080811

But we should also test it when there's a real l10n change to sync.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).