### PR TITLE
Quality: Typo in mockNextRouter: 'pathmame' instead of 'pathname'

### DIFF
--- a/frontend/__mocks__/modules/next__router.ts
+++ b/frontend/__mocks__/modules/next__router.ts
@@ -1,7 +1,7 @@
 export const mockNextRouter = {
   useRouter: jest.fn(() => {
     return {
-      pathmame: "/",
+      pathname: "/",
       push: jest.fn(),
     };
   }),


### PR DESCRIPTION
## Summary

Quality: Typo in mockNextRouter: 'pathmame' instead of 'pathname'

## Problem

**Severity**: `Medium` | **File**: `frontend/__mocks__/modules/next__router.ts:L3`

In the Next.js router mock, the property `pathmame` is defined instead of `pathname`. This typo will cause any code relying on `pathname` to receive `undefined`, potentially breaking routing logic in tests.

## Solution

Change `pathmame` to `pathname` in the mock return object.

## Changes

- `frontend/__mocks__/modules/next__router.ts` (modified)