### PR TITLE
fix MPP-4700: surface OAuth token failure on profile refresh

### DIFF
--- a/frontend/src/hooks/api/profile.test.ts
+++ b/frontend/src/hooks/api/profile.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { useProfiles } from "./profile";
+import { profileFetcher, useProfiles } from "./profile";
 
 jest.mock("./api", () => {
   const actual = jest.requireActual("./api");
@@ -171,5 +171,56 @@ describe("useProfiles", () => {
       await result.current.setSubdomain("another-subdomain");
     expect(subdomainResponse).toBe(mockSubdomainResponse);
     expect(mockMutate).toHaveBeenCalled();
+  });
+});
+
+describe("profileFetcher", () => {
+  const mockApiFetch = jest.fn();
+  const mockAuthenticatedFetch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const api = jest.requireMock("./api");
+    api.apiFetch = mockApiFetch;
+    api.authenticatedFetch = mockAuthenticatedFetch;
+    // Set location.search without redefining the locked-down location object.
+    window.history.replaceState({}, "", "/?fxa_refresh=1");
+  });
+
+  it("re-authenticates and stops fetching when a refresh returns 401", async () => {
+    // jsdom cannot actually navigate, and logs an error when the fetcher calls
+    // document.location.assign. Silence that expected noise.
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockAuthenticatedFetch.mockResolvedValue({
+      status: 401,
+      redirected: false,
+    });
+
+    // The fetcher never resolves once it triggers a redirect, so don't await it.
+    profileFetcher("/profiles/", {});
+
+    await waitFor(() => {
+      expect(mockAuthenticatedFetch).toHaveBeenCalledWith(
+        "/accounts/profile/refresh",
+      );
+    });
+    // It must not fall through to fetch and return stale profile data.
+    expect(mockApiFetch).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("fetches profile data after a successful refresh", async () => {
+    mockAuthenticatedFetch.mockResolvedValue({
+      status: 200,
+      redirected: false,
+      json: async () => ({}),
+    });
+    const profile = createMockProfile();
+    mockApiFetch.mockResolvedValue({ ok: true, json: async () => [profile] });
+
+    const data = await profileFetcher("/profiles/", {});
+
+    expect(data).toEqual([profile]);
+    expect(mockApiFetch).toHaveBeenCalledWith("/profiles/", {});
   });
 });

--- a/frontend/src/hooks/api/profile.ts
+++ b/frontend/src/hooks/api/profile.ts
@@ -1,4 +1,5 @@
 import useSWR, { SWRConfig, SWRResponse } from "swr";
+import { getRuntimeConfig } from "../../config";
 import { DateString } from "../../functions/parseDate";
 import { apiFetch, authenticatedFetch, FetchError } from "./api";
 
@@ -110,7 +111,7 @@ export function useProfiles(): SWRResponse<ProfilesData, unknown> & {
  * The reason that it's needed is that we have to tell the back-end to re-fetch data from
  * Mozilla Accounts if the user was sent back here after trying to subscribe to Premium.
  */
-const profileFetcher = async (
+export const profileFetcher = async (
   url: string,
   requestInit: RequestInit,
 ): Promise<ProfilesData> => {
@@ -121,6 +122,12 @@ const profileFetcher = async (
     const refreshResponse = await authenticatedFetch(
       "/accounts/profile/refresh",
     );
+    // A 401 or a redirect means the stored Mozilla Accounts token is no longer
+    // valid. Send the user to re-authenticate instead of leaving stale data.
+    if (refreshResponse.status === 401 || refreshResponse.redirected) {
+      document.location.assign(getRuntimeConfig().fxaLoginUrl);
+      return new Promise<ProfilesData>(() => {});
+    }
     await refreshResponse.json();
   }
 

--- a/privaterelay/tests/views_tests.py
+++ b/privaterelay/tests/views_tests.py
@@ -10,7 +10,9 @@ from unittest.mock import Mock, patch
 from uuid import uuid4
 
 from django.contrib.auth.models import User
+from django.http import HttpResponse
 from django.test import Client, TestCase, override_settings
+from django.urls import reverse
 from django.utils import timezone
 
 import jwt
@@ -24,6 +26,7 @@ from cryptography.hazmat.primitives.asymmetric.rsa import (
 )
 from markus.testing import MetricsMock
 from model_bakery import baker
+from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
 from pytest_django.fixtures import SettingsWrapper
 from requests import PreparedRequest
 
@@ -38,7 +41,7 @@ from privaterelay.tests.utils import premium_subscription
 from ..apps import PrivateRelayConfig
 from ..fxa_utils import NoSocialToken
 from ..models import Profile
-from ..views import _update_all_data, fxa_verifying_keys
+from ..views import _update_all_data, fxa_verifying_keys, update_fxa
 
 
 def test_no_social_token():
@@ -163,6 +166,41 @@ class UpdateExtraDataAndEmailTest(TestCase):
 
         ea = sa.user.emailaddress_set.get()
         assert ea.email == new_email
+
+
+@pytest.mark.django_db
+def test_update_fxa_returns_401_on_oauth_error() -> None:
+    """A stale-scope token failure returns 401 and is still reported to Sentry."""
+    user = baker.make(User)
+    sa: SocialAccount = baker.make(SocialAccount, user=user, provider="fxa")
+    mock_client = Mock()
+    mock_client.get.side_effect = CustomOAuth2Error("Invalid scopes")
+
+    with (
+        patch("privaterelay.views._get_oauth2_session", return_value=mock_client),
+        patch("privaterelay.views.sentry_sdk.capture_exception") as mock_capture,
+    ):
+        response = update_fxa(sa)
+
+    assert response.status_code == 401
+    mock_capture.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_profile_refresh_redirects_to_login_on_oauth_error(client: Client) -> None:
+    """profile_refresh sends the user to re-authenticate when the token fails."""
+    user = baker.make(User)
+    baker.make(SocialAccount, user=user, provider="fxa")
+    client.force_login(user)
+
+    with patch(
+        "privaterelay.views.update_fxa",
+        return_value=HttpResponse(status=401),
+    ):
+        response = client.get("/accounts/profile/refresh")
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == reverse("fxa_login")
 
 
 @pytest.mark.django_db

--- a/privaterelay/views.py
+++ b/privaterelay/views.py
@@ -60,7 +60,9 @@ def profile_refresh(request):
     profile = request.user.profile
 
     fxa = _get_fxa(request)
-    update_fxa(fxa)
+    response = update_fxa(fxa)
+    if response.status_code == 401:
+        return redirect(reverse("fxa_login"))
     if "clicked-purchase" in request.COOKIES and profile.has_premium:
         event = "user_purchased_premium"
         incr_if_enabled(event, 1)
@@ -304,8 +306,12 @@ def update_fxa_inner(
     try:
         resp = client.get(FirefoxAccountsOAuth2Adapter.profile_url)
     except CustomOAuth2Error as e:
+        # The stored OAuth token has scopes FxA no longer accepts, so the token
+        # refresh fails. Return 401 so the browser-facing profile_refresh can
+        # send the user to re-authenticate. The fxa_rp_events webhook ignores
+        # this return value, so its behavior is unchanged.
         sentry_sdk.capture_exception(e)
-        return HttpResponse("202 Accepted", status=202)
+        return HttpResponse("Authentication with Mozilla Accounts failed", status=401)
 
     sentry_context["profile_status_code"] = resp.status_code
     try:


### PR DESCRIPTION
A stale-scope Mozilla Accounts token made profile refresh fail without telling the user. The error was caught and returned 202, so the browser kept showing old profile data. Now the refresh returns 401 and sends the user to re-authenticate.


This PR fixes MPP-4700.

How to test:
1. Sign up as a new user with Mozilla Accounts. Confirm you land in the dashboard as a signed-in user.
2. Log out. Log back in with the same account. Confirm you return to the dashboard signed in.
3. Close the tab. Open the site again in the same browser. Confirm you return as a signed-in user without re-entering credentials.
4. While signed in, reload the dashboard a few times. Confirm your profile data (email, plan) stays correct and you are never bounced to login.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).