### PR TITLE
fix(analytics): strip URL fragment before reporting pageviews

### DIFF
--- a/frontend/src/components/layout/PageMetadata.tsx
+++ b/frontend/src/components/layout/PageMetadata.tsx
@@ -15,7 +15,10 @@ export const PageMetadata = () => {
       <meta name="description" content={l10n.getString("meta-description-2")} />
       <meta
         property="og:url"
-        content={getRuntimeConfig().frontendOrigin + router.asPath}
+        content={
+          getRuntimeConfig().frontendOrigin +
+          (router.asPath ?? "").split("#")[0]
+        }
       />
       <meta property="og:type" content="website" />
       <meta property="og:title" content={l10n.getString("meta-title")} />

--- a/frontend/src/pages/_app.page.test.tsx
+++ b/frontend/src/pages/_app.page.test.tsx
@@ -193,6 +193,20 @@ describe("MyApp component", () => {
     expect(ReactGa.pageview).not.toHaveBeenCalled();
   });
 
+  it("strips the URL fragment from the tracker report pageview (MPP-4722)", async () => {
+    mockedUseMetrics.mockReturnValue("enabled");
+    mockedUseGoogleAnalytics.mockReturnValue(true);
+    mockedUseRouter.mockReturnValue(
+      createMockRouter(
+        "/tracker-report/",
+        '/tracker-report/#{"sender":"sender@example.test"}',
+      ),
+    );
+    render(<MyApp {...defaultAppProps} />);
+    await waitForNextTick();
+    expect(ReactGa.pageview).toHaveBeenCalledWith("/tracker-report/");
+  });
+
   it("provides addon data context and sets element attributes based on login state", () => {
     const mockAddonData = {
       present: true,

--- a/frontend/src/pages/_app.page.tsx
+++ b/frontend/src/pages/_app.page.tsx
@@ -42,7 +42,10 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   useEffect(() => {
     if (!googleAnalytics) return;
-    ReactGa.pageview(router.asPath);
+    // Strip the URL fragment before reporting the pageview. Tracker report
+    // pages carry email metadata (sender, trackers, original link) in the
+    // fragment, and that data must not leave the client. See MPP-4722.
+    ReactGa.pageview((router.asPath ?? "").split("#")[0]);
   }, [router.asPath, googleAnalytics]);
 
   const [waitingForMsw, setIsWaitingForMsw] = useState(


### PR DESCRIPTION
Tracker report pages carry email metadata (sender, trackers, original link) in the URL fragment so it stays on the client. The global pageview hook `reported router.asPath`, which includes the fragment, sending that metadata to Google Analytics. Strip the fragment before the pageview and in the `og:url` meta tag.

This PR fixes MPP-4722.

How to test:
1. `cd frontend && npm run dev:mocked`
2. Open a tab and open the dev tools console
3. Navigate to http://localhost:3000/tracker-report/#{"sender":"sender@example.test","received_at":1655288077484,"trackers":{"ads.googletagmanager.com":2}}
4. In the dev tools console, find the react-ga debug line for pageview
   * [ ] Expected (fixed): the path is `/tracker-report/`. No #, no sender, no trackers.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).