### PR TITLE
fix(relay): Fix 'npm run dev'

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "license": "MPL-2.0",
   "private": true,
   "scripts": {
-    "dev": "NEXT_PUBLIC_DEBUG=true next dev",
+    "dev": "NEXT_PUBLIC_DEBUG=true next dev --webpack",
     "dev:mocked": "NEXT_PUBLIC_MOCK_API=true npm run dev",
     "watch": "chokidar \"src/**/*\" \"next.config.js\" --initial --command=\"npm run watch_build\"",
     "watch_build": "NEXT_PUBLIC_DEBUG=true npm run build",


### PR DESCRIPTION
The default for next.js changed to turbopack. Fix `npm run dev` to use webpack instead.