### PR TITLE
build(gha): add merge_group to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This should fix the issues w/ PRs stalling in the merge queue
