### PR TITLE
fix(emails): drop duplicate MIME-Version and Content-Type headers

### DIFF
--- a/emails/tests/fixtures/README.md
+++ b/emails/tests/fixtures/README.md
@@ -42,6 +42,8 @@ incoming email. Their names all end in `_email_sns_body.json`.
 These fixtures were created outside of an SNS notification, such as exporting from a
 mail client. They are stored in the [Internet Message Format][] (IMF).
 
+- `duplicate_mime_version_incoming.email` - Has two `MIME-Version` headers. SES rejects
+  a forwarded copy that keeps both.
 - `inline_image_incoming.email` - Contains an inline image, referenced in the HTML by
   content ID
 - `plain_text_incoming.email` - A simple email with only plain text content

--- a/emails/tests/fixtures/duplicate_mime_version_incoming.email
+++ b/emails/tests/fixtures/duplicate_mime_version_incoming.email
@@ -1,0 +1,11 @@
+Subject: Duplicate MIME-Version Email
+From: A server <root@server.example.com>
+To: ebsbdsan7@test.com
+Date: Wed, 27 Sep 2023 16:33:12 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+
+This email has two MIME-Version headers.
+SES rejects a forwarded copy that keeps both.

--- a/emails/tests/views_tests.py
+++ b/emails/tests/views_tests.py
@@ -3394,6 +3394,32 @@ def test_replace_headers_read_error_is_handled() -> None:
         assert email[name] == value
 
 
+def test_replace_headers_drops_duplicate_mime_version() -> None:
+    """
+    Only the first copy of a duplicated header is forwarded.
+
+    SES rejects the whole message when MIME-Version appears twice. See MPP-4746.
+    """
+    email = message_from_string(
+        EMAIL_INCOMING["duplicate_mime_version"], policy=relay_policy
+    )
+    assert isinstance(email, EmailMessage)
+    assert email.get_all("MIME-Version") == ["1.0", "1.0"]
+
+    new_headers: OutgoingHeaders = {
+        "Subject": "Duplicate Header Test",
+        "From": "from@example.com",
+        "To": "to@example.com",
+    }
+    issues = _replace_headers(email, new_headers)
+
+    assert email.get_all("MIME-Version") == ["1.0"]
+    assert email.get_all("Content-Type") == ['text/plain; charset="utf-8"']
+    assert issues == [
+        {"header": "MIME-Version", "direction": "in", "duplicates_dropped": 1}
+    ]
+
+
 @pytest.mark.django_db
 def test_opt_out_user_has_minimal_email_dropped_log(caplog):
     user = baker.make(User, email="opt-out@example.com")

--- a/emails/types.py
+++ b/emails/types.py
@@ -43,10 +43,17 @@ class EmailHeaderDefectIssue(TypedDict):
     raw_value: str
 
 
+class EmailHeaderDuplicateIssue(TypedDict):
+    header: str
+    direction: Literal["in"]
+    duplicates_dropped: int
+
+
 EmailHeaderIssue = (
     EmailHeaderExceptionOnReadIssue
     | EmailHeaderExceptionOnWriteIssue
     | EmailHeaderDefectIssue
+    | EmailHeaderDuplicateIssue
 )
 
 EmailHeaderIssues = list[EmailHeaderIssue]

--- a/emails/views.py
+++ b/emails/views.py
@@ -1170,19 +1170,46 @@ def _replace_headers(
                 }
             )
 
-    # Collect headers that will not be forwarded
+    # Collect headers that will not be forwarded, and the kept headers that appear
+    # more than once. SES rejects the whole message when a header it parses, such as
+    # MIME-Version or Content-Type, is duplicated, so only the first copy is kept.
+    first_kept: dict[str, str] = {}
+    duplicate_counts: dict[str, int] = {}
     for header in email.keys():
         header_lower = header.lower()
-        if (
-            header_lower not in replacements
-            and header_lower != "mime-version"
-            and not header_lower.startswith("content-")
-        ):
+        if header_lower in replacements:
+            # The replacement loop below deletes every copy and writes one new value
+            continue
+        if header_lower != "mime-version" and not header_lower.startswith("content-"):
             to_drop.append(header)
+        elif header_lower in first_kept:
+            duplicate_counts[header_lower] = duplicate_counts.get(header_lower, 0) + 1
+        else:
+            first_kept[header_lower] = header
 
     # Drop headers that should be dropped
     for header in to_drop:
         del email[header]
+
+    # Collapse each duplicated header to its first value
+    for header_lower, count in duplicate_counts.items():
+        header = first_kept[header_lower]
+        try:
+            value = email[header]
+        except Exception as e:
+            # The value cannot be read, so leave every copy in place
+            issues.append(
+                {"header": header, "direction": "in", "exception_on_read": repr(e)}
+            )
+        else:
+            del email[header]
+            # Assigning the parsed header object back keeps the original value.
+            # Assigning the raw string would fail on a folded header, because a folded
+            # value contains newlines.
+            email[header] = value
+            issues.append(
+                {"header": header, "direction": "in", "duplicates_dropped": count}
+            )
 
     # Replace the requested headers
     for header, value in headers.items():


### PR DESCRIPTION
Some senders emit the same header twice. SES refuses a message with a duplicate header, so the forward failed and the email was lost. In production that was about 1,170 rejections a day, 93% of every SES rejection Relay saw.

`_replace_headers` keeps `mime-version` and every `content-`* header from the incoming email, because those describe a body Relay reuses rather than rebuilds. Dropping them is not an option: without `Content-Type` the MIME boundary is gone and Python cannot even serialize the message. But the rule only said which headers to keep, never how many of each. Headers outside that set were already collapsed as a side effect, because deleting a header removes every copy of it.

Collapse each duplicated kept header to its first value and record the count in the forwarding issues log. That log entry is the first telemetry Relay has had on duplicate headers.

Reassign the parsed header object rather than the raw string. A folded raw value contains newlines, and the email policy refuses to store those.

The duplicate arrives from outside. Relay never writes `MIME-Version`, and the three places the email library writes it either delete first or check for an existing header. A clean incoming email still produces exactly one top-level `MIME-Version` end to end.

This PR fixes MPP-4746.

How to test:
* `pytest emails/tests/views_tests.py`

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] ~I've added or updated relevant docs in the docs/ directory.~
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol / Nebula colors where applicable (see `/frontend/src/styles/colors.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).