### PR TITLE
refactor(api): hollow out /metrics-event endpoint

### DIFF
--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -605,59 +605,18 @@ def test_lbheartbeat_view(client: Client) -> None:
     assert response.content == b""
 
 
-@override_settings(STATSD_ENABLED=True)
-def test_metrics_event_GET(client: Client, caplog: pytest.LogCaptureFixture) -> None:
-    with MetricsMock() as mm:
-        response = client.get("/metrics-event")
+def test_metrics_event_GET(client: Client) -> None:
+    response = client.get("/metrics-event")
     assert response.status_code == 405
-    assert caplog.record_tuples == [("request.summary", logging.INFO, "")]
-    mm.assert_not_incr("metrics_event")
 
 
 @override_settings(STATSD_ENABLED=True)
-def test_metrics_event_POST_non_json(
+def test_metrics_event_POST_returns_204(
     client: Client, caplog: pytest.LogCaptureFixture
 ) -> None:
     with MetricsMock() as mm:
         response = client.post("/metrics-event")
-    assert response.status_code == 415
+    assert response.status_code == 204
+    assert response.content == b""
     assert caplog.record_tuples == [("request.summary", logging.INFO, "")]
     mm.assert_not_incr("metrics_event")
-
-
-@override_settings(STATSD_ENABLED=True)
-def test_metrics_event_POST_json_no_ga_uuid(
-    client: Client, caplog: pytest.LogCaptureFixture
-) -> None:
-    with MetricsMock() as mm:
-        response = client.post(
-            "/metrics-event", {"category": "addon"}, content_type="application/json"
-        )
-    assert response.status_code == 404
-    assert caplog.record_tuples == [("request.summary", logging.INFO, "")]
-    mm.assert_not_incr("metrics_event")
-
-
-@override_settings(STATSD_ENABLED=True)
-def test_metrics_event_POST_json_ga_uuid_ok(
-    client: Client,
-    caplog: pytest.LogCaptureFixture,
-    settings: SettingsWrapper,
-) -> None:
-    with MetricsMock() as mm:
-        response = client.post(
-            "/metrics-event",
-            {"ga_uuid": "anything-is-ok"},
-            content_type="application/json",
-        )
-    assert response.status_code == 200
-
-    assert caplog.record_tuples == [
-        ("eventsinfo", logging.INFO, "metrics_event"),
-        ("request.summary", logging.INFO, ""),
-    ]
-    record = caplog.records[0]
-    assert getattr(record, "ga_uuid_hash") == "1aa8606ede8415d8"
-    assert getattr(record, "source") == "website"
-
-    mm.assert_incr_once("metrics_event", 1, tags=["source:website"])

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -22,7 +22,6 @@ import sentry_sdk
 from allauth.socialaccount.models import SocialAccount, SocialApp
 from allauth.socialaccount.providers.fxa.views import FirefoxAccountsOAuth2Adapter
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
-from markus.utils import generate_tag
 from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
 from requests.exceptions import JSONDecodeError
 from rest_framework.decorators import api_view, schema
@@ -96,37 +95,13 @@ def profile_subdomain(request):
 
 @csrf_exempt
 @require_http_methods(["POST"])
-def metrics_event(request: HttpRequest) -> JsonResponse:
-    """
-    Handle metrics events from the Relay extension.
+def metrics_event(request: HttpRequest) -> HttpResponse:
+    """Intentionally inert endpoint kept for backward compatibility.
 
-    This used to forward data to Google Analytics, but was not updated for GA4.
-
-    Now it logs the information and updates statsd counters.
+    The browser extension POSTs here fire-and-forget. The endpoint used to forward
+    events to Google Analytics but was never updated for GA4. It now does nothing.
     """
-    try:
-        request_data = json.loads(request.body)
-    except json.JSONDecodeError:
-        return JsonResponse({"msg": "Could not decode JSON"}, status=415)
-    if "ga_uuid" not in request_data:
-        return JsonResponse({"msg": "No GA uuid found"}, status=404)
-    event_data = {
-        "ga_uuid_hash": sha256(request_data["ga_uuid"].encode()).hexdigest()[:16],
-        "category": request_data.get("category", None),
-        "action": request_data.get("action", None),
-        "label": request_data.get("label", None),
-        "value": request_data.get("value", None),
-        "browser": request_data.get("browser", None),  # dimension5 in GA
-        "source": request_data.get("dimension7", "website"),
-    }
-    info_logger.info("metrics_event", extra=event_data)
-    tags = [
-        generate_tag(key, val)
-        for key, val in event_data.items()
-        if val is not None and key != "ga_uuid_hash"
-    ]
-    incr_if_enabled("metrics_event", tags=tags)
-    return JsonResponse({"msg": "OK"}, status=200)
+    return HttpResponse(status=204)
 
 
 @csrf_exempt


### PR DESCRIPTION
The endpoint forwarded extension events to GA but was never updated for GA4. It logged and bumped counters nothing consumed. It was csrf_exempt with no auth. Now it returns 204 and does nothing.

How to test:
1. `pytest` should still pass
2. `POST` to `/metrics-event` with any body:
   * `curl -X POST http://127.0.0.1:8000/metrics-event`
   * [ ] Verify the response is `204` with an empty body.
3. `GET /metrics-event`
   * `curl http://127.0.0.1:8000/metrics-event`
   * [ ] verify it returns `405`.
4. Check application logs — no `metrics_event` entries should appear from the POST. (Note: `request.summary` will still appear.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).