### PR TITLE
fix MPP-4539: fix(sentry): read X-Relay-Client from event headers in before_send

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,4 +1,5 @@
 API_DOCS_ENABLED=False
+SENTRY_TEST_ENABLED=False
 FXA_OAUTH_ENDPOINT=https://oauth.stage.mozaws.net/v1
 FXA_PROFILE_ENDPOINT=https://profile.stage.mozaws.net/v1
 FXA_BASE_ORIGIN=https://accounts.stage.mozaws.net

--- a/api/urls.py
+++ b/api/urls.py
@@ -14,6 +14,7 @@ from .views.emails import (
     DomainAddressViewSet,
     RelayAddressViewSet,
     first_forwarded_email,
+    sentry_test,
 )
 from .views.privaterelay import (
     FlagViewSet,
@@ -91,6 +92,11 @@ urlpatterns: list[URLPattern | URLResolver] = [
         "v1/first-forwarded-email/",
         first_forwarded_email,
         name="first_forwarded_email",
+    ),
+    path(
+        "v1/sentry-test/",
+        enable_if_setting("SENTRY_TEST_ENABLED")(sentry_test),
+        name="sentry_test",
     ),
 ]
 

--- a/api/views/emails.py
+++ b/api/views/emails.py
@@ -251,3 +251,10 @@ def first_forwarded_email(request):
     )
     logger.info(f"Sent first_forwarded_email to user ID: {user.id}")
     return Response(status=HTTP_201_CREATED)
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def sentry_test(request):
+    """endpoint to verify _sentry_before_send."""
+    raise RuntimeError("sentry_before_send test")

--- a/privaterelay/tests/sentry_tests.py
+++ b/privaterelay/tests/sentry_tests.py
@@ -1,0 +1,68 @@
+"""Tests for Sentry configuration and _sentry_before_send hook."""
+
+from typing import cast
+
+from sentry_sdk.types import Event
+
+from privaterelay.settings import _sentry_before_send
+
+
+def test_sentry_before_send_tags_relay_client_platform() -> None:
+    """Events with X-Relay-Client header get relay_client_platform tag and context."""
+    event = cast(Event, {"request": {"headers": {"X-Relay-Client": "appservices-ios"}}})
+    result = _sentry_before_send(event, {})
+    assert result is not None
+    assert result["tags"]["relay_client_platform"] == "ios"
+    assert result["contexts"]["relay_client"] == {
+        "header_value": "appservices-ios",
+        "os": "ios",
+        "platform": "mobile-ios",
+    }
+
+
+def test_sentry_before_send_no_relay_client_header() -> None:
+    """Events without X-Relay-Client header are returned unchanged."""
+    event = cast(Event, {"request": {"headers": {"User-Agent": "curl/8.7.1"}}})
+    result = _sentry_before_send(event, {})
+    assert result is not None
+    assert "tags" not in result
+    assert "contexts" not in result
+
+
+def test_sentry_before_send_no_request() -> None:
+    """Events without a request are returned unchanged."""
+    event = cast(Event, {"exception": {"values": []}})
+    result = _sentry_before_send(event, {})
+    assert result is not None
+    assert "tags" not in result
+    assert "contexts" not in result
+
+
+def test_sentry_before_send_preserves_existing_tags() -> None:
+    """Existing event tags are preserved when relay_client_platform is added."""
+    event = cast(
+        Event,
+        {
+            "request": {"headers": {"X-Relay-Client": "appservices-ios"}},
+            "tags": {"existing_tag": "existing_value"},
+        },
+    )
+    result = _sentry_before_send(event, {})
+    assert result is not None
+    assert result["tags"]["existing_tag"] == "existing_value"
+    assert result["tags"]["relay_client_platform"] == "ios"
+
+
+def test_sentry_before_send_preserves_existing_contexts() -> None:
+    """Existing event contexts are preserved when relay_client context is added."""
+    event = cast(
+        Event,
+        {
+            "request": {"headers": {"X-Relay-Client": "appservices-android"}},
+            "contexts": {"existing_context": {"key": "value"}},
+        },
+    )
+    result = _sentry_before_send(event, {})
+    assert result is not None
+    assert result["contexts"]["existing_context"] == {"key": "value"}
+    assert "relay_client" in result["contexts"]


### PR DESCRIPTION
Also adds a `SENTRY_TEST_ENABLED` env var and `/api/v1/sentry-test/` endpoints for verifying the hook end-to-end.

This PR fixes MPP-4539.

How to test:
1. Check out this branch
2. `export SENTRY_TEST_ENABLED=True`
3. `python manage.py runserver`
4. Go to http://127.0.0.1:8000/accounts/settings/ to get a valid user API key
5. Run curl -v http://127.0.0.1:8000/api/v1/sentry-test/ -H "X-Relay-Client: appservices-ios" -H "Authorization: Token <api key from step 4>" -H "Content-Type: application/json"
6. Check [the Sentry report for the relay project local env](https://mozilla.sentry.io/issues/?environment=local&project=4503976951152641&query=is%3Aunresolved&referrer=latest-event&statsPeriod=1h).
   * [ ] You should see a new event for the `RuntimeError: sentry_before_send test` issue
   * [ ] Verify its Tags include `relay_client_platform`: `ios`
   * [ ] Verify its Contexts include the following:
```
relay_client
header_value: appservices-ios
os: ios
platform: mobile-ios
```
- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).