### PR TITLE
fix(tests): Add environment and suite to E2E failure post

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -96,6 +96,12 @@ jobs:
               - type: section
                 fields:
                   - type: mrkdwn
+                    text: "*Environment:*\n ${{ inputs.environment }}"
+                  - type: mrkdwn
+                    text: "*Suite:*\n ${{ inputs.suite }}"
+              - type: section
+                fields:
+                  - type: mrkdwn
                     text: "*Ref:*\n ${{ github.ref }}"
                   - type: mrkdwn
                     text: "*Triggered by:*\n ${{ github.triggering_actor }}"


### PR DESCRIPTION
When posting to the`#relay-alerts` channel that the E2E test suite failed, include the target environment and test suite.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

The [new alert](https://mozilla.slack.com/archives/C02N3PHRL8P/p1768406919982589):

<img width="408" height="227" alt="pr 6194 alert" src="https://github.com/user-attachments/assets/52543faa-1f0b-42a1-aec3-5601920ad276" />