### PR TITLE
MPP-4563: feat(dashboard): enable alias category filters for free users

### DIFF
--- a/frontend/src/components/dashboard/aliases/AliasList.test.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.test.tsx
@@ -238,37 +238,59 @@ describe("<AliasList> – extra coverage", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("shows CategoryFilter only for Premium users", async () => {
-    const { rerender } = render(
-      <AliasList
-        aliases={[getMockRandomAlias()]}
-        onUpdate={jest.fn()}
-        onCreate={jest.fn()}
-        onDelete={jest.fn()}
-        profile={getMockProfileData({
-          server_storage: true,
-          has_premium: false,
-        })}
-        user={{ email: "u@example.com" }}
-      />,
-    );
-    expect(screen.queryByTestId("category-filter")).not.toBeInTheDocument();
+  it.each([
+    {
+      description: "premium users",
+      hasPremium: true,
+      flagEnabled: false,
+      shouldShowFilter: true,
+    },
+    {
+      description: "free users with increased_free_mask_limit flag",
+      hasPremium: false,
+      flagEnabled: true,
+      shouldShowFilter: true,
+    },
+    {
+      description: "free users without increased_free_mask_limit flag",
+      hasPremium: false,
+      flagEnabled: false,
+      shouldShowFilter: false,
+    },
+  ])(
+    "shows CategoryFilter for $description",
+    async ({ hasPremium, flagEnabled, shouldShowFilter }) => {
+      const renderTest = async () => {
+        render(
+          <AliasList
+            aliases={[getMockRandomAlias()]}
+            onUpdate={jest.fn()}
+            onCreate={jest.fn()}
+            onDelete={jest.fn()}
+            profile={getMockProfileData({
+              server_storage: true,
+              has_premium: hasPremium,
+            })}
+            user={{ email: "u@example.com" }}
+          />,
+        );
 
-    rerender(
-      <AliasList
-        aliases={[getMockRandomAlias()]}
-        onUpdate={jest.fn()}
-        onCreate={jest.fn()}
-        onDelete={jest.fn()}
-        profile={getMockProfileData({
-          server_storage: true,
-          has_premium: true,
-        })}
-        user={{ email: "u@example.com" }}
-      />,
-    );
-    expect(screen.getByTestId("category-filter")).toBeInTheDocument();
-  });
+        if (shouldShowFilter) {
+          expect(screen.getByTestId("category-filter")).toBeInTheDocument();
+        } else {
+          expect(
+            screen.queryByTestId("category-filter"),
+          ).not.toBeInTheDocument();
+        }
+      };
+
+      if (flagEnabled) {
+        await withFlag("increased_free_mask_limit", true, renderTest);
+      } else {
+        await renderTest();
+      }
+    },
+  );
 
   it("search toggle works and match-count shows filtered/total", async () => {
     const a1 = { ...getMockRandomAlias(), description: "alpha" };

--- a/frontend/src/components/dashboard/aliases/AliasList.tsx
+++ b/frontend/src/components/dashboard/aliases/AliasList.tsx
@@ -170,18 +170,20 @@ export const AliasList = (props: Props) => {
     );
   });
 
-  // With at most five aliases, filters aren't really useful
-  // for non-Premium users.
-  const categoryFilter = props.profile.has_premium ? (
-    <div className={styles["category-filter"]}>
-      <CategoryFilter
-        onChange={setCategoryFilters}
-        selectedFilters={categoryFilters}
-        resetChecks={resetCheckBoxes}
-        setCheckboxes={setCheckboxes}
-      />
-    </div>
-  ) : null;
+  // Filters enabled for all users, only blocked and forwarding show for non-premium
+  const categoryFilter =
+    props.profile.has_premium ||
+    isFlagActive(props.runtimeData, "increased_free_mask_limit") ? (
+      <div className={styles["category-filter"]}>
+        <CategoryFilter
+          onChange={setCategoryFilters}
+          selectedFilters={categoryFilters}
+          resetChecks={resetCheckBoxes}
+          setCheckboxes={setCheckboxes}
+          showPremiumFilters={props.profile.has_premium}
+        />
+      </div>
+    ) : null;
 
   const emptyStateMessage =
     props.aliases.length > 0 && aliases.length === 0 ? (

--- a/frontend/src/components/dashboard/aliases/CategoryFilter.test.tsx
+++ b/frontend/src/components/dashboard/aliases/CategoryFilter.test.tsx
@@ -1,0 +1,151 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { mockLocalizedModule } from "../../../../__mocks__/components/Localized";
+import { mockConfigModule } from "../../../../__mocks__/configMock";
+import { mockUseL10nModule } from "../../../../__mocks__/hooks/l10n";
+import { CategoryFilter } from "./CategoryFilter";
+
+jest.mock("../../../config.ts", () => mockConfigModule);
+jest.mock("../../../hooks/l10n.ts", () => mockUseL10nModule);
+jest.mock("../../../components/Localized.tsx", () => mockLocalizedModule);
+
+describe("<CategoryFilter>", () => {
+  it.each([
+    {
+      userType: "premium",
+      showPremiumFilters: true,
+      expectedFilters: {
+        custom: true,
+        random: true,
+        active: true,
+        promoBlocking: true,
+        disabled: true,
+      },
+    },
+    {
+      userType: "free",
+      showPremiumFilters: false,
+      expectedFilters: {
+        custom: false,
+        random: false,
+        active: true,
+        promoBlocking: false,
+        disabled: true,
+      },
+    },
+  ])(
+    "shows correct filter options for $userType users",
+    async ({ showPremiumFilters, expectedFilters }) => {
+      render(
+        <CategoryFilter
+          selectedFilters={{}}
+          onChange={jest.fn()}
+          resetChecks={false}
+          setCheckboxes={jest.fn()}
+          showPremiumFilters={showPremiumFilters}
+        />,
+      );
+
+      const filterButton = screen.getByRole("button", {
+        name: /profile-filter-category-button-tooltip/i,
+      });
+      await userEvent.click(filterButton);
+
+      await waitFor(() => {
+        if (expectedFilters.custom) {
+          expect(screen.getByLabelText(/custom-masks/i)).toBeInTheDocument();
+        } else {
+          expect(
+            screen.queryByLabelText(/custom-masks/i),
+          ).not.toBeInTheDocument();
+        }
+
+        if (expectedFilters.random) {
+          expect(screen.getByLabelText(/random-masks/i)).toBeInTheDocument();
+        } else {
+          expect(
+            screen.queryByLabelText(/random-masks/i),
+          ).not.toBeInTheDocument();
+        }
+
+        expect(screen.getByLabelText(/active-masks/i)).toBeInTheDocument();
+
+        if (expectedFilters.promoBlocking) {
+          expect(
+            screen.getByLabelText(/promo-blocking-masks/i),
+          ).toBeInTheDocument();
+        } else {
+          expect(
+            screen.queryByLabelText(/promo-blocking-masks/i),
+          ).not.toBeInTheDocument();
+        }
+
+        expect(screen.getByLabelText(/disabled-masks/i)).toBeInTheDocument();
+      });
+    },
+  );
+
+  it("calls onChange with selected filters when Apply is clicked", async () => {
+    const onChangeMock = jest.fn();
+    render(
+      <CategoryFilter
+        selectedFilters={{}}
+        onChange={onChangeMock}
+        resetChecks={false}
+        setCheckboxes={jest.fn()}
+        showPremiumFilters={false}
+      />,
+    );
+
+    const filterButton = screen.getByRole("button", {
+      name: /profile-filter-category-button-tooltip/i,
+    });
+    await userEvent.click(filterButton);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/active-masks/i)).toBeInTheDocument();
+    });
+
+    const forwardingCheckbox = screen.getByLabelText(/active-masks/i);
+    await userEvent.click(forwardingCheckbox);
+
+    const applyButton = screen.getByRole("button", { name: /apply/i });
+    await userEvent.click(applyButton);
+
+    expect(onChangeMock).toHaveBeenCalledWith({
+      domainType: undefined,
+      status: "forwarding",
+    });
+  });
+
+  it("calls onChange with reset filters when Reset is clicked", async () => {
+    const onChangeMock = jest.fn();
+    render(
+      <CategoryFilter
+        selectedFilters={{ status: "forwarding" }}
+        onChange={onChangeMock}
+        resetChecks={false}
+        setCheckboxes={jest.fn()}
+        showPremiumFilters={false}
+      />,
+    );
+
+    const filterButton = screen.getByRole("button", {
+      name: /profile-filter-category-button-tooltip/i,
+    });
+    await userEvent.click(filterButton);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/active-masks/i)).toBeInTheDocument();
+    });
+
+    const resetButton = screen.getByRole("button", { name: /reset/i });
+    await userEvent.click(resetButton);
+
+    expect(onChangeMock).toHaveBeenCalledWith({
+      domainType: undefined,
+      status: undefined,
+    });
+  });
+});

--- a/frontend/src/components/dashboard/aliases/CategoryFilter.tsx
+++ b/frontend/src/components/dashboard/aliases/CategoryFilter.tsx
@@ -34,6 +34,7 @@ export type Props = {
   onChange: (selected: SelectedFilters) => void;
   resetChecks: boolean;
   setCheckboxes: (isReset: boolean) => void;
+  showPremiumFilters: boolean;
 };
 
 type OnCloseParams = {
@@ -100,6 +101,7 @@ export const CategoryFilter = (props: Props) => {
           onClose={onClose}
           resetChecks={props.resetChecks}
           setCheckboxes={props.setCheckboxes}
+          showPremiumFilters={props.showPremiumFilters}
         />
       </OverlayContainer>
     </>
@@ -112,6 +114,7 @@ type FilterMenuProps = HTMLAttributes<HTMLDivElement> & {
   isOpen: boolean;
   resetChecks: boolean;
   setCheckboxes: (isReset: boolean) => void;
+  showPremiumFilters: boolean;
 };
 const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
   function FilterMenuWithForwardedRef(
@@ -121,6 +124,7 @@ const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
       isOpen,
       resetChecks,
       setCheckboxes,
+      showPremiumFilters,
       ...otherProps
     },
     overlayRef,
@@ -192,30 +196,38 @@ const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
             onReset={onReset}
             className={styles["filter-form"]}
           >
-            <label>
-              <input
-                type="checkbox"
-                checked={domainType === "custom"}
-                onChange={(e) =>
-                  setDomainType(e.target.checked ? "custom" : undefined)
-                }
-                name="customAliases"
-                id="customAliases"
-              />
-              {l10n.getString("profile-filter-category-option-custom-masks")}
-            </label>
-            <label>
-              <input
-                type="checkbox"
-                checked={domainType === "random"}
-                onChange={(e) =>
-                  setDomainType(e.target.checked ? "random" : undefined)
-                }
-                name="randomAliases"
-                id="randomAliases"
-              />
-              {l10n.getString("profile-filter-category-option-random-masks")}
-            </label>
+            {showPremiumFilters && (
+              <>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={domainType === "custom"}
+                    onChange={(e) =>
+                      setDomainType(e.target.checked ? "custom" : undefined)
+                    }
+                    name="customAliases"
+                    id="customAliases"
+                  />
+                  {l10n.getString(
+                    "profile-filter-category-option-custom-masks",
+                  )}
+                </label>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={domainType === "random"}
+                    onChange={(e) =>
+                      setDomainType(e.target.checked ? "random" : undefined)
+                    }
+                    name="randomAliases"
+                    id="randomAliases"
+                  />
+                  {l10n.getString(
+                    "profile-filter-category-option-random-masks",
+                  )}
+                </label>
+              </>
+            )}
             <label>
               <input
                 type="checkbox"
@@ -228,20 +240,22 @@ const FilterMenu = forwardRef<HTMLDivElement, FilterMenuProps>(
               />
               {l10n.getString("profile-filter-category-option-active-masks")}
             </label>
-            <label>
-              <input
-                type="checkbox"
-                checked={status === "promo-blocking"}
-                onChange={(e) =>
-                  setStatus(e.target.checked ? "promo-blocking" : undefined)
-                }
-                name="promoBlockingAliases"
-                id="promoBlockingAliases"
-              />
-              {l10n.getString(
-                "profile-filter-category-option-promo-blocking-masks",
-              )}
-            </label>
+            {showPremiumFilters && (
+              <label>
+                <input
+                  type="checkbox"
+                  checked={status === "promo-blocking"}
+                  onChange={(e) =>
+                    setStatus(e.target.checked ? "promo-blocking" : undefined)
+                  }
+                  name="promoBlockingAliases"
+                  id="promoBlockingAliases"
+                />
+                {l10n.getString(
+                  "profile-filter-category-option-promo-blocking-masks",
+                )}
+              </label>
+            )}
             <label>
               <input
                 type="checkbox"


### PR DESCRIPTION
# [MPP-4563](https://mozilla-hub.atlassian.net/browse/MPP-4573)
- alias category filter enabled for free users 
- part of mask expansion initiative

# Screenshot (if applicable)
<img width="1379" height="852" alt="Screenshot 2026-03-09 at 11 58 50 AM" src="https://github.com/user-attachments/assets/e171437c-06a9-4838-af29-1c3c4179a2df" />

# How to test
- enable `increased_free_mask_limit `waffle flag locally 
- run app locally 
- notice category filter populated for free users

# Checklist (Definition of Done)
- [X] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [X] Customer Experience team has seen or waived a demo of functionality.
- [X] All acceptance criteria are met.
- [X] Jira ticket has been updated (if needed) to match changes made during the development process.
- [X] I've added or updated relevant docs in the docs/ directory
- [X] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [X] l10n changes have been submitted to the l10n repository, if any.


[MPP-4563]: https://mozilla-hub.atlassian.net/browse/MPP-4563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ