### PR TITLE
fix(emails): hide Relay user's real email in reply body

### DIFF
--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -979,6 +979,28 @@ class SNSNotificationRepliesTest(SNSNotificationTestBase):
             expected_fixture_name="s3_stored_replies",
         )
 
+    def test_reply_hides_relay_user_real_email_in_body(self) -> None:
+        """
+        The user's real email is replaced with the mask in the reply body.
+
+        A client like Outlook quotes the original message, which can include the
+        user's real email (e.g. in a quoted "To:" line). It must not leak to the
+        recipient (MPP-1395 / #1377).
+        """
+        self.mock_get_content.return_value = create_email_from_notification(
+            EMAIL_SNS_BODIES["s3_stored_replies"],
+            text=(
+                "My reply.\n\nOn Mon, sender wrote:\n"
+                "> To: SOURCE@sender.com\n> original quoted text\n"
+            ),
+        )
+        response = _sns_notification(EMAIL_SNS_BODIES["s3_stored_replies"])
+        assert response.status_code == 200
+        self.mock_send_raw_email.assert_called_once()
+        raw_message = self.mock_send_raw_email.call_args[1]["RawMessage"]["Data"]
+        assert "source@sender.com" not in raw_message.lower()
+        assert "a1b2c3d4@test.com" in raw_message
+
     @patch("emails.views._reply_allowed")
     def test_reply_not_allowed(self, mocked_reply_allowed: Mock) -> None:
         mocked_reply_allowed.return_value = False

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -137,13 +137,13 @@ SEND_RAW_EMAIL_FAILED = ClientError(
 
 
 def create_email_from_notification(
-    notification: AWS_SNSMessageJSON, text: str
+    notification: AWS_SNSMessageJSON, text: str, html: str | None = None
 ) -> bytes:
     """
     Create an email from an SNS notification, return the serialized bytes.
 
     The email will have the headers from the notification and the `text` value as the
-    plain text body.
+    plain text body. If `html` is given, it is added as an HTML alternative.
     """
     message_json = notification.get("Message")
     assert message_json
@@ -157,6 +157,8 @@ def create_email_from_notification(
         email[entry["name"]] = entry["value"]
     assert email["Content-Type"].startswith("multipart/alternative")
     email.add_alternative(text, subtype="plain")
+    if html is not None:
+        email.add_alternative(html, subtype="html")
     return email.as_bytes()
 
 
@@ -985,13 +987,18 @@ class SNSNotificationRepliesTest(SNSNotificationTestBase):
 
         A client like Outlook quotes the original message, which can include the
         user's real email (e.g. in a quoted "To:" line). It must not leak to the
-        recipient (MPP-1395 / #1377).
+        recipient in either the plain text or HTML body (MPP-1395 / #1377).
         """
         self.mock_get_content.return_value = create_email_from_notification(
             EMAIL_SNS_BODIES["s3_stored_replies"],
             text=(
                 "My reply.\n\nOn Mon, sender wrote:\n"
                 "> To: SOURCE@sender.com\n> original quoted text\n"
+            ),
+            html=(
+                "<html><body>My reply."
+                "<blockquote>To: SOURCE@sender.com</blockquote>"
+                "</body></html>"
             ),
         )
         response = _sns_notification(EMAIL_SNS_BODIES["s3_stored_replies"])

--- a/emails/views.py
+++ b/emails/views.py
@@ -1225,6 +1225,33 @@ def _replace_headers(
     return issues
 
 
+def _replace_reply_email_in_body(
+    email: EmailMessage, real_address: str, mask_address: str
+) -> None:
+    """
+    Replace the Relay user's real email with their mask in the reply body.
+
+    Relay rewrites a reply's headers to the mask address, but the body is sent as-is.
+    When a user replies from a client that includes the quoted original message,
+    it can include the user's real email (such as in a quoted "To:" line), exposing
+    it to the recipient (MPP-1395 / #1377). Replace it in the plain text and
+    HTML bodies. Matching is case-insensitive because email addresses are.
+    """
+    pattern = re.compile(re.escape(real_address), re.IGNORECASE)
+
+    text_body = email.get_body("plain")
+    if isinstance(text_body, EmailMessage):
+        new_content, count = pattern.subn(mask_address, text_body.get_content())
+        if count:
+            text_body.set_content(new_content)
+
+    html_body = email.get_body("html")
+    if isinstance(html_body, EmailMessage):
+        new_content, count = pattern.subn(mask_address, html_body.get_content())
+        if count:
+            html_body.set_content(new_content, subtype="html")
+
+
 def _convert_html_content(
     html_content: str,
     to_address: str,
@@ -1461,6 +1488,7 @@ def _handle_reply(
     # Convert to a reply email
     # TODO: Issue #1747 - Remove wrapper / prefix in replies
     _replace_headers(email, headers)
+    _replace_reply_email_in_body(email, address.user.email, outbound_from_address)
 
     try:
         ses_send_raw_email(


### PR DESCRIPTION
Relay rewrites a reply's headers to the mask but sent the body as-is. Clients like Outlook quote the original message, which can include the user's real email in a quoted "To:" line, leaking it to the recipient.

Replace the user's real email with the mask in the plain text and HTML reply bodies, mirroring the get_body/set_content pattern the forwarding flow already uses.

This PR fixes #1377, MPP-1395

How to test (easier on dev server):
1. From an external address, send an email to a (premium) Relay mask.
2. From the account's real inbox (e.g. Outlook web), reply to the forwarded message, leaving the quoted original text in place. (or you can manually force this by just typing the real email address in the reply)
3. View the received reply at the external sender.
   - The reply's From and the quoted "To:" line both show the mask (a1b2c3d4@test.com style), not the user's real email.
   - The user's real email appears nowhere in the message body.
4. Edge case: reply with mixed-case real email in the quote — matching is case-insensitive, so it is still masked.


- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).