### PR TITLE
fix(errors): avoid error handling race condition with FXA redirects

### DIFF
--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -97,6 +97,8 @@ const Profile: NextPage = () => {
       getRuntimeConfig().fxaLoginUrl,
     );
     document.location.assign(fxaLoginWithAuthParams);
+    // avoid race condition where we flash the error below before the redirect finishes
+    return null;
   }
 
   const profile = profileData.data?.[0];

--- a/frontend/src/pages/phone.page.tsx
+++ b/frontend/src/pages/phone.page.tsx
@@ -75,6 +75,8 @@ const Phone: NextPage = () => {
 
   if (!userData.isValidating && userData.error) {
     document.location.assign(getRuntimeConfig().fxaLoginUrl);
+    // avoid race condition where we flash the error below before the redirect finishes
+    return null;
   }
 
   // userData errors are handled above, runtimeData errors won't impede rendering


### PR DESCRIPTION
This PR fixes MPP-4524, an issue where we briefly flash an error message for logged out users visiting the dashboard.

How to test:

1. Using `main` or the `2025.12.10` tag run the server locally and log out.
2. Navigate to `http://127.0.0.1:8000/accounts/profile/` or `http://127.0.0.1:8000/phone`. You should see the error flash before being redirected to FXA.
3. Run this branch (make sure to build the frontend) and navigate to either of the above URLs. You should be redirected without any error flashed.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
