### PR TITLE
fix MPP-4552: fix(phones): add rate limiting to vCard endpoint

### DIFF
--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -96,6 +96,10 @@ class RealPhoneRateThrottle(throttling.UserRateThrottle):
     rate = settings.PHONE_RATE_LIMIT
 
 
+class VCardRateThrottle(throttling.AnonRateThrottle):
+    rate = settings.VCARD_RATE_LIMIT
+
+
 @extend_schema(tags=["phones"])
 class RealPhoneViewSet(SaveToRequestUser, viewsets.ModelViewSet):
     """
@@ -547,10 +551,12 @@ def _get_number_details(e164_number):
             ],
         ),
         "404": OpenApiResponse(description="No or unknown lookup key"),
+        "429": OpenApiResponse(description="Rate limit exceeded"),
     },
 )
 @decorators.api_view()
 @decorators.permission_classes([permissions.AllowAny])
+@decorators.throttle_classes([VCardRateThrottle])
 @decorators.renderer_classes([vCardRenderer])
 def vCard(request: Request, lookup_key: str) -> response.Response:
     """

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -791,6 +791,8 @@ else:
     _DEFAULT_PHONE_RATE_LIMIT = "5/minute"
 PHONE_RATE_LIMIT = config("PHONE_RATE_LIMIT", _DEFAULT_PHONE_RATE_LIMIT)
 
+VCARD_RATE_LIMIT = config("VCARD_RATE_LIMIT", "10/minute")
+
 # Turn on logging out on GET in development.
 # This allows `/mock/logout/` in the front-end to clear the
 # session cookie. Without this, after switching accounts in dev mode,


### PR DESCRIPTION
The vCard lookup endpoint was publicly accessible without rate limits. This could allow brute force enumeration attempts. IP-based throttling limits requests to 10 per minute.

This PR fixes MPP-4552.

How to test:

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
      - OpenAPI schema updated with 429 response, serves as API docs
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).