### PR TITLE
fix(e2e): bypass Fastly CAPTCHA on FxA stage with fxa-ci header

### DIFF
--- a/e2e-tests/e2eTestUtils/helpers.ts
+++ b/e2e-tests/e2eTestUtils/helpers.ts
@@ -27,6 +27,36 @@ export const TIMEOUTS = {
   LONG: 10000,
 };
 
+// Strip fxa-ci from all third-party domains to avoid leaking the
+// Fastly bypass secret. extraHTTPHeaders sends fxa-ci on ALL requests
+// (needed because page.route() can't intercept navigation requests
+// after redirects). A broad catch-all route breaks extraHTTPHeaders
+// on navigations, so we list each third-party domain explicitly.
+// FxA domains behind Fastly (accounts, api-accounts, oauth, profile
+// on *.mozaws.net or *.firefox.com) are NOT listed — they need it.
+const STRIP_FXA_CI_PATTERNS = [
+  "**/accounts-cdn*/**",
+  "**/*.sentry.io/**",
+  "**/*.stripe.com/**",
+  "**/*.stripe.network/**",
+  "**/pay.google.com/**",
+  "**/www.google-analytics.com/**",
+  "**/www.googletagmanager.com/**",
+  "**/*.paypal.com/**",
+];
+
+export async function setupFxaCiRoutes(page: Page) {
+  if (!process.env.FXA_CI_SECRET) return;
+  const stripFxaCi = (route: any) => {
+    const headers = { ...route.request().headers() };
+    delete headers["fxa-ci"];
+    return route.continue({ headers });
+  };
+  for (const pattern of STRIP_FXA_CI_PATTERNS) {
+    await page.route(pattern, stripFxaCi);
+  }
+}
+
 // Default free mask limit — matches INCREASED_MAX_NUM_FREE_ALIASES in settings.py.
 // Used in test names (must be static) and as a fallback if the API fetch fails.
 export const MAX_NUM_FREE_ALIASES = 50;

--- a/e2e-tests/fixtures/basePages.ts
+++ b/e2e-tests/fixtures/basePages.ts
@@ -4,6 +4,7 @@ import { test as baseTest } from "@playwright/test";
 import { DashboardPage } from "../pages/dashboardPage";
 import { SubscriptionPaymentPage } from "../pages/subscriptionPaymentPage";
 import { MozillaMonitorPage } from "../pages/mozillaMonitorPage";
+import { setupFxaCiRoutes } from "../e2eTestUtils/helpers";
 
 const test = baseTest.extend<{
   landingPage: LandingPage;
@@ -12,6 +13,10 @@ const test = baseTest.extend<{
   subscriptionPage: SubscriptionPaymentPage;
   mozillaMonitorPage: MozillaMonitorPage;
 }>({
+  page: async ({ page }, use) => {
+    await setupFxaCiRoutes(page);
+    await use(page);
+  },
   authPage: async ({ page }, use) => {
     await use(new AuthPage(page));
   },

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -2,6 +2,7 @@ import {
   ENV_URLS,
   getVerificationCode,
   setEnvVariables,
+  setupFxaCiRoutes,
 } from "./e2eTestUtils/helpers";
 import { AuthPage } from "./pages/authPage";
 import { LandingPage } from "./pages/landingPage";
@@ -11,7 +12,12 @@ const { chromium } = require("@playwright/test");
 async function globalSetup() {
   // playwright setup
   const browser = await chromium.launch();
-  const page = await browser.newPage();
+  const page = await browser.newPage({
+    extraHTTPHeaders: process.env.FXA_CI_SECRET
+      ? { "fxa-ci": process.env.FXA_CI_SECRET }
+      : {},
+  });
+  await setupFxaCiRoutes(page);
 
   // generate email and set env variables
   const randomEmail = `${Date.now()}_tstact@restmail.net`;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -72,10 +72,13 @@ const config = defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
 
-    /* Extra HTTP headers to bypass Fastly CAPTCHA on FxA stage */
+    /* Send fxa-ci header to bypass Fastly CAPTCHA on FxA stage.
+       setupFxaCiRoutes() strips this header from non-FxA domains
+       to avoid CORS preflight failures. */
     extraHTTPHeaders: process.env.FXA_CI_SECRET ? {
       'fxa-ci': process.env.FXA_CI_SECRET,
     } : {},
+
   },
 
   /* Configure projects for test suites and browsers */


### PR DESCRIPTION
Send the fxa-ci header to bypass Fastly's dynamic CAPTCHA challenge on FxA stage. Use extraHTTPHeaders to include the header on all requests, then strip it via route interception from domains that reject it in CORS (accounts-cdn, sentry.io).

Apply the fix to both global-setup.ts (account registration) and test contexts via a shared setupFxaCiRoutes() helper in basePages.ts.

How to test:
https://github.com/mozilla/fx-private-relay/actions/runs/25081688630 ran.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).