### PR TITLE
MPP-4486 - fix(l10n-sync): add missing \ after --body flag

### DIFF
--- a/.github/workflows/l10n-sync.yml
+++ b/.github/workflows/l10n-sync.yml
@@ -51,7 +51,7 @@ jobs:
           # Create PR using gh CLI
           PR_URL=$(gh pr create \
             --title "chore: Merge in latest l10n strings" \
-            --body "Automated pull request to sync the latest localization strings from the l10n repository."
+            --body "Automated pull request to sync the latest localization strings from the l10n repository." \
             --base main \
             --head "$BRANCH_NAME")
           
@@ -67,4 +67,3 @@ jobs:
         run: gh pr merge ${{ steps.create_pr.outputs.pr_number }} --auto --merge
         env:
           GH_TOKEN: ${{ secrets.L10N_UPDATE_TOKEN }}
-


### PR DESCRIPTION
This PR fixes #MPP-4486.

How to test:
Merge this PR and then check [the workflow](https://github.com/mozilla/fx-private-relay/actions/workflows/l10n-sync.yml) again tomorrow or next day there's an l10n update.

The [previous workflow run](https://github.com/mozilla/fx-private-relay/actions/runs/19184631679/job/54848735760) was able to create the PR with the body, but it gave this error:
```
/home/runner/work/_temp/9a75c782-8551-4fb0-9f17-308601dcb229.sh: line 22: --base: command not found
```

(I merged [the PR it sent](https://github.com/mozilla/fx-private-relay/pull/6032).)


- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).