### PR TITLE
build(playwright): add ability to use FXA CI production secret

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,9 @@ on:
       E2E_TEST_BASE_URL:
         required: true
       FXA_CI_SECRET:
-        required: true 
+        required: true
+      FXA_PROD_CI_SECRET:
+        required: false 
   workflow_dispatch:
     inputs:
       environment:
@@ -71,6 +73,7 @@ jobs:
           E2E_TEST_ACCOUNT_PREMIUM: ${{ secrets.E2E_TEST_ACCOUNT_PREMIUM }}
           E2E_TEST_BASE_URL: ${{ secrets.E2E_TEST_BASE_URL }}
           FXA_CI_SECRET: ${{ secrets.FXA_CI_SECRET }}
+          FXA_PROD_CI_SECRET: ${{ secrets.FXA_PROD_CI_SECRET }}
       - name: Send GitHub Action trigger data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3

--- a/e2e-tests/e2eTestUtils/helpers.ts
+++ b/e2e-tests/e2eTestUtils/helpers.ts
@@ -45,8 +45,18 @@ const STRIP_FXA_CI_PATTERNS = [
   "**/*.paypal.com/**",
 ];
 
+// Returns the appropriate FxA CI secret based on the environment.
+// Production tests use FXA_PROD_CI_SECRET, while dev/stage/local use FXA_CI_SECRET.
+export function getFxaCiSecret(): string | undefined {
+  const env = process.env.E2E_TEST_ENV;
+  if (env === "prod" && process.env.FXA_PROD_CI_SECRET) {
+    return process.env.FXA_PROD_CI_SECRET;
+  }
+  return process.env.FXA_CI_SECRET;
+}
+
 export async function setupFxaCiRoutes(page: Page) {
-  if (!process.env.FXA_CI_SECRET) return;
+  if (!getFxaCiSecret()) return;
   const stripFxaCi = (route: any) => {
     const headers = { ...route.request().headers() };
     delete headers["fxa-ci"];

--- a/e2e-tests/e2eTestUtils/helpers.ts
+++ b/e2e-tests/e2eTestUtils/helpers.ts
@@ -49,7 +49,10 @@ const STRIP_FXA_CI_PATTERNS = [
 // Production tests use FXA_PROD_CI_SECRET, while dev/stage/local use FXA_CI_SECRET.
 export function getFxaCiSecret(): string | undefined {
   const env = process.env.E2E_TEST_ENV;
-  if (env === "prod" && process.env.FXA_PROD_CI_SECRET) {
+  if (env === "prod") {
+    if (!process.env.FXA_PROD_CI_SECRET) {
+      throw new Error("FXA_PROD_CI_SECRET is required for prod environment");
+    }
     return process.env.FXA_PROD_CI_SECRET;
   }
   return process.env.FXA_CI_SECRET;

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -1,5 +1,6 @@
 import {
   ENV_URLS,
+  getFxaCiSecret,
   getVerificationCode,
   setEnvVariables,
   setupFxaCiRoutes,
@@ -12,10 +13,9 @@ const { chromium } = require("@playwright/test");
 async function globalSetup() {
   // playwright setup
   const browser = await chromium.launch();
+  const fxaCiSecret = getFxaCiSecret();
   const page = await browser.newPage({
-    extraHTTPHeaders: process.env.FXA_CI_SECRET
-      ? { "fxa-ci": process.env.FXA_CI_SECRET }
-      : {},
+    extraHTTPHeaders: fxaCiSecret ? { "fxa-ci": fxaCiSecret } : {},
   });
   await setupFxaCiRoutes(page);
 

--- a/e2e-tests/pages/dashboardPage.ts
+++ b/e2e-tests/pages/dashboardPage.ts
@@ -142,10 +142,26 @@ export class DashboardPage {
   }
 
   async skipOnboarding() {
-    const onboardingElem = this.page.getByRole("button", { name: "Skip" });
+    // Premium onboarding step 1 shows "Set up Relay Premium" instead of Skip.
+    const setupBtn = this.page.getByRole("button", {
+      name: "Set up Relay Premium",
+    });
+    if (await setupBtn.isVisible({ timeout: TIMEOUTS.SHORT })) {
+      await setupBtn.click();
+      // Steps 2 and 3 each have a Skip button; click through both.
+      const skipBtn = this.page.getByRole("button", { name: /Skip/ });
+      for (let i = 0; i < 2; i++) {
+        if (await skipBtn.isVisible({ timeout: TIMEOUTS.SHORT })) {
+          await skipBtn.click();
+        }
+      }
+      return;
+    }
 
-    if (await onboardingElem.isVisible({ timeout: TIMEOUTS.LONG })) {
-      await onboardingElem.click();
+    // Free-tier onboarding has a single Skip button.
+    const freeSkip = this.page.getByRole("button", { name: "Skip" });
+    if (await freeSkip.isVisible({ timeout: TIMEOUTS.SHORT })) {
+      await freeSkip.click();
     }
   }
 
@@ -232,6 +248,9 @@ export class DashboardPage {
     await this.page.waitForURL(/\/accounts\/profile\//, {
       timeout: TIMEOUTS.LONG,
     });
+
+    // Dismiss onboarding if the account was reset or is new.
+    await this.skipOnboarding();
 
     // DRF SessionAuthentication requires X-CSRFToken on mutating requests.
     // Use browser fetch (via page.evaluate) so the Origin header is sent,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { devices, defineConfig } from '@playwright/test';
+import { getFxaCiSecret } from './e2e-tests/e2eTestUtils/helpers';
 
 /**
  * Read environment variables from file.
@@ -82,8 +83,8 @@ const config = defineConfig({
     /* Send fxa-ci header to bypass Fastly CAPTCHA on FxA stage.
        setupFxaCiRoutes() strips this header from non-FxA domains
        to avoid CORS preflight failures. */
-    extraHTTPHeaders: process.env.FXA_CI_SECRET ? {
-      'fxa-ci': process.env.FXA_CI_SECRET,
+    extraHTTPHeaders: getFxaCiSecret() ? {
+      'fxa-ci': getFxaCiSecret(),
     } : {},
 
   },


### PR DESCRIPTION
This PR fixes MPP-4676 to allow a second FXA secret for production environment testing.

How to test:
- [x] Add secret to GH
- [x] Run E2E tests against prod using this branch

Checklist:
- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] I've added or updated relevant docs in the docs/ directory.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).