### PR TITLE
build(frontend): upgrade ESLint v8 to v9, fix all violations

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "build": "next build",
     "build:mocked": "NEXT_PUBLIC_MOCK_API=true NEXT_PUBLIC_DEBUG=true npm run build",
     "start": "next start",
-    "lint": "stylelint '**/*.scss' && prettier --check './src' && eslint --config .eslintrc.js",
+    "lint": "stylelint '**/*.scss' && prettier --check './src' && ESLINT_USE_FLAT_CONFIG=false eslint --config .eslintrc.js './src'",
     "licensecheck": "license-checker --excludePrivatePackages --production --onlyAllow 'MPL; MIT; BSD-3-Clause; BSD-2-Clause; 0BSD; Apache-2.0; ISC; Zlib; CC0; Unlicense; WTFPL; Unicode-DFS-2016;'",
     "test": "jest",
     "postinstall": "msw init public/ --save"
@@ -46,7 +46,7 @@
     "@types/jest-axe": "^3.5.9",
     "@types/react": "^19.2.14",
     "babel-jest": "^30.2.0",
-    "eslint": "^8.57.1",
+    "eslint": "^9.39.3",
     "eslint-config-next": "^16.1.6",
     "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-testing-library": "^7.15.4",

--- a/frontend/src/components/GoogleAnalyticsWorkaround.test.tsx
+++ b/frontend/src/components/GoogleAnalyticsWorkaround.test.tsx
@@ -48,9 +48,9 @@ describe("GoogleAnalyticsWorkaround", () => {
   });
 
   it("renders scripts with correct configuration and content", () => {
-    let result = render(<GoogleAnalyticsWorkaround gaId="G-TEST123" />);
-    let initScript = screen.getByTestId("_next-ga-init");
-    let mainScript = screen.getByTestId("_next-ga");
+    let view = render(<GoogleAnalyticsWorkaround gaId="G-TEST123" />);
+    const initScript = screen.getByTestId("_next-ga-init");
+    const mainScript = screen.getByTestId("_next-ga");
     let scriptContent = initScript.innerHTML;
 
     expect(mainScript).toHaveAttribute(
@@ -63,9 +63,9 @@ describe("GoogleAnalyticsWorkaround", () => {
     expect(scriptContent).toContain("function gtag()");
     expect(scriptContent).toContain(".push(arguments)");
     expect(scriptContent).toContain("gtag('js', new Date())");
-    result.unmount();
+    view.unmount();
 
-    result = render(
+    view = render(
       <GoogleAnalyticsWorkaround
         gaId="G-TEST123"
         dataLayerName="customLayer"
@@ -73,23 +73,23 @@ describe("GoogleAnalyticsWorkaround", () => {
     );
     scriptContent = screen.getByTestId("_next-ga-init").innerHTML;
     expect(scriptContent).toContain("window['customLayer']");
-    result.unmount();
+    view.unmount();
 
-    result = render(
+    view = render(
       <GoogleAnalyticsWorkaround gaId="G-TEST123" debugMode={true} />,
     );
     scriptContent = screen.getByTestId("_next-ga-init").innerHTML;
     expect(scriptContent).toContain("'debug_mode': true");
-    result.unmount();
+    view.unmount();
 
-    result = render(
+    view = render(
       <GoogleAnalyticsWorkaround gaId="G-TEST123" debugMode={false} />,
     );
     scriptContent = screen.getByTestId("_next-ga-init").innerHTML;
     expect(scriptContent).toContain("'debug_mode': false");
-    result.unmount();
+    view.unmount();
 
-    result = render(
+    view = render(
       <GoogleAnalyticsWorkaround gaId="G-TEST123" nonce="test-nonce" />,
     );
     expect(screen.getByTestId("_next-ga-init")).toHaveAttribute(
@@ -100,9 +100,9 @@ describe("GoogleAnalyticsWorkaround", () => {
       "data-nonce",
       "test-nonce",
     );
-    result.unmount();
+    view.unmount();
 
-    result = render(
+    view = render(
       <GoogleAnalyticsWorkaround
         gaId="G-ALL"
         dataLayerName="myLayer"
@@ -130,7 +130,7 @@ describe("GoogleAnalyticsWorkaround", () => {
 
     performanceMarkSpy?.mockRestore();
     const originalMark = performance.mark;
-    delete (performance as any).mark;
+    delete (performance as unknown as Record<string, unknown>).mark;
     expect(() =>
       render(<GoogleAnalyticsWorkaround gaId="G-TEST456" />),
     ).not.toThrow();
@@ -158,15 +158,15 @@ describe("sendGAEvent", () => {
     expect(consoleWarnSpy).not.toHaveBeenCalled();
 
     process.env.NODE_ENV = "production";
-    delete (window as any).dataLayer;
+    delete (window as unknown as Record<string, unknown>).dataLayer;
     sendGAEvent("event", "click_event", { button: "submit" });
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       "@next/third-parties: GA dataLayer dataLayer does not exist",
     );
 
     const mockGtag = jest.fn();
-    (window as any).gtag = mockGtag;
-    (window as any).dataLayer = [];
+    (window as unknown as Record<string, unknown>).gtag = mockGtag;
+    (window as unknown as Record<string, unknown>).dataLayer = [];
 
     sendGAEvent("event", "conversion", { value: 100, currency: "USD" });
     expect(mockGtag).toHaveBeenCalledWith("event", "conversion", {
@@ -184,7 +184,7 @@ describe("sendGAEvent", () => {
     sendGAEvent("event", "simple_event", {});
     expect(mockGtag).toHaveBeenCalledWith("event", "simple_event", {});
 
-    delete (window as any).gtag;
-    delete (window as any).dataLayer;
+    delete (window as unknown as Record<string, unknown>).gtag;
+    delete (window as unknown as Record<string, unknown>).dataLayer;
   });
 });

--- a/frontend/src/components/GoogleAnalyticsWorkaround.tsx
+++ b/frontend/src/components/GoogleAnalyticsWorkaround.tsx
@@ -41,9 +41,11 @@ export const GoogleAnalyticsWorkaround = (
 ) => {
   const { gaId, dataLayerName = "dataLayer", nonce, debugMode } = props;
 
-  if (currDataLayerName === undefined) {
-    currDataLayerName = dataLayerName;
-  }
+  useEffect(() => {
+    if (currDataLayerName === undefined) {
+      currDataLayerName = dataLayerName;
+    }
+  }, [dataLayerName]);
 
   useEffect(() => {
     if (typeof performance.mark !== "function") {

--- a/frontend/src/components/Icons.test.tsx
+++ b/frontend/src/components/Icons.test.tsx
@@ -1,30 +1,31 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 
 const IconsModule = jest.requireActual("./Icons");
 const { InfoIcon, CheckIcon, CloseIcon, LockIcon, SearchIcon } = IconsModule;
 
 describe("Icons", () => {
   it("renders icons with correct attributes and accessibility", () => {
-    const { container: infoContainer } = render(<InfoIcon alt="Information" />);
-    expect(
-      screen.getByRole("img", { name: "Information" }),
-    ).toBeInTheDocument();
-    const infoSvg = infoContainer.querySelector("svg");
+    render(<InfoIcon alt="Information" />);
+    const infoSvg = screen.getByRole("img", { name: "Information" });
+    expect(infoSvg).toBeInTheDocument();
     expect(infoSvg).toHaveAttribute("viewBox", "0 0 28 28");
     expect(infoSvg).toHaveAttribute("width", "28");
     expect(infoSvg).toHaveAttribute("height", "28");
     expect(infoSvg).toHaveAttribute("aria-label", "Information");
     expect(infoSvg).toHaveAttribute("role", "img");
-    expect(infoContainer.querySelector("title")).toHaveTextContent(
-      "Information",
+    expect(within(infoSvg).getByText("Information").tagName.toLowerCase()).toBe(
+      "title",
     );
 
-    const { container: checkContainer } = render(<CheckIcon alt="Success" />);
+    render(<CheckIcon alt="Success" />);
     expect(screen.getByRole("img", { name: "Success" })).toBeInTheDocument();
 
-    const { container: lockContainer } = render(<LockIcon alt="Locked" />);
-    expect(screen.getByRole("img", { name: "Locked" })).toBeInTheDocument();
-    expect(lockContainer.querySelector("title")).toHaveTextContent("Locked");
+    render(<LockIcon alt="Locked" />);
+    const lockSvg = screen.getByRole("img", { name: "Locked" });
+    expect(lockSvg).toBeInTheDocument();
+    expect(within(lockSvg).getByText("Locked").tagName.toLowerCase()).toBe(
+      "title",
+    );
 
     render(
       <>
@@ -40,19 +41,13 @@ describe("Icons", () => {
     const { container: emptyAlt1 } = render(<InfoIcon alt="" />);
     const { container: emptyAlt2 } = render(<CloseIcon alt="" />);
 
-    expect(emptyAlt1.querySelector("svg")).toHaveAttribute(
-      "aria-hidden",
-      "true",
-    );
-    expect(emptyAlt2.querySelector("svg")).toHaveAttribute(
-      "aria-hidden",
-      "true",
-    );
+    expect(within(emptyAlt1).queryByRole("img")).not.toBeInTheDocument();
+    expect(within(emptyAlt2).queryByRole("img")).not.toBeInTheDocument();
   });
 
   it("supports custom props and dimensions", () => {
     const handleClick = jest.fn();
-    const { container } = render(
+    render(
       <InfoIcon
         alt="Custom"
         width={50}
@@ -65,16 +60,16 @@ describe("Icons", () => {
       />,
     );
 
-    const svg = container.querySelector("svg");
+    const svg = screen.getByTestId("custom-icon");
     expect(svg).toHaveAttribute("viewBox", "0 0 28 28");
     expect(svg).toHaveAttribute("width", "50");
     expect(svg).toHaveAttribute("height", "50");
     expect(svg).toHaveAttribute("data-testid", "custom-icon");
     expect(svg).toHaveAttribute("data-feature", "security");
-    expect(svg?.getAttribute("class")).toContain("custom-class");
+    expect(svg).toHaveClass("custom-class");
     expect(svg).toHaveStyle({ opacity: 0.5 });
 
-    svg?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    svg.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/Localized.tsx
+++ b/frontend/src/components/Localized.tsx
@@ -3,7 +3,7 @@
 // just fine:
 // eslint-disable-next-line no-restricted-imports
 import { LocalizedProps, Localized as OriginalLocalized } from "@fluent/react";
-import { cloneElement, isValidElement, useEffect, useState } from "react";
+import { cloneElement, isValidElement, useSyncExternalStore } from "react";
 import { useL10n } from "../hooks/l10n";
 
 /**
@@ -25,12 +25,12 @@ import { useL10n } from "../hooks/l10n";
  * but since that's only for SEO and the initial render, that's acceptable.
  */
 export const Localized = (props: LocalizedProps) => {
-  const [isPrerendering, setIsPrerendering] = useState(true);
+  const isPrerendering = useSyncExternalStore(
+    () => () => {},
+    () => false,
+    () => true,
+  );
   const l10n = useL10n();
-
-  useEffect(() => {
-    setIsPrerendering(false);
-  }, []);
 
   if (isPrerendering) {
     // `useL10n` makes sure that this is a prerenderable string

--- a/frontend/src/components/ReactAriaI18nProvider.test.tsx
+++ b/frontend/src/components/ReactAriaI18nProvider.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ReactAriaI18nProvider } from "./ReactAriaI18nProvider";
+import * as l10nHook from "../hooks/l10n";
 
 const mockI18nProvider = jest.fn();
 
@@ -28,9 +29,9 @@ describe("ReactAriaI18nProvider", () => {
   });
 
   it("integrates l10n with react-aria I18nProvider and renders children", () => {
-    const useL10nSpy = jest.spyOn(require("../hooks/l10n"), "useL10n");
+    const useL10nSpy = jest.spyOn(l10nHook, "useL10n");
 
-    let result = render(
+    let view = render(
       <ReactAriaI18nProvider>
         <div data-testid="test-child">Child content</div>
       </ReactAriaI18nProvider>,
@@ -42,13 +43,13 @@ describe("ReactAriaI18nProvider", () => {
       expect.objectContaining({ locale: "en-GB" }),
     );
 
-    let provider = screen.getByTestId("i18n-provider");
+    const provider = screen.getByTestId("i18n-provider");
     expect(provider).toHaveAttribute("data-locale", "en-GB");
     expect(screen.getByTestId("test-child")).toHaveTextContent("Child content");
-    result.unmount();
+    view.unmount();
 
     global.getLocaleMock.mockReturnValue("fr");
-    result = render(
+    view = render(
       <ReactAriaI18nProvider>
         <div>French content</div>
       </ReactAriaI18nProvider>,
@@ -56,10 +57,10 @@ describe("ReactAriaI18nProvider", () => {
     expect(mockI18nProvider).toHaveBeenCalledWith(
       expect.objectContaining({ locale: "fr" }),
     );
-    result.unmount();
+    view.unmount();
 
     global.getLocaleMock.mockReturnValue("es-ES");
-    result = render(
+    view = render(
       <ReactAriaI18nProvider>
         <div>Spanish content</div>
       </ReactAriaI18nProvider>,

--- a/frontend/src/components/dashboard/PremiumOnboarding.tsx
+++ b/frontend/src/components/dashboard/PremiumOnboarding.tsx
@@ -272,33 +272,34 @@ export const PremiumOnboarding = (props: Props) => {
   );
 };
 
+type FeatureItemProps = {
+  name: string;
+};
+
+const FeatureItem = (props: FeatureItemProps) => {
+  const l10n = useL10n();
+  return (
+    <li>
+      <CheckIcon alt={""} className={styles["check-icon"]} />
+      <p>
+        <strong>
+          {l10n.getString(
+            `multi-part-onboarding-premium-welcome-feature-headline-${props.name}`,
+          )}
+        </strong>
+        <br />
+        <span>
+          {l10n.getString(
+            `multi-part-onboarding-premium-welcome-feature-body-${props.name}`,
+          )}
+        </span>
+      </p>
+    </li>
+  );
+};
+
 const StepOne = () => {
   const l10n = useL10n();
-
-  type FeatureItemProps = {
-    name: string;
-  };
-
-  const FeatureItem = (props: FeatureItemProps) => {
-    return (
-      <li>
-        <CheckIcon alt={""} className={styles["check-icon"]} />
-        <p>
-          <strong>
-            {l10n.getString(
-              `multi-part-onboarding-premium-welcome-feature-headline-${props.name}`,
-            )}
-          </strong>
-          <br />
-          <span>
-            {l10n.getString(
-              `multi-part-onboarding-premium-welcome-feature-body-${props.name}`,
-            )}
-          </span>
-        </p>
-      </li>
-    );
-  };
 
   return (
     <div className={`${styles.step} ${styles["step-welcome"]}`}>

--- a/frontend/src/components/dashboard/aliases/CategoryFilter.tsx
+++ b/frontend/src/components/dashboard/aliases/CategoryFilter.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
   useEffect,
+  startTransition,
 } from "react";
 import {
   FocusScope,
@@ -168,9 +169,11 @@ const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
     // This is for the empty state message, where a user's filters return no alias'
     // When they click "Clear all filters", the checkboxes should be reset.
     useEffect(() => {
-      setDomainType(undefined);
-      setStatus(undefined);
-      setCheckboxes(false); // Finished reset, toggle back to false
+      startTransition(() => {
+        setDomainType(undefined);
+        setStatus(undefined);
+        setCheckboxes(false); // Finished reset, toggle back to false
+      });
     }, [resetChecks, setCheckboxes]);
 
     return (

--- a/frontend/src/components/dashboard/aliases/LabelEditor.tsx
+++ b/frontend/src/components/dashboard/aliases/LabelEditor.tsx
@@ -1,6 +1,7 @@
 import {
   FocusEventHandler,
   FormEventHandler,
+  startTransition,
   useEffect,
   useRef,
   useState,
@@ -29,8 +30,11 @@ export const LabelEditor = (props: Props) => {
   const justSaved = labelJustUpdated && hasSaved;
 
   useEffect(() => {
-    setLabelJustUpdated(true);
-    const updateTimeout = setTimeout(() => setLabelJustUpdated(false), 1000);
+    startTransition(() => setLabelJustUpdated(true));
+    const updateTimeout = setTimeout(
+      () => startTransition(() => setLabelJustUpdated(false)),
+      1000,
+    );
     return () => clearTimeout(updateTimeout);
   }, [props.label]);
 

--- a/frontend/src/components/dashboard/subdomain/SearchForm.tsx
+++ b/frontend/src/components/dashboard/subdomain/SearchForm.tsx
@@ -1,4 +1,4 @@
-import { FormEventHandler, ChangeEventHandler, useState } from "react";
+import { FormEventHandler, useState } from "react";
 import { toast } from "react-toastify";
 import { authenticatedFetch } from "../../../hooks/api/api";
 import { useL10n } from "../../../hooks/l10n";

--- a/frontend/src/components/landing/HighlightedFeatures.tsx
+++ b/frontend/src/components/landing/HighlightedFeatures.tsx
@@ -16,50 +16,51 @@ type HighlightedItemProps = {
   isNew?: boolean;
 };
 
+const HighlightedItem = (props: HighlightedItemProps) => {
+  const l10n = useL10n();
+  const variables = {
+    mask_limit: "5",
+    mozmail: "mozmail.com",
+  };
+
+  const newCallOut = (
+    <span className={styles["new-callout"]}>
+      {l10n.getString("highlighted-features-section-new-item")}
+    </span>
+  );
+
+  return (
+    <div className={styles["highlighted-feature-wrapper"]}>
+      <div className={styles["highlighted-feature-description"]}>
+        <>
+          {/* Add "New" pill to new features */}
+          {props.isNew && (
+            <div className={styles["new-callout-wrapper"]}>{newCallOut}</div>
+          )}
+          <h3 className={styles["highlighted-feature-headline"]}>
+            {l10n.getString(
+              `highlighted-features-section-${props.name}-headline`,
+            )}
+          </h3>
+          <p className={styles["highlighted-feature-body"]}>
+            {l10n.getString(
+              `highlighted-features-section-${props.name}-body-2`,
+              variables,
+            )}
+          </p>
+        </>
+      </div>
+      <Image
+        alt=""
+        src={props.image}
+        className={styles["highlighted-feature-image"]}
+      />
+    </div>
+  );
+};
+
 export const HighlightedFeatures = () => {
   const l10n = useL10n();
-
-  const HighlightedItem = (props: HighlightedItemProps) => {
-    const variables = {
-      mask_limit: "5",
-      mozmail: "mozmail.com",
-    };
-
-    const newCallOut = (
-      <span className={styles["new-callout"]}>
-        {l10n.getString("highlighted-features-section-new-item")}
-      </span>
-    );
-
-    return (
-      <div className={styles["highlighted-feature-wrapper"]}>
-        <div className={styles["highlighted-feature-description"]}>
-          <>
-            {/* Add "New" pill to new features */}
-            {props.isNew && (
-              <div className={styles["new-callout-wrapper"]}>{newCallOut}</div>
-            )}
-            <h3 className={styles["highlighted-feature-headline"]}>
-              {l10n.getString(
-                `highlighted-features-section-${props.name}-headline`,
-              )}
-            </h3>
-            <p className={styles["highlighted-feature-body"]}>
-              {l10n.getString(
-                `highlighted-features-section-${props.name}-body-2`,
-                variables,
-              )}
-            </p>
-          </>
-        </div>
-        <Image
-          alt=""
-          src={props.image}
-          className={styles["highlighted-feature-image"]}
-        />
-      </div>
-    );
-  };
 
   return (
     <div>

--- a/frontend/src/components/layout/navigation/AppPicker.tsx
+++ b/frontend/src/components/layout/navigation/AppPicker.tsx
@@ -15,7 +15,7 @@ import {
   useMenuItem,
   useFocus,
 } from "react-aria";
-import { Key, ReactNode, useRef, useState, useEffect, RefObject } from "react";
+import { Key, ReactNode, useRef, useState, useEffect } from "react";
 import { AriaMenuItemProps, AriaMenuOptions } from "@react-aria/menu";
 import styles from "./AppPicker.module.scss";
 import FirefoxLogo from "../images/fx.png";
@@ -85,16 +85,11 @@ export const AppPicker = (props: Props) => {
       ? document.location.host
       : "relay.firefox.com",
   );
-  const linkRefs: Record<
-    keyof typeof products,
-    RefObject<HTMLAnchorElement | null>
-  > = {
-    monitor: useRef<HTMLAnchorElement>(null),
-    fxDesktop: useRef<HTMLAnchorElement>(null),
-    fxMobile: useRef<HTMLAnchorElement>(null),
-    solo: useRef<HTMLAnchorElement>(null),
-    vpn: useRef<HTMLAnchorElement>(null),
-  };
+  const vpnLinkRef = useRef<HTMLAnchorElement>(null);
+  const monitorLinkRef = useRef<HTMLAnchorElement>(null);
+  const fxDesktopLinkRef = useRef<HTMLAnchorElement>(null);
+  const fxMobileLinkRef = useRef<HTMLAnchorElement>(null);
+  const soloLinkRef = useRef<HTMLAnchorElement>(null);
   const mozillaLinkRef = useRef<HTMLAnchorElement>(null);
 
   const onSelect = (itemKey: Key) => {
@@ -125,7 +120,7 @@ export const AppPicker = (props: Props) => {
     >
       <Item key={products.vpn.id} textValue={l10n.getString("fx-vpn")}>
         <a
-          ref={linkRefs.vpn}
+          ref={vpnLinkRef}
           href={products.vpn.url}
           className={`${styles["menu-link"]} ${styles["vpn-link"]}`}
           target="_blank"
@@ -137,7 +132,7 @@ export const AppPicker = (props: Props) => {
       </Item>
       <Item key={products.monitor.id} textValue={l10n.getString("moz-monitor")}>
         <a
-          ref={linkRefs.monitor}
+          ref={monitorLinkRef}
           href={products.monitor.url}
           className={`${styles["menu-link"]} ${styles["monitor-link"]}`}
           target="_blank"
@@ -152,7 +147,7 @@ export const AppPicker = (props: Props) => {
         textValue={l10n.getString("fx-desktop-2")}
       >
         <a
-          ref={linkRefs.fxDesktop}
+          ref={fxDesktopLinkRef}
           href={products.fxDesktop.url}
           className={`${styles["menu-link"]} ${styles["fx-desktop-link"]}`}
           target="_blank"
@@ -167,7 +162,7 @@ export const AppPicker = (props: Props) => {
         textValue={l10n.getString("fx-mobile-2")}
       >
         <a
-          ref={linkRefs.fxMobile}
+          ref={fxMobileLinkRef}
           href={products.fxMobile.url}
           className={`${styles["menu-link"]} ${styles["fx-mobile-link"]}`}
           target="_blank"
@@ -179,7 +174,7 @@ export const AppPicker = (props: Props) => {
       </Item>
       <Item key={products.solo.id} textValue={l10n.getString("fx-solo-ai")}>
         <a
-          ref={linkRefs.solo}
+          ref={soloLinkRef}
           href={products.solo.url}
           className={`${styles["menu-link"]} ${styles["solo-link"]}`}
           target="_blank"

--- a/frontend/src/components/layout/navigation/Navigation.tsx
+++ b/frontend/src/components/layout/navigation/Navigation.tsx
@@ -16,6 +16,24 @@ import {
 } from "../../../functions/getPlan";
 import { useL10n } from "../../../hooks/l10n";
 
+type ToggleButtonProps = {
+  mobileMenuExpanded?: boolean;
+  handleToggle: CallableFunction;
+};
+const ToggleButton = ({
+  mobileMenuExpanded,
+  handleToggle,
+}: ToggleButtonProps) => (
+  <button
+    className={styles["menu-toggle"]}
+    aria-expanded={mobileMenuExpanded}
+    onClick={() => handleToggle()}
+  >
+    {/* passing toggle state to show correct icon */}
+    <MenuToggle toggleState={mobileMenuExpanded} />
+  </button>
+);
+
 export type Props = {
   theme: "free" | "premium";
   hasPremium: boolean;
@@ -72,17 +90,6 @@ export const Navigation = (props: Props) => {
       </Link>
     ) : null;
 
-  const ToggleButton = () => (
-    <button
-      className={styles["menu-toggle"]}
-      aria-expanded={mobileMenuExpanded}
-      onClick={() => handleToggle()}
-    >
-      {/* passing toggle state to show correct icon */}
-      <MenuToggle toggleState={mobileMenuExpanded} />
-    </button>
-  );
-
   return (
     <nav className={styles["site-nav"]}>
       {isLoggedIn ? emailDashboardLink : landingLink}
@@ -131,7 +138,10 @@ export const Navigation = (props: Props) => {
           <UpgradeButton />
         )}
 
-      <ToggleButton />
+      <ToggleButton
+        mobileMenuExpanded={mobileMenuExpanded}
+        handleToggle={handleToggle}
+      />
 
       <AppPicker theme={theme} style={styles["hidden-mobile"]} />
 

--- a/frontend/src/components/layout/navigation/SignInButton.tsx
+++ b/frontend/src/components/layout/navigation/SignInButton.tsx
@@ -12,21 +12,21 @@ export type Props = {
 
 export const SignInButton = (props: Props): React.JSX.Element => {
   const l10n = useL10n();
-  const signInFxaFlowTracker = useFxaFlowTracker({
+  const { flowData: signInFlowData, ref: signInRef } = useFxaFlowTracker({
     category: "Sign In",
     label: "nav-profile-sign-in",
     entrypoint: "relay-sign-in-header",
   });
   const applyUtmParams = useUtmApplier();
   const signInUrl = applyUtmParams(
-    getLoginUrl("relay-sign-in-header", signInFxaFlowTracker.flowData),
+    getLoginUrl("relay-sign-in-header", signInFlowData),
   );
   const gaEvent = useGaEvent();
 
   return (
     <a
       href={signInUrl}
-      ref={signInFxaFlowTracker.ref}
+      ref={signInRef}
       onClick={() => {
         gaEvent({
           category: "Sign In",

--- a/frontend/src/components/layout/navigation/SignUpButton.tsx
+++ b/frontend/src/components/layout/navigation/SignUpButton.tsx
@@ -11,21 +11,21 @@ export type Props = {
 };
 export const SignUpButton = (props: Props): React.JSX.Element => {
   const l10n = useL10n();
-  const signUpFxaFlowTracker = useFxaFlowTracker({
+  const { flowData: signUpFlowData, ref: signUpRef } = useFxaFlowTracker({
     category: "Sign In",
     label: "nav-profile-sign-up",
     entrypoint: "relay-sign-up-header",
   });
   const applyUtmParams = useUtmApplier();
   const signUpUrl = applyUtmParams(
-    getLoginUrl("relay-sign-up-header", signUpFxaFlowTracker.flowData),
+    getLoginUrl("relay-sign-up-header", signUpFlowData),
   );
   const gaEvent = useGaEvent();
 
   return (
     <a
       href={signUpUrl}
-      ref={signUpFxaFlowTracker.ref}
+      ref={signUpRef}
       onClick={() => {
         gaEvent({
           category: "Sign In",

--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -3,6 +3,7 @@ import {
   HTMLAttributes,
   ReactNode,
   RefObject,
+  useMemo,
   useRef,
 } from "react";
 import {
@@ -135,6 +136,8 @@ export const WhatsNewMenu = (props: Props) => {
   const triggerRef = useRef<HTMLButtonElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
   const addonData = useAddonData();
+  // eslint-disable-next-line react-hooks/purity
+  const now = useMemo(() => Date.now(), []);
 
   const entries: WhatsNewEntry[] = [
     {
@@ -623,6 +626,7 @@ export const WhatsNewMenu = (props: Props) => {
             className={styles.cta}
             href="https://www.mozilla.org/newsletter/security-and-privacy/"
             target="_blank"
+            rel="noreferrer"
           >
             {l10n.getString("whatsnew-feature-mailing-list-cta")}
           </a>
@@ -653,7 +657,7 @@ export const WhatsNewMenu = (props: Props) => {
       ),
     );
     // Filter out entries that are in the future:
-    return entryDate.getTime() <= Date.now();
+    return entryDate.getTime() <= now;
   });
   entriesNotInFuture.sort(entriesDescByDateSorter);
 
@@ -665,7 +669,7 @@ export const WhatsNewMenu = (props: Props) => {
         entry.announcementDate.day,
       ),
     );
-    const ageInMilliSeconds = Date.now() - entryDate.getTime();
+    const ageInMilliSeconds = now - entryDate.getTime();
     // Automatically move entries to the archive after 30 days:
     const isExpired = ageInMilliSeconds > 30 * 24 * 60 * 60 * 1000;
     return !entry.dismissal.isDismissed && !isExpired;

--- a/frontend/src/components/layout/topmessage/CsatSurvey.test.tsx
+++ b/frontend/src/components/layout/topmessage/CsatSurvey.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mockCookiesModule } from "../../../../__mocks__/functions/cookies";
 import { mockGetLocaleModule } from "../../../../__mocks__/functions/getLocale";
@@ -24,26 +24,30 @@ describe("CsatSurvey", () => {
       const { container: newFree } = render(
         <CsatSurvey profile={getMockProfileData({ has_premium: false })} />,
       );
-      expect(newFree.querySelector("button")).toBeNull();
+      expect(within(newFree).queryByRole("button")).not.toBeInTheDocument();
 
       mockFirstSeenDaysAgo(7);
       const { container: weekOldFree } = render(
         <CsatSurvey profile={getMockProfileData({ has_premium: false })} />,
       );
-      expect(weekOldFree.querySelector("button")).toBeTruthy();
+      expect(within(weekOldFree).getAllByRole("button")[0]).toBeInTheDocument();
 
       mockCookieDismissal("free-7days");
       const { container: dismissedFree } = render(
         <CsatSurvey profile={getMockProfileData({ has_premium: false })} />,
       );
-      expect(dismissedFree.querySelector("button")).toBeNull();
+      expect(
+        within(dismissedFree).queryByRole("button"),
+      ).not.toBeInTheDocument();
 
       mockFirstSeenDaysAgo(30);
       mockCookieDismissal("free-7days");
       const { container: monthOldWithOldDismissal } = render(
         <CsatSurvey profile={getMockProfileData({ has_premium: false })} />,
       );
-      expect(monthOldWithOldDismissal.querySelector("button")).toBeTruthy();
+      expect(
+        within(monthOldWithOldDismissal).getAllByRole("button")[0],
+      ).toBeInTheDocument();
 
       const newPremium = getMockProfileData({
         has_premium: true,
@@ -52,7 +56,9 @@ describe("CsatSurvey", () => {
       const { container: newPremiumContainer } = render(
         <CsatSurvey profile={newPremium} />,
       );
-      expect(newPremiumContainer.querySelector("button")).toBeNull();
+      expect(
+        within(newPremiumContainer).queryByRole("button"),
+      ).not.toBeInTheDocument();
 
       const weekOldPremium = getMockProfileData({
         has_premium: true,
@@ -63,18 +69,26 @@ describe("CsatSurvey", () => {
       const { container: weekOldPremiumContainer } = render(
         <CsatSurvey profile={weekOldPremium} />,
       );
-      expect(weekOldPremiumContainer.querySelector("button")).toBeTruthy();
+      expect(
+        within(weekOldPremiumContainer).getAllByRole("button")[0],
+      ).toBeInTheDocument();
     });
 
     it("handles edge cases", () => {
       const useFirstSeen = (
-        jest.requireMock("../../../hooks/firstSeen.ts") as any
+        jest.requireMock("../../../hooks/firstSeen.ts") as {
+          useFirstSeen: jest.Mock;
+        }
       ).useFirstSeen;
       const getLocale = (
-        jest.requireMock("../../../functions/getLocale.ts") as any
+        jest.requireMock("../../../functions/getLocale.ts") as {
+          getLocale: jest.Mock;
+        }
       ).getLocale;
       const getCookie: jest.Mock = (
-        jest.requireMock("../../../functions/cookies.ts") as any
+        jest.requireMock("../../../functions/cookies.ts") as {
+          getCookie: jest.Mock;
+        }
       ).getCookie;
 
       useFirstSeen.mockReturnValue(new Date(0));
@@ -83,13 +97,15 @@ describe("CsatSurvey", () => {
       const { container: validLocale } = render(
         <CsatSurvey profile={getMockProfileData({ has_premium: false })} />,
       );
-      expect(validLocale.querySelector("button")).toBeTruthy();
+      expect(within(validLocale).getAllByRole("button")[0]).toBeInTheDocument();
 
       getLocale.mockReturnValue("fy");
       const { container: invalidLocale } = render(
         <CsatSurvey profile={getMockProfileData({ has_premium: false })} />,
       );
-      expect(invalidLocale.querySelector("button")).toBeNull();
+      expect(
+        within(invalidLocale).queryByRole("button"),
+      ).not.toBeInTheDocument();
 
       useFirstSeen.mockReturnValue(
         new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
@@ -102,7 +118,9 @@ describe("CsatSurvey", () => {
       const { container: unknownDateContainer } = render(
         <CsatSurvey profile={unknownSubDate} />,
       );
-      expect(unknownDateContainer.querySelector("button")).toBeTruthy();
+      expect(
+        within(unknownDateContainer).getAllByRole("button")[0],
+      ).toBeInTheDocument();
 
       useFirstSeen.mockReturnValue(
         new Date(Date.now() - 6 * 30 * 24 * 60 * 60 * 1001),
@@ -115,17 +133,23 @@ describe("CsatSurvey", () => {
       const { container: reShowAfterTime } = render(
         <CsatSurvey profile={getMockProfileData({ has_premium: false })} />,
       );
-      expect(reShowAfterTime.querySelector("button")).toBeTruthy();
+      expect(
+        within(reShowAfterTime).getAllByRole("button")[0],
+      ).toBeInTheDocument();
     });
   });
 
   describe("User interactions", () => {
     it("handles complete survey submission flow", async () => {
       const useFirstSeen = (
-        jest.requireMock("../../../hooks/firstSeen.ts") as any
+        jest.requireMock("../../../hooks/firstSeen.ts") as {
+          useFirstSeen: jest.Mock;
+        }
       ).useFirstSeen;
       const getCookie: jest.Mock = (
-        jest.requireMock("../../../functions/cookies.ts") as any
+        jest.requireMock("../../../functions/cookies.ts") as {
+          getCookie: jest.Mock;
+        }
       ).getCookie;
 
       useFirstSeen.mockReturnValue(new Date(0));
@@ -169,10 +193,14 @@ describe("CsatSurvey", () => {
 
     it("allows dismissal without answering", async () => {
       const useFirstSeen = (
-        jest.requireMock("../../../hooks/firstSeen.ts") as any
+        jest.requireMock("../../../hooks/firstSeen.ts") as {
+          useFirstSeen: jest.Mock;
+        }
       ).useFirstSeen;
       const getCookie: jest.Mock = (
-        jest.requireMock("../../../functions/cookies.ts") as any
+        jest.requireMock("../../../functions/cookies.ts") as {
+          getCookie: jest.Mock;
+        }
       ).getCookie;
 
       useFirstSeen.mockReturnValue(new Date(0));

--- a/frontend/src/components/layout/topmessage/CsatSurvey.tsx
+++ b/frontend/src/components/layout/topmessage/CsatSurvey.tsx
@@ -7,7 +7,7 @@ import {
 import { ProfileData } from "../../../hooks/api/profile";
 import { CloseIcon } from "../../Icons";
 import { parseDate } from "../../../functions/parseDate";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { getLocale } from "../../../functions/getLocale";
 import { useGaEvent } from "../../../hooks/gaEvent";
 import { useL10n } from "../../../hooks/l10n";
@@ -69,6 +69,8 @@ export const CsatSurvey = (props: Props) => {
   const l10n = useL10n();
   const [answer, setAnswer] = useState<keyof SurveyLinks>();
   const gaEvent = useGaEvent();
+  // eslint-disable-next-line react-hooks/purity
+  const now = useMemo(() => Date.now(), []);
 
   let reasonToShow:
     | null
@@ -99,7 +101,7 @@ export const CsatSurvey = (props: Props) => {
         // hence the type assertion:
         (firstSeen as Date);
     const daysSinceSubscription =
-      (Date.now() - subscriptionDate.getTime()) / 1000 / 60 / 60 / 24;
+      (now - subscriptionDate.getTime()) / 1000 / 60 / 60 / 24;
     if (daysSinceSubscription >= 90) {
       if (!premium90DaysDismissal.isDismissed) {
         reasonToShow = "premium90days";
@@ -115,7 +117,7 @@ export const CsatSurvey = (props: Props) => {
     }
   } else if (!props.profile.has_premium && firstSeen instanceof Date) {
     const daysSinceFirstSeen =
-      (Date.now() - firstSeen.getTime()) / 1000 / 60 / 60 / 24;
+      (now - firstSeen.getTime()) / 1000 / 60 / 60 / 24;
     if (daysSinceFirstSeen >= 90) {
       if (!free90DaysDismissal.isDismissed) {
         reasonToShow = "free90days";

--- a/frontend/src/components/layout/topmessage/HolidayPromoBanner.test.tsx
+++ b/frontend/src/components/layout/topmessage/HolidayPromoBanner.test.tsx
@@ -21,12 +21,12 @@ const mockHolidayDate = () => {
   const realDate = Date;
   const mockDate = new realDate("2023-12-15");
   global.Date = class extends realDate {
-    constructor(...args: any[]) {
+    constructor(...args: ConstructorParameters<typeof Date>) {
       super();
       if (args.length === 0) {
-        return mockDate as any;
+        return mockDate as unknown as Date;
       }
-      return new realDate(...args) as any;
+      return new realDate(...args) as unknown as Date;
     }
     static now() {
       return mockDate.getTime();
@@ -39,14 +39,18 @@ describe("HolidayPromoBanner", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     global.gaEventMock.mockClear();
-    const useRouter = (jest.requireMock("next/router") as any).useRouter;
+    const useRouter = (
+      jest.requireMock("next/router") as { useRouter: jest.Mock }
+    ).useRouter;
     useRouter.mockReturnValue({ pathname: "/", push: jest.fn() });
   });
 
   it("respects visibility conditions", () => {
     const runtimeData = getMockRuntimeDataWithPeriodicalPremium();
     const profile = getMockProfileData({ has_premium: false });
-    const useRouter = (jest.requireMock("next/router") as any).useRouter;
+    const useRouter = (
+      jest.requireMock("next/router") as { useRouter: jest.Mock }
+    ).useRouter;
 
     const { container: loading } = render(
       <HolidayPromoBanner
@@ -55,7 +59,7 @@ describe("HolidayPromoBanner", () => {
         profile={undefined}
       />,
     );
-    expect(loading.firstChild).toBeNull();
+    expect(loading).toBeEmptyDOMElement();
 
     const { container: noPremium } = render(
       <HolidayPromoBanner
@@ -64,7 +68,7 @@ describe("HolidayPromoBanner", () => {
         profile={undefined}
       />,
     );
-    expect(noPremium.firstChild).toBeNull();
+    expect(noPremium).toBeEmptyDOMElement();
 
     const { container: noRuntime } = render(
       <HolidayPromoBanner
@@ -73,7 +77,7 @@ describe("HolidayPromoBanner", () => {
         profile={undefined}
       />,
     );
-    expect(noRuntime.firstChild).toBeNull();
+    expect(noRuntime).toBeEmptyDOMElement();
 
     useRouter.mockReturnValue({ pathname: "/", push: jest.fn() });
     const { container: wrongPath } = render(
@@ -83,18 +87,18 @@ describe("HolidayPromoBanner", () => {
         profile={profile}
       />,
     );
-    expect(wrongPath.firstChild).toBeNull();
+    expect(wrongPath).toBeEmptyDOMElement();
 
     const realDate = mockHolidayDate();
     useRouter.mockReturnValue({ pathname: "/premium", push: jest.fn() });
-    const { container: visible } = render(
+    render(
       <HolidayPromoBanner
         isLoading={false}
         runtimeData={runtimeData}
         profile={profile}
       />,
     );
-    expect(visible.querySelector("aside")).toBeInTheDocument();
+    expect(screen.getByRole("complementary")).toBeInTheDocument();
     global.Date = realDate;
   });
 

--- a/frontend/src/components/layout/topmessage/InterviewRecruitment.test.tsx
+++ b/frontend/src/components/layout/topmessage/InterviewRecruitment.test.tsx
@@ -18,7 +18,9 @@ describe("InterviewRecruitment", () => {
 
   it("respects dismissal state", () => {
     const useLocalDismissal = (
-      jest.requireMock("../../../hooks/localDismissal.ts") as any
+      jest.requireMock("../../../hooks/localDismissal.ts") as {
+        useLocalDismissal: jest.Mock;
+      }
     ).useLocalDismissal;
 
     useLocalDismissal.mockReturnValue({
@@ -26,14 +28,14 @@ describe("InterviewRecruitment", () => {
       dismiss: jest.fn(),
     });
     const { container: dismissed } = render(<InterviewRecruitment />);
-    expect(dismissed.firstChild).toBeNull();
+    expect(dismissed).toBeEmptyDOMElement();
 
     useLocalDismissal.mockReturnValue({
       isDismissed: false,
       dismiss: jest.fn(),
     });
-    const { container: visible } = render(<InterviewRecruitment />);
-    expect(visible.querySelector("aside")).toBeInTheDocument();
+    render(<InterviewRecruitment />);
+    expect(screen.getByRole("complementary")).toBeInTheDocument();
 
     expect(useLocalDismissal).toHaveBeenCalledWith(
       "interview-recruitment-2022-08",
@@ -43,7 +45,9 @@ describe("InterviewRecruitment", () => {
   it("renders complete banner with interactions and tracking", async () => {
     const mockDismiss = jest.fn();
     const useLocalDismissal = (
-      jest.requireMock("../../../hooks/localDismissal.ts") as any
+      jest.requireMock("../../../hooks/localDismissal.ts") as {
+        useLocalDismissal: jest.Mock;
+      }
     ).useLocalDismissal;
     useLocalDismissal.mockReturnValue({
       isDismissed: false,

--- a/frontend/src/components/layout/topmessage/NpsSurvey.test.tsx
+++ b/frontend/src/components/layout/topmessage/NpsSurvey.test.tsx
@@ -25,37 +25,41 @@ describe("NpsSurvey", () => {
     mockFirstSeenDaysAgo(4);
     mockLoginStatus("logged-in");
     const useProfiles = (
-      jest.requireMock("../../../hooks/api/profile.ts") as any
+      jest.requireMock("../../../hooks/api/profile.ts") as {
+        useProfiles: jest.Mock;
+      }
     ).useProfiles;
     useProfiles.mockReturnValue({ data: [getMockProfileData({ id: 123 })] });
   });
 
   it("respects visibility conditions", () => {
-    const { container: visible } = render(<NpsSurvey />);
-    expect(visible.querySelector("aside")).toBeInTheDocument();
+    render(<NpsSurvey />);
+    expect(screen.getByRole("complementary")).toBeInTheDocument();
 
     mockLocalDismissal(true);
     const { container: dismissed } = render(<NpsSurvey />);
-    expect(dismissed.firstChild).toBeNull();
+    expect(dismissed).toBeEmptyDOMElement();
 
     mockLocalDismissal(false);
     mockFirstSeen(new Date(Date.now() - 1000));
     const { container: tooNew } = render(<NpsSurvey />);
-    expect(tooNew.firstChild).toBeNull();
+    expect(tooNew).toBeEmptyDOMElement();
 
     mockFirstSeenDaysAgo(4);
     mockLoginStatus("logged-out");
     const { container: loggedOut } = render(<NpsSurvey />);
-    expect(loggedOut.firstChild).toBeNull();
+    expect(loggedOut).toBeEmptyDOMElement();
 
     mockLoginStatus("logged-in");
     mockFirstSeen(null);
     const { container: noFirstSeen } = render(<NpsSurvey />);
-    expect(noFirstSeen.firstChild).toBeNull();
+    expect(noFirstSeen).toBeEmptyDOMElement();
 
     mockFirstSeenDaysAgo(4);
     const useLocalDismissal = (
-      jest.requireMock("../../../hooks/localDismissal.ts") as any
+      jest.requireMock("../../../hooks/localDismissal.ts") as {
+        useLocalDismissal: jest.Mock;
+      }
     ).useLocalDismissal;
     expect(useLocalDismissal).toHaveBeenCalledWith("nps-survey_123", {
       duration: 30 * 24 * 60 * 60,
@@ -65,7 +69,9 @@ describe("NpsSurvey", () => {
   it("renders complete survey with rating categories and tracking", async () => {
     const mockDismiss = jest.fn();
     const useLocalDismissal = (
-      jest.requireMock("../../../hooks/localDismissal.ts") as any
+      jest.requireMock("../../../hooks/localDismissal.ts") as {
+        useLocalDismissal: jest.Mock;
+      }
     ).useLocalDismissal;
     useLocalDismissal.mockReturnValue({
       isDismissed: false,
@@ -102,7 +108,9 @@ describe("NpsSurvey", () => {
   it("handles dismissal without tracking", async () => {
     const mockDismiss = jest.fn();
     const useLocalDismissal = (
-      jest.requireMock("../../../hooks/localDismissal.ts") as any
+      jest.requireMock("../../../hooks/localDismissal.ts") as {
+        useLocalDismissal: jest.Mock;
+      }
     ).useLocalDismissal;
     useLocalDismissal.mockReturnValue({
       isDismissed: false,

--- a/frontend/src/components/layout/topmessage/NpsSurvey.tsx
+++ b/frontend/src/components/layout/topmessage/NpsSurvey.tsx
@@ -5,6 +5,7 @@ import { useIsLoggedIn } from "../../../hooks/session";
 import { useProfiles } from "../../../hooks/api/profile";
 import { CloseIcon } from "../../Icons";
 import { useGaEvent } from "../../../hooks/gaEvent";
+import { useMemo } from "react";
 import { useL10n } from "../../../hooks/l10n";
 
 /**
@@ -22,11 +23,13 @@ export const NpsSurvey = () => {
   const isLoggedIn = useIsLoggedIn();
   const l10n = useL10n();
   const gaEvent = useGaEvent();
+  // eslint-disable-next-line react-hooks/purity
+  const now = useMemo(() => Date.now(), []);
 
   const hasBeenUserForThreeDays =
     isLoggedIn === "logged-in" &&
     firstSeen instanceof Date &&
-    Date.now() - firstSeen.getTime() > 3 * 24 * 60 * 60;
+    now - firstSeen.getTime() > 3 * 24 * 60 * 60;
 
   // TODO: Show if either the user has been one for three days,
   // *or* they've been a Premium customer for three days:

--- a/frontend/src/components/layout/topmessage/PhoneSurvey.test.tsx
+++ b/frontend/src/components/layout/topmessage/PhoneSurvey.test.tsx
@@ -26,19 +26,23 @@ describe("PhoneSurvey", () => {
 
   it("respects visibility conditions", () => {
     const useLocalDismissal = (
-      jest.requireMock("../../../hooks/localDismissal.ts") as any
+      jest.requireMock("../../../hooks/localDismissal.ts") as {
+        useLocalDismissal: jest.Mock;
+      }
     ).useLocalDismissal;
     const useRelayNumber = (
-      jest.requireMock("../../../hooks/api/relayNumber.ts") as any
+      jest.requireMock("../../../hooks/api/relayNumber.ts") as {
+        useRelayNumber: jest.Mock;
+      }
     ).useRelayNumber;
 
-    const { container: visible } = render(<PhoneSurvey />);
-    expect(visible.querySelector("aside")).toBeInTheDocument();
+    render(<PhoneSurvey />);
+    expect(screen.getByRole("complementary")).toBeInTheDocument();
     expect(useLocalDismissal).toHaveBeenCalledWith("phone-survey-2022-11");
 
     mockLocalDismissal(true);
     const { container: dismissed } = render(<PhoneSurvey />);
-    expect(dismissed.firstChild).toBeNull();
+    expect(dismissed).toBeEmptyDOMElement();
 
     mockLocalDismissal(false);
     useRelayNumber.mockReturnValue({
@@ -46,28 +50,30 @@ describe("PhoneSurvey", () => {
       data: undefined,
     });
     const { container: withError } = render(<PhoneSurvey />);
-    expect(withError.firstChild).toBeNull();
+    expect(withError).toBeEmptyDOMElement();
 
     useRelayNumber.mockReturnValue({ error: undefined, data: null });
     const { container: nullData } = render(<PhoneSurvey />);
-    expect(nullData.firstChild).toBeNull();
+    expect(nullData).toBeEmptyDOMElement();
 
     setMockRelayNumberData([]);
     const { container: emptyData } = render(<PhoneSurvey />);
-    expect(emptyData.firstChild).toBeNull();
+    expect(emptyData).toBeEmptyDOMElement();
 
     setMockRelayNumberData([
       getMockRelayNumber({ id: 1 }),
       getMockRelayNumber({ id: 2 }),
     ]);
-    const { container: multipleNumbers } = render(<PhoneSurvey />);
-    expect(multipleNumbers.querySelector("aside")).toBeInTheDocument();
+    render(<PhoneSurvey />);
+    expect(screen.getAllByRole("complementary").length).toBeGreaterThan(0);
   });
 
   it("renders complete banner with interactions and tracking", async () => {
     const mockDismiss = jest.fn();
     const useLocalDismissal = (
-      jest.requireMock("../../../hooks/localDismissal.ts") as any
+      jest.requireMock("../../../hooks/localDismissal.ts") as {
+        useLocalDismissal: jest.Mock;
+      }
     ).useLocalDismissal;
     useLocalDismissal.mockReturnValue({
       isDismissed: false,

--- a/frontend/src/components/layout/topmessage/TopMessage.test.tsx
+++ b/frontend/src/components/layout/topmessage/TopMessage.test.tsx
@@ -29,25 +29,37 @@ jest.mock("./CsatSurvey", () => ({
 describe("TopMessage", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    const useRouter = (jest.requireMock("next/router") as any).useRouter;
+    const useRouter = (
+      jest.requireMock("next/router") as { useRouter: jest.Mock }
+    ).useRouter;
     useRouter.mockReturnValue({ pathname: "/", push: jest.fn() });
     const isFlagActive = (
-      jest.requireMock("../../../functions/waffle.ts") as any
+      jest.requireMock("../../../functions/waffle.ts") as {
+        isFlagActive: jest.Mock;
+      }
     ).isFlagActive;
     isFlagActive.mockReturnValue(false);
     const getLocale = (
-      jest.requireMock("../../../functions/getLocale.ts") as any
+      jest.requireMock("../../../functions/getLocale.ts") as {
+        getLocale: jest.Mock;
+      }
     ).getLocale;
     getLocale.mockReturnValue("en-US");
   });
 
   it("renders InterviewRecruitment based on conditions", () => {
-    const useRouter = (jest.requireMock("next/router") as any).useRouter;
+    const useRouter = (
+      jest.requireMock("next/router") as { useRouter: jest.Mock }
+    ).useRouter;
     const isFlagActive = (
-      jest.requireMock("../../../functions/waffle.ts") as any
+      jest.requireMock("../../../functions/waffle.ts") as {
+        isFlagActive: jest.Mock;
+      }
     ).isFlagActive;
     const getLocale = (
-      jest.requireMock("../../../functions/getLocale.ts") as any
+      jest.requireMock("../../../functions/getLocale.ts") as {
+        getLocale: jest.Mock;
+      }
     ).getLocale;
     const profile = getMockProfileData({ has_premium: false });
     const runtimeData = getMockRuntimeDataWithPeriodicalPremium();
@@ -58,51 +70,49 @@ describe("TopMessage", () => {
       push: jest.fn(),
     });
     isFlagActive.mockReturnValue(true);
-    let result = render(
+    let view = render(
       <TopMessage profile={profile} runtimeData={runtimeData} />,
     );
     expect(screen.getByTestId("interview-recruitment")).toBeInTheDocument();
-    result.unmount();
+    view.unmount();
 
     isFlagActive.mockReturnValue(false);
-    result = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
+    view = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
     expect(
       screen.queryByTestId("interview-recruitment"),
     ).not.toBeInTheDocument();
     expect(screen.getByTestId("csat-survey")).toBeInTheDocument();
-    result.unmount();
+    view.unmount();
 
     isFlagActive.mockReturnValue(true);
     useRouter.mockReturnValue({ pathname: "/premium", push: jest.fn() });
-    result = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
+    view = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
     expect(
       screen.queryByTestId("interview-recruitment"),
     ).not.toBeInTheDocument();
-    result.unmount();
+    view.unmount();
 
     useRouter.mockReturnValue({
       pathname: "/accounts/profile",
       push: jest.fn(),
     });
     runtimeData.PERIODICAL_PREMIUM_PLANS.country_code = "ca";
-    result = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
+    view = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
     expect(
       screen.queryByTestId("interview-recruitment"),
     ).not.toBeInTheDocument();
-    result.unmount();
+    view.unmount();
 
     runtimeData.PERIODICAL_PREMIUM_PLANS.country_code = "us";
     getLocale.mockReturnValue("fr-FR");
-    result = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
+    view = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
     expect(
       screen.queryByTestId("interview-recruitment"),
     ).not.toBeInTheDocument();
-    result.unmount();
+    view.unmount();
 
     getLocale.mockReturnValue("en-US");
-    result = render(
-      <TopMessage profile={undefined} runtimeData={runtimeData} />,
-    );
+    view = render(<TopMessage profile={undefined} runtimeData={runtimeData} />);
     expect(
       screen.queryByTestId("interview-recruitment"),
     ).not.toBeInTheDocument();
@@ -110,10 +120,14 @@ describe("TopMessage", () => {
 
   it("renders PhoneSurvey based on conditions", () => {
     const isFlagActive = (
-      jest.requireMock("../../../functions/waffle.ts") as any
+      jest.requireMock("../../../functions/waffle.ts") as {
+        isFlagActive: jest.Mock;
+      }
     ).isFlagActive;
     const getLocale = (
-      jest.requireMock("../../../functions/getLocale.ts") as any
+      jest.requireMock("../../../functions/getLocale.ts") as {
+        getLocale: jest.Mock;
+      }
     ).getLocale;
     const profile = getMockProfileData({ has_phone: true });
     const runtimeData = getMockRuntimeDataWithPhones();
@@ -122,41 +136,41 @@ describe("TopMessage", () => {
       (_, flag) => flag === "phone_launch_survey",
     );
     runtimeData.PHONE_PLANS.country_code = "us";
-    let result = render(
+    let view = render(
       <TopMessage profile={profile} runtimeData={runtimeData} />,
     );
     expect(screen.getByTestId("phone-survey")).toBeInTheDocument();
-    result.unmount();
+    view.unmount();
 
     runtimeData.PHONE_PLANS.country_code = "ca";
-    result = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
+    view = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
     expect(screen.getByTestId("phone-survey")).toBeInTheDocument();
-    result.unmount();
+    view.unmount();
 
     isFlagActive.mockReturnValue(false);
-    result = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
+    view = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
     expect(screen.queryByTestId("phone-survey")).not.toBeInTheDocument();
     expect(screen.getByTestId("csat-survey")).toBeInTheDocument();
-    result.unmount();
+    view.unmount();
 
     isFlagActive.mockImplementation(
       (_, flag) => flag === "phone_launch_survey",
     );
     const noPhoneProfile = getMockProfileData({ has_phone: false });
-    result = render(
+    view = render(
       <TopMessage profile={noPhoneProfile} runtimeData={runtimeData} />,
     );
     expect(screen.queryByTestId("phone-survey")).not.toBeInTheDocument();
-    result.unmount();
+    view.unmount();
 
     runtimeData.PHONE_PLANS.country_code = "uk";
-    result = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
+    view = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
     expect(screen.queryByTestId("phone-survey")).not.toBeInTheDocument();
-    result.unmount();
+    view.unmount();
 
     runtimeData.PHONE_PLANS.country_code = "us";
     getLocale.mockReturnValue("de-DE");
-    result = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
+    view = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
     expect(screen.queryByTestId("phone-survey")).not.toBeInTheDocument();
   });
 
@@ -164,34 +178,38 @@ describe("TopMessage", () => {
     const profile = getMockProfileData({ has_premium: false });
     const runtimeData = getMockRuntimeDataWithPeriodicalPremium();
 
-    let result = render(
+    let view = render(
       <TopMessage profile={profile} runtimeData={runtimeData} />,
     );
     expect(screen.getByTestId("csat-survey")).toBeInTheDocument();
-    result.unmount();
+    view.unmount();
 
     const premiumProfile = getMockProfileData({ has_premium: true });
-    result = render(
+    view = render(
       <TopMessage profile={premiumProfile} runtimeData={runtimeData} />,
     );
     expect(screen.getByTestId("csat-survey")).toBeInTheDocument();
-    result.unmount();
+    view.unmount();
 
     const { container: noProfile } = render(
       <TopMessage profile={undefined} runtimeData={runtimeData} />,
     );
-    expect(noProfile.firstChild).toBeNull();
+    expect(noProfile).toBeEmptyDOMElement();
 
     const { container: nothingDefined } = render(
       <TopMessage profile={undefined} runtimeData={undefined} />,
     );
-    expect(nothingDefined.firstChild).toBeNull();
+    expect(nothingDefined).toBeEmptyDOMElement();
   });
 
   it("respects priority order", () => {
-    const useRouter = (jest.requireMock("next/router") as any).useRouter;
+    const useRouter = (
+      jest.requireMock("next/router") as { useRouter: jest.Mock }
+    ).useRouter;
     const isFlagActive = (
-      jest.requireMock("../../../functions/waffle.ts") as any
+      jest.requireMock("../../../functions/waffle.ts") as {
+        isFlagActive: jest.Mock;
+      }
     ).isFlagActive;
 
     useRouter.mockReturnValue({
@@ -204,18 +222,18 @@ describe("TopMessage", () => {
     runtimeData.PERIODICAL_PREMIUM_PLANS.country_code = "us";
     runtimeData.PHONE_PLANS.country_code = "us";
 
-    let result = render(
+    let view = render(
       <TopMessage profile={profile} runtimeData={runtimeData} />,
     );
     expect(screen.getByTestId("interview-recruitment")).toBeInTheDocument();
     expect(screen.queryByTestId("phone-survey")).not.toBeInTheDocument();
     expect(screen.queryByTestId("csat-survey")).not.toBeInTheDocument();
-    result.unmount();
+    view.unmount();
 
     isFlagActive.mockImplementation(
       (_, flag) => flag === "phone_launch_survey",
     );
-    result = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
+    view = render(<TopMessage profile={profile} runtimeData={runtimeData} />);
     expect(screen.getByTestId("phone-survey")).toBeInTheDocument();
     expect(screen.queryByTestId("csat-survey")).not.toBeInTheDocument();
   });

--- a/frontend/src/components/waitlist/WaitlistPage.tsx
+++ b/frontend/src/components/waitlist/WaitlistPage.tsx
@@ -1,7 +1,13 @@
 import styles from "./WaitlistPage.module.scss";
 import { Layout } from "../layout/Layout";
 import { Button } from "../Button";
-import { FormEventHandler, ReactNode, useEffect, useState } from "react";
+import {
+  FormEventHandler,
+  ReactNode,
+  startTransition,
+  useEffect,
+  useState,
+} from "react";
 import { getLocale } from "../../functions/getLocale";
 import { toast } from "react-toastify";
 import { CountryPicker } from "./CountryPicker";
@@ -33,11 +39,9 @@ export const WaitlistPage = (props: Props) => {
   );
 
   useEffect(() => {
-    if (
-      typeof email === "undefined" &&
-      typeof usersData.data?.[0]?.email === "string"
-    ) {
-      setEmail(usersData.data[0].email);
+    const userEmail = usersData.data?.[0]?.email;
+    if (typeof email === "undefined" && typeof userEmail === "string") {
+      startTransition(() => setEmail(userEmail));
     }
   }, [email, usersData]);
 
@@ -52,7 +56,7 @@ export const WaitlistPage = (props: Props) => {
       );
 
       // Set the locale to the matched locale or fallback to "en" if not found
-      setLocale(matchedLocale || "en");
+      startTransition(() => setLocale(matchedLocale || "en"));
     }
   }, [props.supportedLocales]);
 

--- a/frontend/src/hooks/addon.ts
+++ b/frontend/src/hooks/addon.ts
@@ -4,6 +4,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import { LocalLabel } from "./localLabels";
@@ -42,11 +43,13 @@ function useMutationObserver(
   options: MutationObserverInit,
   callback: MutationCallback,
 ) {
-  const [observer, setObserver] = useState<MutationObserver>();
+  const observerRef = useRef<MutationObserver | undefined>(undefined);
 
   useEffect(() => {
-    const observer = new MutationObserver(callback);
-    setObserver(observer);
+    observerRef.current = new MutationObserver(callback);
+    return () => {
+      observerRef.current?.disconnect();
+    };
   }, [callback]);
 
   useEffect(() => {
@@ -54,12 +57,8 @@ function useMutationObserver(
       return;
     }
 
-    observer?.observe(elementRef.current, options);
-
-    return () => {
-      observer?.disconnect();
-    };
-  }, [observer, options, elementRef]);
+    observerRef.current?.observe(elementRef.current, options);
+  }, [options, elementRef]);
 }
 
 /**
@@ -127,11 +126,7 @@ const parseAddonData = (addonElement: HTMLElement): AddonData => {
 export function useAddonElementWatcher(
   addonElementRef: RefObject<HTMLElement | null>,
 ): AddonData {
-  const [addonData, setAddonData] = useState<AddonData>(
-    addonElementRef.current !== null
-      ? parseAddonData(addonElementRef.current)
-      : defaultAddonData,
-  );
+  const [addonData, setAddonData] = useState<AddonData>(defaultAddonData);
   useEffect(() => {
     if (addonElementRef.current === null) {
       return;

--- a/frontend/src/hooks/api/aliases.test.ts
+++ b/frontend/src/hooks/api/aliases.test.ts
@@ -21,27 +21,28 @@ jest.mock("./api", () => {
   };
 });
 
-const createMockAlias = (type: "random" | "custom", id: number): any => ({
-  mask_type: type,
-  id,
-  address: `test${id}`,
-  full_address: `test${id}@${type === "random" ? "relay.firefox.com" : "test.mozmail.com"}`,
-  domain: type === "random" ? 1 : 2,
-  enabled: true,
-  block_list_emails: false,
-  block_level_one_trackers: true,
-  description: "",
-  created_at: "2025-01-01T00:00:00Z",
-  last_modified_at: "2025-01-01T00:00:00Z",
-  last_used_at: null,
-  num_forwarded: 0,
-  num_blocked: 0,
-  num_spam: 0,
-  num_replied: 0,
-  num_level_one_trackers_blocked: 0,
-  used_on: "",
-  ...(type === "random" ? { generated_for: "" } : {}),
-});
+const createMockAlias = (type: "random" | "custom", id: number): AliasData =>
+  ({
+    mask_type: type,
+    id,
+    address: `test${id}`,
+    full_address: `test${id}@${type === "random" ? "relay.firefox.com" : "test.mozmail.com"}`,
+    domain: type === "random" ? 1 : 2,
+    enabled: true,
+    block_list_emails: false,
+    block_level_one_trackers: true,
+    description: "",
+    created_at: "2025-01-01T00:00:00Z",
+    last_modified_at: "2025-01-01T00:00:00Z",
+    last_used_at: null,
+    num_forwarded: 0,
+    num_blocked: 0,
+    num_spam: 0,
+    num_replied: 0,
+    num_level_one_trackers_blocked: 0,
+    used_on: "",
+    ...(type === "random" ? { generated_for: "" } : {}),
+  }) as AliasData;
 
 describe("useAliases", () => {
   const mockRandomMutate = jest.fn();

--- a/frontend/src/hooks/api/inboundContact.test.ts
+++ b/frontend/src/hooks/api/inboundContact.test.ts
@@ -39,7 +39,7 @@ describe("useInboundContact", () => {
       mutate: mockMutate,
     });
 
-    let { result, rerender } = renderHook(() => useInboundContact());
+    const { result, rerender } = renderHook(() => useInboundContact());
 
     expect(useApiV1).toHaveBeenCalledWith("/inboundcontact/");
     expect(result.current.isLoading).toBe(true);

--- a/frontend/src/hooks/api/profile.test.ts
+++ b/frontend/src/hooks/api/profile.test.ts
@@ -67,7 +67,7 @@ describe("useProfiles", () => {
       mutate: mockMutate,
     });
 
-    let { result, rerender } = renderHook(() => useProfiles());
+    const { result, rerender } = renderHook(() => useProfiles());
 
     const calls = useSWR.mock.calls;
     expect(calls[0][0]).toBe("/profiles/");

--- a/frontend/src/hooks/api/realPhone.test.ts
+++ b/frontend/src/hooks/api/realPhone.test.ts
@@ -18,15 +18,16 @@ jest.mock("./api", () => {
   };
 });
 
-const createMockPhone = (verified: boolean): any => ({
-  id: 1,
-  number: "+15555551234",
-  verification_code: "123456",
-  verification_sent_date: "2025-01-01T00:00:00Z",
-  verified,
-  verified_date: verified ? "2025-01-01T00:05:00Z" : null,
-  country_code: "US",
-});
+const createMockPhone = (verified: boolean): RealPhone =>
+  ({
+    id: 1,
+    number: "+15555551234",
+    verification_code: "123456",
+    verification_sent_date: "2025-01-01T00:00:00Z",
+    verified,
+    verified_date: verified ? "2025-01-01T00:05:00Z" : null,
+    country_code: "US",
+  }) as RealPhone;
 
 describe("useRealPhonesData", () => {
   const mockMutate = jest.fn();
@@ -49,7 +50,7 @@ describe("useRealPhonesData", () => {
       mutate: mockMutate,
     });
 
-    let { result, rerender } = renderHook(() => useRealPhonesData());
+    const { result, rerender } = renderHook(() => useRealPhonesData());
 
     expect(useApiV1).toHaveBeenCalledWith("/realphone/");
     expect(result.current.isLoading).toBe(true);

--- a/frontend/src/hooks/api/relayNumber.test.ts
+++ b/frontend/src/hooks/api/relayNumber.test.ts
@@ -48,7 +48,7 @@ describe("useRelayNumber", () => {
     jest.requireMock("./api").apiFetch = mockApiFetch;
   });
 
-  const mockApiResponse = (data: any, error?: Error, isLoading = false) => {
+  const mockApiResponse = (data: unknown, error?: Error, isLoading = false) => {
     useApiV1.mockReturnValue({
       data,
       error,
@@ -60,7 +60,7 @@ describe("useRelayNumber", () => {
 
   it("fetches relay number data with loading, success, and error states", async () => {
     mockApiResponse(undefined, undefined, true);
-    let { result, rerender } = renderHook(() => useRelayNumber());
+    const { result, rerender } = renderHook(() => useRelayNumber());
 
     expect(useApiV1).toHaveBeenCalledWith("/relaynumber/");
     expect(result.current.isLoading).toBe(true);
@@ -115,7 +115,7 @@ describe("useRelayNumber", () => {
 describe("useRelayNumberSuggestions", () => {
   const useApiV1 = jest.requireMock("./api").useApiV1;
 
-  const mockApiResponse = (data: any, error?: Error, isLoading = false) => {
+  const mockApiResponse = (data: unknown, error?: Error, isLoading = false) => {
     useApiV1.mockReturnValue({
       data,
       error,
@@ -127,7 +127,7 @@ describe("useRelayNumberSuggestions", () => {
 
   it("fetches relay number suggestions with all loading states", async () => {
     mockApiResponse(undefined, undefined, true);
-    let { result, rerender } = renderHook(() => useRelayNumberSuggestions());
+    const { result, rerender } = renderHook(() => useRelayNumberSuggestions());
 
     expect(useApiV1).toHaveBeenCalledWith("/relaynumber/suggestions/");
     expect(result.current.isLoading).toBe(true);

--- a/frontend/src/hooks/api/user.test.ts
+++ b/frontend/src/hooks/api/user.test.ts
@@ -15,7 +15,7 @@ describe("useUsers", () => {
       mutate: jest.fn(),
     });
 
-    let { result, rerender } = renderHook(() => useUsers());
+    const { result, rerender } = renderHook(() => useUsers());
 
     const calls = useApiV1.mock.calls;
     expect(calls[0][0]).toBe("/users/");

--- a/frontend/src/hooks/firstSeen.test.ts
+++ b/frontend/src/hooks/firstSeen.test.ts
@@ -23,7 +23,7 @@ describe("useFirstSeen", () => {
     const useIsLoggedIn = jest.requireMock("./session").useIsLoggedIn;
 
     useIsLoggedIn.mockReturnValue("logged-out");
-    let { result, rerender } = renderHook(() => useFirstSeen());
+    const { result, rerender } = renderHook(() => useFirstSeen());
     expect(result.current).toBeNull();
 
     useIsLoggedIn.mockReturnValue("unknown");
@@ -45,14 +45,16 @@ describe("useFirstSeen", () => {
     rerender();
     expect(mockCookiesModule.setCookie).not.toHaveBeenCalled();
 
+    // Test "first visit" scenario with a new profile (no existing cookie)
     mockCookiesModule.getCookie.mockReturnValue(undefined);
+    setMockProfileData({ id: 124 });
     const now = Date.now();
     const dateSpy = jest.spyOn(Date, "now").mockReturnValue(now);
 
     rerender();
     expect(result.current?.getTime()).toBe(now);
     expect(mockCookiesModule.setCookie).toHaveBeenCalledWith(
-      "first_seen_123",
+      "first_seen_124",
       now.toString(),
       {
         maxAgeInSeconds: 315360000,

--- a/frontend/src/hooks/firstSeen.ts
+++ b/frontend/src/hooks/firstSeen.ts
@@ -1,3 +1,4 @@
+import { startTransition, useEffect, useState } from "react";
 import { getCookie, setCookie } from "../functions/cookies";
 import { useProfiles } from "./api/profile";
 import { useIsLoggedIn } from "./session";
@@ -14,23 +15,31 @@ import { useIsLoggedIn } from "./session";
 export function useFirstSeen(): Date | null {
   const isLoggedIn = useIsLoggedIn();
   const profileData = useProfiles();
+  const profileId = profileData.data?.[0]?.id;
 
-  if (!(isLoggedIn === "logged-in") || !profileData.data?.[0].id) {
+  const [firstSeen, setFirstSeen] = useState<Date | null>(null);
+
+  useEffect(() => {
+    if (isLoggedIn !== "logged-in" || typeof profileId === "undefined") {
+      return;
+    }
+    const firstSeenString = getCookie("first_seen_" + profileId);
+    if (typeof firstSeenString === "string") {
+      startTransition(() =>
+        setFirstSeen(new Date(Number.parseInt(firstSeenString, 10))),
+      );
+      return;
+    }
+    const currentTimestamp = Date.now();
+    setCookie("first_seen_" + profileId, currentTimestamp.toString(), {
+      maxAgeInSeconds: 10 * 365 * 24 * 60 * 60,
+    });
+    startTransition(() => setFirstSeen(new Date(currentTimestamp)));
+  }, [isLoggedIn, profileId]);
+
+  if (isLoggedIn !== "logged-in" || typeof profileId === "undefined") {
     return null;
   }
 
-  const firstSeenString = getCookie("first_seen_" + profileData.data[0].id);
-  if (typeof firstSeenString === "string") {
-    return new Date(Number.parseInt(firstSeenString, 10));
-  }
-
-  const currentTimestamp = Date.now();
-  setCookie(
-    "first_seen_" + profileData.data[0].id,
-    currentTimestamp.toString(),
-    {
-      maxAgeInSeconds: 10 * 365 * 24 * 60 * 60,
-    },
-  );
-  return new Date(currentTimestamp);
+  return firstSeen;
 }

--- a/frontend/src/hooks/gaEvent.test.ts
+++ b/frontend/src/hooks/gaEvent.test.ts
@@ -27,7 +27,7 @@ describe("useGaEvent", () => {
       jest.requireMock("./googleAnalytics").useGoogleAnalytics;
 
     useGoogleAnalytics.mockReturnValue(false);
-    let { result, rerender } = renderHook(() => useGaEvent());
+    const { result, rerender } = renderHook(() => useGaEvent());
 
     result.current({ category: "Test", action: "Action", label: "Label" });
     expect(mockEvent).not.toHaveBeenCalled();

--- a/frontend/src/hooks/hasRenderedClientSide.test.ts
+++ b/frontend/src/hooks/hasRenderedClientSide.test.ts
@@ -3,7 +3,7 @@ import { useHasRenderedClientSide } from "./hasRenderedClientSide";
 
 describe("useHasRenderedClientSide", () => {
   it("returns true in test environment and maintains state across renders and remounts", () => {
-    let { result, rerender, unmount } = renderHook(() =>
+    const { result, rerender, unmount } = renderHook(() =>
       useHasRenderedClientSide(),
     );
 

--- a/frontend/src/hooks/hasRenderedClientSide.ts
+++ b/frontend/src/hooks/hasRenderedClientSide.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 /**
  * Hook to help selectively opting out of static site generation
@@ -19,11 +19,9 @@ import { useEffect, useState } from "react";
  *          subsequent renders are guaranteed to be on the client-side.
  */
 export function useHasRenderedClientSide() {
-  const [hasRenderedClientSide, setHasRenderedClientSide] = useState(false);
-
-  useEffect(() => {
-    setHasRenderedClientSide(true);
-  }, []);
-
-  return hasRenderedClientSide;
+  return useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
 }

--- a/frontend/src/hooks/interval.test.ts
+++ b/frontend/src/hooks/interval.test.ts
@@ -13,7 +13,7 @@ describe("useInterval", () => {
   it("handles interval lifecycle, delay changes, callback updates, and cleanup", () => {
     const callback = jest.fn();
 
-    let { rerender, unmount } = renderHook(
+    const { rerender, unmount } = renderHook(
       ({ cb, delay }) => useInterval(cb, delay),
       { initialProps: { cb: callback, delay: 1000 } },
     );

--- a/frontend/src/hooks/l10n.ts
+++ b/frontend/src/hooks/l10n.ts
@@ -2,7 +2,7 @@
 // should be used instead, but of course this hook can use it just fine:
 // eslint-disable-next-line no-restricted-imports
 import { ReactLocalization, useLocalization } from "@fluent/react";
-import { createElement, Fragment, useEffect, useState } from "react";
+import { createElement, Fragment, useSyncExternalStore } from "react";
 
 /**
  * Equivalent to ReactLocalization.getString, but returns a React Fragment.
@@ -39,14 +39,14 @@ type ExtendedReactLocalization = ReactLocalization & {
  */
 export const useL10n = (): ExtendedReactLocalization => {
   const { l10n } = useLocalization();
-  const [isPrerendering, setIsPrerendering] = useState(true);
+  const isPrerendering = useSyncExternalStore(
+    () => () => {},
+    () => false,
+    () => true,
+  );
 
   const getFragment: GetFragment = (id, args, fallback) =>
     l10n.getElement(createElement(Fragment, null, fallback ?? id), id, args);
-
-  useEffect(() => {
-    setIsPrerendering(false);
-  }, []);
 
   if (isPrerendering) {
     const prerenderingL10n: ExtendedReactLocalization = {
@@ -73,9 +73,7 @@ export const useL10n = (): ExtendedReactLocalization => {
     return prerenderingL10n;
   }
 
-  const extendedL10n: ExtendedReactLocalization =
-    l10n as ExtendedReactLocalization;
-  extendedL10n.getFragment = getFragment;
-
-  return extendedL10n;
+  return Object.assign(Object.create(l10n as unknown as object), {
+    getFragment,
+  }) as ExtendedReactLocalization;
 };

--- a/frontend/src/hooks/localDismissal.ts
+++ b/frontend/src/hooks/localDismissal.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { startTransition, useEffect, useState } from "react";
 import { getCookie, setCookie } from "../functions/cookies";
 
 export type DismissOptions = {
@@ -36,7 +36,9 @@ export function useLocalDismissal(
   // Whenever `key` (and therefore `cookieId`) changes, re-check the appropriate
   // cookie.
   useEffect(() => {
-    setIsDismissed(hasDismissedCookie(cookieId, options.duration));
+    startTransition(() =>
+      setIsDismissed(hasDismissedCookie(cookieId, options.duration)),
+    );
   }, [cookieId, options.duration]);
 
   const dismiss = (dismissOptions?: DismissOptions) => {

--- a/frontend/src/hooks/session.test.ts
+++ b/frontend/src/hooks/session.test.ts
@@ -13,7 +13,7 @@ describe("useIsLoggedIn", () => {
       error: undefined,
       isLoading: true,
     });
-    let { result, rerender } = renderHook(() => useIsLoggedIn());
+    const { result, rerender } = renderHook(() => useIsLoggedIn());
     expect(result.current).toBe("unknown");
 
     useProfiles.mockReturnValue({

--- a/frontend/src/pages/phone.page.tsx
+++ b/frontend/src/pages/phone.page.tsx
@@ -4,7 +4,7 @@ import { useProfiles } from "../hooks/api/profile";
 import { useUsers } from "../hooks/api/user";
 import { PhoneOnboarding } from "../components/phones/onboarding/PhoneOnboarding";
 import { useRelayNumber } from "../hooks/api/relayNumber";
-import { useEffect, useState } from "react";
+import { startTransition, useEffect, useState } from "react";
 import { PhoneDashboard } from "../components/phones/dashboard/PhoneDashboard";
 import { getRuntimeConfig } from "../config";
 import { PurchasePhonesPlan } from "../components/phones/onboarding/PurchasePhonesPlan";
@@ -69,7 +69,7 @@ const Phone: NextPage = () => {
       Array.isArray(relayNumberData.data) &&
       relayNumberData.data.length === 0
     ) {
-      setIsInOnboarding(true);
+      startTransition(() => setIsInOnboarding(true));
     }
   }, [isInOnboarding, relayNumberData]);
 

--- a/frontend/src/pages/vpn-relay-welcome.page.test.tsx
+++ b/frontend/src/pages/vpn-relay-welcome.page.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, cleanup } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { setMockProfileData } from "../../__mocks__/hooks/api/profile";
 import { setMockRuntimeData } from "../../__mocks__/hooks/api/runtimeData";

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@types/jest-axe": "^3.5.9",
         "@types/react": "^19.2.14",
         "babel-jest": "^30.2.0",
-        "eslint": "^8.57.1",
+        "eslint": "^9.39.3",
         "eslint-config-next": "^16.1.6",
         "eslint-plugin-jest-dom": "^5.5.0",
         "eslint-plugin-testing-library": "^7.15.4",
@@ -69,125 +69,6 @@
         "stylelint-config-recommended-scss": "^17.0.0",
         "stylelint-scss": "^7.0.0",
         "typescript": "^5.9.3"
-      }
-    },
-    "frontend/node_modules/eslint": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.1",
-        "@humanwhocodes/config-array": "^0.13.0",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "@ungap/structured-clone": "^1.2.0",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
-        "espree": "^9.6.1",
-        "esquery": "^1.4.2",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "frontend/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "frontend/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "frontend/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "frontend/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -994,7 +875,6 @@
       "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
@@ -1010,7 +890,6 @@
       "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0"
       },
@@ -1024,7 +903,6 @@
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -1032,38 +910,17 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/eslintrc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+    "node_modules/@eslint/js": {
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
+      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/js": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -1072,7 +929,6 @@
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -1083,7 +939,6 @@
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
@@ -1200,7 +1055,6 @@
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1211,29 +1065,12 @@
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-      "deprecated": "Use @eslint/config-array instead",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.3",
-        "debug": "^4.3.1",
-        "minimatch": "^3.0.5"
-      },
-      "engines": {
-        "node": ">=10.10.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -1250,21 +1087,12 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "deprecated": "Use @eslint/object-schema instead",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -4973,8 +4801,7 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -7416,19 +7243,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -7777,12 +7591,11 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
+      "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7790,7 +7603,7 @@
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.2",
+        "@eslint/js": "9.39.3",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -8195,23 +8008,6 @@
         "eslint": "^8.57.0 || ^9.0.0"
       }
     },
-    "node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
@@ -8231,7 +8027,6 @@
       "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -8250,27 +8045,12 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -8288,7 +8068,6 @@
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -8302,7 +8081,6 @@
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
@@ -8321,7 +8099,6 @@
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -8335,7 +8112,6 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -8353,7 +8129,6 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -8368,7 +8143,6 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -8382,7 +8156,6 @@
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -8396,7 +8169,6 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -8407,7 +8179,6 @@
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -8424,7 +8195,6 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -8433,24 +8203,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.9.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esquery": {
@@ -8679,19 +8431,6 @@
         }
       }
     },
-    "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flat-cache": "^3.0.4"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -8716,31 +8455,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/flat-cache": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.3",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/flat-cache/node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-buffer": "3.0.1"
       }
     },
     "node_modules/flatted": {
@@ -9092,22 +8806,6 @@
         "which": "bin/which"
       }
     },
-    "node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -9225,13 +8923,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/graphql": {
       "version": "16.12.0",
@@ -9950,16 +9641,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-plain-object": {
@@ -14044,45 +13725,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -15876,13 +15518,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/third-party-capital": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
@@ -16076,19 +15711,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {


### PR DESCRIPTION
Use `ESLINT_USE_FLAT_CONFIG=false` to keep `.eslintrc.js`. Add explicit `'./src'` pattern, required by v9 legacy config mode.

ESLint v9 can run some plugins that v8 silently ignored. Fix all newly-enforced violations:

`react-hooks/globals|/refs|/static-components` (React Compiler rules):
* SSR hydration `useState+useEffect` → `useSyncExternalStore`
* `setState` in effects → `startTransition`
* in `render`:
  * components, ref access → moved to module scope
  * `Date.now()` → `useMemo(() => Date.now(), [])` with eslint-disable
  * `Object.assign` instead of mutation

`testing-library/no-container|no-node-access`:
* `container.querySelector()` → `within()`
* `firstChild` checks → `toBeEmptyDOMElement()`

`testing-library/render-result-naming-convention`:
* render result variable "result" → "view"

`@typescript-eslint/no-explicit-any`:
* `any` → typed or `unknown`

`jest-dom/prefer-empty|prefer-in-document|prefer-to-have-attribute`:
* `toHaveTextContent("")` → `toBeEmptyDOMElement()`
* `toBeNull()` → `not.toBeInTheDocument()`
* `getAttribute("class")` → `toHaveClass()`

`prefer-const`
* `let` → `const` where never reassigned

How to test:

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).