### PR TITLE
MPP-4496: add cooldown to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 8
     open-pull-requests-limit: 10
     groups:
       eslint:
@@ -35,6 +37,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 8
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "django-stubs"
@@ -73,7 +77,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 8
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 8


### PR DESCRIPTION
Adds dependency cooldowns to mitigate supply-chain attacks. Effects a 7–14 day delay before adopting new releases, letting public detection catch compromised packages before they reach us.

See https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns.

This PR is under the BLE ticket #MPP-4496.

How to test:
Check dependabot next week!

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] I've added or updated relevant docs in the docs/ directory.
      - Note: our dependency docs don't specifically mention a frequency.
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).