### PR TITLE
fix: add permissions to build and push workflow

### DIFF
--- a/.github/workflows/build-and-push-to-gar.yml
+++ b/.github/workflows/build-and-push-to-gar.yml
@@ -33,6 +33,9 @@ jobs:
   build-and-push:
     name: Build and push Docker image
     needs: determine-metadata
+    permissions:
+      contents: read
+      id-token: write     
     uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@v5.3.4
     with:
       image_name: fx-private-relay


### PR DESCRIPTION
https://github.com/mozilla/fx-private-relay/actions/runs/19539947095/job/55943338246

> Error: google-github-actions/auth failed with: retry function failed after 4 attempts: gitHub Actions did not inject $ACTIONS_ID_TOKEN_REQUEST_TOKEN or $ACTIONS_ID_TOKEN_REQUEST_URL into this job. This most likely means the GitHub Actions workflow permissions are incorrect, or this job is being run from a fork.

Unlike the [previous permissions](https://github.com/mozilla/fx-private-relay/pull/6055/files#diff-ad1eacbab0869fdf64054e961ebf857809b924095ae9636bc3da2e7a2a89e24fL15-L18) that were set, we don't need `packages` since we're not pushing to GHCR.