### PR TITLE
Fix a11y: improve contrast for Relay domain banner text

### DIFF
--- a/frontend/src/components/Banner.module.scss
+++ b/frontend/src/components/Banner.module.scss
@@ -90,7 +90,7 @@
 
   .info-icon {
     align-self: center;
-    color: color.$violet-30;
+    color: color.$violet-70;
   }
 }
 
@@ -158,7 +158,7 @@
     }
 
     .info & {
-      color: color.$violet-30;
+      color: color.$violet-70;
       margin-right: $spacing-xs;
     }
   }


### PR DESCRIPTION
This PR improves color contrast for the Relay domain banner text by replacing
$violet-30 with $violet-70 to meet WCAG AA contrast requirements.

This change improves readability and accessibility for users with low vision
or color sensitivity.
