### PR TITLE
fix(phones): fix MPP-4688: convert Django ValidationError to 400 in relay number creation

### DIFF
--- a/api/tests/phones_views_tests.py
+++ b/api/tests/phones_views_tests.py
@@ -571,6 +571,25 @@ def test_relaynumber_post_with_existing_returns_error(phone_user, mocked_twilio_
     mock_create.assert_not_called()
 
 
+def test_relaynumber_post_unsupported_country_returns_400(
+    phone_user, mocked_twilio_client
+):
+    _make_real_phone(phone_user, verified=True)
+    mock_create = Mock()
+    mocked_twilio_client.incoming_phone_numbers.create = mock_create
+
+    client = APIClient()
+    client.force_authenticate(phone_user)
+    path = "/api/v1/relaynumber/"
+    data = {"number": "+447911123456"}
+    response = client.post(path, data, format="json")
+
+    assert response.status_code == 400
+    decoded_content = response.content.decode()
+    assert "supported country" in decoded_content
+    mock_create.assert_not_called()
+
+
 def test_relaynumber_patch_to_toggle(phone_user, mocked_twilio_client):
     _make_real_phone(phone_user, verified=True)
     relay_number = _make_relay_number(phone_user)

--- a/api/views/phones.py
+++ b/api/views/phones.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models.query import QuerySet
 from django.forms import model_to_dict
 
@@ -317,7 +317,10 @@ class RelayNumberViewSet(SaveToRequestUser, viewsets.ModelViewSet):
         existing_number = RelayNumber.objects.filter(user=request.user)
         if existing_number:
             raise exceptions.ValidationError("User already has a RelayNumber.")
-        return super().create(request, *args, **kwargs)
+        try:
+            return super().create(request, *args, **kwargs)
+        except ValidationError as e:
+            raise exceptions.ValidationError(e.message)
 
     def partial_update(self, request, *args, **kwargs):
         """


### PR DESCRIPTION
`RelayNumber.save()` raises `django.core.exceptions.ValidationError`, which DRF does not handle. The error passed through as a 500. Catch it in `RelayNumberViewSet.create()` and re-raise as a DRF `ValidationError` so the client gets a 400.

This PR fixes MPP-4688.

How to test:
  1. Run: `pytest api/tests/phones_views_tests.py` — all 163 tests pass
  2. Log in as a phone-subscribed user with a verified real phone and no existing relay number
  3. `POST` to `/api/v1/relaynumber/` with `{"number": "+447911123456"}` (UK number)
  4. Verify the response is `400` (not `500`) with "supported country" in the body
  5. Confirm no new Sentry errors are created for the request

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).