### PR TITLE
fix(auth): enforce relay scope on bearer token auth

### DIFF
--- a/api/authentication.py
+++ b/api/authentication.py
@@ -95,6 +95,12 @@ def get_fxa_uid_from_oauth_token(token: str, use_cache: bool = True) -> str:
         raise NotFound("FXA did not return an FXA UID.")
     fxa_uid = str(raw_fxa_uid)
 
+    scopes = fxa_resp_data.get("json", {}).get("scope", "").split()
+    if settings.RELAY_SCOPE not in scopes:
+        raise AuthenticationFailed(
+            "FXA token is missing scope: https://identity.mozilla.com/apps/relay."
+        )
+
     # cache valid access_token and fxa_resp_data until access_token expiration
     # TODO: revisit this since the token can expire before its time
     if isinstance(fxa_resp_data.get("json", {}).get("exp"), int):

--- a/api/tests/authentication_tests.py
+++ b/api/tests/authentication_tests.py
@@ -31,6 +31,7 @@ class FxaResponse(TypedDict, total=False):
     sub: str
     exp: int
     error: str
+    scope: str
 
 
 class CachedFxaResponse(TypedDict):
@@ -48,7 +49,10 @@ def _setup_fxa_response(
         json=json,
     )
     if json is None:
-        return {"status_code": status_code}
+        return {
+            "status_code": status_code,
+            "json": {"scope": "https://identity.mozilla.com/apps/relay"},
+        }
     return {"status_code": status_code, "json": json}
 
 
@@ -85,6 +89,7 @@ class AuthenticationMiscellaneous(TestCase):
             "active": True,
             "sub": self.uid,
             "exp": exp_time,
+            "scope": "https://identity.mozilla.com/apps/relay",
         }
         status_code = 200
         expected_fxa_resp_data = {"status_code": status_code, "json": json_data}
@@ -105,7 +110,13 @@ class AuthenticationMiscellaneous(TestCase):
         # Note: FXA iat and exp are timestamps in *milliseconds*
         exp_time = (now_time + 60 * 60) * 1000
         fxa_response = _setup_fxa_response(
-            200, {"active": True, "sub": self.uid, "exp": exp_time}
+            200,
+            {
+                "active": True,
+                "sub": self.uid,
+                "exp": exp_time,
+                "scope": "https://identity.mozilla.com/apps/relay",
+            },
         )
         cache_key = get_cache_key(user_token)
 
@@ -214,12 +225,62 @@ class AuthenticationMiscellaneous(TestCase):
         self.fail("Should have raised AuthenticationFailed")
 
     @responses.activate
+    def test_get_fxa_uid_from_oauth_token_has_wrong_scope_returns_error_response(  # noqa: E501
+        self,
+    ) -> None:
+        now_time = int(datetime.now().timestamp())
+        # Note: FXA iat and exp are timestamps in *milliseconds*
+        exp_time = (now_time + 60 * 60) * 1000
+        json_data: FxaResponse = {
+            "active": True,
+            "sub": self.uid,
+            "exp": exp_time,
+            "scope": "foo",
+        }
+        status_code = 200
+        fxa_response = _setup_fxa_response(status_code, json_data)
+        missing_scopes_token = "missing-scopes-123"
+        cache_key = get_cache_key(missing_scopes_token)
+
+        assert cache.get(cache_key) is None
+
+        # get fxa response with no fxa uid for the first time
+        try:
+            get_fxa_uid_from_oauth_token(missing_scopes_token)
+        except AuthenticationFailed as e:
+            assert (
+                str(e.detail)
+                == "FXA token is missing scope: https://identity.mozilla.com/apps/relay."
+            )
+            assert responses.assert_call_count(self.fxa_verify_path, 1) is True
+        assert cache.get(cache_key) == fxa_response
+
+        # now check that the 2nd call did NOT make another fxa request
+        try:
+            get_fxa_uid_from_oauth_token(missing_scopes_token)
+        except AuthenticationFailed as e:
+            assert (
+                str(e.detail)
+                == "FXA token is missing scope: https://identity.mozilla.com/apps/relay."
+            )
+            assert responses.assert_call_count(self.fxa_verify_path, 1) is True
+            return
+        self.fail("Should have raised AuthenticationFailed")
+
+    @responses.activate
     def test_get_fxa_uid_from_oauth_token_returns_fxa_response_with_no_fxa_uid(self):
         user_token = "user-123"
         now_time = int(datetime.now().timestamp())
         # Note: FXA iat and exp are timestamps in *milliseconds*
         exp_time = (now_time + 60 * 60) * 1000
-        fxa_response = _setup_fxa_response(200, {"active": True, "exp": exp_time})
+        fxa_response = _setup_fxa_response(
+            200,
+            {
+                "active": True,
+                "exp": exp_time,
+                "scope": "https://identity.mozilla.com/apps/relay",
+            },
+        )
         cache_key = get_cache_key(user_token)
 
         assert cache.get(cache_key) is None
@@ -329,8 +390,14 @@ class FxaTokenAuthenticationTest(TestCase):
 
     @responses.activate
     def test_200_resp_from_fxa_no_matching_user_raises_APIException(self) -> None:
+        # I think this scope is realistic for a user that has not not accepted terms
         fxa_response = _setup_fxa_response(
-            200, {"active": True, "sub": "not-a-relay-user"}
+            200,
+            {
+                "active": True,
+                "sub": "not-a-relay-user",
+                "scope": "https://identity.mozilla.com/apps/relay",
+            },
         )
         non_user_token = "non-user-123"
         client = APIClient()
@@ -359,7 +426,15 @@ class FxaTokenAuthenticationTest(TestCase):
         now_time = int(datetime.now().timestamp())
         # Note: FXA iat and exp are timestamps in *milliseconds*
         exp_time = (now_time + 60 * 60) * 1000
-        _setup_fxa_response(200, {"active": True, "sub": self.uid, "exp": exp_time})
+        _setup_fxa_response(
+            200,
+            {
+                "active": True,
+                "sub": self.uid,
+                "exp": exp_time,
+                "scope": "https://identity.mozilla.com/apps/relay",
+            },
+        )
         inactive_user_token = "inactive-user-123"
         client = APIClient()
         client.credentials(HTTP_AUTHORIZATION=f"Bearer {inactive_user_token}")
@@ -382,7 +457,13 @@ class FxaTokenAuthenticationTest(TestCase):
         # Note: FXA iat and exp are timestamps in *milliseconds*
         exp_time = (now_time + 60 * 60) * 1000
         fxa_response = _setup_fxa_response(
-            200, {"active": True, "sub": self.uid, "exp": exp_time}
+            200,
+            {
+                "active": True,
+                "sub": self.uid,
+                "exp": exp_time,
+                "scope": "https://identity.mozilla.com/apps/relay",
+            },
         )
 
         assert cache.get(get_cache_key(user_token)) is None
@@ -413,7 +494,13 @@ class FxaTokenAuthenticationTest(TestCase):
         # Note: FXA iat and exp are timestamps in *milliseconds*
         exp_time = (now_time + 60 * 60) * 1000
         fxa_response = _setup_fxa_response(
-            200, {"active": True, "sub": self.uid, "exp": exp_time}
+            200,
+            {
+                "active": True,
+                "sub": self.uid,
+                "exp": exp_time,
+                "scope": "https://identity.mozilla.com/apps/relay",
+            },
         )
 
         assert cache.get(get_cache_key(user_token)) is None

--- a/api/tests/privaterelay_views_tests.py
+++ b/api/tests/privaterelay_views_tests.py
@@ -291,7 +291,13 @@ class TermsAcceptedUserViewTest(TestCase):
         # Note: FXA iat and exp are timestamps in *milliseconds*
         exp_time = (now_time + 60 * 60) * 1000
         fxa_response = _setup_fxa_response(
-            200, {"active": True, "sub": self.uid, "exp": exp_time}
+            200,
+            {
+                "active": True,
+                "sub": self.uid,
+                "exp": exp_time,
+                "scope": "https://identity.mozilla.com/apps/relay",
+            },
         )
         # setup fxa profile response
         profile_json = {
@@ -340,7 +346,15 @@ class TermsAcceptedUserViewTest(TestCase):
         self._setup_client(user_token)
         now_time = int(datetime.now().timestamp())
         exp_time = (now_time + 60 * 60) * 1000
-        _setup_fxa_response(200, {"active": True, "sub": self.uid, "exp": exp_time})
+        _setup_fxa_response(
+            200,
+            {
+                "active": True,
+                "sub": self.uid,
+                "exp": exp_time,
+                "scope": "https://identity.mozilla.com/apps/relay",
+            },
+        )
         # FxA profile server is down
         responses.add(responses.GET, FXA_PROFILE_URL, status=502, body="")
         response = self.client.post(self.path)

--- a/docs/fx-integration.md
+++ b/docs/fx-integration.md
@@ -49,10 +49,6 @@ Firefox uses [Relay's REST API][relay-rest-api]. In particular, it uses these en
 
 ## Testing with local, dev, or stage Relay
 
-As of 2023-07-13, Relay integration is only enabled for Nightly users, so to test
-reliably you'll need to use Nightly. By 2023-08-29, it should be available for all
-Firefox users signed into the browser with their FxA.
-
 To test the Firefox integration outside of the production environment, you need to
 configure a Firefox profile to use non-production Relay and FxA servers.
 
@@ -60,6 +56,7 @@ configure a Firefox profile to use non-production Relay and FxA servers.
 2. Go to `about:config`
 3. Change values per the table below
 4. Restart Firefox with the profile
+5. Make sure you are logging in with a user that you have logged in with in your local instance (i.e. follow the login flow from 127.0.0.1:8000)
 
 |             | `identity.fxaccounts.autoconfig.uri` | `signon.firefoxRelay.base_url`          | `signon.firefoxRelay.manage_url` |
 | ----------- | ------------------------------------ | --------------------------------------- | -------------------------------- |

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -428,6 +428,10 @@ TEMPLATES = [
 
 RELAY_FIREFOX_DOMAIN: str = config("RELAY_FIREFOX_DOMAIN", "relay.firefox.com")
 MOZMAIL_DOMAIN: str = config("MOZMAIL_DOMAIN", "mozmail.com")
+# A particular scope that we require OAuth applications to have
+RELAY_SCOPE: str = config(
+    "RELAY_SCOPE", "https://identity.mozilla.com/apps/relay", cast=str
+)
 MAX_NUM_FREE_ALIASES: int = config("MAX_NUM_FREE_ALIASES", 5, cast=int)
 PERIODICAL_PREMIUM_PROD_ID: str = config("PERIODICAL_PREMIUM_PROD_ID", "")
 PREMIUM_PLAN_ID_US_MONTHLY: str = config(
@@ -607,7 +611,11 @@ AUTHENTICATION_BACKENDS = (
 SOCIALACCOUNT_PROVIDERS = {
     "fxa": {
         # Note: to request "profile" scope, must be a trusted Mozilla client
-        "SCOPE": ["profile", "https://identity.mozilla.com/account/subscriptions"],
+        "SCOPE": [
+            "profile",
+            "https://identity.mozilla.com/account/subscriptions",
+            RELAY_SCOPE,
+        ],
         "AUTH_PARAMS": {"access_type": "offline"},
         "OAUTH_ENDPOINT": config(
             "FXA_OAUTH_ENDPOINT", "https://oauth.accounts.firefox.com/v1"


### PR DESCRIPTION
This PR fixes MPP-4437.

Changes:
- Enforce Relay scope being needed for Bearer token auth.
- Add Relay scope to the default scopes that the application requests. Even though a request coming from the web application will ultimately use session authentication, we should still generate a token that _could_ be used for Bearer auth.

How to test:

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
