### PR TITLE
MPP-4568 - fix(relay-landing): update free masks string

### DIFF
--- a/frontend/pendingTranslations.ftl
+++ b/frontend/pendingTranslations.ftl
@@ -193,6 +193,20 @@ vpn-relay-go-vpn-body-2 = Protect your online activity.
 -brand-name-solo-ai = Solo AI
 fx-solo-ai = { -brand-name-solo-ai }
 
-highlighted-features-section-unlimited-masks-body-1 = Everyone gets { $mask_limit } email masks for free. 
+highlighted-features-section-unlimited-masks-body-2 = Everyone gets { $mask_limit } email masks for free. 
     But with { -brand-name-relay-premium }, you can generate as many masks as you need to help protect your email 
     from spammers, hackers, data breaches, and online trackers.
+
+highlighted-features-section-masks-on-the-go-body-2 = { -brand-name-relay-premium } gives you a unique { -brand-name-relay } email domain so you can instantly 
+    create new masks anywhere you are. Simply add any word or phrase before the @ symbol. At a restaurant? Use restaurant@yourdomain.{ $mozmail }. 
+    Shopping? Try shop@yourdomain.{ $mozmail }.
+
+highlighted-features-section-replying-body-2 = { -brand-name-relay-premium } lets you respond to emails from your
+    masked email account, so senders will never know your real email address. With phone masking, you can reply 
+    to texts from your masked phone number to protect your real number. 
+
+highlighted-features-section-block-promotions-body-2 = With { -brand-name-relay-premium }, you can block promotional emails from reaching your 
+    inbox while still receiving emails like receipts or shipping information. 
+
+highlighted-features-section-remove-trackers-body-2 = { -brand-name-relay } can remove common email trackers from any emails forwarded to you, helping 
+    you stay invisible to trackers and advertisers.

--- a/frontend/src/components/landing/HighlightedFeatures.test.tsx
+++ b/frontend/src/components/landing/HighlightedFeatures.test.tsx
@@ -48,7 +48,7 @@ describe("HighlightedFeatures", () => {
       ).toBeInTheDocument();
       expect(
         screen.getByText(
-          `l10n string: [highlighted-features-section-${n}-body-1], with vars: {"mask_limit":"5","mozmail":"mozmail.com"}`,
+          `l10n string: [highlighted-features-section-${n}-body-2], with vars: {"mask_limit":"5","mozmail":"mozmail.com"}`,
         ),
       ).toBeInTheDocument();
     }

--- a/frontend/src/components/landing/HighlightedFeatures.tsx
+++ b/frontend/src/components/landing/HighlightedFeatures.tsx
@@ -46,7 +46,7 @@ export const HighlightedFeatures = () => {
             </h3>
             <p className={styles["highlighted-feature-body"]}>
               {l10n.getString(
-                `highlighted-features-section-${props.name}-body-1`,
+                `highlighted-features-section-${props.name}-body-2`,
                 variables,
               )}
             </p>


### PR DESCRIPTION
This PR fixes [MPP-4568](https://mozilla-hub.atlassian.net/browse/MPP-4568)

- string update to 'Everyone gets 5 email masks for free. But with ⁨Relay Premium⁩, you can generate as many masks as you need to help protect your email from spammers, hackers, data breaches, and online trackers.' on landing page

Screenshot:

<img width="1279" height="679" alt="Screenshot 2026-02-20 at 12 00 00 PM" src="https://github.com/user-attachments/assets/38daf736-52b8-4db4-8b8c-90a32a59be87" />

How to test:
- navigate to landing page
- notice string change

- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).


[MPP-4568]: https://mozilla-hub.atlassian.net/browse/MPP-4568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ