### PR TITLE
chore(.claude): add Claude Code skills for PR workflow and flag retirement

### DIFF
--- a/.claude/skills/pr-ready/SKILL.md
+++ b/.claude/skills/pr-ready/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: pr-ready
+description: Run pre-commit checks, review PR checklist, and draft a commit message for Relay changes
+tags: [git, pr, lint, relay]
+---
+
+# PR Ready
+
+Get changes ready to submit as a PR. Runs lint checks, reviews the PR checklist, and drafts a commit message.
+
+## Step 1: Run pre-commit checks
+
+```bash
+cd frontend && npx --no-install lint-staged --cwd ..
+```
+
+This runs stylelint, prettier, eslint, black, mypy, and ruff on staged files. Fix any errors before continuing.
+
+## Step 2: Review PR checklist
+
+Inspect `git diff --cached` (or `git diff HEAD` if nothing staged) and answer each item:
+
+- **l10n**: Do changes touch any user-visible strings? If yes, have they been submitted to the l10n repo?
+- **Tests**: Does the change fix a bug? If yes, is there a unit test to prevent regression?
+- **Docs**: Do changes affect architecture, APIs, or workflows? If yes, is `docs/` updated?
+- **UI**: Do any UI changes follow the [coding standards](../../docs/coding-standards.md)?
+  - Protocol/Nebula colors used (see `/frontend/src/styles/colors.scss`)
+  - CSS classes use `mzp-` prefix for Protocol, no prefix for custom styles
+  - Simple selectors, minimal nesting, `//` comments in Sass
+  - ESLint and stylelint rules satisfied
+
+Report the checklist status. Flag any items that need attention before the PR is submitted.
+
+## Step 3: Draft a conventional commit message
+
+Review the staged changes and write a commit message. Do NOT run `git commit`.
+
+**Format:**
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+```
+
+**Types:** `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `build`, `ci`, `chore`
+
+**Style:**
+
+- Short, declarative first line
+- Active verbs, concrete nouns, no adverbs
+- Body explains WHY, not what
+- Breaking changes: use `feat!:` or `feat(scope)!:` + `BREAKING CHANGE:` footer
+
+Present the message. Do not commit.
+
+## Step 4: Draft "How to test:" section
+
+Write a brief testing guide for the PR reviewer. Base it on the staged changes.
+
+**Format:**
+
+```
+How to test:
+1. <setup step, if needed>
+2. <action to take>
+3. <what to verify>
+```
+
+**Guidelines:**
+
+- Start with any required setup (flag, env var, account state)
+- Describe the specific action a reviewer must take
+- State the expected outcome — what they should see or not see
+- Cover the happy path first, then edge cases if the change warrants it
+
+Present the section. Do not open a PR.

--- a/.claude/skills/retire-waffle-flag/SKILL.md
+++ b/.claude/skills/retire-waffle-flag/SKILL.md
@@ -1,0 +1,569 @@
+---
+name: Retire Django Waffle Flag
+description: This skill should be used when the user asks to "retire a waffle flag", "remove a Django waffle flag", "delete a feature flag", or mentions "flag retirement" in the context of the Firefox Relay codebase.
+version: 1.0.0
+---
+
+# Retire Django Waffle Flag
+
+Retire a Django waffle feature flag from the Firefox Relay codebase by removing all conditional logic and keeping only the flag-enabled (new) behavior.
+
+## Overview
+
+Waffle flags control feature behavior through conditionals. Retirement means:
+
+- Remove all flag checks
+- Keep flag-enabled behavior (new code)
+- Delete flag-disabled code (legacy code)
+- Delete legacy components
+- Clean up tests and configs
+
+## 5-Step Workflow
+
+### Step 1: Search for all flag references
+
+Run these commands to find all usages:
+
+```bash
+# Backend: Python/Django code
+grep -r "flag_name" --include="*.py" emails/ api/ privaterelay/
+
+# Frontend: TypeScript/React code
+grep -r "flag_name" --include="*.tsx" --include="*.ts" frontend/src/
+
+# Tests
+grep -r "flag_name" --include="*test*.py" --include="*test*.tsx"
+
+# Config files
+grep -r "flag_name" frontend/src/hooks/api/ frontend/__mocks__/
+```
+
+### Step 2: Analyze and categorize findings
+
+Group findings by type:
+
+| Type                | Location                                       | Action                                  |
+| ------------------- | ---------------------------------------------- | --------------------------------------- |
+| Backend flag check  | `flag_is_active_in_task("flag_name", ...)`     | Remove conditional, keep if-true branch |
+| Frontend flag check | `isFlagActive(props.runtimeData, "flag_name")` | Remove conditional, keep true branch    |
+| Test decorator      | `@override_flag("flag_name", active=True)`     | Remove decorator                        |
+| Test decorator      | `@override_flag("flag_name", active=False)`    | Delete entire test                      |
+| Config entry        | `["flag_name", true]` in WAFFLE_FLAGS          | Remove array entry                      |
+| Legacy component    | Component only used when flag=false            | Delete file + styles + tests            |
+
+### Step 3: Plan the changes
+
+Create a checklist:
+
+- List files to modify (with line numbers)
+- List files to delete
+- Identify which behavior to keep (usually flag=true)
+- Note deprecated components that might break
+
+### Step 4: Execute changes
+
+Work in this order:
+
+**4.1 Backend changes**
+
+```python
+# BEFORE: Conditional check
+if flag_is_active_in_task("flag_name", user):
+    new_behavior()
+else:
+    old_behavior()
+
+# AFTER: Always use new behavior
+new_behavior()
+```
+
+Remove imports if unused:
+
+```python
+# Remove if not used elsewhere in file
+from privaterelay.utils import flag_is_active_in_task
+```
+
+**4.2 Identify orphaned components (CRITICAL)**
+
+Before proceeding, identify components that will become orphaned after flag removal.
+
+**For each old component in the false/else branches:**
+
+1. **Search for ALL imports of the component:**
+
+```bash
+grep -r "import.*OldComponent" --include="*.tsx" --include="*.ts" frontend/src/
+```
+
+2. **Categorize each import:**
+   - Used in flag conditional being removed → Will be removed
+   - Used in deprecated file → Needs update (mark for step 4.5)
+   - Used in active code → NOT orphaned, KEEP IT
+
+3. **If ONLY used in conditionals being removed → ORPHANED**
+
+4. **List ALL files to delete:**
+   - Component file: `OldComponent.tsx`
+   - Styles file: `OldComponent.module.scss`
+   - Test file: `OldComponent.test.tsx`
+
+**Orphaned components checklist:**
+
+- [ ] Identified all old components from step 2 analysis
+- [ ] Searched imports for each component
+- [ ] Categorized each import (conditional/deprecated/active)
+- [ ] Listed complete file sets to delete (.tsx + .scss + .test.tsx)
+- [ ] Noted deprecated files needing updates
+
+**Example:**
+
+```bash
+# Flag check shows:
+{isFlagActive(data, "flag") ? <NewModal /> : <OldModal />}
+
+# Search for OldModal:
+grep -r "OldModal" --include="*.tsx" frontend/src/
+
+# Results:
+# - AliasGen.tsx:89  → In flag conditional (ORPHANED)
+# - Alias.tsx:42     → Deprecated file (NEEDS UPDATE)
+
+# Conclusion: OldModal is ORPHANED
+# Delete: OldModal.tsx, OldModal.module.scss, OldModal.test.tsx
+# Update: Alias.tsx imports
+```
+
+**STOP:** Do not proceed until orphaned components are identified.
+
+**4.3 Delete orphaned components (DO THIS EARLY)**
+
+Delete orphaned components NOW, before tests pass. This forces fixing import issues.
+
+```bash
+# Delete each orphaned component set
+rm frontend/src/components/path/OldComponent.tsx
+rm frontend/src/components/path/OldComponent.module.scss
+rm frontend/src/components/path/OldComponent.test.tsx
+```
+
+**Why delete early?**
+
+- Tests will break immediately
+- Forces you to fix imports and usage
+- Prevents "tests pass, skip deletion" scenario
+- Ensures complete cleanup
+
+**4.4 Frontend component changes**
+
+```typescript
+// BEFORE: Conditional rendering
+{isFlagActive(props.runtimeData, "flag_name") ? (
+  <NewComponent />
+) : (
+  <OldComponent />
+)}
+
+// AFTER: Always render new component
+<NewComponent />
+```
+
+Remove imports if unused:
+
+```typescript
+// Remove if not used elsewhere
+import { isFlagActive } from "../../../functions/waffle";
+import { OldComponent } from "./OldComponent";
+```
+
+**4.5 Fix deprecated components (if needed)**
+
+If deprecated components import deleted components, update them NOW:
+
+```typescript
+// Deprecated component that breaks
+import { OldComponent } from "./OldComponent";  // File deleted!
+
+// Fix by updating to new component
+import { NewComponent } from "./NewComponent";
+
+// Update usage to match new component props
+<OldComponent prop={value} />  // Old way
+<NewComponent prop={value} additionalProp={value2} />  // New way
+```
+
+Add comment explaining why deprecated file wasn't deleted:
+
+```typescript
+// Deprecated: marked for removal in MPP-XXXX
+// Updated to use NewComponent after flag retirement
+```
+
+**4.6 Test file changes**
+
+```python
+# Remove decorator from tests that verify new behavior
+@override_flag("flag_name", active=True)  # DELETE THIS LINE
+def test_new_behavior(self):
+    # Keep test body
+    assert new_behavior_works
+
+# Delete entire tests that verify old behavior
+@override_flag("flag_name", active=False)  # DELETE ENTIRE TEST
+def test_old_behavior(self):
+    assert old_behavior_works
+```
+
+Remove imports if unused:
+
+```python
+from waffle.testutils import override_flag  # Remove if not used
+```
+
+**4.7 Config file changes**
+
+```typescript
+// frontend/src/hooks/api/runtimeData-default.ts
+WAFFLE_FLAGS: [
+  ["other_flag", true],
+  ["flag_name", true], // DELETE THIS LINE
+  ["another_flag", true],
+];
+
+// frontend/__mocks__/api/mockData.ts
+WAFFLE_FLAGS: [
+  ["other_flag", true],
+  ["flag_name", true], // DELETE THIS LINE
+  ["another_flag", true],
+];
+```
+
+### Step 5: Test and validate
+
+**5.1 Run backend tests**
+
+```bash
+# Run specific tests
+pytest emails/tests/validator_tests.py -v
+pytest api/tests/ -v
+
+# Run full backend suite
+pytest
+```
+
+**5.2 Run frontend tests**
+
+```bash
+# Run component tests
+npm test -- ComponentName
+
+# Run full frontend suite
+npm test
+```
+
+**5.3 Verify complete cleanup**
+
+**Check 1: No flag references remain**
+
+```bash
+grep -r "flag_name" --exclude-dir=node_modules --exclude-dir=.git \
+  --exclude-dir=out --exclude-dir=.next .
+```
+
+Expected: No matches in source code
+
+**Check 2: No orphaned components remain (CRITICAL)**
+
+For EACH component from step 4.2, verify complete deletion:
+
+```bash
+# Example: Verify AddressPickerModal is deleted
+find frontend/src -name "AddressPickerModal.*"
+```
+
+Expected: No files found
+
+If files found:
+
+- Review why they weren't deleted in step 4.3
+- Verify they are truly orphaned (not used in active code)
+- Delete them now
+
+Repeat for ALL components from step 4.2 orphan list.
+
+**Check 3: No orphaned imports remain**
+
+For EACH deleted component, verify no imports remain:
+
+```bash
+# Example: Check AddressPickerModal imports
+grep -r "import.*AddressPickerModal" --include="*.tsx" --include="*.ts" frontend/src/
+```
+
+Expected: No matches (or only in deprecated files you updated in step 4.5)
+
+If imports found:
+
+- In deprecated files → Did you update them in step 4.5?
+- In active files → Component may not be orphaned, investigate
+- In test files → Update or remove the test
+
+Repeat for ALL deleted components from step 4.3.
+
+**Check 4: No test mocks of deleted components**
+
+```bash
+# Example: Check for test mocks
+grep -r "jest.mock.*AddressPickerModal" --include="*.test.tsx" frontend/src/
+```
+
+Expected: No matches
+
+If mocks found: Remove the mock from the test file.
+
+**Check 5: No unused waffle imports**
+
+Check files you modified for unused isFlagActive imports:
+
+```bash
+# Example: Check if isFlagActive still used
+grep -n "isFlagActive" frontend/src/components/aliases/MaskCard.tsx
+```
+
+Expected: Either:
+
+- No matches (import was removed) ✓
+- Matches show import used for OTHER flags ✓
+- Only import line, no usage → Remove the import
+
+## Quick Patterns Reference
+
+### Backend Patterns
+
+**Pattern 1: Simple conditional**
+
+```python
+# BEFORE
+if flag_is_active_in_task("flag_name", None):
+    check_something()
+
+# AFTER
+check_something()
+```
+
+**Pattern 2: If-else choice**
+
+```python
+# BEFORE
+if flag_is_active_in_task("flag_name", user):
+    return new_algorithm()
+else:
+    return old_algorithm()
+
+# AFTER
+return new_algorithm()
+```
+
+**Pattern 3: Early return**
+
+```python
+# BEFORE
+if not flag_is_active_in_task("flag_name", user):
+    return
+
+do_new_thing()
+
+# AFTER
+do_new_thing()
+```
+
+### Frontend Patterns
+
+**Pattern 1: Component choice**
+
+```typescript
+// BEFORE
+{isFlagActive(data, "flag_name") ? <NewComp /> : <OldComp />}
+
+// AFTER
+<NewComp />
+```
+
+**Pattern 2: With complex props**
+
+```typescript
+// BEFORE
+{isFlagActive(data, "flag_name") ? (
+  <NewModal
+    isOpen={state.isOpen}
+    onClose={close}
+    data={data}
+  />
+) : (
+  <OldModal
+    isOpen={state.isOpen}
+    onClose={close}
+  />
+)}
+
+// AFTER
+<NewModal
+  isOpen={state.isOpen}
+  onClose={close}
+  data={data}
+/>
+```
+
+**Pattern 3: With function callback**
+
+```typescript
+// BEFORE: Old function only used by old component
+const onPickOld = (value: string) => {
+  handleOld(value);
+  close();
+};
+
+const dialog = isFlagActive(data, "flag_name") ? (
+  <NewModal onPick={onPickNew} />
+) : (
+  <OldModal onPick={onPickOld} />
+);
+
+// AFTER: Delete onPickOld function
+const dialog = <NewModal onPick={onPickNew} />;
+```
+
+## Test Patterns
+
+**Keep test, remove decorator:**
+
+```python
+# This tests desired behavior - keep it
+@override_flag("flag_name", active=True)  # REMOVE
+def test_prevents_deleted_address_reuse(self):
+    # Test body stays
+```
+
+**Delete entire test:**
+
+```python
+# This tests old behavior - delete it
+@override_flag("flag_name", active=False)  # DELETE ENTIRE TEST
+def test_allows_deleted_address_reuse(self):
+    # This behavior no longer supported
+```
+
+**Test mock updates:**
+
+```typescript
+// BEFORE: Mock for both components
+jest.mock("./OldComponent", () => ({
+  /* ... */
+}));
+jest.mock("./NewComponent", () => ({
+  /* ... */
+}));
+
+// AFTER: Remove old component mock
+jest.mock("./NewComponent", () => ({
+  /* ... */
+}));
+```
+
+## Common Issues
+
+**Issue 1: Deprecated components break**
+
+If you see errors like `Cannot find module './OldComponent'` in deprecated files:
+
+- Update deprecated component to import new component
+- Update usage to match new component props
+- See `references/common-issues.md` for details
+
+**Issue 2: Test cascades fail**
+
+Multiple test files may fail when legacy component is deleted:
+
+- Find all imports of deleted component
+- Update to use new component
+- Adjust test expectations for new component behavior
+
+**Issue 3: Modal behavior differences**
+
+Old vs new components may have different UX:
+
+- New modal may skip confirmation checkbox
+- Update tests to match new UX flow
+- See `references/frontend-patterns.md` for examples
+
+## Validation Checklist
+
+Before completing flag retirement:
+
+- [ ] Search found all flag references (Step 1)
+- [ ] Categorized changes (backend, frontend, tests, config) (Step 2)
+- [ ] Identified correct behavior to keep (flag-enabled) (Step 3)
+- [ ] Modified backend files (removed conditionals) (Step 4.1)
+- [ ] **Identified orphaned components (Step 4.2) - CRITICAL**
+- [ ] **Deleted orphaned components (Step 4.3) - CRITICAL**
+- [ ] Modified frontend files (removed conditionals) (Step 4.4)
+- [ ] Fixed deprecated component imports (if any) (Step 4.5)
+- [ ] Updated test files (removed decorators, deleted old tests) (Step 4.6)
+- [ ] Updated config files (removed flag entries) (Step 4.7)
+- [ ] Backend tests pass (Step 5.1)
+- [ ] Frontend tests pass (Step 5.2)
+- [ ] **No orphaned component files remain (Step 5.3.2) - CRITICAL**
+- [ ] **No orphaned imports remain (Step 5.3.3) - CRITICAL**
+- [ ] No flag references remain in source (Step 5.3.1)
+- [ ] **PR removes 500+ lines (if fewer, review step 4.2-4.3)**
+- [ ] Committed changes with conventional commit message
+
+## Detailed References
+
+For detailed patterns and troubleshooting:
+
+- `references/backend-patterns.md` - Django/Python patterns
+- `references/frontend-patterns.md` - TypeScript/React patterns
+- `references/common-issues.md` - Troubleshooting guide
+
+For templates and examples:
+
+- `examples/flag-retirement-checklist.md` - Step-by-step checklist template
+
+## Completeness Metrics
+
+A complete flag retirement should show significant code deletion. If your PR removes <300 lines, you likely missed orphaned components.
+
+### Expected Deletion Ranges
+
+| Cleanup Level  | Lines Removed | What's Included                               |
+| -------------- | ------------- | --------------------------------------------- |
+| **Incomplete** | 50-200        | Flag references only, dead code remains       |
+| **Partial**    | 200-500       | Flag + some components, orphans likely remain |
+| **Complete**   | 500-1500+     | Flag + ALL orphaned components deleted        |
+
+### Verification Checklist
+
+Before submitting your PR, verify:
+
+- [ ] Backend flag conditionals removed
+- [ ] Frontend flag conditionals removed
+- [ ] Config flag entries removed
+- [ ] Old behavior tests deleted
+- [ ] **Legacy components deleted** (this is usually 70-90% of the work)
+- [ ] Deprecated components updated
+- [ ] All tests pass
+
+**Example: custom_domain_management_redesign flag**
+
+- Incomplete cleanup: 109 lines removed (flag only)
+- Complete cleanup: 1,280 lines removed (flag + components)
+
+### Cost Savings
+
+Using this skill with complete cleanup reduces:
+
+- Token usage: ~70% (from ~160k to ~50k tokens)
+- Cost: ~70% (from ~$4.00 to ~$1.30)
+- Time: ~50% (from ~40min to ~20min)
+- **Maintenance burden: Eliminates 500-1500 lines of dead code**

--- a/.claude/skills/retire-waffle-flag/examples/flag-retirement-checklist.md
+++ b/.claude/skills/retire-waffle-flag/examples/flag-retirement-checklist.md
@@ -1,0 +1,363 @@
+# Waffle Flag Retirement Checklist Template
+
+Use this checklist when retiring a Django waffle flag from Firefox Relay.
+
+## Flag Information
+
+**Flag name:** `_____________`
+**Jira ticket:** `MPP-____`
+**Date:** `____-__-__`
+**Engineer:** `_____________`
+
+**Flag purpose:**
+_Brief description of what the flag controls_
+
+**Behavior to keep:**
+
+- [ ] Flag enabled (new behavior)
+- [ ] Flag disabled (old behavior)
+
+## Step 1: Search and Discovery
+
+### Backend Search
+
+```bash
+grep -r "flag_name" --include="*.py" emails/ api/ privaterelay/
+```
+
+**Findings:**
+
+- [ ] `____/____/____.py` line \_\_\_ (flag_is_active_in_task)
+- [ ] `____/____/____.py` line \_\_\_ (flag_is_active)
+- [ ] `____/____.py` line \_\_\_ (test with @override_flag)
+
+### Frontend Search
+
+```bash
+grep -r "flag_name" --include="*.tsx" --include="*.ts" frontend/src/
+```
+
+**Findings:**
+
+- [ ] `____/____/____.tsx` line \_\_\_ (isFlagActive)
+- [ ] `____/____.tsx` line \_\_\_ (component conditional)
+- [ ] `____/____.test.tsx` line \_\_\_ (test)
+
+### Config Search
+
+```bash
+grep -r "flag_name" frontend/src/hooks/api/ frontend/__mocks__/
+```
+
+**Findings:**
+
+- [ ] `runtimeData-default.ts` line \_\_\_
+- [ ] `mockData.ts` line \_\_\_
+
+## Step 2: Categorization
+
+### Backend Files (\_\_ total)
+
+| File | Type                | Action             | Lines |
+| ---- | ------------------- | ------------------ | ----- |
+|      | flag check          | Remove conditional |       |
+|      | test (active=True)  | Remove decorator   |       |
+|      | test (active=False) | Delete test        |       |
+
+### Frontend Files (\_\_ total)
+
+| File | Type      | Action             | Lines |
+| ---- | --------- | ------------------ | ----- |
+|      | component | Remove conditional |       |
+|      | test      | Update/delete      |       |
+|      | config    | Remove entry       |       |
+
+### Components to Delete (\_\_ files)
+
+- [ ] `____Component.tsx`
+- [ ] `____Component.module.scss`
+- [ ] `____Component.test.tsx`
+- [ ] `____Modal.tsx`
+- [ ] `____Modal.module.scss`
+- [ ] `____Modal.test.tsx`
+
+## Step 3: Implementation Plan
+
+### 3.1 Backend Changes
+
+**Files to modify:**
+
+- [ ] `emails/validators.py`
+  - Line \_\_\_: Remove if-else, keep if-true branch
+  - Line \_\_\_: Remove flag_is_active_in_task import
+- [ ] `emails/tests/validator_tests.py`
+  - Line \_\_\_: Remove @override_flag decorator
+- [ ] `emails/tests/models_tests.py`
+  - Line \_\_\_: Delete test_old_behavior (entire test)
+  - Line \_\_\_: Remove @override_flag from test_new_behavior
+- [ ] `api/tests/emails_views_tests.py`
+  - Line \_\_\_: Remove @override_flag decorator
+
+### 3.2 Identify Orphaned Components (CRITICAL)
+
+**For each old component in flag conditionals:**
+
+| Component Name | Import Locations | Categorization | Orphaned? |
+| -------------- | ---------------- | -------------- | --------- |
+|                |                  |                |           |
+|                |                  |                |           |
+
+**Orphaned component file sets to delete:**
+
+- [ ] `____Component.tsx` + `.module.scss` + `.test.tsx` (\_\_ lines total)
+- [ ] `____Modal.tsx` + `.module.scss` + `.test.tsx` (\_\_ lines total)
+- [ ] `____Button.tsx` + `.module.scss` + `.test.tsx` (\_\_ lines total)
+
+**Total lines to delete:** ~\_\_\_ lines
+
+**Deprecated files needing updates:**
+
+- [ ] `____Deprecated.tsx` - imports deleted component
+
+### 3.3 Delete Orphaned Components (DO EARLY)
+
+- [ ] Deleted `____Component.tsx`
+- [ ] Deleted `____Component.module.scss`
+- [ ] Deleted `____Component.test.tsx`
+- [ ] Deleted `____Modal.tsx`
+- [ ] Deleted `____Modal.module.scss`
+- [ ] Deleted `____Modal.test.tsx`
+
+**Status:** Tests will break - this is expected!
+
+### 3.4 Frontend Changes
+
+**Files to modify:**
+
+- [ ] `frontend/src/components/____/____.tsx`
+  - Line \_\_\_: Remove isFlagActive conditional
+  - Line \_\_\_: Keep <NewComponent />
+  - Line \_\_\_: Remove <OldComponent />
+  - Line \_\_\_: Remove OldComponent import
+  - Line \_\_\_: Remove isFlagActive import (if unused)
+- [ ] `frontend/src/components/____/____.tsx`
+  - Line \_\_\_: Remove conditional
+  - Line **_-_**: Delete onPickOld function (if exists)
+- [ ] `frontend/src/components/____/____.test.tsx`
+  - Line \_\_\_: Delete flag-controlled test
+  - Line \_\_\_: Remove OldComponent mock
+
+**Config files:**
+
+- [ ] `frontend/src/hooks/api/runtimeData-default.ts`
+  - Line \_\_\_: Remove ["flag_name", true]
+- [ ] `frontend/__mocks__/api/mockData.ts`
+  - Line \_\_\_: Remove ["flag_name", true]
+
+### 3.5 Fix Deprecated Components (if needed)
+
+**Files identified in step 3.2:**
+
+- [ ] `____Deprecated.tsx`
+  - Line \_\_\_: Update import to NewComponent
+  - Line \_\_\_: Update usage
+  - Line \_\_\_: Add comment about flag retirement
+
+## Step 4: Execution
+
+### 4.1 Make Backend Changes
+
+- [ ] Modified: `emails/validators.py`
+- [ ] Modified: `emails/tests/validator_tests.py`
+- [ ] Modified: `emails/tests/models_tests.py`
+- [ ] Modified: `api/tests/emails_views_tests.py`
+
+### 4.2 Identified Orphaned Components
+
+- [ ] Completed orphaned component analysis
+- [ ] Listed all file sets to delete
+- [ ] Total lines to delete: \_\_\_ lines
+
+### 4.3 Deleted Orphaned Components (EARLY)
+
+- [ ] Deleted: `____Component.*` files
+- [ ] Deleted: `____Modal.*` files
+- [ ] Deleted: `____Button.*` files
+- [ ] Tests now break (expected!)
+
+### 4.4 Make Frontend Changes
+
+- [ ] Modified: Component files
+- [ ] Modified: Test files
+- [ ] Modified: Config files
+
+### 4.5 Fix Deprecated Components
+
+- [ ] Updated: Deprecated component imports
+
+## Step 5: Testing and Validation
+
+### 5.1 Backend Tests
+
+```bash
+pytest emails/tests/validator_tests.py::TestClass::test_name -v
+pytest emails/tests/models_tests.py::TestClass::test_name -v
+pytest api/tests/emails_views_tests.py::test_name -v
+```
+
+**Results:**
+
+- [ ] validator_tests.py: PASSED
+- [ ] models_tests.py: PASSED
+- [ ] emails_views_tests.py: PASSED
+
+**Full backend test:**
+
+```bash
+pytest
+```
+
+- [ ] All backend tests: PASSED
+
+### 5.2 Frontend Tests
+
+```bash
+npm test -- ComponentName.test.tsx
+npm test -- AnotherComponent.test.tsx
+```
+
+**Results:**
+
+- [ ] Component test 1: PASSED
+- [ ] Component test 2: PASSED
+
+**Full frontend test:**
+
+```bash
+npm test
+```
+
+- [ ] All frontend tests: PASSED
+
+### 5.3 Verification
+
+**Check 1: No flag references remain**
+
+```bash
+grep -r "flag_name" --exclude-dir=node_modules --exclude-dir=.git \
+  --exclude-dir=out --exclude-dir=.next .
+```
+
+- [ ] No references found in source code
+
+**Check 2: No orphaned components remain (CRITICAL)**
+
+```bash
+# Verify each component from step 4.3 is deleted
+find frontend/src -name "____Component.*"
+find frontend/src -name "____Modal.*"
+find frontend/src -name "____Button.*"
+```
+
+- [ ] No component files found
+- [ ] No style files found
+- [ ] No test files found
+
+**Check 3: No orphaned imports remain**
+
+```bash
+# Check deleted components not imported
+grep -r "import.*____Component" --include="*.tsx" frontend/src/
+grep -r "import.*____Modal" --include="*.tsx" frontend/src/
+```
+
+- [ ] No imports found (except fixed deprecated files)
+
+**Check 4: No unused waffle imports**
+
+```bash
+# Check modified files for unused isFlagActive
+grep -n "isFlagActive" frontend/src/modified/files/*.tsx
+```
+
+- [ ] Either no matches or import still used for other flags
+
+**Check 5: Build succeeds**
+
+```bash
+npm run build
+```
+
+- [ ] Frontend build: SUCCESS
+
+## Step 6: Commit
+
+### Commit Message
+
+```
+refactor: MPP-____: retire flag_name waffle flag
+
+Remove flag and keep new behavior. Flag was added in [date] and is now default.
+
+Changes:
+- Backend always [describe behavior]
+- Frontend uses [NewComponent] and [NewModal]
+- Delete legacy [OldComponent] and [OldModal] components
+- Remove flag from configs and tests
+```
+
+### Commit and Push
+
+```bash
+git add -A
+git commit -m "..."
+git push
+```
+
+- [ ] Committed changes
+- [ ] Pushed to remote
+
+## Step 7: Follow-up
+
+### Database Cleanup
+
+**After deployment**, delete flag from databases or file ticket:
+
+- [ ] Dev environment: Flag deleted
+- [ ] Stage environment: Flag deleted
+- [ ] Production environment: Flag deleted
+
+**OR**
+
+- [ ] Filed follow-up ticket: **\_\_\_\_**
+
+## Summary
+
+**Files modified:** \*\*
+**Files deleted:** \*\*
+**Tests updated:** \*\*
+**Lines changed:** +\_** -**_
+**Time spent:** _** minutes
+**Cost:\*\* ~$\_\_\_
+
+### Completeness Check
+
+**Lines removed:** \_\_\_ lines
+
+Completeness assessment:
+
+- [ ] **Incomplete (<200 lines):** Flag only, dead code remains
+- [ ] **Partial (200-500 lines):** Flag + some components, review step 4.2-4.3
+- [ ] **Complete (500-1500+ lines):** Flag + ALL orphaned components ✓
+
+If <300 lines removed, review orphaned component analysis in step 4.2.
+
+---
+
+## Notes
+
+_Add any notes about unusual issues, decisions, or things to remember:_
+
+-
+-
+-

--- a/.claude/skills/retire-waffle-flag/references/backend-patterns.md
+++ b/.claude/skills/retire-waffle-flag/references/backend-patterns.md
@@ -1,0 +1,385 @@
+# Backend Patterns for Django Waffle Flag Retirement
+
+Detailed patterns for retiring waffle flags in Django/Python code.
+
+## Flag Check Functions
+
+### flag_is_active_in_task
+
+Used in background tasks and non-request contexts:
+
+```python
+from privaterelay.utils import flag_is_active_in_task
+
+# Pattern: Simple check
+if flag_is_active_in_task("flag_name", None):
+    do_something()
+
+# Pattern: With user context
+if flag_is_active_in_task("flag_name", user):
+    do_user_specific_thing()
+
+# Pattern: In property
+@property
+def feature_enabled(self):
+    return flag_is_active_in_task("flag_name", self.user)
+```
+
+**Retirement:**
+Remove conditional, keep flag-enabled behavior.
+
+### flag_is_active
+
+Used in view/request contexts:
+
+```python
+from waffle import flag_is_active
+
+def my_view(request):
+    if flag_is_active(request, "flag_name"):
+        return new_response()
+    else:
+        return old_response()
+```
+
+**Retirement:**
+Remove conditional, keep flag-enabled path.
+
+## Common Backend Patterns
+
+### Pattern 1: Validation Logic
+
+```python
+# BEFORE
+def valid_address(address, domain, subdomain=None):
+    # ... other checks ...
+    address_already_deleted = 0
+
+    # TODO: Remove flag_name flag, assume on
+    if not subdomain or flag_is_active_in_task("flag_name", None):
+        address_already_deleted = DeletedAddress.objects.filter(
+            address_hash=hash_address(address, domain, subdomain)
+        ).count()
+
+    if address_already_deleted > 0:
+        return False
+    return True
+
+# AFTER
+def valid_address(address, domain, subdomain=None):
+    # ... other checks ...
+    address_already_deleted = DeletedAddress.objects.filter(
+        address_hash=hash_address(address, domain, subdomain)
+    ).count()
+
+    if address_already_deleted > 0:
+        return False
+    return True
+```
+
+### Pattern 2: Model Methods
+
+```python
+# BEFORE
+class MyModel(models.Model):
+    def should_process(self):
+        if flag_is_active_in_task("flag_name", self.user):
+            return self.new_criteria()
+        else:
+            return self.old_criteria()
+
+# AFTER
+class MyModel(models.Model):
+    def should_process(self):
+        return self.new_criteria()
+```
+
+### Pattern 3: View Logic
+
+```python
+# BEFORE
+def my_api_view(request):
+    if flag_is_active(request, "flag_name"):
+        data = process_new_way(request.data)
+    else:
+        data = process_old_way(request.data)
+    return Response(data)
+
+# AFTER
+def my_api_view(request):
+    data = process_new_way(request.data)
+    return Response(data)
+```
+
+### Pattern 4: Early Returns
+
+```python
+# BEFORE
+def process_email(email):
+    # Skip if flag disabled
+    if not flag_is_active_in_task("flag_name", email.user):
+        return
+
+    # New processing logic
+    check_spam(email)
+    filter_trackers(email)
+    forward(email)
+
+# AFTER
+def process_email(email):
+    # Always do new processing
+    check_spam(email)
+    filter_trackers(email)
+    forward(email)
+```
+
+### Pattern 5: Configuration/Settings
+
+```python
+# BEFORE
+def get_feature_config(user):
+    config = BASE_CONFIG.copy()
+
+    if flag_is_active_in_task("flag_name", user):
+        config.update(NEW_SETTINGS)
+    else:
+        config.update(OLD_SETTINGS)
+
+    return config
+
+# AFTER
+def get_feature_config(user):
+    config = BASE_CONFIG.copy()
+    config.update(NEW_SETTINGS)
+    return config
+```
+
+## Import Cleanup
+
+### Removing flag_is_active_in_task
+
+```python
+# Check if used elsewhere in file
+grep -n "flag_is_active_in_task" filename.py
+
+# If only used for retired flag, remove import
+from privaterelay.utils import flag_is_active_in_task  # DELETE
+```
+
+### Removing flag_is_active
+
+```python
+# Check usage
+grep -n "flag_is_active" filename.py
+
+# Remove if not used
+from waffle import flag_is_active  # DELETE
+```
+
+## Test Patterns
+
+### Pattern 1: Remove decorator, keep test
+
+Tests that verify new (desired) behavior:
+
+```python
+# BEFORE
+from waffle.testutils import override_flag
+
+class MyTestCase(TestCase):
+    @override_flag("flag_name", active=True)
+    def test_new_behavior_works(self):
+        result = do_thing()
+        assert result == expected_new_result
+
+# AFTER
+class MyTestCase(TestCase):
+    def test_new_behavior_works(self):
+        result = do_thing()
+        assert result == expected_new_result
+```
+
+### Pattern 2: Delete entire test
+
+Tests that verify old (deprecated) behavior:
+
+```python
+# DELETE THIS ENTIRE TEST
+@override_flag("flag_name", active=False)
+def test_old_behavior_works(self):
+    result = do_thing()
+    assert result == expected_old_result
+```
+
+### Pattern 3: Test pairs
+
+Often you'll find paired tests:
+
+```python
+# DELETE: Tests old behavior
+@override_flag("flag_name", active=False)
+def test_can_reuse_deleted_address(self):
+    address = create_address()
+    address.delete()
+    # Should succeed
+    new_address = create_address()
+    assert new_address.address == address.address
+
+# KEEP: Tests new behavior (remove decorator)
+@override_flag("flag_name", active=True)  # DELETE THIS LINE
+def test_cannot_reuse_deleted_address(self):
+    address = create_address()
+    address.delete()
+    # Should fail
+    with pytest.raises(ValidationError):
+        create_address()
+```
+
+### Pattern 4: Import cleanup
+
+```python
+# BEFORE
+from django.test import TestCase
+from waffle.testutils import override_flag
+
+from ..models import MyModel
+
+# Check if override_flag used elsewhere
+grep -n "override_flag" test_file.py
+
+# AFTER (if not used elsewhere)
+from django.test import TestCase
+
+from ..models import MyModel
+```
+
+## API Test Patterns
+
+### Pattern 1: DRF test decorators
+
+```python
+# BEFORE
+@pytest.mark.django_db
+@override_flag("flag_name", active=True)
+def test_api_endpoint_behavior(api_client, user):
+    response = api_client.post("/api/endpoint/", data)
+    assert response.status_code == 200
+
+# AFTER
+@pytest.mark.django_db
+def test_api_endpoint_behavior(api_client, user):
+    response = api_client.post("/api/endpoint/", data)
+    assert response.status_code == 200
+```
+
+### Pattern 2: Multiple decorators
+
+```python
+# BEFORE
+@override_settings(DEBUG=True)
+@override_flag("flag_name", active=True)
+@pytest.mark.django_db
+def test_complex_scenario():
+    # Test body
+    pass
+
+# AFTER
+@override_settings(DEBUG=True)
+@pytest.mark.django_db
+def test_complex_scenario():
+    # Test body
+    pass
+```
+
+## Edge Cases
+
+### Case 1: Flag used in multiple conditions
+
+```python
+# BEFORE
+def process(item, user):
+    if flag_is_active_in_task("flag_name", user):
+        validate_new_way(item)
+
+    # ... other logic ...
+
+    if flag_is_active_in_task("flag_name", user):
+        format_new_way(item)
+
+    return item
+
+# AFTER
+def process(item, user):
+    validate_new_way(item)
+
+    # ... other logic ...
+
+    format_new_way(item)
+
+    return item
+```
+
+### Case 2: Nested conditionals
+
+```python
+# BEFORE
+if user.has_premium:
+    if flag_is_active_in_task("flag_name", user):
+        return premium_new_feature()
+    else:
+        return premium_old_feature()
+else:
+    return free_feature()
+
+# AFTER
+if user.has_premium:
+    return premium_new_feature()
+else:
+    return free_feature()
+```
+
+### Case 3: Flag in complex boolean
+
+```python
+# BEFORE
+if user.is_active and flag_is_active_in_task("flag_name", user):
+    do_thing()
+
+# AFTER
+if user.is_active:
+    do_thing()
+```
+
+## Validation Steps
+
+After modifying backend code:
+
+1. **Run unit tests:**
+
+```bash
+pytest path/to/modified_file_tests.py -v
+```
+
+2. **Run integration tests:**
+
+```bash
+pytest api/tests/ -v
+```
+
+3. **Check for remaining references:**
+
+```bash
+grep -r "flag_name" --include="*.py" .
+```
+
+4. **Verify imports cleaned up:**
+
+```bash
+grep -r "flag_is_active" --include="*.py" modified_files/
+```
+
+5. **Run full test suite:**
+
+```bash
+pytest
+```

--- a/.claude/skills/retire-waffle-flag/references/common-issues.md
+++ b/.claude/skills/retire-waffle-flag/references/common-issues.md
@@ -1,0 +1,465 @@
+# Common Issues When Retiring Waffle Flags
+
+Troubleshooting guide for common problems encountered during flag retirement.
+
+## Issue 1: Deprecated Component Breakage
+
+### Symptom
+
+```
+Cannot find module './OldComponent' from 'src/components/Deprecated.tsx'
+```
+
+Test suites fail with module not found errors after deleting legacy components.
+
+### Cause
+
+Deprecated components still import deleted legacy components.
+
+### Example
+
+```typescript
+// Deprecated component marked with TODO
+// Deprecated, flag "mask_redesign" is in use and uses <MaskCard/> instead
+// TODO MPP-4463: Remove code and tests
+
+import { OldComponent } from "./OldComponent"; // File was deleted!
+```
+
+### Solution
+
+**Step 1: Identify affected deprecated components**
+
+```bash
+grep -r "OldComponent" --include="*.tsx" frontend/src/
+```
+
+**Step 2: Update imports in deprecated files**
+
+```typescript
+// BEFORE
+import { OldComponent } from "./OldComponent";
+
+// AFTER
+import { NewComponent } from "./NewComponent";
+```
+
+**Step 3: Update usage**
+
+```typescript
+// BEFORE
+<OldComponent onAction={props.onAction} data={props.data} />
+
+// AFTER
+<NewComponent onAction={props.onAction} data={props.data} />
+```
+
+**Step 4: Update test mocks**
+
+```typescript
+// In test file
+// BEFORE
+jest.mock("./OldComponent", () => ({
+  /* ... */
+}));
+
+// AFTER
+jest.mock("./NewComponent", () => ({
+  /* ... */
+}));
+```
+
+### Prevention
+
+Before deleting legacy components, search for all imports:
+
+```bash
+grep -r "ComponentName" --include="*.tsx" --include="*.ts" frontend/src/
+```
+
+## Issue 2: Test Cascade Failures
+
+### Symptom
+
+Multiple test files fail after deleting legacy component:
+
+```
+FAIL  src/components/AliasList.test.tsx
+FAIL  src/pages/profile.test.tsx
+FAIL  src/components/FreeOnboarding.test.tsx
+```
+
+All with same error: `Cannot find module './OldComponent'`
+
+### Cause
+
+Legacy component was imported and used in many files, including deprecated ones.
+
+### Solution
+
+**Step 1: Find all affected files**
+
+```bash
+# Find all test imports
+grep -r "OldComponent" --include="*.test.tsx" frontend/src/
+
+# Find all component imports
+grep -r "OldComponent" --include="*.tsx" frontend/src/
+```
+
+**Step 2: Update each file**
+For each file found, apply the same fix as Issue 1.
+
+**Step 3: Run tests incrementally**
+
+```bash
+# Test each fixed file
+npm test -- FileName.test.tsx
+
+# When all pass, run full suite
+npm test
+```
+
+### Prevention
+
+Use grep to identify all usages before deletion:
+
+```bash
+grep -r "ComponentName" \
+  --include="*.tsx" \
+  --include="*.ts" \
+  --exclude-dir=node_modules \
+  frontend/
+```
+
+## Issue 3: Modal UX Differences
+
+### Symptom
+
+Tests fail with:
+
+```
+Unable to find a label with the text of: "modal-delete-confirmation"
+```
+
+### Cause
+
+New component has different UX flow than old component.
+
+Common differences:
+
+- Old modal: Confirmation checkbox before delete button
+- New modal: Direct delete button (no checkbox)
+
+### Example
+
+```typescript
+// BEFORE: Test expects checkbox
+const checkbox = screen.getByLabelText(
+  "l10n string: [modal-delete-confirmation-2]",
+);
+await user.click(checkbox);
+
+const deleteButton = screen.getAllByRole("button", { name: "Delete" });
+await user.click(deleteButton[1]);
+
+// AFTER: New modal has no checkbox
+const deleteButton = screen.getAllByRole("button", { name: "Delete" });
+await user.click(deleteButton[1]);
+```
+
+### Solution
+
+**Step 1: Understand new component UX**
+Read new component code to see what elements exist:
+
+```typescript
+// Check what the new component renders
+<AliasDeletionButtonPermanent
+  onDelete={onDelete}
+  alias={alias}
+/>
+```
+
+**Step 2: Update test to match new UX**
+Remove steps that don't exist in new component:
+
+```typescript
+// DELETE: Checkbox interaction
+const checkbox = screen.getByLabelText("confirmation");
+await user.click(checkbox);
+
+// KEEP: Button click
+const deleteButton = screen.getByRole("button", { name: "Delete" });
+await user.click(deleteButton);
+```
+
+**Step 3: Add comment explaining change**
+
+```typescript
+// The new permanent deletion modal doesn't have a checkbox
+const deleteButton = screen.getAllByRole("button", { name: "Delete" });
+await user.click(deleteButton[1]);
+```
+
+### Prevention
+
+Review new component UX before updating tests.
+
+## Issue 4: Import Cleanup Missed
+
+### Symptom
+
+Linter warnings or unused import errors:
+
+```
+'isFlagActive' is defined but never used
+'OldComponent' is defined but never used
+```
+
+### Cause
+
+Removed flag checks but forgot to remove imports.
+
+### Solution
+
+**Step 1: Check for other usages**
+
+```bash
+grep -n "isFlagActive" path/to/file.tsx
+grep -n "OldComponent" path/to/file.tsx
+```
+
+**Step 2: Remove if not used**
+
+```typescript
+// BEFORE
+import { isFlagActive } from "../../../functions/waffle";
+import { NewComponent } from "./NewComponent";
+import { OldComponent } from "./OldComponent";
+
+// AFTER (if not used elsewhere)
+import { NewComponent } from "./NewComponent";
+```
+
+**Step 3: Remove waffle import if not used**
+
+```typescript
+// Check if any other flags checked in file
+grep "isFlagActive" file.tsx
+
+// If none, remove import
+import { isFlagActive } from "../../../functions/waffle";  // DELETE
+```
+
+### Prevention
+
+After removing flag checks, always search file for import usage:
+
+```bash
+grep -n "ImportName" file.tsx
+```
+
+## Issue 5: Config Synchronization
+
+### Symptom
+
+Mock data doesn't match default runtime data:
+
+- Tests pass locally
+- Tests fail in CI
+
+### Cause
+
+Flag removed from one config file but not the other.
+
+### Files to check
+
+```
+frontend/src/hooks/api/runtimeData-default.ts  (default config)
+frontend/__mocks__/api/mockData.ts             (mock config)
+```
+
+### Solution
+
+**Step 1: Remove from both files**
+
+```typescript
+// runtimeData-default.ts
+WAFFLE_FLAGS: [
+  ["other_flag", true],
+  ["flag_name", true], // DELETE
+];
+
+// mockData.ts
+WAFFLE_FLAGS: [
+  ["other_flag", true],
+  ["flag_name", true], // DELETE
+];
+```
+
+**Step 2: Verify arrays match**
+
+```bash
+# Compare flag lists
+grep -A 20 "WAFFLE_FLAGS" frontend/src/hooks/api/runtimeData-default.ts
+grep -A 20 "WAFFLE_FLAGS" frontend/__mocks__/api/mockData.ts
+```
+
+### Prevention
+
+Always update both config files in same commit.
+
+## Issue 6: Test Mock Function Mismatch
+
+### Symptom
+
+```
+TypeError: Cannot read property 'setModalOpenedState' of undefined
+```
+
+### Cause
+
+New component requires props that old component didn't.
+
+### Example
+
+```typescript
+// Old component
+<OldComponent
+  onDelete={onDelete}
+  alias={alias}
+/>
+
+// New component needs additional prop
+<NewComponent
+  onDelete={onDelete}
+  alias={alias}
+  setModalOpenedState={setModalOpenedState}  // NEW PROP
+/>
+```
+
+### Solution
+
+**Step 1: Add missing props to test**
+
+```typescript
+// BEFORE
+const { onDelete } = renderComponent({
+  alias: mockAlias,
+  onDelete: jest.fn(),
+});
+
+// AFTER
+const { onDelete } = renderComponent({
+  alias: mockAlias,
+  onDelete: jest.fn(),
+  setModalOpenedState: jest.fn(), // ADD
+});
+```
+
+**Step 2: Update mock implementation**
+
+```typescript
+jest.mock("./NewComponent", () => ({
+  NewComponent: ({
+    onDelete,
+    alias,
+    setModalOpenedState  // ADD TO MOCK
+  }: Props) => (
+    <button onClick={onDelete}>Delete</button>
+  ),
+}));
+```
+
+### Prevention
+
+Compare prop types of old vs new components before updating tests.
+
+## Issue 7: Circular Dependencies
+
+### Symptom
+
+```
+Dependency cycle detected
+```
+
+### Cause
+
+Updating deprecated component creates circular import.
+
+### Solution
+
+**Step 1: Identify cycle**
+
+```bash
+npm run build  # Shows circular dependency path
+```
+
+**Step 2: Break cycle**
+Usually caused by deprecated component trying to import from file that imports it.
+
+**Step 3: Consider deletion**
+If component is deprecated, consider deleting it instead of fixing imports.
+
+### Prevention
+
+Check import graph before modifying deprecated files.
+
+## Issue 8: Build Output Not Cleaned
+
+### Symptom
+
+Tests pass but flag still referenced in built files.
+
+### Cause
+
+Old build artifacts remain in `out/` or `.next/` directories.
+
+### Solution
+
+```bash
+# Clean build artifacts
+rm -rf frontend/out frontend/.next
+
+# Rebuild
+npm run build
+```
+
+### Prevention
+
+Clean before final validation:
+
+```bash
+npm run clean
+npm run build
+npm test
+```
+
+## Quick Troubleshooting Checklist
+
+When tests fail after flag retirement:
+
+- [ ] Check for deprecated components importing deleted files
+- [ ] Search for all imports of deleted component
+- [ ] Update test mocks to match new component
+- [ ] Remove unused imports (isFlagActive, old components)
+- [ ] Verify config files synchronized (runtimeData-default.ts, mockData.ts)
+- [ ] Check new component prop requirements
+- [ ] Clean build artifacts
+- [ ] Run tests incrementally (file by file)
+- [ ] Search for remaining flag references
+
+## Getting Help
+
+If stuck, search for similar patterns:
+
+```bash
+# Find other retired flags for examples
+git log --all --grep="retire.*flag"
+
+# Look for similar test patterns
+grep -r "jest.mock" frontend/src/**/*.test.tsx
+```
+
+Check recent commits for flag retirement examples.

--- a/.claude/skills/retire-waffle-flag/references/frontend-patterns.md
+++ b/.claude/skills/retire-waffle-flag/references/frontend-patterns.md
@@ -1,0 +1,562 @@
+# Frontend Patterns for Django Waffle Flag Retirement
+
+Detailed patterns for retiring waffle flags in TypeScript/React code.
+
+## Flag Check Function
+
+### isFlagActive
+
+Used throughout React components:
+
+```typescript
+import { isFlagActive } from "../../../functions/waffle";
+
+// Check if flag is active
+if (isFlagActive(props.runtimeData, "flag_name")) {
+  return <NewComponent />;
+}
+```
+
+**Retirement:**
+Remove conditional, keep flag-enabled rendering.
+
+## Component Patterns
+
+### Pattern 1: Conditional Rendering
+
+```typescript
+// BEFORE
+{isFlagActive(props.runtimeData, "flag_name") ? (
+  <NewComponent
+    prop1={value1}
+    prop2={value2}
+  />
+) : (
+  <OldComponent
+    prop1={value1}
+  />
+)}
+
+// AFTER
+<NewComponent
+  prop1={value1}
+  prop2={value2}
+/>
+```
+
+### Pattern 2: With Complex Props
+
+```typescript
+// BEFORE
+const dialog = modalState.isOpen ? (
+  isFlagActive(props.runtimeData, "flag_name") ? (
+    <CustomAddressGenerationModal
+      isOpen={modalState.isOpen}
+      onClose={() => modalState.close()}
+      onUpdate={onSuccessClose}
+      onPick={onPick}
+      subdomain={props.subdomain}
+      aliasGeneratedState={aliasGeneratedState}
+      findAliasDataFromPrefix={props.findAliasDataFromPrefix}
+    />
+  ) : (
+    <AddressPickerModal
+      isOpen={modalState.isOpen}
+      onClose={() => modalState.close()}
+      onPick={onPickNonRedesign}
+      subdomain={props.subdomain}
+    />
+  )
+) : null;
+
+// AFTER
+const dialog = modalState.isOpen ? (
+  <CustomAddressGenerationModal
+    isOpen={modalState.isOpen}
+    onClose={() => modalState.close()}
+    onUpdate={onSuccessClose}
+    onPick={onPick}
+    subdomain={props.subdomain}
+    aliasGeneratedState={aliasGeneratedState}
+    findAliasDataFromPrefix={props.findAliasDataFromPrefix}
+  />
+) : null;
+```
+
+### Pattern 3: With Callback Functions
+
+```typescript
+// BEFORE
+const onPickNew = (address: string, settings: Settings) => {
+  props.onCreate({
+    mask_type: "custom",
+    address: address,
+    blockPromotionals: settings.blockPromotionals,
+  });
+  modalState.close();
+};
+
+const onPickOld = (address: string, settings: Settings) => {
+  props.onCreate({
+    mask_type: "custom",
+    address: address,
+    blockPromotionals: settings.blockPromotionals,
+  });
+  modalState.close();
+};
+
+const dialog = isFlagActive(props.runtimeData, "flag_name") ? (
+  <NewModal onPick={onPickNew} />
+) : (
+  <OldModal onPick={onPickOld} />
+);
+
+// AFTER (delete onPickOld function)
+const onPickNew = (address: string, settings: Settings) => {
+  props.onCreate({
+    mask_type: "custom",
+    address: address,
+    blockPromotionals: settings.blockPromotionals,
+  });
+  modalState.close();
+};
+
+const dialog = <NewModal onPick={onPickNew} />;
+```
+
+### Pattern 4: Component in JSX
+
+```typescript
+// BEFORE
+return (
+  <div className={styles.container}>
+    {isFlagActive(props.runtimeData, "flag_name") ? (
+      <AliasDeletionButtonPermanent
+        setModalOpenedState={props.setModalOpenedState}
+        onDelete={props.onDelete}
+        alias={props.mask}
+      />
+    ) : (
+      <AliasDeletionButton
+        onDelete={props.onDelete}
+        alias={props.mask}
+      />
+    )}
+  </div>
+);
+
+// AFTER
+return (
+  <div className={styles.container}>
+    <AliasDeletionButtonPermanent
+      setModalOpenedState={props.setModalOpenedState}
+      onDelete={props.onDelete}
+      alias={props.mask}
+    />
+  </div>
+);
+```
+
+### Pattern 5: Conditional Logic
+
+```typescript
+// BEFORE
+const showFeature = isFlagActive(props.runtimeData, "flag_name");
+
+return (
+  <div>
+    {showFeature && <NewFeatureComponent />}
+    {!showFeature && <OldFeatureComponent />}
+  </div>
+);
+
+// AFTER
+return (
+  <div>
+    <NewFeatureComponent />
+  </div>
+);
+```
+
+## Import Cleanup
+
+### Removing isFlagActive
+
+```typescript
+// BEFORE
+import { isFlagActive } from "../../../functions/waffle";
+import { NewComponent } from "./NewComponent";
+import { OldComponent } from "./OldComponent";
+
+// Check if used elsewhere in file
+// Search for: isFlagActive
+
+// AFTER (if not used elsewhere)
+import { NewComponent } from "./NewComponent";
+```
+
+### Removing Old Component Imports
+
+```typescript
+// BEFORE
+import { AliasDeletionButton } from "./AliasDeletionButton";
+import { AliasDeletionButtonPermanent } from "./AliasDeletionButtonPermanent";
+
+// AFTER
+import { AliasDeletionButtonPermanent } from "./AliasDeletionButtonPermanent";
+```
+
+## Identifying Orphaned Components (CRITICAL)
+
+Before deleting components, identify which ones are truly orphaned.
+
+### Orphaned vs. Still-Used Components
+
+**Orphaned component:** Only used in flag conditionals being removed
+**Still-used component:** Also used in active code paths
+
+### Detection Process
+
+**Step 1: Extract old components from flag conditionals**
+
+Look at each conditional being removed:
+
+```typescript
+// Example 1: Component conditional
+{isFlagActive(data, "flag") ? <NewModal /> : <OldModal />}
+// → OldModal is a candidate for deletion
+
+// Example 2: Import conditional
+isFlagActive(data, "flag") ? (
+  <CustomAddressGenerationModal ... />
+) : (
+  <AddressPickerModal ... />
+)
+// → AddressPickerModal is a candidate
+```
+
+**Step 2: Search for ALL usages of candidate component**
+
+```bash
+# Search for every import and usage
+grep -rn "OldModal" --include="*.tsx" --include="*.ts" frontend/src/
+
+# Output example:
+# AliasGenerationButton.tsx:87   → In flag conditional (will be removed)
+# Alias.tsx:42                   → In deprecated component (needs update)
+# MaskCreation.test.tsx:12       → In test mock (will be removed with test)
+```
+
+**Step 3: Categorize each usage**
+
+| Location Type                     | Action          | Orphaned? |
+| --------------------------------- | --------------- | --------- |
+| In flag conditional being removed | Will be removed | Yes ✓     |
+| In deprecated file                | Needs update    | Yes ✓     |
+| In test of removed conditional    | Will be removed | Yes ✓     |
+| In active code path               | Keep using it   | No ✗      |
+
+**Step 4: Verify component is orphaned**
+
+Component is orphaned if:
+
+- ✓ ALL usages are in code being removed
+- ✓ OR only used in deprecated files
+- ✗ ANY usage in active code → NOT orphaned, keep it
+
+### Example: Complete Analysis
+
+```bash
+# Flag shows:
+{isFlagActive(data, "custom_domain_management_redesign") ? (
+  <CustomAddressGenerationModal />
+) : (
+  <AddressPickerModal />
+)}
+
+# Search for AddressPickerModal:
+grep -rn "AddressPickerModal" --include="*.tsx" frontend/src/
+
+# Results:
+# AliasGenerationButton.tsx:245  - import statement
+# AliasGenerationButton.tsx:369  - Usage in flag conditional
+# → Both in same file, both in conditional being removed
+
+# Conclusion: AddressPickerModal is ORPHANED
+# Delete:
+#   - AddressPickerModal.tsx (241 lines)
+#   - AddressPickerModal.module.scss (194 lines)
+#   - AddressPickerModal.test.tsx (221 lines)
+# Total: 656 lines removed
+```
+
+### Orphaned Component Checklist
+
+For each flag conditional with old component:
+
+- [ ] Extracted old component name
+- [ ] Searched ALL usages (grep entire codebase)
+- [ ] Categorized each usage location
+- [ ] Verified NO active code uses it
+- [ ] Identified file set (.tsx + .scss + .test.tsx)
+- [ ] Added to deletion list
+
+**CRITICAL:** Do not proceed to deletion until ALL old components are analyzed.
+
+## Component Deletion
+
+### Step 1: Delete component files (from orphaned analysis)
+
+```bash
+rm frontend/src/components/path/OldComponent.tsx
+rm frontend/src/components/path/OldComponent.module.scss
+rm frontend/src/components/path/OldComponent.test.tsx
+```
+
+**Delete early:** Before tests pass, to force fixing imports.
+
+### Step 2: Handle deprecated components
+
+If deprecated components imported deleted component:
+
+```typescript
+// Deprecated component that breaks
+import { OldComponent } from "./OldComponent";  // File deleted!
+
+// Fix by updating to new component
+import { NewComponent } from "./NewComponent";
+
+// Update usage to match new component props
+<OldComponent prop={value} />  // Old way
+<NewComponent prop={value} />  // New way
+```
+
+## Config File Patterns
+
+### Pattern 1: runtimeData-default.ts
+
+```typescript
+// BEFORE
+export const DEFAULT_RUNTIME_DATA: RuntimeData = {
+  // ... other fields ...
+  WAFFLE_FLAGS: [
+    ["free_user_onboarding", true],
+    ["tracker_removal", true],
+    ["flag_name", true], // DELETE THIS LINE
+    ["phones", true],
+    ["mask_redesign", true],
+  ],
+};
+
+// AFTER
+export const DEFAULT_RUNTIME_DATA: RuntimeData = {
+  // ... other fields ...
+  WAFFLE_FLAGS: [
+    ["free_user_onboarding", true],
+    ["tracker_removal", true],
+    ["phones", true],
+    ["mask_redesign", true],
+  ],
+};
+```
+
+### Pattern 2: mockData.ts
+
+```typescript
+// BEFORE
+export const mockedRuntimeData: RuntimeData = {
+  // ... other fields ...
+  WAFFLE_FLAGS: [
+    ["tracker_removal", true],
+    ["phone_launch_survey", true],
+    ["flag_name", true], // DELETE THIS LINE
+    ["mask_redesign", true],
+  ],
+};
+
+// AFTER
+export const mockedRuntimeData: RuntimeData = {
+  // ... other fields ...
+  WAFFLE_FLAGS: [
+    ["tracker_removal", true],
+    ["phone_launch_survey", true],
+    ["mask_redesign", true],
+  ],
+};
+```
+
+## Test Patterns
+
+### Pattern 1: Component test with flag check
+
+```typescript
+// BEFORE
+import { setFlag } from "../../../__mocks__/api/mockData";
+
+test("deletion button variant is waffle-flag controlled", async () => {
+  const user = userEvent.setup();
+
+  setFlag("flag_name", true);
+  const { rerender } = renderComponent({ isOpen: true });
+  await user.click(
+    screen.getByRole("button", { name: "new-button" }),
+  );
+  expect(onAction).toHaveBeenCalled();
+
+  setFlag("flag_name", false);
+  rerender(<Component {...props} />);
+  await user.click(screen.getByRole("button", { name: "old-button" }));
+  expect(onAction).toHaveBeenCalledTimes(2);
+});
+
+// AFTER
+// Delete entire test - behavior no longer flag-controlled
+```
+
+### Pattern 2: Mock removal
+
+```typescript
+// BEFORE
+jest.mock("./OldComponent", () => ({
+  OldComponent: ({ onDelete }: { onDelete: () => void }) => (
+    <button onClick={onDelete} aria-label="old-button">
+      Delete
+    </button>
+  ),
+}));
+
+jest.mock("./NewComponent", () => ({
+  NewComponent: ({ onDelete }: { onDelete: () => void }) => (
+    <button onClick={onDelete} aria-label="new-button">
+      Delete Permanent
+    </button>
+  ),
+}));
+
+// AFTER
+jest.mock("./NewComponent", () => ({
+  NewComponent: ({ onDelete }: { onDelete: () => void }) => (
+    <button onClick={onDelete} aria-label="new-button">
+      Delete Permanent
+    </button>
+  ),
+}));
+```
+
+### Pattern 3: Test expectations update
+
+If new component has different UX than old:
+
+```typescript
+// BEFORE: Old component had confirmation checkbox
+const confirmationCheckbox = screen.getByLabelText("Are you sure?");
+await user.click(confirmationCheckbox);
+
+const confirmButton = screen.getAllByRole("button", { name: "Delete" });
+await user.click(confirmButton[1]);
+
+// AFTER: New component has no checkbox
+const confirmButton = screen.getAllByRole("button", { name: "Delete" });
+await user.click(confirmButton[1]);
+```
+
+## Edge Cases
+
+### Case 1: Multiple flags in same component
+
+```typescript
+// BEFORE
+return (
+  <div>
+    {isFlagActive(data, "flag_name_1") && <Feature1 />}
+    {isFlagActive(data, "flag_name_2") && <Feature2 />}
+  </div>
+);
+
+// Retiring only flag_name_1
+return (
+  <div>
+    <Feature1 />
+    {isFlagActive(data, "flag_name_2") && <Feature2 />}
+  </div>
+);
+```
+
+### Case 2: Nested flags
+
+```typescript
+// BEFORE
+{isFlagActive(data, "flag_name") ? (
+  <div>
+    <NewFeature />
+    {isFlagActive(data, "other_flag") && <ExtraFeature />}
+  </div>
+) : (
+  <OldFeature />
+)}
+
+// AFTER
+<div>
+  <NewFeature />
+  {isFlagActive(data, "other_flag") && <ExtraFeature />}
+</div>
+```
+
+### Case 3: Flag in useEffect
+
+```typescript
+// BEFORE
+useEffect(() => {
+  if (isFlagActive(props.runtimeData, "flag_name")) {
+    initializeNewFeature();
+  } else {
+    initializeOldFeature();
+  }
+}, [props.runtimeData]);
+
+// AFTER
+useEffect(() => {
+  initializeNewFeature();
+}, []);
+```
+
+## Validation Steps
+
+After modifying frontend code:
+
+1. **Run component tests:**
+
+```bash
+npm test -- ComponentName.test.tsx
+```
+
+2. **Run full frontend tests:**
+
+```bash
+npm test
+```
+
+3. **Check for remaining references:**
+
+```bash
+grep -r "flag_name" --include="*.tsx" --include="*.ts" \
+  --exclude-dir=node_modules frontend/src/
+```
+
+4. **Verify imports cleaned up:**
+
+```bash
+grep -r "isFlagActive" frontend/src/modified/files/
+```
+
+5. **Verify legacy components deleted:**
+
+```bash
+find frontend/src/ -name "OldComponent*"
+```
+
+6. **Check build succeeds:**
+
+```bash
+npm run build
+```

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ docs/api_schema.yaml
 docs/api_docs.html
 
 .claude/settings.local.json
+.claude/plans/*


### PR DESCRIPTION
Adds two skills:
- pr-ready: runs lint-staged, reviews PR checklist, drafts commit message
- retire-waffle-flag: guides step-by-step removal of Django waffle flags

Also ignores `.claude/plans/*` from git.

## How to test:
### `/retire-waffle-flag` skill:
1. Run `/retire-waffle-flag` in Claude Code
   * [ ] It should scan the code-base for waffle flags that can be retired
2. Pick a flag to retire
   * [ ] It should work with you to remove the flag from the code-base
### `/pr-ready` skill:
1. Stage any file changes in the relay repo.
2. Run `/pr-ready` in Claude Code.
3. Claude should run lint-staged, review PR checklsit, and draft a commit message

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).