### PR TITLE
fix(emails): detect bulk email signals beyond List-* headers

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -874,7 +874,17 @@ def _get_verdict(receipt, verdict_type):
 
 def _check_email_from_list(headers):
     for header in headers:
-        if header["name"].lower().startswith("list-"):
+        name = header["name"].lower()
+        # RFC 2369 defines List-* headers (List-Unsubscribe, List-ID, etc.)
+        # as standard indicators that an email was sent by a mailing list.
+        if name.startswith("list-"):
+            return True
+        # Feedback-ID is required by Google for bulk senders and used by many
+        # ESPs to track campaigns. Transactional emails do not include it.
+        if name == "feedback-id":
+            return True
+        # Precedence: bulk or list is a classic indicator of bulk mail.
+        if name == "precedence" and header["value"].lower() in ("bulk", "list"):
             return True
     return False
 


### PR DESCRIPTION
Some promotional emails skip RFC 2369 List-* headers but still include Feedback-ID or Precedence: bulk. These were forwarded through masks set to block promotional emails.

Relay now checks Feedback-ID (required by Google for bulk senders) and Precedence: bulk/list in addition to the existing List-* check.

How to test:
1. Create a premium account
2. Sign a mask up to a service that sends list/group/bulk emails (e.g., Duolingo)
3. Set the mask to block promotional emails
4. (Maybe have to wait a couple days?) Verify the mask blocks promotional emails (e.g., blocked counter goes up & nothing sent to real inbox)

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).