### PR TITLE
MPP-4411 - fix(relay): update dashboard messaging for tracker removal

### DIFF
--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -473,22 +473,24 @@ const Profile: NextPage = () => {
             typeof profile.level_one_trackers_blocked === "number" && (
               <div className={styles.stat}>
                 <dt className={styles.label}>
-                  {l10n.getString("profile-stat-label-trackers-removed")}
+                  {profile.remove_level_one_email_trackers
+                    ? l10n.getString("profile-stat-label-trackers-removed")
+                    : l10n.getString("profile-stat-label-trackers-detected")}
                 </dt>
                 <dd className={styles.value}>
                   {numberFormatter.format(profile.level_one_trackers_blocked)}
-                  <StatExplainer>
-                    <p>
-                      {l10n.getString(
-                        "profile-stat-label-trackers-learn-more-part1",
-                      )}
-                    </p>
-                    <p>
-                      {l10n.getString(
-                        "profile-stat-label-trackers-learn-more-part2-2",
-                      )}
-                    </p>
-                  </StatExplainer>
+                  {profile.remove_level_one_email_trackers ? null : (
+                    <div className={styles["learn-more-wrapper"]}>
+                      <Link
+                        href="/accounts/settings/"
+                        className={styles["open-button"]}
+                      >
+                        {l10n.getString(
+                          "profile-stat-label-trackers-remove-trackers",
+                        )}
+                      </Link>
+                    </div>
+                  )}
                 </dd>
               </div>
             )}

--- a/frontend/src/pages/accounts/profile.test.tsx
+++ b/frontend/src/pages/accounts/profile.test.tsx
@@ -231,10 +231,11 @@ describe("The dashboard", () => {
     expect(countOf72.parentElement?.textContent).toMatch("72");
   });
 
-  it("shows and hides the StatExplainer tooltip for trackers removed", async () => {
+  it("shows 'Remove trackers' link for users not opted into tracker removal", async () => {
     setMockProfileDataOnce({
       has_premium: true,
       level_one_trackers_blocked: 123,
+      remove_level_one_email_trackers: false,
     });
     setMockAliasesDataOnce({ random: [], custom: [] });
     setMockRuntimeDataOnce({
@@ -244,28 +245,16 @@ describe("The dashboard", () => {
 
     render(<Profile />);
 
-    const learnMoreButton = screen.getByRole("button", {
-      name: "l10n string: [profile-stat-learn-more], with vars: {}",
-    });
-    await userEvent.click(learnMoreButton);
-
-    const tooltip = await screen.findByText(
-      "l10n string: [profile-stat-label-trackers-learn-more-part1], with vars: {}",
+    const trackersDetectedLabel = screen.getByText(
+      /profile-stat-label-trackers-detected/,
     );
-    expect(tooltip).toBeInTheDocument();
+    expect(trackersDetectedLabel).toBeInTheDocument();
 
-    const closeButton = screen.getByRole("button", {
-      name: "l10n string: [profile-stat-learn-more-close], with vars: {}",
+    const removeTrackersLink = screen.getByRole("link", {
+      name: "l10n string: [profile-stat-label-trackers-remove-trackers], with vars: {}",
     });
-    await userEvent.click(closeButton);
-
-    await waitFor(() => {
-      expect(
-        screen.queryByText(
-          "l10n string: [profile-stat-label-trackers-learn-more-part1], with vars: {}",
-        ),
-      ).not.toBeInTheDocument();
-    });
+    expect(removeTrackersLink).toBeInTheDocument();
+    expect(removeTrackersLink).toHaveAttribute("href", "/accounts/settings/");
   });
 
   it("shows the domain search form for Premium users that do not have a domain yet", () => {
@@ -1274,10 +1263,11 @@ describe("The dashboard", () => {
     expect(secondAlias).not.toBeInTheDocument();
   });
 
-  it("shows correct count of email trackers removed for Premium users with tracker removal flag", () => {
+  it("shows correct count of email trackers removed for Premium users with tracker removal enabled", () => {
     setMockProfileDataOnce({
       has_premium: true,
       level_one_trackers_blocked: 99,
+      remove_level_one_email_trackers: true,
     });
     setMockAliasesDataOnce({ random: [], custom: [] });
     setMockRuntimeDataOnce({
@@ -1293,6 +1283,12 @@ describe("The dashboard", () => {
 
     // eslint-disable-next-line testing-library/no-node-access
     expect(trackersCount.parentElement?.textContent).toMatch("99");
+
+    // Verify no "Remove trackers" link is shown when tracker removal is enabled
+    const removeTrackersLink = screen.queryByRole("link", {
+      name: "l10n string: [profile-stat-label-trackers-remove-trackers], with vars: {}",
+    });
+    expect(removeTrackersLink).not.toBeInTheDocument();
   });
 
   describe("error state", () => {


### PR DESCRIPTION
# [MPP-4411](https://mozilla-hub.atlassian.net/browse/MPP-4411)
# How to test:
- navigate to dashboard 
- notice changes in tracker removal verbiage

# Screenshot
<img width="1710" height="688" alt="Screenshot 2026-01-02 at 1 32 15 PM" src="https://github.com/user-attachments/assets/f42739d2-0919-4c3f-9a92-3d51d6775a5b" />

# Checklist
- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

[MPP-4411]: https://mozilla-hub.atlassian.net/browse/MPP-4411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ