### PR TITLE
fix: Fetch submodules in "prebuild_script" of build and push workflow

### DIFF
--- a/.github/workflows/build-and-push-to-gar.yml
+++ b/.github/workflows/build-and-push-to-gar.yml
@@ -47,4 +47,5 @@ jobs:
         GIT_BRANCH=${{ needs.determine-metadata.outputs.git_branch }}
         GIT_SHA=${{ github.sha }}
         GIT_TAG=${{ needs.determine-metadata.outputs.git_tag }}
+      prebuild_script: "git submodule update --init --recursive"
       postbuild_script: "./scripts/smoketest.sh fx-private-relay"


### PR DESCRIPTION
After merging [this PR](https://github.com/mozilla/fx-private-relay/pull/6055), I noticed [this error](https://github.com/mozilla/fx-private-relay/actions/runs/19508527093/job/55841534778).

That happened because we [don't use](https://github.com/mozilla-it/deploy-actions/blob/a34e7a868025b983d7c948354ca3d1e887ed778d/.github/workflows/build-and-push.yml#L73-L78) `submodules: true` in the `checkout` step of the reusable workflow.

Because there isn't an option to fetch submodules in the reusable workflow (yet), and since the Dockerfile [takes care of building the `version.json` file](https://github.com/mozilla/fx-private-relay/blob/ad49483290d3a150224f38fc22e3083966f5e7fb/Dockerfile#L72-L80), in this PR, we use the [`prebuild_script`](https://github.com/mozilla-it/deploy-actions/blob/main/.github/workflows/docs/build-and-push.md#prebuild-scripts) as a place to fetch the submodules so the build can continue on.


