### PR TITLE
Fix 6602 review findings

### DIFF
--- a/frontend/src/pages/_app.page.test.tsx
+++ b/frontend/src/pages/_app.page.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 // eslint-disable-next-line testing-library/no-manual-cleanup
 import { act, render, screen, cleanup } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { hydrateRoot } from "react-dom/client";
 import { axe } from "jest-axe";
 import type { AppProps } from "next/app";
 import { useRouter } from "next/router";
@@ -37,6 +39,10 @@ import {
 } from "../hooks/googleAnalytics";
 import { useAddonElementWatcher } from "../hooks/addon";
 import { getL10n } from "../functions/getL10n";
+// The `useL10n` hook is mocked project-wide in jest.setup.ts, so it can't tell
+// us which bundle the provider actually holds. Hence the raw hook here:
+// eslint-disable-next-line no-restricted-imports
+import { useLocalization } from "@fluent/react";
 import type { ReactLocalization } from "@fluent/react";
 import type { LocalLabel } from "../hooks/localLabels";
 
@@ -60,6 +66,9 @@ setMockRuntimeData();
 
 const mockL10n = {
   bundles: [{ locales: ["en"] }],
+} as unknown as ReactLocalization;
+const mockNegotiatedL10n = {
+  bundles: [{ locales: ["nl"] }],
 } as unknown as ReactLocalization;
 
 const MockComponent = () => <div>Test Component</div>;
@@ -146,8 +155,9 @@ describe("MyApp component", () => {
 
   it("initializes l10n, renders providers, and handles component rendering", async () => {
     const { container } = render(<MyApp {...defaultAppProps} />);
-    // In a browser environment (jsdom), l10n is initialized with
-    // non-deterministic locales via the useState lazy initializer.
+    // Both bundles are built: the deterministic one for the render that has to
+    // match the pre-rendered HTML, and the negotiated one for after that.
+    expect(mockedGetL10n).toHaveBeenCalledWith({ deterministicLocales: true });
     expect(mockedGetL10n).toHaveBeenCalledWith({ deterministicLocales: false });
 
     expect(screen.getByText("Test Component")).toBeInTheDocument();
@@ -155,6 +165,35 @@ describe("MyApp component", () => {
     const overlayProvider = container.querySelector("#overlayProvider");
     expect(overlayProvider).toBeInTheDocument();
     expect(overlayProvider).toHaveAttribute("id", "overlayProvider");
+  });
+
+  it("keeps the hydration render on the deterministic `en` bundle", async () => {
+    mockedGetL10n.mockImplementation(({ deterministicLocales }) =>
+      deterministicLocales ? mockL10n : mockNegotiatedL10n,
+    );
+    const renderedLocales: string[] = [];
+    const LocaleSpy = () => {
+      const [bundle] = [...useLocalization().l10n.bundles];
+      renderedLocales.push(bundle.locales[0]);
+      return <div>Locale spy</div>;
+    };
+    const appProps = { ...defaultAppProps, Component: LocaleSpy };
+
+    const mountPoint = document.createElement("div");
+    mountPoint.innerHTML = renderToString(<MyApp {...appProps} />);
+    document.body.appendChild(mountPoint);
+    renderedLocales.length = 0;
+
+    const root = await act(async () =>
+      hydrateRoot(mountPoint, <MyApp {...appProps} />),
+    );
+
+    // Anything but `en` first would mismatch the pre-rendered HTML.
+    expect(renderedLocales[0]).toBe("en");
+    expect(renderedLocales[renderedLocales.length - 1]).toBe("nl");
+
+    await act(async () => root.unmount());
+    mountPoint.remove();
   });
 
   it("handles Google Analytics initialization and pageview tracking", async () => {

--- a/frontend/src/pages/_app.page.test.tsx
+++ b/frontend/src/pages/_app.page.test.tsx
@@ -15,7 +15,14 @@ jest.mock("../hooks/session");
 jest.mock("../hooks/metrics");
 jest.mock("../hooks/googleAnalytics");
 jest.mock("../hooks/addon");
-jest.mock("../functions/getL10n");
+// `_app.page.tsx` builds both bundles at import time, before any test body runs.
+jest.mock("../functions/getL10n", () => ({
+  getL10n: jest.fn(
+    ({ deterministicLocales }: { deterministicLocales: boolean }) => ({
+      bundles: [{ locales: [deterministicLocales ? "en" : "nl"] }],
+    }),
+  ),
+}));
 jest.mock("react-ga", () => ({
   __esModule: true,
   default: {
@@ -43,7 +50,6 @@ import { getL10n } from "../functions/getL10n";
 // us which bundle the provider actually holds. Hence the raw hook here:
 // eslint-disable-next-line no-restricted-imports
 import { useLocalization } from "@fluent/react";
-import type { ReactLocalization } from "@fluent/react";
 import type { LocalLabel } from "../hooks/localLabels";
 
 const mockedUseIsLoggedIn = useIsLoggedIn as jest.MockedFunction<
@@ -61,15 +67,13 @@ const mockedUseAddonElementWatcher =
 const mockedGetL10n = getL10n as jest.MockedFunction<typeof getL10n>;
 const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
 
+// `clearMocks` wipes these before the first test runs, so record them here.
+const l10nOptionsAtImport = mockedGetL10n.mock.calls.map(
+  ([options]) => options,
+);
+
 setMockProfileData();
 setMockRuntimeData();
-
-const mockL10n = {
-  bundles: [{ locales: ["en"] }],
-} as unknown as ReactLocalization;
-const mockNegotiatedL10n = {
-  bundles: [{ locales: ["nl"] }],
-} as unknown as ReactLocalization;
 
 const MockComponent = () => <div>Test Component</div>;
 
@@ -139,7 +143,6 @@ describe("MyApp component", () => {
       localLabels: [],
       sendEvent: jest.fn(),
     });
-    mockedGetL10n.mockReturnValue(mockL10n);
     mockedUseRouter.mockReturnValue(createMockRouter());
   });
 
@@ -153,13 +156,15 @@ describe("MyApp component", () => {
     expect(results).toHaveNoViolations();
   }, 10000);
 
-  it("initializes l10n, renders providers, and handles component rendering", async () => {
-    const { container } = render(<MyApp {...defaultAppProps} />);
-    // Both bundles are built: the deterministic one for the render that has to
-    // match the pre-rendered HTML, and the negotiated one for after that.
-    expect(mockedGetL10n).toHaveBeenCalledWith({ deterministicLocales: true });
-    expect(mockedGetL10n).toHaveBeenCalledWith({ deterministicLocales: false });
+  it("builds both l10n bundles", () => {
+    expect(l10nOptionsAtImport).toStrictEqual([
+      { deterministicLocales: true },
+      { deterministicLocales: false },
+    ]);
+  });
 
+  it("renders providers and handles component rendering", async () => {
+    const { container } = render(<MyApp {...defaultAppProps} />);
     expect(screen.getByText("Test Component")).toBeInTheDocument();
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     const overlayProvider = container.querySelector("#overlayProvider");
@@ -168,9 +173,6 @@ describe("MyApp component", () => {
   });
 
   it("keeps the hydration render on the deterministic `en` bundle", async () => {
-    mockedGetL10n.mockImplementation(({ deterministicLocales }) =>
-      deterministicLocales ? mockL10n : mockNegotiatedL10n,
-    );
     const renderedLocales: string[] = [];
     const LocaleSpy = () => {
       const [bundle] = [...useLocalization().l10n.bundles];

--- a/frontend/src/pages/_app.page.tsx
+++ b/frontend/src/pages/_app.page.tsx
@@ -1,19 +1,14 @@
 import "../styles/globals.scss";
-import {
-  createElement,
-  useEffect,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { createElement, useEffect, useRef, useState } from "react";
 import type { AppProps } from "next/app";
 import { useRouter } from "next/router";
-import { LocalizationProvider, ReactLocalization } from "@fluent/react";
+import { LocalizationProvider } from "@fluent/react";
 import { OverlayProvider } from "react-aria";
 import ReactGa from "react-ga";
 import { getL10n } from "../functions/getL10n";
 import { AddonDataContext, useAddonElementWatcher } from "../hooks/addon";
 import { ReactAriaI18nProvider } from "../components/ReactAriaI18nProvider";
+import { useHasRenderedClientSide } from "../hooks/hasRenderedClientSide";
 import { useIsLoggedIn } from "../hooks/session";
 import { useMetrics } from "../hooks/metrics";
 import {
@@ -22,18 +17,12 @@ import {
 } from "../hooks/googleAnalytics";
 import "@stripe/stripe-js";
 
-// The l10n bundles never change, so there is nothing to subscribe to. We only
-// use useSyncExternalStore because it is the one hook that can return a
-// different value while React is still matching the DOM against the
-// pre-rendered HTML than it returns afterwards. The `useL10n` hook uses the
-// same trick.
-const subscribeToNothing = () => () => {};
-const useIsHydrating = () =>
-  useSyncExternalStore(
-    subscribeToNothing,
-    () => false,
-    () => true,
-  );
+// The `en` bundle serves the pre-render and the hydration render; the user's
+// preferred locales take over after that. See the `useL10n` hook.
+// @fluent/react can't load locales asynchronously on the client yet, see
+// https://github.com/projectfluent/fluent.js/wiki/ReactLocalization/43a959b35fbf9eea694367f948cfb1387914657c#flexibility
+const deterministicL10n = getL10n({ deterministicLocales: true });
+const negotiatedL10n = getL10n({ deterministicLocales: false });
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
@@ -43,21 +32,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   const addonDataElementRef = useRef<HTMLElement>(null);
 
   const addonData = useAddonElementWatcher(addonDataElementRef);
-  // When pre-rendering and during hydration, we deterministically load the `en`
-  // bundle. React compares the pre-rendered HTML against the first client-side
-  // render, and at build time we don't know the user's locale, so that first
-  // render has to stay English. Only after hydration do we load the bundles for
-  // the user's preferred locales. (See the `useL10n` hook for more detail.)
-  // Unfortunately we can't load additional needed locales asynchronously
-  // on the client-side yet using @fluent/react, see
-  // https://github.com/projectfluent/fluent.js/wiki/ReactLocalization/43a959b35fbf9eea694367f948cfb1387914657c#flexibility
-  const [deterministicL10n] = useState<ReactLocalization>(() =>
-    getL10n({ deterministicLocales: true }),
-  );
-  const [negotiatedL10n] = useState<ReactLocalization>(() =>
-    getL10n({ deterministicLocales: false }),
-  );
-  const l10n = useIsHydrating() ? deterministicL10n : negotiatedL10n;
+  const l10n = useHasRenderedClientSide() ? negotiatedL10n : deterministicL10n;
 
   useEffect(() => {
     if (metricsEnabled === "enabled" && !googleAnalytics) {

--- a/frontend/src/pages/_app.page.tsx
+++ b/frontend/src/pages/_app.page.tsx
@@ -1,5 +1,11 @@
 import "../styles/globals.scss";
-import { createElement, useEffect, useRef, useState } from "react";
+import {
+  createElement,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import type { AppProps } from "next/app";
 import { useRouter } from "next/router";
 import { LocalizationProvider, ReactLocalization } from "@fluent/react";
@@ -16,6 +22,19 @@ import {
 } from "../hooks/googleAnalytics";
 import "@stripe/stripe-js";
 
+// The l10n bundles never change, so there is nothing to subscribe to. We only
+// use useSyncExternalStore because it is the one hook that can return a
+// different value while React is still matching the DOM against the
+// pre-rendered HTML than it returns afterwards. The `useL10n` hook uses the
+// same trick.
+const subscribeToNothing = () => () => {};
+const useIsHydrating = () =>
+  useSyncExternalStore(
+    subscribeToNothing,
+    () => false,
+    () => true,
+  );
+
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const isLoggedIn = useIsLoggedIn();
@@ -24,15 +43,21 @@ function MyApp({ Component, pageProps }: AppProps) {
   const addonDataElementRef = useRef<HTMLElement>(null);
 
   const addonData = useAddonElementWatcher(addonDataElementRef);
-  // When pre-rendering, we deterministically load the `en` bundle.
-  // On the client, we load the bundles relevant to the user's preferred
-  // locales. (See the `useL10n` hook for more detail on why.)
+  // When pre-rendering and during hydration, we deterministically load the `en`
+  // bundle. React compares the pre-rendered HTML against the first client-side
+  // render, and at build time we don't know the user's locale, so that first
+  // render has to stay English. Only after hydration do we load the bundles for
+  // the user's preferred locales. (See the `useL10n` hook for more detail.)
   // Unfortunately we can't load additional needed locales asynchronously
   // on the client-side yet using @fluent/react, see
   // https://github.com/projectfluent/fluent.js/wiki/ReactLocalization/43a959b35fbf9eea694367f948cfb1387914657c#flexibility
-  const [l10n] = useState<ReactLocalization>(() =>
-    getL10n({ deterministicLocales: typeof window === "undefined" }),
+  const [deterministicL10n] = useState<ReactLocalization>(() =>
+    getL10n({ deterministicLocales: true }),
   );
+  const [negotiatedL10n] = useState<ReactLocalization>(() =>
+    getL10n({ deterministicLocales: false }),
+  );
+  const l10n = useIsHydrating() ? deterministicL10n : negotiatedL10n;
 
   useEffect(() => {
     if (metricsEnabled === "enabled" && !googleAnalytics) {

--- a/frontend/src/pages/mock/login.page.tsx
+++ b/frontend/src/pages/mock/login.page.tsx
@@ -138,7 +138,7 @@ const MockLogin: NextPage = () => {
 // Wrapped in a function so eslint-plugin-react-hooks doesn't flag it
 // as an impure call during render (it specifically tracks Date.now).
 function getTimestamp(): number {
-  return getTimestamp();
+  return Date.now();
 }
 
 function byUseDate(a: UsedToken, b: UsedToken) {

--- a/frontend/src/pages/mock/login.page.tsx
+++ b/frontend/src/pages/mock/login.page.tsx
@@ -39,7 +39,9 @@ const MockLogin: NextPage = () => {
   const onLogin: FormEventHandler = (event) => {
     event.preventDefault();
 
-    login(token, getTimestamp());
+    // Safe here: event handler, not render. In render it would break hydration.
+    // eslint-disable-next-line react-hooks/purity
+    login(token, Date.now());
   };
 
   const login = async (token: string, timestamp: number) => {
@@ -67,7 +69,8 @@ const MockLogin: NextPage = () => {
 
   const chooseToken = (token: string) => {
     setToken(token);
-    login(token, getTimestamp());
+    // eslint-disable-next-line react-hooks/purity
+    login(token, Date.now());
   };
 
   const existingTokenElements = usedTokens
@@ -134,12 +137,6 @@ const MockLogin: NextPage = () => {
     </div>
   );
 };
-
-// Wrapped in a function so eslint-plugin-react-hooks doesn't flag it
-// as an impure call during render (it specifically tracks Date.now).
-function getTimestamp(): number {
-  return Date.now();
-}
 
 function byUseDate(a: UsedToken, b: UsedToken) {
   return b.lastUsed - a.lastUsed;


### PR DESCRIPTION
This PR fixes review comments from @Vinnl: https://github.com/mozilla/fx-private-relay/pull/6602#pullrequestreview-4819510587.

How to test:
  1. `cd frontend && npm run dev:mocked`
  2. Open http://localhost:3000/mock/login
  3. Click any mock account button.
     * [ ] You land on the dashboard and the console shows no "too much recursion" error
  4. Set your browser's preferred language to one Relay translates, such as Dutch.
  5. Reload the site
     * [ ] no React hydration errors in the console

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).