### PR TITLE
refactor(circle): don't fail workflow if circle fails to upload coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
           command: |
             pip install coveralls
             cp /tmp/workspace/test-results/backend-coverage/.coverage .
-            coveralls --merge=/tmp/workspace/test-results/frontend-coverage/coveralls.json
+            coveralls --merge=/tmp/workspace/test-results/frontend-coverage/coveralls.json || true
 
   deploy:
     executor:


### PR DESCRIPTION
How to test:
Hard ... open a PR while coveralls is down?

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).