### PR TITLE
ci(dependabot): group codeql-action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,6 +85,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 8
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action/*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot opens a separate PR for each `github/codeql-action` sub-action. The workflow pins `init`, `autobuild`, and `analyze` to the same SHA. Each bump became three PRs: https://github.com/mozilla/fx-private-relay/pulls?q=is%3Apr+is%3Aopen+codeql-action

Group them so the bumps arrive as one PR.

How to test:
1. Merge this PR
2. Close the 3 separate open PRs
3. Comment `@dependabot recreate` on one of them
   * [ ] Dependabot should recreate a new single PR to update `codeql-action`

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).