### PR TITLE
MPP-4647 - fix(relay): return sorted masks from API

### DIFF
--- a/api/tests/emails_views_tests.py
+++ b/api/tests/emails_views_tests.py
@@ -1,5 +1,6 @@
 """Tests for api/views/email_views.py"""
 
+from datetime import timedelta
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
@@ -13,7 +14,6 @@ from pytest_django.fixtures import DjangoAssertNumQueries, SettingsWrapper
 from rest_framework.exceptions import MethodNotAllowed, NotAuthenticated
 from rest_framework.test import APIClient
 from waffle.testutils import override_flag
-from datetime import timedelta
 
 from emails.models import DomainAddress, RelayAddress
 from privaterelay.tests.utils import (
@@ -863,12 +863,17 @@ def test_get_relayaddress_ordered_by_created_at_desc(
     free_api_client: APIClient, free_user: User
 ) -> None:
     """GET /relayaddresses/ returns addresses ordered newest first."""
-
     now = timezone.now()
 
-    addr_oldest = baker.make(RelayAddress, user=free_user, created_at=now - timedelta(days=3))
-    addr_newest = baker.make(RelayAddress, user=free_user, created_at=now - timedelta(days=1))
-    addr_middle = baker.make(RelayAddress, user=free_user, created_at=now - timedelta(days=2))
+    addr_oldest = baker.make(
+        RelayAddress, user=free_user, created_at=now - timedelta(days=3)
+    )
+    addr_middle = baker.make(
+        RelayAddress, user=free_user, created_at=now - timedelta(days=2)
+    )
+    addr_newest = baker.make(
+        RelayAddress, user=free_user, created_at=now - timedelta(days=1)
+    )
 
     url = reverse("relayaddress-list")
     response = free_api_client.get(url)
@@ -876,9 +881,9 @@ def test_get_relayaddress_ordered_by_created_at_desc(
 
     assert response.status_code == 200
     assert len(data) == 3
-    assert data[0]["id"] == address2.id
-    assert data[1]["id"] == address3.id
-    assert data[2]["id"] == address1.id
+    assert data[0]["id"] == addr_newest.id
+    assert data[1]["id"] == addr_middle.id
+    assert data[2]["id"] == addr_oldest.id
 
 
 def test_first_forwarded_email_unauth(client: Client) -> None:

--- a/api/tests/emails_views_tests.py
+++ b/api/tests/emails_views_tests.py
@@ -858,6 +858,37 @@ def test_get_relayaddress(
     assert len(data) == address_count
 
 
+def test_get_relayaddress_ordered_by_created_at_desc(
+    free_api_client: APIClient, free_user: User
+) -> None:
+    """GET /relayaddresses/ returns addresses ordered newest first."""
+    from datetime import timedelta
+
+    now = timezone.now()
+
+    address1 = RelayAddress.objects.create(user=free_user)
+    address1.created_at = now - timedelta(days=3)
+    address1.save()
+
+    address2 = RelayAddress.objects.create(user=free_user)
+    address2.created_at = now - timedelta(days=1)
+    address2.save()
+
+    address3 = RelayAddress.objects.create(user=free_user)
+    address3.created_at = now - timedelta(days=2)
+    address3.save()
+
+    url = reverse("relayaddress-list")
+    response = free_api_client.get(url)
+    data = response.json()
+
+    assert response.status_code == 200
+    assert len(data) == 3
+    assert data[0]["id"] == address2.id
+    assert data[1]["id"] == address3.id
+    assert data[2]["id"] == address1.id
+
+
 def test_first_forwarded_email_unauth(client: Client) -> None:
     response = client.post("/api/v1/first-forwarded-email/")
     assert response.status_code == 401

--- a/api/tests/emails_views_tests.py
+++ b/api/tests/emails_views_tests.py
@@ -866,17 +866,9 @@ def test_get_relayaddress_ordered_by_created_at_desc(
 
     now = timezone.now()
 
-    address1 = RelayAddress.objects.create(user=free_user)
-    address1.created_at = now - timedelta(days=3)
-    address1.save()
-
-    address2 = RelayAddress.objects.create(user=free_user)
-    address2.created_at = now - timedelta(days=1)
-    address2.save()
-
-    address3 = RelayAddress.objects.create(user=free_user)
-    address3.created_at = now - timedelta(days=2)
-    address3.save()
+      addr_oldest = baker.make(RelayAddress, user=free_user, created_at=now - timedelta(days=3))
+      addr_newest = baker.make(RelayAddress, user=free_user, created_at=now - timedelta(days=1))
+      addr_middle = baker.make(RelayAddress, user=free_user, created_at=now - timedelta(days=2))
 
     url = reverse("relayaddress-list")
     response = free_api_client.get(url)

--- a/api/tests/emails_views_tests.py
+++ b/api/tests/emails_views_tests.py
@@ -866,9 +866,9 @@ def test_get_relayaddress_ordered_by_created_at_desc(
 
     now = timezone.now()
 
-      addr_oldest = baker.make(RelayAddress, user=free_user, created_at=now - timedelta(days=3))
-      addr_newest = baker.make(RelayAddress, user=free_user, created_at=now - timedelta(days=1))
-      addr_middle = baker.make(RelayAddress, user=free_user, created_at=now - timedelta(days=2))
+    addr_oldest = baker.make(RelayAddress, user=free_user, created_at=now - timedelta(days=3))
+    addr_newest = baker.make(RelayAddress, user=free_user, created_at=now - timedelta(days=1))
+    addr_middle = baker.make(RelayAddress, user=free_user, created_at=now - timedelta(days=2))
 
     url = reverse("relayaddress-list")
     response = free_api_client.get(url)

--- a/api/tests/emails_views_tests.py
+++ b/api/tests/emails_views_tests.py
@@ -13,6 +13,7 @@ from pytest_django.fixtures import DjangoAssertNumQueries, SettingsWrapper
 from rest_framework.exceptions import MethodNotAllowed, NotAuthenticated
 from rest_framework.test import APIClient
 from waffle.testutils import override_flag
+from datetime import timedelta
 
 from emails.models import DomainAddress, RelayAddress
 from privaterelay.tests.utils import (
@@ -862,7 +863,6 @@ def test_get_relayaddress_ordered_by_created_at_desc(
     free_api_client: APIClient, free_user: User
 ) -> None:
     """GET /relayaddresses/ returns addresses ordered newest first."""
-    from datetime import timedelta
 
     now = timezone.now()
 

--- a/api/views/emails.py
+++ b/api/views/emails.py
@@ -124,7 +124,9 @@ class RelayAddressViewSet(AddressViewSet[RelayAddress]):
 
     def get_queryset(self) -> QuerySet[RelayAddress]:
         if isinstance(self.request.user, User):
-            return RelayAddress.objects.filter(user=self.request.user)
+            return RelayAddress.objects.filter(user=self.request.user).order_by(
+                "-created_at"
+            )
         return RelayAddress.objects.none()
 
 


### PR DESCRIPTION
# Fixes [MPP-4647](https://mozilla-hub.atlassian.net/browse/MPP-4647)
- alias API endpoint now returns aliases sorted so client side does not need to

## How to test:
- go to dashboard
- generate masks
- ensure new ones are placed at top of list

## Checklist
- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

[MPP-4647]: https://mozilla-hub.atlassian.net/browse/MPP-4647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ