### PR TITLE
fix(ci): prevent secret leaks in Playwright artifacts

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -71,13 +71,6 @@ jobs:
           E2E_TEST_ACCOUNT_PREMIUM: ${{ secrets.E2E_TEST_ACCOUNT_PREMIUM }}
           E2E_TEST_BASE_URL: ${{ secrets.E2E_TEST_BASE_URL }}
           FXA_CI_SECRET: ${{ secrets.FXA_CI_SECRET }}
-      - name: Upload html report as artifact to troubleshoot failures.
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: always()
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 5
       - name: Send GitHub Action trigger data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -54,10 +54,14 @@ const config = defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [
-    ['list'],
-    ['html'],
-  ],
+  /* HTML reporter generates detailed reports with step arguments that can
+     contain secrets. Only enable it for local runs where the output stays
+     on the developer's machine. CI uses the list reporter only — pass/fail
+     results appear in the workflow log, and GitHub Actions masks secret
+     values there automatically. */
+  reporter: process.env.CI
+    ? [['list']]
+    : [['list'], ['html']],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
@@ -66,11 +70,14 @@ const config = defineConfig({
     /* automatically take screenshot only on failures */
     screenshot: 'only-on-failure',
 
-    /* automatically record video on retry  */
-    video: 'retry-with-video',
+    /* Video disabled — recordings can capture credential entry and end up
+       in uploaded artifacts on this public repo. */
+    video: 'off',
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    /* Trace disabled — trace files capture full network data (headers,
+       request/response bodies) which includes secrets passed via env vars
+       and extraHTTPHeaders. See MPP-4662. */
+    trace: 'off',
 
     /* Send fxa-ci header to bypass Fastly CAPTCHA on FxA stage.
        setupFxaCiRoutes() strips this header from non-FxA domains


### PR DESCRIPTION
Trace files, video recordings, and HTML reports captured credentials and auth headers. Artifacts were uploaded on every run to a public repo.

- Disable trace and video capture at source
- Disable HTML reporter on CI (keep for local debugging)
- Remove artifact upload step entirely

This PR fixes MPP-4662.

How to test:
1. https://github.com/mozilla/fx-private-relay/actions/runs/25462242100/job/74707089133
  * [x] Verify no upload html report step
  * [x] Verify no artifact uploaded
  * [x] Verify "Run playwright tests" still passed
  
- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).