### PR TITLE
fix(emails) MPP-4684: remove Feedback-ID as promotional email signal

### DIFF
--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -3212,7 +3212,9 @@ def test_build_reply_requires_premium_email_after_forward():
     [
         ([{"name": "List-Unsubscribe", "value": "https://example.com/unsub"}], True),
         ([{"name": "list-id", "value": "<list.example.com>"}], True),
-        ([{"name": "Feedback-ID", "value": "campaign:sender:amazonses.com"}], True),
+        # Feedback-ID alone is not a reliable signal — many ESPs (SendGrid,
+        # Mailgun, Amazon SES) attach it to transactional mail too (MPP-4684).
+        ([{"name": "Feedback-ID", "value": "campaign:sender:amazonses.com"}], False),
         ([{"name": "Precedence", "value": "bulk"}], True),
         ([{"name": "Precedence", "value": "list"}], True),
         # Precedence: first-class is not a list signal
@@ -3226,14 +3228,14 @@ def test_build_reply_requires_premium_email_after_forward():
             ],
             True,
         ),
-        # Feedback-ID mixed with non-list headers
+        # Feedback-ID without list headers is not blocked (MPP-4684)
         (
             [
                 {"name": "From", "value": "support@duolingo.com"},
                 {"name": "Feedback-ID", "value": "campaign:amazonses.com"},
                 {"name": "Subject", "value": "Welcome!"},
             ],
-            True,
+            False,
         ),
         # transactional email with no list headers
         (

--- a/emails/views.py
+++ b/emails/views.py
@@ -890,10 +890,6 @@ def _check_email_from_list(headers):
         # as standard indicators that an email was sent by a mailing list.
         if name.startswith("list-"):
             return True
-        # Feedback-ID is required by Google for bulk senders and used by many
-        # ESPs to track campaigns. Transactional emails do not include it.
-        if name == "feedback-id":
-            return True
         # Precedence: bulk or list is a classic indicator of bulk mail.
         if name == "precedence" and header["value"].lower() in ("bulk", "list"):
             return True


### PR DESCRIPTION
`Feedback-ID` is not a reliable indicator of promotional email. Many ESPs (SendGrid, Mailgun, Amazon SES) attach it to all outbound mail, including transactional messages like verification codes and password resets. This caused "Block Promotional Emails" to silently drop legitimate emails.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #MPP-4684.

How to test:
  1. Create a Premium Relay account (or use an existing one).
  2. Create a mask with "Block Promotional Emails" enabled.
  3. Use that mask to sign up for Reddit (or any service that sends verification emails through an ESP like SendGrid or Mailgun).
     * [ ] Verify the verification code email arrives at your real inbox.
  4. (Optional): Send a real promotional/mailing-list email (with `List-Unsubscribe` or `Precedence:` bulk headers) to the same mask.
     * [ ] Verify it is still blocked.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).