### PR TITLE
fix(frontend): bypass browser cache on API reads so mutations refresh

### DIFF
--- a/frontend/src/hooks/api/api.test.ts
+++ b/frontend/src/hooks/api/api.test.ts
@@ -36,6 +36,23 @@ describe("useApiV1", () => {
     });
   });
 
+  it("fetches with cache: no-store so mutate() bypasses the browser cache (MPP-4717)", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    } as Response;
+    (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+    renderHook(() => useApiV1("/realphone", { dedupingInterval: 0 }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ cache: "no-store" }),
+      );
+    });
+  });
+
   it("shows a toast when we 500", async () => {
     const mockRuntimeConfig = mockConfigModule.getRuntimeConfig();
     mockConfigModule.getRuntimeConfig.mockReturnValueOnce({

--- a/frontend/src/hooks/api/api.ts
+++ b/frontend/src/hooks/api/api.ts
@@ -37,6 +37,12 @@ export const authenticatedFetch = async (
     headers.set("X-CSRFToken", csrfToken);
   }
   const options: Parameters<typeof fetch>[1] = {
+    // Bypass the browser HTTP cache. The API sends Cache-Control: max-age=60 on
+    // list endpoints to protect the origin from the autofill client, but that
+    // stops SWR from revalidating after a mutation, leaving the dashboard stale
+    // (MPP-4717). no-store keeps SWR reads fresh; the origin is still capped by
+    // the per-user throttle.
+    cache: "no-store",
     ...init,
     headers: headers,
     credentials: "include",


### PR DESCRIPTION
MPP-4692 added `Cache-Control: max-age=60` to the address and profile list endpoints to protect the origin from the autofill client. That header also made the browser serve a stale list to SWR after a delete or block/forward toggle, so the dashboard did not update until a page refresh. Deleting the same row twice then hit a 404.

Set `cache: "no-store"` on the fetcher so SWR reads always revalidate. The `Cache-Control` header still helps the autofill client, and the per-user throttle still caps the origin.

This PR fixes MPP-4717.

How to test:
1. Sign into the Relay dashboard with a few masks.
2. Expand a mask and delete it. Repeat on another mask.
3. Toggle a mask between forwarding and blocking.
4. Verify the list updates each time with no page refresh.
5. In DevTools Network, confirm `GET /api/v1/relayaddresses/` returns a real 200, not "(from disk cache)".

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).