### PR TITLE
fix(tests): Update TermsAcceptedUserViewTest, reproduce bugs (MPP-3505, MPP-3928)

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -5,7 +5,6 @@ from django.contrib.sites.models import Site
 
 import pytest
 from allauth.socialaccount.models import SocialApp
-from model_bakery import baker
 from rest_framework.test import APIClient
 
 from privaterelay.tests.utils import make_free_test_user, make_premium_test_user
@@ -43,5 +42,7 @@ def prem_api_client(premium_user: User) -> APIClient:
 
 @pytest.fixture
 def fxa_social_app(db: None) -> SocialApp:
-    app: SocialApp = baker.make(SocialApp, provider="fxa", sites=[Site.objects.first()])
-    return app
+    social_app, _created = SocialApp.objects.get_or_create(provider="fxa")
+    if _created:
+        social_app.sites.set((Site.objects.first(),))
+    return social_app


### PR DESCRIPTION
This PR refactors the test case `TermsAcceptedUserViewTest`, and adds tests to reproduce some unhandled exceptions (MPP-3505 and MPP-3928).

The changes:

* Switch from `TestCase` to `APITestCase`, so `self.client` will be the API test client
* Move constants from `setUp` to the class, and re-use the same token
* Fix test names that say the cache is tested, but don't.
* Add test to demonstrate that a user created during a slow profile fetch is not an issue. I once suspected this was the cause of MPP-3505.
* Add test to show a timeout during a profile fetch is not caught. We might as well catch that too.
* Add tests that create a user during the `django-allauth` `complete_social_app` call in two ways. If the user is added before the `process_auto_signup` call, then a `NoReverseMatch` is raised (MPP-3928). If the user is added after the call, then a `IntegrityError` is raised.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
