### PR TITLE
MPP-4440 - Remove Legal Link from Relay Dashboard

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -268,15 +268,6 @@ export const Layout = (props: Props) => {
                 </li>
                 <li>
                   <a
-                    href="https://www.mozilla.org/about/legal/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {l10n.getString("nav-footer-legal")}
-                  </a>
-                </li>
-                <li>
-                  <a
                     href="https://github.com/mozilla/fx-private-relay"
                     rel="noopener noreferrer"
                     target="_blank"


### PR DESCRIPTION
# [MPP-4440](https://mozilla-hub.atlassian.net/jira/software/c/projects/MPP/boards/198?assignee=712020%3A3fadd77f-3063-46d8-99bd-cc38c5164574&selectedIssue=MPP-4440) 

# Screenshot
<img width="1768" height="1039" alt="Screenshot 2025-12-22 at 10 50 15 AM" src="https://github.com/user-attachments/assets/b7da5d14-20e3-4bf2-9e01-52a885f4086d" />

# How to test
- navigate to Relay Dashboard
- notice the 'Legal' link in the footer is gone

# Checklist (Definition of Done)

- [X] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [X] Customer Experience team has seen or waived a demo of functionality.
- [X] All acceptance criteria are met.
- [X] Jira ticket has been updated (if needed) to match changes made during the development process.
- [X] I've added or updated relevant docs in the docs/ directory
- [X] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [X] [l10n changes have been submitted to the l10n repository, if any.](https://github.com/mozilla-l10n/fx-private-relay-l10n/pull/184)


[MPP-4440]: https://mozilla-hub.atlassian.net/browse/MPP-4440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ