### PR TITLE
fix MPP-4539: add platform detection for mobile vs desktop clients

### DIFF
--- a/privaterelay/glean_interface.py
+++ b/privaterelay/glean_interface.py
@@ -44,13 +44,15 @@ class RequestData(NamedTuple):
 
     user_agent: str | None = None
     ip_address: str | None = None
+    platform: str | None = None
 
     @classmethod
     def from_request(cls, request: HttpRequest) -> RequestData:
         user_agent = request.headers.get("user-agent", None)
         client_ip, is_routable = get_client_ip(request)
         ip_address = client_ip if (client_ip and is_routable) else None
-        return cls(user_agent=user_agent, ip_address=ip_address)
+        platform = getattr(request, "relay_client_platform", None)
+        return cls(user_agent=user_agent, ip_address=ip_address, platform=platform)
 
 
 class UserData(NamedTuple):
@@ -161,7 +163,7 @@ class RelayGleanLogger(EventsServerEventLogger):
             user_agent=_opt_str_to_glean(request_data.user_agent),
             ip_address=_opt_str_to_glean(request_data.ip_address),
             fxa_id=_opt_str_to_glean(user_data.fxa_id),
-            platform="",
+            platform=_opt_str_to_glean(request_data.platform),
             n_random_masks=user_data.n_random_masks,
             n_domain_masks=user_data.n_domain_masks,
             n_deleted_random_masks=user_data.n_deleted_random_masks,
@@ -193,7 +195,7 @@ class RelayGleanLogger(EventsServerEventLogger):
             user_agent=_opt_str_to_glean(request_data.user_agent),
             ip_address=_opt_str_to_glean(request_data.ip_address),
             fxa_id=_opt_str_to_glean(user_data.fxa_id),
-            platform="",
+            platform=_opt_str_to_glean(request_data.platform),
             n_random_masks=user_data.n_random_masks,
             n_domain_masks=user_data.n_domain_masks,
             n_deleted_random_masks=user_data.n_deleted_random_masks,
@@ -248,7 +250,7 @@ class RelayGleanLogger(EventsServerEventLogger):
             user_agent=_opt_str_to_glean(request_data.user_agent),
             ip_address=_opt_str_to_glean(request_data.ip_address),
             fxa_id=_opt_str_to_glean(user_data.fxa_id),
-            platform="",
+            platform=_opt_str_to_glean(request_data.platform),
             n_random_masks=user_data.n_random_masks,
             n_domain_masks=user_data.n_domain_masks,
             n_deleted_random_masks=user_data.n_deleted_random_masks,
@@ -277,7 +279,7 @@ class RelayGleanLogger(EventsServerEventLogger):
             user_agent=_opt_str_to_glean(request_data.user_agent),
             ip_address=_opt_str_to_glean(request_data.ip_address),
             fxa_id=_opt_str_to_glean(user_data.fxa_id),
-            platform="",
+            platform=_opt_str_to_glean(request_data.platform),
             n_random_masks=user_data.n_random_masks,
             n_domain_masks=user_data.n_domain_masks,
             n_deleted_random_masks=user_data.n_deleted_random_masks,
@@ -308,7 +310,7 @@ class RelayGleanLogger(EventsServerEventLogger):
             user_agent=_opt_str_to_glean(request_data.user_agent),
             ip_address=_opt_str_to_glean(request_data.ip_address),
             fxa_id=_opt_str_to_glean(user_data.fxa_id),
-            platform="",
+            platform=_opt_str_to_glean(request_data.platform),
             n_random_masks=user_data.n_random_masks,
             n_domain_masks=user_data.n_domain_masks,
             n_deleted_random_masks=user_data.n_deleted_random_masks,

--- a/privaterelay/tests/glean_tests.py
+++ b/privaterelay/tests/glean_tests.py
@@ -89,6 +89,20 @@ def test_request_data_non_routable_ip_is_discarded(rf: RequestFactory) -> None:
     assert RequestData.from_request(request).ip_address is None
 
 
+def test_request_data_defaults_to_none(rf: RequestFactory) -> None:
+    request = rf.get("/api/v1/relayaddresses/")
+    assert RequestData.from_request(request).platform is None
+
+
+def test_request_data_reads_platform_from_middleware(rf: RequestFactory) -> None:
+    request = rf.get("/api/v1/relayaddresses/")
+
+    # Simulate middleware setting attributes
+    setattr(request, "relay_client_platform", "mobile-ios")
+
+    assert RequestData.from_request(request).platform == "mobile-ios"
+
+
 @pytest.mark.django_db
 def test_user_data_free_user() -> None:
     """Data is extracted for a free user."""

--- a/privaterelay/tests/utils_tests.py
+++ b/privaterelay/tests/utils_tests.py
@@ -23,6 +23,7 @@ from ..utils import (
     get_countries_info_from_request_and_mapping,
     get_subplat_upgrade_link_by_language,
     get_version_info,
+    parse_relay_client_platform,
 )
 
 
@@ -684,3 +685,22 @@ def test_get_subplat_upgrade_link_by_language_invalid_header(
 
     link = get_subplat_upgrade_link_by_language("en-gb;q=1.0000")
     assert link == expected_link
+
+
+@pytest.mark.parametrize(
+    "relay_client_platform, expected_os_platform",
+    (
+        ("appservices-ios", ("ios", "mobile-ios")),
+        ("appservices-android", ("android", "mobile-android")),
+        ("appservices-macos", ("macos", "desktop-macos")),
+        ("appservices-linux", ("linux", "desktop-linux")),
+        ("appservices-windows", ("windows", "desktop-windows")),
+        ("AppServices-iOS", ("ios", "mobile-ios")),
+        ("", ("", "")),
+        ("invalid-header-value", ("", "")),
+    ),
+)
+def test_parse_relay_client_platform(
+    relay_client_platform: str, expected_os_platform: tuple
+) -> None:
+    assert parse_relay_client_platform(relay_client_platform) == expected_os_platform


### PR DESCRIPTION
Parse X-Relay-Client header to distinguish between Firefox Mobile (iOS/Android) and Firefox Desktop (macOS/Linux/Windows) in metrics and error tracking.

This PR fixes #MPP-4539.

How to test:
1. Run `pytest`

I think most other testing will have to be done on the dev server?

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).