### PR TITLE
MPP-4486 feat(l10n-sync): use mergify to auto-merge PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,25 @@
+queue_rules:
+  - name: default
+    conditions:
+      - status-success=ci/circleci: build_frontend
+      - status-success=ci/circleci: build_test_backend
+      - status-success=ci/circleci: test_frontend
+
+pull_request_rules:
+  # Automatically approve and merge l10n updates from GitHub Actions
+  - name: L10N auto-merge
+    conditions:
+      - author=github-actions[bot]
+      - files~=^privaterelay/locales/
+      # Ensure ONLY l10n files are modified
+      - -files~=^(?!privaterelay/locales/)
+      - status-success=ci/circleci: build_frontend
+      - status-success=ci/circleci: build_test_backend
+      - status-success=ci/circleci: test_frontend
+    actions:
+      review:
+        type: APPROVE
+        message: "LGTM 😎"
+      queue:
+        name: default
+        method: merge

--- a/.github/workflows/l10n-sync.yml
+++ b/.github/workflows/l10n-sync.yml
@@ -61,9 +61,3 @@ jobs:
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.L10N_UPDATE_TOKEN }}
-
-      - name: Enable auto-merge
-        if: steps.check_changes.outputs.has_changes == 'true' && steps.create_pr.outputs.pr_number
-        run: gh pr merge ${{ steps.create_pr.outputs.pr_number }} --auto --merge
-        env:
-          GH_TOKEN: ${{ secrets.L10N_UPDATE_TOKEN }}


### PR DESCRIPTION
This PR fixes #MPP-4486. See https://mozilla.slack.com/archives/C4FK623KL/p1762875534412169 for more context.

How to test:
1. Have Mozilla GitHub admins (re-)install the [mergify](https://github.com/marketplace/mergify) app.
2. Merge this PR.
3. Next time an l10n PR comes in from the github action, mergify should auto-merge it.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [ ] I've added or updated relevant docs in the docs/ directory.
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).