### PR TITLE
fix(api): reject unowned masks in first-forwarded-email endpoint

### DIFF
--- a/api/tests/emails_views_tests.py
+++ b/api/tests/emails_views_tests.py
@@ -16,6 +16,7 @@ from rest_framework.test import APIClient
 from waffle.testutils import override_flag
 
 from emails.models import DomainAddress, RelayAddress
+from emails.utils import get_domains_from_settings
 from privaterelay.tests.utils import (
     create_expected_glean_event,
     get_glean_event,
@@ -953,3 +954,18 @@ def test_first_forwarded_email_success(
     assert response.status_code == 201
     assert response.content == b""
     mock_ses_client.send_email.assert_called_once()
+
+
+def test_first_forwarded_email_other_users_subdomain_no_create(
+    free_api_client: APIClient,
+    premium_user: User,
+) -> None:
+    """A mask on another user's subdomain returns 404 without creating it (MPP-4689)."""
+    mozmail_domain = get_domains_from_settings()["MOZMAIL_DOMAIN"]
+    mask = f"attacker-label@{premium_user.profile.subdomain}.{mozmail_domain}"
+    with override_flag("free_user_onboarding", True):
+        response = free_api_client.post(
+            "/api/v1/first-forwarded-email/", {"mask": mask}
+        )
+    assert response.status_code == 404
+    assert not DomainAddress.objects.filter(user=premium_user).exists()

--- a/api/views/emails.py
+++ b/api/views/emails.py
@@ -228,8 +228,11 @@ def first_forwarded_email(request):
     mask = str(serializer.data.get("mask"))
     user = request.user
     try:
-        address = _get_address(mask)
-        RelayAddress.objects.get(user=user, address=address)
+        # create=False so an unowned mask cannot be side-effect created on
+        # another user's account before the ownership check below (MPP-4689).
+        address = _get_address(mask, create=False)
+        if not isinstance(address, RelayAddress) or address.user_id != user.id:
+            raise RelayAddress.DoesNotExist()
     except ObjectDoesNotExist:
         return Response(f"{mask} does not exist for user.", status=HTTP_404_NOT_FOUND)
     profile = user.profile


### PR DESCRIPTION
`POST /api/v1/first-forwarded-email/` called `_get_address(mask)` with the default `create=True`, so a mask on another user's subdomain was created on that user's account before the ownership check ran. This let a free user write masks into a victim's inventory and bump the victim's daily abuse counter.

Pass `create=False` and make the ownership check explicit and type-aware, so no `DomainAddress` is created and only a `RelayAddress` owned by the caller is accepted.

This PR fixes MPP-4689.

How to test:
1. Enable the `free_user_onboarding` waffle flag.
2. Set up two accounts: a free "attacker" and a premium "victim" with a claimed subdomain (e.g. victim-sub).
3. As the free user, `POST` to `/api/v1/first-forwarded-email/` with `{"mask": "any-label@victim-sub.mozmail.com"}`.
   * [ ] Verify the response is `404` "... does not exist for user."
   * [ ] Verify no new mask appears in the victim's `/api/v1/domainaddresses/` inventory, and the victim's daily abuse counter did not increment.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).