### PR TITLE
MPP-4568 - fix(relay-landing): update free masks string to mention da…

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -193,3 +193,6 @@ vpn-relay-go-vpn-body-2 = Protect your online activity.
 -brand-name-solo-ai = Solo AI
 fx-solo-ai = { -brand-name-solo-ai }
 
+highlighted-features-section-unlimited-masks-body-1 = Everyone gets { $mask_limit } email masks for free. 
+    But with { -brand-name-relay-premium }, you can generate as many masks as you need to help protect your email 
+    from spammers, hackers, data breaches, and online trackers.

--- a/frontend/src/components/landing/HighlightedFeatures.test.tsx
+++ b/frontend/src/components/landing/HighlightedFeatures.test.tsx
@@ -48,7 +48,7 @@ describe("HighlightedFeatures", () => {
       ).toBeInTheDocument();
       expect(
         screen.getByText(
-          `l10n string: [highlighted-features-section-${n}-body], with vars: {"mask_limit":"5","mozmail":"mozmail.com"}`,
+          `l10n string: [highlighted-features-section-${n}-body-1], with vars: {"mask_limit":"5","mozmail":"mozmail.com"}`,
         ),
       ).toBeInTheDocument();
     }

--- a/frontend/src/components/landing/HighlightedFeatures.tsx
+++ b/frontend/src/components/landing/HighlightedFeatures.tsx
@@ -46,7 +46,7 @@ export const HighlightedFeatures = () => {
             </h3>
             <p className={styles["highlighted-feature-body"]}>
               {l10n.getString(
-                `highlighted-features-section-${props.name}-body`,
+                `highlighted-features-section-${props.name}-body-1`,
                 variables,
               )}
             </p>


### PR DESCRIPTION
This PR fixes [MPP-4568](https://mozilla-hub.atlassian.net/browse/MPP-4568)

- string update to 'Everyone gets 5 email masks for free. But with ⁨Relay Premium⁩, you can generate as many masks as you need to help protect your email from spammers, hackers, data breaches, and online trackers.' on landing page

Screenshot:
<img width="1361" height="674" alt="Screenshot 2026-02-18 at 8 08 59 AM" src="https://github.com/user-attachments/assets/c0c9a548-1f95-4208-924d-b3c75cdf107e" />

How to test:
- navigate to landing page
- notice string change

- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).


[MPP-4568]: https://mozilla-hub.atlassian.net/browse/MPP-4568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ