### PR TITLE
feat(emails): cap worker DB statement time

### DIFF
--- a/emails/management/commands/process_emails_from_sqs.py
+++ b/emails/management/commands/process_emails_from_sqs.py
@@ -20,8 +20,10 @@ from typing import Any, cast
 from urllib.parse import urlsplit
 
 from django import setup
+from django.conf import settings
 from django.core.management.base import CommandError
 from django.db import connection
+from django.db.backends.base.base import BaseDatabaseWrapper
 from django.http import HttpResponse
 
 import boto3
@@ -495,6 +497,34 @@ def run_sns_inbound_logic(
         if not cursor.db.is_usable():
             cursor.db.close()
 
+    set_worker_statement_timeout(connection)
+
     result = cast(HttpResponse, _sns_inbound_logic(topic_arn, message_type, json_body))
     connection.close()
     return result
+
+
+def set_worker_statement_timeout(conn: BaseDatabaseWrapper) -> None:
+    """Cap how long a single query runs on the worker's DB connection.
+
+    Email processing can wait on a locked row. One example is the per-user daily
+    abuse counter in Profile.update_abuse_metric, which two pods can contend on
+    when they process email for the same user at once. That wait is bounded by
+    lock_timeout, which is set on the Cloud SQL instance itself (see
+    webservices-infra). This adds statement_timeout as a backstop for any query
+    that runs long for some other reason.
+
+    statement_timeout is set here on the worker, not on the instance, because
+    migrations and the cleanup cron jobs share the same database and run long on
+    purpose. A cap on the whole instance would kill them. Web and API
+    connections are unaffected. See MPP-4723.
+    """
+    if conn.vendor != "postgresql":
+        return
+    statement_ms = int(settings.PROCESS_EMAIL_STATEMENT_TIMEOUT_SECONDS * 1000)
+    with conn.cursor() as cursor:
+        # set_config with a bind parameter avoids interpolating into a SET statement.
+        # false = session-level, so it persists for the life of this connection.
+        cursor.execute(
+            "SELECT set_config('statement_timeout', %s, false)", [str(statement_ms)]
+        )

--- a/emails/tests/mgmt_process_emails_statement_timeout_tests.py
+++ b/emails/tests/mgmt_process_emails_statement_timeout_tests.py
@@ -1,0 +1,49 @@
+"""Tests for the email worker's Postgres statement_timeout. See MPP-4723.
+
+These live apart from mgmt_process_emails_from_sqs_tests.py because that module
+mocks django.db.connection for every test. The behavior here needs a real
+database connection, so a slow query is actually canceled.
+"""
+
+from unittest.mock import Mock
+
+from django.db import OperationalError, connection
+
+import pytest
+from pytest_django.fixtures import SettingsWrapper
+
+from emails.management.commands.process_emails_from_sqs import (
+    set_worker_statement_timeout,
+)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_statement_timeout_cancels_slow_query(settings: SettingsWrapper) -> None:
+    """A query that runs past statement_timeout is canceled by the database.
+
+    Skipped on non-PostgreSQL backends, where the worker sets no timeout.
+    """
+    if connection.vendor != "postgresql":
+        pytest.skip("statement_timeout is a PostgreSQL feature")
+
+    settings.PROCESS_EMAIL_STATEMENT_TIMEOUT_SECONDS = 0.1
+    set_worker_statement_timeout(connection)
+
+    try:
+        with pytest.raises(OperationalError, match="statement timeout"):
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT pg_sleep(1)")
+    finally:
+        # Clear the session timeout so it does not affect test teardown.
+        with connection.cursor() as cursor:
+            cursor.execute("SET statement_timeout = 0")
+
+
+def test_statement_timeout_skips_non_postgresql() -> None:
+    """On non-PostgreSQL backends (e.g. SQLite), no timeout is set."""
+    conn = Mock(spec_set=["vendor", "cursor"])
+    conn.vendor = "sqlite"
+
+    set_worker_statement_timeout(conn)
+
+    conn.cursor.assert_not_called()

--- a/privaterelay/settings.py
+++ b/privaterelay/settings.py
@@ -954,6 +954,14 @@ PROCESS_EMAIL_MAX_SECONDS_PER_MESSAGE = config(
     PROCESS_EMAIL_MAX_SECONDS or 120.0,
     cast=float,
 )
+# Cap how long a single query runs on the worker's DB session, as a backstop for
+# a slow query. Applied only in the worker subprocess; web and API connections are
+# unaffected. The row-lock wait is bounded separately by lock_timeout, set on the
+# Cloud SQL instance in webservices-infra. 0 disables (Postgres semantics).
+# See MPP-4723.
+PROCESS_EMAIL_STATEMENT_TIMEOUT_SECONDS = config(
+    "PROCESS_EMAIL_STATEMENT_TIMEOUT_SECONDS", 30.0, cast=float
+)
 
 # Django 3.2 switches default to BigAutoField
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"


### PR DESCRIPTION
The email worker had no limit on how long a query could run. Set statement_timeout on the worker's Postgres session as a backstop for a slow query.

The row-lock wait is set separately by lock_timeout on the Cloud SQL instance in webservices-infra.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes https://mozilla-hub.atlassian.net/browse/MPP-4723.

How to test:
1. Merge this so it landes on the dev server.
2. Check the dev server email job still works.
3. Check the dev server logs show "Message processed" with normal `message_process_time_s` and no new "statement timeout" / OperationalError errors from the relay-emails container.
  * We *DO* expect to see `message_process_time_s` log messages when we get to the next prod surge of emails.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).