### PR TITLE
fix MPP-4559: feat(masks): make free mask limit configurable per environment

### DIFF
--- a/api/views/privaterelay.py
+++ b/api/views/privaterelay.py
@@ -38,7 +38,7 @@ from rest_framework.status import (
 )
 from rest_framework.viewsets import ModelViewSet
 from sentry_sdk import capture_exception
-from waffle import get_waffle_flag_model
+from waffle import flag_is_active, get_waffle_flag_model
 from waffle.models import Sample, Switch
 
 from emails.utils import incr_if_enabled
@@ -292,6 +292,11 @@ def runtime_data(request):
             "WAFFLE_SAMPLES": sample_values,
             "MAX_MINUTES_TO_VERIFY_REAL_PHONE": (
                 settings.MAX_MINUTES_TO_VERIFY_REAL_PHONE
+            ),
+            "MAX_NUM_FREE_ALIASES": (
+                settings.INCREASED_MAX_NUM_FREE_ALIASES
+                if flag_is_active(request, "increased_free_mask_limit")
+                else settings.MAX_NUM_FREE_ALIASES
             ),
         }
     )

--- a/frontend/__mocks__/api/mockData.ts
+++ b/frontend/__mocks__/api/mockData.ts
@@ -109,6 +109,9 @@ export const mockedRuntimeData: RuntimeData = {
   WAFFLE_SWITCHES: [],
   WAFFLE_SAMPLES: [],
   MAX_MINUTES_TO_VERIFY_REAL_PHONE: 5,
+  // Note: Set to 5 for test performance. Production default is 50 (see runtimeData-default.ts),
+  // but tests use 5 to avoid creating 49 aliases to trigger limit-related UI.
+  MAX_NUM_FREE_ALIASES: 5,
 };
 
 export const mockedUsers: Record<(typeof mockIds)[number], UserData> = {

--- a/frontend/src/components/dashboard/CornerNotification.test.tsx
+++ b/frontend/src/components/dashboard/CornerNotification.test.tsx
@@ -48,6 +48,10 @@ describe("CornerNotification", () => {
   const mockDismiss = jest.fn();
   const mockAlias = mockedRelayaddresses.full[0];
 
+  // Note: mockedRuntimeData has MAX_NUM_FREE_ALIASES: 5, so the notification
+  // triggers at 4 aliases (limit - 1). We keep the mock at 5 instead of 50
+  // for test performance (creating 49 aliases would be unnecessarily slow).
+  // The component logic is tested with the dynamic calculation.
   const defaultProps = {
     profile: {
       ...mockedProfiles.some,
@@ -70,7 +74,7 @@ describe("CornerNotification", () => {
     mockL10n.getString.mockClear();
   });
 
-  it("renders when flag is active, user has 4 aliases, is not premium, and not dismissed", () => {
+  it("renders when flag is active, user has MAX_NUM_FREE_ALIASES-1 aliases, is not premium, and not dismissed", () => {
     render(<CornerNotification {...defaultProps} />);
     expect(
       screen.getByText("upsell-banner-4-masks-us-heading-2"),
@@ -111,7 +115,7 @@ describe("CornerNotification", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not render if aliases are less than 4", () => {
+  it("does not render if aliases are less than MAX_NUM_FREE_ALIASES-1", () => {
     render(
       <CornerNotification {...defaultProps} aliases={[mockAlias, mockAlias]} />,
     );

--- a/frontend/src/components/dashboard/CornerNotification.tsx
+++ b/frontend/src/components/dashboard/CornerNotification.tsx
@@ -37,11 +37,14 @@ export const CornerNotification = (props: Props) => {
   const title = l10n.getString(`upsell-banner-4-masks-us-heading-2`);
   const description = l10n.getString(`upsell-banner-4-masks-us-description-2`);
 
+  const maxFreeAliases = runtimeData.MAX_NUM_FREE_ALIASES;
+  const showAtMaskCount = maxFreeAliases - 1;
+
   if (
     isFlagActive(runtimeData, "four_mask_limit_upsell") &&
     !profile.has_premium &&
     !dismissal.isDismissed &&
-    aliases.length === 4
+    aliases.length === showAtMaskCount
   ) {
     return (
       <aside

--- a/frontend/src/components/dashboard/aliases/AliasGenerationButton.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasGenerationButton.tsx
@@ -63,7 +63,9 @@ export const AliasGenerationButton = (props: Props) => {
   });
   const gaEvent = useGaEvent();
 
-  const maxAliases = getRuntimeConfig().maxFreeAliases;
+  const maxAliases =
+    props.runtimeData?.MAX_NUM_FREE_ALIASES ??
+    getRuntimeConfig().maxFreeAliases;
   if (!props.profile.has_premium && props.aliases.length >= maxAliases) {
     // If the user does not have Premium, has reached the alias limit,
     // and Premium is not available to them, show a greyed-out button:

--- a/frontend/src/hooks/api/runtimeData-default.ts
+++ b/frontend/src/hooks/api/runtimeData-default.ts
@@ -10,6 +10,7 @@ export const DEFAULT_RUNTIME_DATA: RuntimeData = {
   MEGABUNDLE_PRODUCT_ID: "prod_SOYBYCOWallcgz",
   BASKET_ORIGIN: "https://basket.mozilla.org",
   MAX_MINUTES_TO_VERIFY_REAL_PHONE: 5,
+  MAX_NUM_FREE_ALIASES: 5,
   WAFFLE_FLAGS: [
     ["free_user_onboarding", true],
     ["holiday_promo_2023", false],

--- a/frontend/src/hooks/api/types.ts
+++ b/frontend/src/hooks/api/types.ts
@@ -32,4 +32,5 @@ export type RuntimeData = {
   WAFFLE_SWITCHES: WaffleValue;
   WAFFLE_SAMPLES: WaffleValue;
   MAX_MINUTES_TO_VERIFY_REAL_PHONE: number;
+  MAX_NUM_FREE_ALIASES: number;
 };

--- a/frontend/src/pages/accounts/profile.page.tsx
+++ b/frontend/src/pages/accounts/profile.page.tsx
@@ -183,7 +183,8 @@ const Profile: NextPage = () => {
     );
   }
 
-  const freeMaskLimit = getRuntimeConfig().maxFreeAliases;
+  const freeMaskLimit =
+    runtimeData.data?.MAX_NUM_FREE_ALIASES ?? getRuntimeConfig().maxFreeAliases;
   const freeMaskLimitReached =
     allAliases.length >= freeMaskLimit && !profile.has_premium;
 

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -435,6 +435,9 @@ RELAY_SCOPE: str = config(
     "RELAY_SCOPE", "https://identity.mozilla.com/apps/relay", cast=str
 )
 MAX_NUM_FREE_ALIASES: int = config("MAX_NUM_FREE_ALIASES", 5, cast=int)
+INCREASED_MAX_NUM_FREE_ALIASES: int = config(
+    "INCREASED_MAX_NUM_FREE_ALIASES", 50, cast=int
+)
 PERIODICAL_PREMIUM_PROD_ID: str = config("PERIODICAL_PREMIUM_PROD_ID", "")
 PREMIUM_PLAN_ID_US_MONTHLY: str = config(
     "PREMIUM_PLAN_ID_US_MONTHLY", "price_1LXUcnJNcmPzuWtRpbNOajYS"


### PR DESCRIPTION
This PR fixes MPP-4559.

How to test:
1. Checkout this branch
2. Set your `MAX_NUM_FREE_ALIASES` env var to a new number (e.g., `10`)
3. `cd frontend && npm run build`
4. `cd .. && python manage.py collectstatic`
5. `python manage.py runserver`
6. Go to the dashboard as a free user and create the new max number of free aliases
   * [ ] When you create 1 less than the max, you should see the bottom-right upgrade notification
   * [ ] When you create the max number, you should see the top "hero" upgrade banner
7. (Optional) Set your `MAX_NUM_FREE_ALIASES` env var to a new higher number (e.g., `15`)
8. Repeat steps 3-6 to check that the code works as expected with the new higher env var value

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added or updated a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).