### PR TITLE
feat(api): add cache-control headers and per-user rate limits to high-traffic endpoints

### DIFF
--- a/api/tests/emails_views_tests.py
+++ b/api/tests/emails_views_tests.py
@@ -886,6 +886,16 @@ def test_get_relayaddress_ordered_by_created_at_desc(
     assert data[2]["id"] == addr_oldest.id
 
 
+@pytest.mark.django_db
+def test_relayaddress_list_cache_control(
+    free_api_client: APIClient, free_user: User
+) -> None:
+    RelayAddress.objects.create(user=free_user)
+    response = free_api_client.get(reverse("relayaddress-list"))
+    assert response.status_code == 200
+    assert response["Cache-Control"] == "private, max-age=60"
+
+
 def test_first_forwarded_email_unauth(client: Client) -> None:
     response = client.post("/api/v1/first-forwarded-email/")
     assert response.status_code == 401

--- a/api/tests/privaterelay_views_tests.py
+++ b/api/tests/privaterelay_views_tests.py
@@ -111,6 +111,20 @@ def test_runtime_data_uses_sp3_plan_mapping(client: Client) -> None:
     )
 
 
+@pytest.mark.django_db
+def test_runtime_data_cache_control(client: Client) -> None:
+    response = client.get(reverse("runtime_data"))
+    assert response.status_code == 200
+    assert response["Cache-Control"] == "public, max-age=300"
+
+
+@pytest.mark.django_db
+def test_profile_list_cache_control(free_api_client: APIClient) -> None:
+    response = free_api_client.get(reverse("profiles-list"))
+    assert response.status_code == 200
+    assert response["Cache-Control"] == "private, max-age=60"
+
+
 def test_patch_premium_user_subdomain_cannot_be_changed(
     premium_user: User, prem_api_client: Client
 ) -> None:

--- a/api/views/emails.py
+++ b/api/views/emails.py
@@ -1,7 +1,7 @@
 """API views for emails"""
 
 from logging import getLogger
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from django.apps import apps
 from django.conf import settings
@@ -15,6 +15,7 @@ from django_filters import rest_framework as filters
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework.decorators import api_view, permission_classes, throttle_classes
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 from rest_framework.status import (
@@ -42,6 +43,11 @@ from ..serializers.emails import (
 from . import SaveToRequestUser
 
 logger = getLogger("events")
+
+
+class AddressRateThrottle(UserRateThrottle):
+    scope = "address"
+    rate = settings.ADDRESS_RATE_LIMIT
 
 
 class RelayAddressFilter(filters.FilterSet):
@@ -113,6 +119,16 @@ class AddressViewSet(Generic[_Address], SaveToRequestUser, ModelViewSet):
             is_random_mask=is_random_mask,
         )
 
+    def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        response = super().list(request, *args, **kwargs)
+        response["Cache-Control"] = "private, max-age=60"
+        return response
+
+    def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        response = super().retrieve(request, *args, **kwargs)
+        response["Cache-Control"] = "private, max-age=60"
+        return response
+
 
 @extend_schema(tags=["emails"])
 class RelayAddressViewSet(AddressViewSet[RelayAddress]):
@@ -120,6 +136,7 @@ class RelayAddressViewSet(AddressViewSet[RelayAddress]):
 
     serializer_class = RelayAddressSerializer
     permission_classes = [IsAuthenticated, IsOwner]
+    throttle_classes = [AddressRateThrottle]
     filterset_class = RelayAddressFilter
 
     def get_queryset(self) -> QuerySet[RelayAddress]:
@@ -159,6 +176,7 @@ class DomainAddressViewSet(AddressViewSet[DomainAddress]):
 
     serializer_class = DomainAddressSerializer
     permission_classes = [IsAuthenticated, IsOwner]
+    throttle_classes = [AddressRateThrottle]
     filterset_class = DomainAddressFilter
 
     def get_queryset(self) -> QuerySet[DomainAddress]:

--- a/api/views/privaterelay.py
+++ b/api/views/privaterelay.py
@@ -35,6 +35,7 @@ from rest_framework.status import (
     HTTP_202_ACCEPTED,
     HTTP_400_BAD_REQUEST,
 )
+from rest_framework.throttling import UserRateThrottle
 from rest_framework.viewsets import ModelViewSet
 from sentry_sdk import capture_exception
 from waffle import flag_is_active, get_waffle_flag_model
@@ -62,18 +63,34 @@ FXA_PROFILE_URL = (
 )
 
 
+class ProfileRateThrottle(UserRateThrottle):
+    scope = "profile"
+    rate = settings.PROFILE_RATE_LIMIT
+
+
 @extend_schema(tags=["privaterelay"])
 class ProfileViewSet(ModelViewSet):
     """Relay user extended profile data."""
 
     serializer_class = ProfileSerializer
     permission_classes = [IsAuthenticated, IsOwner]
+    throttle_classes = [ProfileRateThrottle]
     http_method_names = ["get", "post", "head", "put", "patch"]
 
     def get_queryset(self) -> QuerySet[Profile]:
         if isinstance(self.request.user, User):
             return Profile.objects.filter(user=self.request.user)
         return Profile.objects.none()
+
+    def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        response = super().list(request, *args, **kwargs)
+        response["Cache-Control"] = "private, max-age=60"
+        return response
+
+    def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        response = super().retrieve(request, *args, **kwargs)
+        response["Cache-Control"] = "private, max-age=60"
+        return response
 
 
 @extend_schema(tags=["privaterelay"])
@@ -219,7 +236,7 @@ def runtime_data(request):
     phone_plans = get_sp3_country_language_mapping("phones")
     bundle_plans = get_sp3_country_language_mapping("bundle")
     megabundle_plans = get_sp3_country_language_mapping("megabundle")
-    return Response(
+    response = Response(
         {
             "FXA_ORIGIN": settings.FXA_BASE_ORIGIN,
             "PERIODICAL_PREMIUM_PRODUCT_ID": settings.PERIODICAL_PREMIUM_PROD_ID,
@@ -254,6 +271,8 @@ def runtime_data(request):
             ),
         }
     )
+    response["Cache-Control"] = "public, max-age=300"
+    return response
 
 
 @extend_schema(

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -788,6 +788,15 @@ PHONE_RATE_LIMIT = config("PHONE_RATE_LIMIT", _DEFAULT_PHONE_RATE_LIMIT)
 
 VCARD_RATE_LIMIT = config("VCARD_RATE_LIMIT", "10/minute")
 
+if IN_PYTEST or RELAY_CHANNEL in ["local", "dev", "stage"]:
+    _DEFAULT_PROFILE_RATE_LIMIT = "1000/minute"
+    _DEFAULT_ADDRESS_RATE_LIMIT = "1000/minute"
+else:
+    _DEFAULT_PROFILE_RATE_LIMIT = "30/minute"
+    _DEFAULT_ADDRESS_RATE_LIMIT = "30/minute"
+PROFILE_RATE_LIMIT = config("PROFILE_RATE_LIMIT", _DEFAULT_PROFILE_RATE_LIMIT)
+ADDRESS_RATE_LIMIT = config("ADDRESS_RATE_LIMIT", _DEFAULT_ADDRESS_RATE_LIMIT)
+
 # Turn on logging out on GET in development.
 # This allows `/mock/logout/` in the front-end to clear the
 # session cookie. Without this, after switching accounts in dev mode,


### PR DESCRIPTION
Defense-in-depth against client-driven request surges like the FF 151 incident ([IIM-173](https://mozilla-hub.atlassian.net/browse/IIM-173)). Browser-side `Cache-Control` headers prevent re-fetching for 60s even when client-side caching breaks. Per-user throttles (30/min) cap runaway loops at the origin.

- `Profile`, `RelayAddress`, `DomainAddress` `GET`s: `Cache-Control: private, max-age=60`
- `ProfileViewSet`: 30/min per-user throttle via `PROFILE_RATE_LIMIT` (scope `"profile"`)
- `RelayAddress`/`DomainAddress` `ViewSets`: 30/min per-user throttle via `ADDRESS_RATE_LIMIT` (scope `"address"`)
- Distinct throttle scopes keep profile and address limits in separate buckets instead of colliding on the default `"user"` scope
- Rate limits relaxed to 1000/min in test/local/dev environments

`runtime_data` is intentionally left uncached: its response varies per user (waffle flags, request geo) and SWR already memoizes it for the session, so a shared/edge cache would risk cross-user data.

This PR fixes MPP-4692.

How to test:


- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

[IIM-173]: https://mozilla-hub.atlassian.net/browse/IIM-173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ