### PR TITLE
MPP-4654: bug(news) update expiration date on news for mask expansion

### DIFF
--- a/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
+++ b/frontend/src/components/layout/navigation/whatsnew/WhatsNewMenu.tsx
@@ -666,8 +666,8 @@ export const WhatsNewMenu = (props: Props) => {
     ),
     announcementDate: {
       year: 2026,
-      month: 3,
-      day: 15,
+      month: 4,
+      day: 27,
     },
   };
 


### PR DESCRIPTION
# This PR fixes [MPP-4654](https://mozilla-hub.atlassian.net/browse/MPP-4654)

## How to test:
- log in 
- news popup should show on dashboard

## Checklist
- [X] l10n changes have been submitted to the l10n repository, if any.
- [X] I've added a unit test to test for potential regressions of this bug.
- [X] I've added or updated relevant docs in the docs/ directory.
- [X] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

## Screenshot
<img width="489" height="573" alt="Screenshot 2026-04-28 at 7 32 37 AM" src="https://github.com/user-attachments/assets/6a835a18-4a7e-452b-80de-aefd86dd12bd" />

[MPP-4654]: https://mozilla-hub.atlassian.net/browse/MPP-4654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ