### PR TITLE
chore: Rename references from mozilla-it/deploy-actions to mozilla/deploy-actions

### DIFF
--- a/.github/workflows/build-and-push-to-gar.yml
+++ b/.github/workflows/build-and-push-to-gar.yml
@@ -36,7 +36,7 @@ jobs:
     permissions:
       contents: read
       id-token: write     
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2
+    uses: mozilla/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2
     with:
       image_name: fx-private-relay
       gar_name: ${{ vars.GCP_MOZCLOUD_GAR_NAME_PROD }}


### PR DESCRIPTION
This PR fixes [MZCLD-2266](https://mozilla-hub.atlassian.net/browse/MZCLD-2266)


[MZCLD-2266]: https://mozilla-hub.atlassian.net/browse/MZCLD-2266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ