### PR TITLE
fix(logs): fix MPP-4599: close DB connection after processing each email

### DIFF
--- a/emails/management/commands/process_emails_from_sqs.py
+++ b/emails/management/commands/process_emails_from_sqs.py
@@ -495,4 +495,6 @@ def run_sns_inbound_logic(
         if not cursor.db.is_usable():
             cursor.db.close()
 
-    return cast(HttpResponse, _sns_inbound_logic(topic_arn, message_type, json_body))
+    result = cast(HttpResponse, _sns_inbound_logic(topic_arn, message_type, json_body))
+    connection.close()
+    return result


### PR DESCRIPTION
Each email is processed in a subprocess via `multiprocessing.Pool`. When the subprocess exited without closing its DB connection, PostgreSQL logged 'Connection reset by peer' for every message — tens of thousands per hour in production.

This PR fixes MPP-4599.

How to test:
`pytest`
1. Deploy to dev/stage with this change.
2. Process a batch of emails (or wait for normal traffic).
3. Check Cloud SQL logs for 'Connection reset by peer': https://cloudlogging.app.goo.gl/rSezUY1gb1BRTUpd7
   * [ ] log volume drops to near zero compared to baseline.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).