### PR TITLE
fix(masks): fix MPP-4679: skip abuse metric for email-auto-created domain addresses

### DIFF
--- a/emails/models.py
+++ b/emails/models.py
@@ -268,7 +268,11 @@ class DomainAddress(models.Model):
             ).exists():
                 raise DomainAddrDuplicateException(duplicate_address=self.address)
 
-            self.user.profile.update_abuse_metric(address_created=True)
+            # MPP-4679: Only count toward abuse limits if user creates the mask.
+            # Addresses auto-created by inbound email (first_emailed_at is set)
+            # may not be user-initiated, so shouldn't flag the user's account.
+            if not self.first_emailed_at:
+                self.user.profile.update_abuse_metric(address_created=True)
             self.user.profile.last_engagement = datetime.now(UTC)
             self.user.profile.save(update_fields=["last_engagement"])
             incr_if_enabled("domainaddress.create")

--- a/emails/tests/models_tests.py
+++ b/emails/tests/models_tests.py
@@ -600,6 +600,21 @@ class DomainAddressTest(TestCase):
         self.user.profile.refresh_from_db()
         assert self.user.profile.last_engagement == pre_save_last_engagement
 
+    @override_settings(MAX_ADDRESS_CREATION_PER_DAY=10)
+    def test_email_auto_created_addresses_do_not_flag_account(self) -> None:
+        for i in range(15):
+            DomainAddress.make_domain_address(self.user, f"auto-{i}", True)
+        self.user.profile.refresh_from_db()
+        assert not self.user.profile.is_flagged
+        assert DomainAddress.objects.filter(user=self.user).count() == 15
+
+    @override_settings(MAX_ADDRESS_CREATION_PER_DAY=10)
+    def test_api_created_addresses_flag_account(self) -> None:
+        for i in range(10):
+            DomainAddress.make_domain_address(self.user, f"api-{i}")
+        self.user.profile.refresh_from_db()
+        assert self.user.profile.is_flagged
+
     def test_delete_updates_profile_last_engagement(self) -> None:
         domain_address = DomainAddress.make_domain_address(self.user, address="delete")
         assert self.user.profile.last_engagement


### PR DESCRIPTION
Inbound email to a subdomain auto-creates `DomainAddress` records.

Skip `update_abuse_metric` when `first_emailed_at` is set, so only user-initiated mask creation counts toward the abuse threshold.

This PR fixes MPP-4679.

How to test:
  1. Set `MAX_ADDRESS_CREATION_PER_DAY=10` in your environment
  2. Create a premium user with a subdomain via the admin or shell
  3. Send 15+ emails to random addresses at the user's subdomain
     (e.g., random1@subdomain.mozmail.com through random15@...)
     using the SNS email handler or test fixtures
  4. Verify: the user's account is NOT flagged (`profile.is_flagged == False`)
     and all 15 DomainAddress records exist
  5. Now create 10 masks via the API (`POST /api/v1/domainaddresses/`)
  6. Verify: the user's account IS flagged after the 10th API-created mask

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).