### PR TITLE
MPP-4503 - fix(onboarding): remove "Add Relay extension" CTA for Premium users on non-Firefox browsers

### DIFF
--- a/frontend/src/components/dashboard/PremiumOnboarding.tsx
+++ b/frontend/src/components/dashboard/PremiumOnboarding.tsx
@@ -124,8 +124,8 @@ export const PremiumOnboarding = (props: Props) => {
         </button>
       );
     } else {
-      const getAddon = () => {
-        props.onNextStep(2);
+      const continueToNextStep = () => {
+        props.onNextStep(shouldShowStepThree ? 3 : 2);
         gaEvent({
           category: "Premium Onboarding",
           action: "Engage",
@@ -134,7 +134,7 @@ export const PremiumOnboarding = (props: Props) => {
         });
       };
       button = (
-        <Button ref={continueWithDomainButtonRef} onClick={getAddon}>
+        <Button ref={continueWithDomainButtonRef} onClick={continueToNextStep}>
           {l10n.getString("multi-part-onboarding-continue")}
         </Button>
       );


### PR DESCRIPTION
# This PR fixes [MPP-4503](https://mozilla-hub.atlassian.net/browse/MPP-4503)

# How to test:
- login as a premium (new user) on a non-Firefox browser
- 3rd step 'Add Relay Extension' should NOT appear

# Checklist
- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

[MPP-4503]: https://mozilla-hub.atlassian.net/browse/MPP-4503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ