### PR TITLE
Mpp 4633/fix reply issue

### DIFF
--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -2280,6 +2280,11 @@ class SNSNotificationValidUserEmailsInS3Test(TestCase):
         # no longer has the premium subscription
         mocked_reply_allowed.return_value = False
 
+        # Mock the reply record to have the same user as the address (MPP-4633 fix)
+        mock_reply = Mock()
+        mock_reply.address = self.address
+        mocked_reply_record.return_value = mock_reply
+
         with self.assertLogs(INFO_LOG) as caplog:
             response = _sns_notification(EMAIL_SNS_BODIES["s3_stored"])
         self.mock_remove_message_from_s3.assert_called_once_with(self.bucket, self.key)
@@ -2432,6 +2437,72 @@ class SNSNotificationValidUserEmailsInS3Test(TestCase):
             "email_suppressed_for_dmarc_failure",
             tags=["dmarcPolicy:reject", "dmarcVerdict:FAIL"],
         )
+
+    @patch("emails.views._get_keys_from_headers")
+    @patch("emails.views._get_reply_record_from_lookup_key")
+    def test_cross_account_reply_bypass_blocked(
+        self, mocked_reply_record: Mock, mocked_get_keys: Mock
+    ) -> None:
+        """
+        Security test for MPP-4633: Verify that reply records from a different user
+        cannot be used to bypass victim mask policies.
+
+        An attacker should not be able to use their own reply Message-ID in an
+        In-Reply-To header to bypass a victim's "Block all email" setting.
+        """
+        # Create attacker user with their own mask and reply record
+        attacker_user = baker.make(User, email="attacker@example.com")
+        baker.make(SocialAccount, user=attacker_user, provider="fxa")
+        attacker_mask = baker.make(
+            RelayAddress, user=attacker_user, address="attacker", domain=2
+        )
+
+        # Create a reply record for the attacker's mask
+        attacker_message_id = "<attacker-msg-id-123@example.com>"
+        lookup_key, encryption_key = derive_reply_keys(
+            get_message_id_bytes(attacker_message_id)
+        )
+        metadata = {
+            "message-id": str(uuid4()),
+            "from": "external@example.com",
+        }
+        encrypted_metadata = encrypt_reply_metadata(encryption_key, metadata)
+        attacker_reply = Reply.objects.create(
+            lookup=b64_lookup_key(lookup_key),
+            encrypted_metadata=encrypted_metadata,
+            relay_address=attacker_mask,
+        )
+
+        # Configure victim's mask to block all email
+        self.address.enabled = False
+        self.address.save()
+
+        # Mock the reply lookup to return the attacker's reply record
+        mocked_get_keys.return_value = (lookup_key, encryption_key)
+        mocked_reply_record.return_value = attacker_reply
+
+        # Send email to victim's mask with attacker's Message-ID in In-Reply-To
+        with self.assertLogs(GLEAN_LOG) as caplog, MetricsMock() as mm:
+            response = _sns_notification(EMAIL_SNS_BODIES["s3_stored"])
+
+        # Verify the email was blocked due to victim's mask being disabled
+        # The fix prevents the attacker's reply record from bypassing victim's policies
+        assert response.status_code == 200
+        assert response.content == b"Address is temporarily disabled."
+
+        # Verify the victim's mask blocked counter was incremented (not attacker's)
+        self.address.refresh_from_db()
+        assert self.address.num_blocked == 1
+
+        # Verify the attacker's mask was NOT affected
+        attacker_mask.refresh_from_db()
+        assert attacker_mask.num_blocked == 0
+
+        # Verify proper logging
+        assert (event := get_glean_event(caplog)) is not None
+        expected = self.expected_glean_event(event["timestamp"], "block_all")
+        assert event == expected
+        mm.assert_incr_once("email_for_disabled_address")
 
 
 class SnsMessageTest(TestCase):

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -2451,34 +2451,19 @@ class SNSNotificationValidUserEmailsInS3Test(TestCase):
         In-Reply-To header to bypass a victim's "Block all email" setting.
         """
         # Create attacker user with their own mask and reply record
-        attacker_user = baker.make(User, email="attacker@example.com")
+        attacker_user = make_free_test_user("attacker@example.com")
         baker.make(SocialAccount, user=attacker_user, provider="fxa")
         attacker_mask = baker.make(
             RelayAddress, user=attacker_user, address="attacker", domain=2
         )
 
         # Create a reply record for the attacker's mask
-        attacker_message_id = "<attacker-msg-id-123@example.com>"
-        lookup_key, encryption_key = derive_reply_keys(
-            get_message_id_bytes(attacker_message_id)
-        )
-        metadata = {
-            "message-id": str(uuid4()),
-            "from": "external@example.com",
-        }
-        encrypted_metadata = encrypt_reply_metadata(encryption_key, metadata)
-        attacker_reply = Reply.objects.create(
-            lookup=b64_lookup_key(lookup_key),
-            encrypted_metadata=encrypted_metadata,
-            relay_address=attacker_mask,
-        )
-
+        attacker_reply = baker.make(Reply, relay_address=attacker_mask)
         # Configure victim's mask to block all email
         self.address.enabled = False
         self.address.save()
-
         # Mock the reply lookup to return the attacker's reply record
-        mocked_get_keys.return_value = (lookup_key, encryption_key)
+        mocked_get_keys.return_value = ("lookup_key", "encryption_key")
         mocked_reply_record.return_value = attacker_reply
 
         # Send email to victim's mask with attacker's Message-ID in In-Reply-To

--- a/emails/views.py
+++ b/emails/views.py
@@ -691,6 +691,14 @@ def _handle_received(message_json: AWS_SNSMessageJSON) -> HttpResponse:
     try:
         lookup_key, _ = _get_keys_from_headers(mail["headers"])
         reply_record = _get_reply_record_from_lookup_key(lookup_key)
+
+        # SECURITY: Verify the reply record belongs to the same user as the recipient
+        # This prevents cross-account authorization bypass where an attacker could use
+        # their own reply Message-ID to bypass a victim's mask policies (MPP-4633)
+        if reply_record.address.user != address.user:
+            # Reply record belongs to a different user - treat as regular email
+            raise Reply.DoesNotExist
+
         user_address = address
         address = reply_record.address
         message_id = _get_message_id_from_headers(mail["headers"])


### PR DESCRIPTION
This PR fixes MPP-4633.

How to test:
I've tested this change locally and the fix prevents cross-account replies.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
