### PR TITLE
fix(emails) MPP-4739: tracker regex backtracking

### DIFF
--- a/emails/tests/utils_tests.py
+++ b/emails/tests/utils_tests.py
@@ -1,8 +1,10 @@
 import base64
 import json
 import random
+import signal
 import zlib
 from base64 import b64encode
+from types import FrameType
 from typing import Literal, TypedDict
 from unittest.mock import patch
 from urllib.parse import quote_plus
@@ -391,6 +393,36 @@ class RemoveTrackers(TestCase):
         assert changed_content == content
         assert general_removed == 0
         assert general_count == 0
+
+
+@override_settings(SITE_ORIGIN="https://test.com")
+def test_remove_trackers_does_not_backtrack_on_dotted_url() -> None:
+    """A non-matching dotted URL must not blow up the tracker regex.
+
+    Uses the real tracker list, not a stub. The other tests here patch it down to
+    three domains, which is fast no matter how bad the pattern is. The cost is
+    paid by every domain that fails to match, so only the full list shows it.
+    """
+    url = "https://click.mailer.example/r?u=" + "seg." * 20 + "end&id=9"
+    content = f'<a href="{url}">click</a>'
+
+    def on_timeout(signum: int, frame: FrameType | None) -> None:
+        raise AssertionError("remove_trackers did not finish in 10s; regex backtracked")
+
+    # Fail fast on a regression. Without a bound, the old pattern runs for hours
+    # on 20 dots instead of failing, which is useless in a test suite.
+    previous = signal.signal(signal.SIGALRM, on_timeout)
+    signal.alarm(10)
+    try:
+        changed_content, tracker_details = remove_trackers(
+            content, "spammer@email.com", "1682472064"
+        )
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous)
+
+    assert changed_content == content
+    assert tracker_details["tracker_removed"] == 0
 
 
 def test_encode_dict_gza85() -> None:

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -442,7 +442,8 @@ def set_user_group(user):
 
 
 def convert_domains_to_regex_patterns(domain_pattern):
-    return r"""(["'])(\S*://(\S*\.)*""" + re.escape(domain_pattern) + r"\S*)\1"
+    # A subdomain label must not contain a dot, or this backtracks. See MPP-4739.
+    return r"""(["'])(\S*://([^\s"'.]*\.)*""" + re.escape(domain_pattern) + r"\S*)\1"
 
 
 def count_tracker(html_content, trackers):


### PR DESCRIPTION
`convert_domains_to_regex_patterns` built a subdomain match from `(\S*\.)*`. `\S*` matches a dot, so a dotted URL could be split into groups exponentially many ways, and the engine tried them all before failing. Cost grew about 4x per added dot.

Every one of the 214 level-one tracker domains paid that cost, because they all fail to match. `remove_trackers` then scanned the content three times, and `_convert_html_content` added two more passes when tracker sampling was on. A 130-byte email holding one link with 17 dots ran past the worker's 120s per-message kill. Prod saw about 1200 kills a day across 400 messages, each retried three times, or roughly 40 pod-hours a day.

Replace `\S*` with `[^\s"'.]*` so a subdomain label cannot contain a dot. The regex now has one way to match a URL instead of many, so it no longer backtracks. The same URLs still match: checked against the old pattern across 17 URL shapes with no difference.

Add a guard test that runs the real tracker list under a 10s alarm. The existing tests stub the list down to three domains, which is fast whatever the pattern does, so they could not catch this.

This PR fixes MPP-4739.

How to test:
1. Confirm tests still pass
2. Run the following code on main and on this branch:
```
       from emails.utils import remove_trackers
       url = "https://click.mailer.example/r?u=" + "seg." * 18 + "end&id=9"
       remove_trackers(f'<a href="{url}">x</a>', "s@example.com", 1700000000000)
```
   * [ ] On this branch, it should return immediately. On `main`, it takes significantly longer.

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).