### PR TITLE
build(github): update deploy-actions reference for moved repo

### DIFF
--- a/.github/workflows/build-and-push-to-gar.yml
+++ b/.github/workflows/build-and-push-to-gar.yml
@@ -35,8 +35,9 @@ jobs:
     needs: determine-metadata
     permissions:
       contents: read
-      id-token: write     
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@4784cb70739a4f32ce010921f60fb1ebbc791a38 # v6.2.2
+      id-token: write
+    # version 6.2.3
+    uses: mozilla/deploy-actions/.github/workflows/build-and-push.yml@47edfe10709f2978fdcb5fd3037599d72aa10661
     with:
       image_name: fx-private-relay
       gar_name: ${{ vars.GCP_MOZCLOUD_GAR_NAME_PROD }}


### PR DESCRIPTION
Fixes issue caused by move from `mozilla-it` to `mozilla` repo

How to test:
We'll have to merge to test 😄 

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).