### PR TITLE
fix MPP-4485 - fix(settings): disable sentry cache_spans

### DIFF
--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -870,7 +870,7 @@ if SENTRY_ENVIRONMENT == "prod" and SITE_ORIGIN != "https://relay.firefox.com":
 
 sentry_sdk.init(
     dsn=config("SENTRY_DSN", None),
-    integrations=[DjangoIntegration(cache_spans=not DEBUG)],
+    integrations=[DjangoIntegration()],
     debug=SENTRY_DEBUG,
     include_local_variables=DEBUG,
     release=sentry_release,


### PR DESCRIPTION
This PR fixes #MPP-4485.

How to test:
All tests should pass.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).