### PR TITLE
Update e2e tests for mask limit config mpp 4563

### DIFF
--- a/e2e-tests/e2eTestUtils/helpers.ts
+++ b/e2e-tests/e2eTestUtils/helpers.ts
@@ -27,6 +27,20 @@ export const TIMEOUTS = {
   LONG: 10000,
 };
 
+// Default free mask limit — matches INCREASED_MAX_NUM_FREE_ALIASES in settings.py.
+// Used in test names (must be static) and as a fallback if the API fetch fails.
+export const MAX_NUM_FREE_ALIASES = 50;
+
+// Fetches the live mask limit from the runtime data API for the current environment.
+export const fetchMaxNumFreeAliases = async (
+  baseUrl: string,
+): Promise<number> => {
+  const context = await request.newContext();
+  const res = await context.get(`${baseUrl}/api/v1/runtime_data/`);
+  const data = await res.json();
+  return data.MAX_NUM_FREE_ALIASES ?? MAX_NUM_FREE_ALIASES;
+};
+
 export const getVerificationCode = async (
   testEmail: string,
   page: Page,

--- a/e2e-tests/specs/relay-premium-functionality.spec.ts
+++ b/e2e-tests/specs/relay-premium-functionality.spec.ts
@@ -1,6 +1,19 @@
 import test, { expect } from "../fixtures/basePages";
+import {
+  ENV_URLS,
+  fetchMaxNumFreeAliases,
+  MAX_NUM_FREE_ALIASES,
+} from "../e2eTestUtils/helpers";
+
+let freeMaskLimit = MAX_NUM_FREE_ALIASES;
 
 test.describe("Premium - General Functionalities, Desktop", () => {
+  test.beforeAll(async () => {
+    const env = process.env.E2E_TEST_ENV ?? "stage";
+    const baseUrl = ENV_URLS[env] as string;
+    freeMaskLimit = await fetchMaxNumFreeAliases(baseUrl);
+  });
+
   test.beforeEach(async ({ landingPage, authPage, dashboardPage }) => {
     await landingPage.open();
     await landingPage.goToSignIn();
@@ -9,11 +22,11 @@ test.describe("Premium - General Functionalities, Desktop", () => {
     await dashboardPage.maybeDeleteMasks(true, parseInt(totalMasks as string));
   });
 
-  test("Verify that a premium user can make more than 5 masks", async ({
+  test(`Verify that a premium user can make more than ${MAX_NUM_FREE_ALIASES} masks`, async ({
     dashboardPage,
   }) => {
     expect(await dashboardPage.emailMasksUsedAmount.textContent()).toBe("0");
-    await dashboardPage.generateMask(6, true);
+    await dashboardPage.generateMask(freeMaskLimit + 1, true);
 
     await expect
       .poll(
@@ -24,7 +37,7 @@ test.describe("Premium - General Functionalities, Desktop", () => {
           intervals: [1_000],
         },
       )
-      .toContain("6");
+      .toContain(String(freeMaskLimit + 1));
   });
 
   test("Verify that a user can click the mask blocking options", async ({


### PR DESCRIPTION
This PR fixes MPP-4563.

How to test:
1. Set up e2e credentials and `E2E_TEST_ENV=stage` in your `.env`
2. Run: `npm run test:relay-only:stage`
   * [ ] Verify the "Check the free user can only create 50 masks" test passes
   * [ ] Verify the "Verify that a premium user can make more than 50 masks" test passes
   * [ ] `global-setup` should no longer fail with WAF 403s on account creation

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).