### PR TITLE
fix(emails): stop silently dropping emails SES rejects

### DIFF
--- a/emails/management/commands/process_emails_from_sqs.py
+++ b/emails/management/commands/process_emails_from_sqs.py
@@ -374,6 +374,7 @@ class Command(CommandFromDjangoSettings):
         Return is a dict suitable for logging context, with these keys:
         * success: True if message was processed successfully
         * error: The processing error, omitted on success
+        * status_code: The HTTP status from the email code, omitted if it raised
         * message_body_quoted: Set if the message was non-JSON, omitted for valid JSON
         * pause_count: Set to 1 if paused due to temporary error, or omitted
           with no error
@@ -409,9 +410,18 @@ class Command(CommandFromDjangoSettings):
             return results
 
         def success_callback(result: HttpResponse) -> None:
-            """Handle return from successful call to _sns_inbound_logic"""
-            # TODO: extract data from _sns_inbound_logic return
-            pass
+            """Handle return from a call to _sns_inbound_logic that did not raise.
+
+            The email code signals a retryable failure by returning 5xx rather than
+            raising, so a 5xx is not a success. Counting it as one deletes the message
+            from the queue and loses the email.
+            """
+            status_code = result.status_code
+            results["status_code"] = status_code
+            if status_code >= 500:
+                incr_if_enabled("message_from_sqs_retryable_error")
+                results["success"] = False
+                results["error"] = f"_sns_inbound_logic returned {status_code}"
 
         def error_callback(exc_info: BaseException) -> None:
             """Handle exception raised by _sns_inbound_logic"""

--- a/emails/tests/fixtures/README.md
+++ b/emails/tests/fixtures/README.md
@@ -42,6 +42,8 @@ incoming email. Their names all end in `_email_sns_body.json`.
 These fixtures were created outside of an SNS notification, such as exporting from a
 mail client. They are stored in the [Internet Message Format][] (IMF).
 
+- `duplicate_mime_version_incoming.email` - Has two `MIME-Version` headers. SES rejects
+  a forwarded copy that keeps both.
 - `inline_image_incoming.email` - Contains an inline image, referenced in the HTML by
   content ID
 - `plain_text_incoming.email` - A simple email with only plain text content

--- a/emails/tests/fixtures/duplicate_mime_version_incoming.email
+++ b/emails/tests/fixtures/duplicate_mime_version_incoming.email
@@ -1,0 +1,11 @@
+Subject: Duplicate MIME-Version Email
+From: A server <root@server.example.com>
+To: ebsbdsan7@test.com
+Date: Wed, 27 Sep 2023 16:33:12 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+
+This email has two MIME-Version headers.
+SES rejects a forwarded copy that keeps both.

--- a/emails/tests/mgmt_process_emails_from_sqs_tests.py
+++ b/emails/tests/mgmt_process_emails_from_sqs_tests.py
@@ -94,8 +94,9 @@ def mock_django_db_connection() -> Iterator[Mock]:
 
 @pytest.fixture(autouse=True)
 def mock_sns_inbound_logic() -> Iterator[Mock]:
-    """Mock _sns_inbound_logic(topic_arn, message_type, json_body) to do nothing"""
+    """Mock _sns_inbound_logic(topic_arn, message_type, json_body) to return 200"""
     with patch(f"{MOCK_BASE}._sns_inbound_logic") as mock_sns_inbound_logic:
+        mock_sns_inbound_logic.return_value = HttpResponse(status=200)
         yield mock_sns_inbound_logic
 
 
@@ -320,6 +321,7 @@ def test_one_message(
     assert set(msg_extra.keys()) == {
         "message_process_time_s",
         "sqs_message_id",
+        "status_code",
         "success",
         "subprocess_setup_time_s",
     }
@@ -414,6 +416,22 @@ def test_ses_generic_failure(
     assert summary["total_messages"] == 1
     assert summary["failed_messages"] == 1
     msg.delete.assert_not_called()
+
+
+def test_retryable_5xx_is_not_deleted(
+    mock_sns_inbound_logic: Mock, mock_sqs_client: Mock, caplog: LogCaptureFixture
+) -> None:
+    """A 5xx from the email code is a failure, so the message stays on the queue."""
+    mock_sns_inbound_logic.return_value = HttpResponse(status=503)
+    msg = fake_sqs_message(json.dumps(TEST_SNS_MESSAGE))
+    mock_sqs_client.return_value = fake_queue([msg], [])
+    call_command(COMMAND_NAME)
+
+    assert summary_from_exit_log(caplog)["failed_messages"] == 1
+    msg.delete.assert_not_called()
+    msg_extra = log_extra(omit_markus_logs(caplog)[1])
+    assert msg_extra["success"] is False
+    assert msg_extra["error"] == "_sns_inbound_logic returned 503"
 
 
 def test_ses_python_error(

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -135,6 +135,18 @@ SEND_RAW_EMAIL_FAILED = ClientError(
     error_response={"Error": {"Code": "the code", "Message": "the message"}},
 )
 
+# Set mocked ses_client.send_raw_email.side_effect = SEND_RAW_EMAIL_REJECTED to
+# simulate a rejection that a retry cannot fix
+SEND_RAW_EMAIL_REJECTED = ClientError(
+    operation_name="SES.send_raw_email",
+    error_response={
+        "Error": {
+            "Code": "InvalidParameterValue",
+            "Message": "Duplicate header 'MIME-Version'.",
+        }
+    },
+)
+
 
 def create_email_from_notification(
     notification: AWS_SNSMessageJSON, text: str, html: str | None = None
@@ -2426,6 +2438,25 @@ class SNSNotificationValidUserEmailsInS3Test(TestCase):
         assert response.content == b"SES client error on Raw Email"
         self.assert_log_incoming_email_dropped(caplog, "error_sending", can_retry=True)
 
+    @override_settings(STATSD_ENABLED=True)
+    @patch("emails.apps.EmailsConfig.ses_client", spec_set=["send_raw_email"])
+    @patch("emails.views.get_message_content_from_s3")
+    def test_permanent_ses_rejection_is_counted_not_retried(
+        self, mocked_get_content: Mock, mocked_ses_client: Mock
+    ) -> None:
+        """A rejection that a retry cannot fix is counted instead of redriven."""
+        mocked_get_content.return_value = create_email_from_notification(
+            EMAIL_SNS_BODIES["s3_stored"], text="text_content"
+        )
+        mocked_ses_client.send_raw_email.side_effect = SEND_RAW_EMAIL_REJECTED
+
+        with self.assertLogs(INFO_LOG) as caplog, MetricsMock() as mm:
+            response = _sns_notification(EMAIL_SNS_BODIES["s3_stored"])
+        assert response.status_code == 400
+        assert response.content == b"SES permanently rejected the email"
+        self.assert_log_incoming_email_dropped(caplog, "error_sending", can_retry=False)
+        mm.assert_incr_once("ses_permanent_rejection")
+
     @patch("emails.apps.EmailsConfig.ses_client", spec_set=["send_raw_email"])
     @patch("emails.views.get_message_content_from_s3")
     def test_successful_email_in_s3_deleted(
@@ -3392,6 +3423,32 @@ def test_replace_headers_read_error_is_handled() -> None:
     # set to the desired new values.
     for name, value in new_headers.items():
         assert email[name] == value
+
+
+def test_replace_headers_drops_duplicate_mime_version() -> None:
+    """
+    Only the first copy of a duplicated header is forwarded.
+
+    SES rejects the whole message when MIME-Version appears twice. See MPP-4746.
+    """
+    email = message_from_string(
+        EMAIL_INCOMING["duplicate_mime_version"], policy=relay_policy
+    )
+    assert isinstance(email, EmailMessage)
+    assert email.get_all("MIME-Version") == ["1.0", "1.0"]
+
+    new_headers: OutgoingHeaders = {
+        "Subject": "Duplicate Header Test",
+        "From": "from@example.com",
+        "To": "to@example.com",
+    }
+    issues = _replace_headers(email, new_headers)
+
+    assert email.get_all("MIME-Version") == ["1.0"]
+    assert email.get_all("Content-Type") == ['text/plain; charset="utf-8"']
+    assert issues == [
+        {"header": "MIME-Version", "direction": "in", "duplicates_dropped": 1}
+    ]
 
 
 @pytest.mark.django_db

--- a/emails/types.py
+++ b/emails/types.py
@@ -43,10 +43,17 @@ class EmailHeaderDefectIssue(TypedDict):
     raw_value: str
 
 
+class EmailHeaderDuplicateIssue(TypedDict):
+    header: str
+    direction: Literal["in"]
+    duplicates_dropped: int
+
+
 EmailHeaderIssue = (
     EmailHeaderExceptionOnReadIssue
     | EmailHeaderExceptionOnWriteIssue
     | EmailHeaderDefectIssue
+    | EmailHeaderDuplicateIssue
 )
 
 EmailHeaderIssues = list[EmailHeaderIssue]

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -248,6 +248,17 @@ def ses_send_raw_email(
         raise
 
 
+# SES error codes that will fail the same way on every retry. The list is deliberately
+# short: an unrecognized code is treated as transient, so the message is retried and
+# ends up in the dead-letter queue instead of being discarded.
+PERMANENT_SES_ERROR_CODES = frozenset({"InvalidParameterValue"})
+
+
+def is_permanent_ses_error(error: ClientError) -> bool:
+    """Return True if SES will reject this message identically on every retry."""
+    return error.response.get("Error", {}).get("Code") in PERMANENT_SES_ERROR_CODES
+
+
 def urlize_and_linebreaks(text, autoescape=True):
     return linebreaksbr(urlize(text, autoescape=autoescape), autoescape=autoescape)
 

--- a/emails/views.py
+++ b/emails/views.py
@@ -76,6 +76,7 @@ from .utils import (
     get_reply_to_address,
     histogram_if_enabled,
     incr_if_enabled,
+    is_permanent_ses_error,
     parse_email_header,
     remove_message_from_s3,
     remove_trackers,
@@ -842,7 +843,14 @@ def _handle_received(message_json: AWS_SNSMessageJSON) -> HttpResponse:
             destination_address=destination_address,
             message=forwarded_email,
         )
-    except ClientError:
+    except ClientError as e:
+        if is_permanent_ses_error(e):
+            # A retry would be rejected the same way, so do not ask for one. Count the
+            # rejection instead, so the volume is visible and alertable.
+            incr_if_enabled("ses_permanent_rejection", 1)
+            logger.error("ses_permanent_rejection", extra=e.response["Error"])
+            log_email_dropped(reason="error_sending", mask=address, can_retry=False)
+            return HttpResponse("SES permanently rejected the email", status=400)
         # 503 service unavailable response to SNS so it can retry
         log_email_dropped(reason="error_sending", mask=address, can_retry=True)
         return HttpResponse("SES client error on Raw Email", status=503)
@@ -1170,19 +1178,46 @@ def _replace_headers(
                 }
             )
 
-    # Collect headers that will not be forwarded
+    # Collect headers that will not be forwarded, and the kept headers that appear
+    # more than once. SES rejects the whole message when a header it parses, such as
+    # MIME-Version or Content-Type, is duplicated, so only the first copy is kept.
+    first_kept: dict[str, str] = {}
+    duplicate_counts: dict[str, int] = {}
     for header in email.keys():
         header_lower = header.lower()
-        if (
-            header_lower not in replacements
-            and header_lower != "mime-version"
-            and not header_lower.startswith("content-")
-        ):
+        if header_lower in replacements:
+            # The replacement loop below deletes every copy and writes one new value
+            continue
+        if header_lower != "mime-version" and not header_lower.startswith("content-"):
             to_drop.append(header)
+        elif header_lower in first_kept:
+            duplicate_counts[header_lower] = duplicate_counts.get(header_lower, 0) + 1
+        else:
+            first_kept[header_lower] = header
 
     # Drop headers that should be dropped
     for header in to_drop:
         del email[header]
+
+    # Collapse each duplicated header to its first value
+    for header_lower, count in duplicate_counts.items():
+        header = first_kept[header_lower]
+        try:
+            value = email[header]
+        except Exception as e:
+            # The value cannot be read, so leave every copy in place
+            issues.append(
+                {"header": header, "direction": "in", "exception_on_read": repr(e)}
+            )
+        else:
+            del email[header]
+            # Assigning the parsed header object back keeps the original value.
+            # Assigning the raw string would fail on a folded header, because a folded
+            # value contains newlines.
+            email[header] = value
+            issues.append(
+                {"header": header, "direction": "in", "duplicates_dropped": count}
+            )
 
     # Replace the requested headers
     for header, value in headers.items():


### PR DESCRIPTION
Relay dropped between 800 and 1,300 emails a day in production, measured across two 24-hour windows. The user never got the mail and was never told. Two defects combined.

Some senders emit a duplicate MIME-Version header. _replace_headers keeps mime-version and every content-* header from the incoming email so the body still parses, but it kept every copy rather than the first. SES refuses a message with a duplicate header, so the forward failed. That was 93% of the volume.

The email code signals a retryable failure by returning 5xx rather than raising. Nothing read the status. success_callback in the SQS worker was an empty stub, so results["success"] stayed True and the batch loop deleted the message. PROCESS_EMAIL_DELETE_FAILED_MESSAGES defaults to False, so the intent was that failures are kept on the queue. The 5xx path defeated that. This defect is the older of the two: the worker has discarded the return value since its first commit in April 2022.

Collapse each duplicated kept header to its first value. Reassign the parsed header object rather than the raw string, because a folded raw value contains newlines and the email policy refuses to store those.

Have success_callback read result.status_code and mark a 5xx as failed. The message then stays on the queue and SQS redrives it, which is what every can_retry=True drop log already claimed was happening. This applies to every 5xx in the email path, not just SES failures: error_from_header and error_storage had the same silent deletion.

Retrying a permanent SES rejection costs three more sends and then dies in the DLQ, which the sqs-dlq cron deletes. Add is_permanent_ses_error, return 400 for those, and increment ses_permanent_rejection so the volume is counted rather than vanishing. The list holds one code, InvalidParameterValue. An unrecognized code stays transient, so an unexpected failure retries and ends up visible instead of discarded. The 400 also lets _sns_notification remove the S3 object, since no retry is coming.

See MPP-4746.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #<issue ID>.

How to test:

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] I've added or updated relevant docs in the docs/ directory.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description

# Screenshot (if applicable)

Not applicable.

# How to test

# Checklist (Definition of Done)

- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] Customer Experience team has seen or waived a demo of functionality.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] I've added or updated relevant docs in the docs/ directory
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] l10n changes have been submitted to the l10n repository, if any.
