### PR TITLE
build(django): bump django to 5.2.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.42.97
 codetiming==1.4.0
 cryptography==47.0.0
-Django==5.2.13
+Django==5.2.14
 dj-database-url==3.1.2
 django-allauth[socialaccount]==65.16.1
 django-cors-headers==4.9.0


### PR DESCRIPTION
This brings in latest django with small security fixes.

How to test:

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
