### PR TITLE
fix(e2e): send fxa-ci header in global setup to bypass Fastly CAPTCHA

### DIFF
--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -11,7 +11,25 @@ const { chromium } = require("@playwright/test");
 async function globalSetup() {
   // playwright setup
   const browser = await chromium.launch();
-  const page = await browser.newPage();
+  const page = await browser.newPage({
+    // Send fxa-ci header to bypass Fastly CAPTCHA on FxA stage
+    extraHTTPHeaders: process.env.FXA_CI_SECRET
+      ? { "fxa-ci": process.env.FXA_CI_SECRET }
+      : {},
+  });
+
+  // Strip fxa-ci from api-accounts requests to avoid CORS preflight failures.
+  // The fxa-ci custom header triggers a CORS preflight on cross-origin fetch()
+  // calls. api-accounts doesn't include fxa-ci in Access-Control-Allow-Headers,
+  // so the browser blocks the response. This breaks the OAuth client info fetch
+  // and causes "Invalid OAuth parameter: scope" errors.
+  if (process.env.FXA_CI_SECRET) {
+    await page.route("**/api-accounts*/**", (route: any) => {
+      const headers = { ...route.request().headers() };
+      delete headers["fxa-ci"];
+      return route.continue({ headers });
+    });
+  }
 
   // generate email and set env variables
   const randomEmail = `${Date.now()}_tstact@restmail.net`;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -71,11 +71,6 @@ const config = defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-
-    /* Extra HTTP headers to bypass Fastly CAPTCHA on FxA stage */
-    extraHTTPHeaders: process.env.FXA_CI_SECRET ? {
-      'fxa-ci': process.env.FXA_CI_SECRET,
-    } : {},
   },
 
   /* Configure projects for test suites and browsers */


### PR DESCRIPTION
PR #6469 added the header to playwright.config.ts, but config-level extraHTTPHeaders only apply to test contexts. The global setup creates its own browser page, so the header was never sent during sign-up.

How to test:
1. Ensure the `FXA_CI_SECRET` GitHub Actions secret is set for the repo.
2. Run the full e2e test suite from this branch against stage
   * [ ] https://github.com/mozilla/fx-private-relay/actions/runs/24898986921 It should pass.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).