### PR TITLE
fix(deps): bump Django from 5.2.12 to 5.2.13 to address security advisories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.42.84
 codetiming==1.4.0
 cryptography==46.0.7
-Django==5.2.12
+Django==5.2.13
 dj-database-url==3.1.2
 django-allauth[socialaccount]==65.15.1
 django-cors-headers==4.9.0


### PR DESCRIPTION
-   Updates Django from 5.2.12 to 5.2.13 to address five security vulnerabilities.
-  Fixes Dependabot alerts 153, 154, 155, 156, 157:
  1. **CVE: Privilege abuse in GenericInlineModelAdmin** - Add permissions
  on inline model instances were not validated on submission of forged POST
  data
  2. **CVE: Privilege abuse in ModelAdmin.list_editable** - Admin changelist
   forms incorrectly allowed new instances to be created via forged POST
  data
  3. **CVE: DoS via MultiPartParser** - Attackers could degrade performance
  by submitting multipart uploads with excessive whitespace in
  base64-encoded content
  4. **CVE: ASGI Content-Length bypass** - Requests with missing or
  understated Content-Length headers could bypass
  DATA_UPLOAD_MAX_MEMORY_SIZE limits
  5. **CVE: ASGI header spoofing** - Attackers could spoof headers by
  exploiting underscore/hyphen conflation in header mapping