### PR TITLE
fix MPP-4579: fix(phones): stop sync from advancing reset date withou…

### DIFF
--- a/privaterelay/management/commands/sync_phone_related_dates_on_profile.py
+++ b/privaterelay/management/commands/sync_phone_related_dates_on_profile.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandParser
@@ -56,11 +56,6 @@ def sync_phone_related_dates_on_profile(group: str) -> int:
             # initialize the reset date for phone subscription users to the start of the
             # subscription
             profile.date_phone_subscription_reset = start_date
-        thirtyone_days_ago = datetime_now - timedelta(settings.MAX_DAYS_IN_MONTH)
-        while profile.date_phone_subscription_reset < thirtyone_days_ago:
-            profile.date_phone_subscription_reset += timedelta(
-                settings.MAX_DAYS_IN_MONTH
-            )
         profile.save()
         num_updated_accounts += 1
     return num_updated_accounts

--- a/privaterelay/tests/mgmt_sync_phone_related_dates_on_profile_tests.py
+++ b/privaterelay/tests/mgmt_sync_phone_related_dates_on_profile_tests.py
@@ -240,8 +240,7 @@ def test_yearly_phone_subscriber_with_subscription_date_older_than_31_days_profi
 
     profile = phone_user.profile
     profile.refresh_from_db()
-    sixty_two_days_from_subsciprion_date = date_subscribed_phone + timedelta(62)
-    assert profile.date_phone_subscription_reset == sixty_two_days_from_subsciprion_date
+    assert profile.date_phone_subscription_reset == date_subscribed_phone
     assert profile.date_subscribed_phone == date_subscribed_phone
     assert profile.date_phone_subscription_start == date_subscribed_phone
     assert profile.date_phone_subscription_end == date_subscribed_phone + timedelta(365)


### PR DESCRIPTION
This PR fixes MPP-4579.

How to test:
`pytest`

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).